### PR TITLE
プランナの割当にヒステリシスを導入

### DIFF
--- a/session/crane_planner_base/include/crane_planner_base/planner_base.hpp
+++ b/session/crane_planner_base/include/crane_planner_base/planner_base.hpp
@@ -27,6 +27,7 @@ struct RobotRole
 {
   std::string planner_name;
   std::string role_name;
+  double score = 0.;
 };
 
 class PlannerBase
@@ -50,11 +51,12 @@ public:
   }
 
   crane_msgs::srv::RobotSelect::Response doRobotSelect(
-    const crane_msgs::srv::RobotSelect::Request::SharedPtr request)
+    const crane_msgs::srv::RobotSelect::Request::SharedPtr request,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles)
   {
     crane_msgs::srv::RobotSelect::Response response;
     response.selected_robots =
-      getSelectedRobots(request->selectable_robots_num, request->selectable_robots);
+      getSelectedRobots(request->selectable_robots_num, request->selectable_robots, prev_roles);
 
     robots.clear();
     for (auto id : response.selected_robots) {
@@ -93,22 +95,34 @@ public:
 
   Status getStatus() const { return status; }
 
+  const std::vector<RobotIdentifier> & getRobots() const { return robots; }
+
   static std::shared_ptr<std::unordered_map<uint8_t, RobotRole>> robot_roles;
 
   const std::string name;
 
 protected:
   virtual auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> = 0;
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> = 0;
 
   auto getSelectedRobotsByScore(
     uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
-    std::function<double(const std::shared_ptr<RobotInfo> &)> score_func) -> std::vector<uint8_t>
+    std::function<double(const std::shared_ptr<RobotInfo> &)> score_func,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles,
+    std::function<double(const std::shared_ptr<RobotInfo> &)> hysterisys_func =
+      [](const std::shared_ptr<RobotInfo> &) { return 0.; }) -> std::vector<uint8_t>
   {
     std::vector<std::pair<int, double>> robot_with_score;
     for (const auto & id : selectable_robots) {
-      robot_with_score.emplace_back(id, score_func(world_model->getOurRobot(id)));
+      if (auto prev = prev_roles.find(id);
+          prev != prev_roles.end() && prev->second.planner_name == name) {
+        robot_with_score.emplace_back(
+          id,
+          score_func(world_model->getOurRobot(id)) + hysterisys_func(world_model->getOurRobot(id)));
+      } else {
+        robot_with_score.emplace_back(id, score_func(world_model->getOurRobot(id)));
+      }
     }
     std::sort(
       std::begin(robot_with_score), std::end(robot_with_score),

--- a/session/crane_planner_base/include/crane_planner_base/planner_base.hpp
+++ b/session/crane_planner_base/include/crane_planner_base/planner_base.hpp
@@ -110,7 +110,7 @@ protected:
     uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
     std::function<double(const std::shared_ptr<RobotInfo> &)> score_func,
     const std::unordered_map<uint8_t, RobotRole> & prev_roles,
-    std::function<double(const std::shared_ptr<RobotInfo> &)> hysterisys_func =
+    std::function<double(const std::shared_ptr<RobotInfo> &)> hysteresis_func =
       [](const std::shared_ptr<RobotInfo> &) { return 0.; }) -> std::vector<uint8_t>
   {
     std::vector<std::pair<int, double>> robot_with_score;
@@ -119,7 +119,7 @@ protected:
           prev != prev_roles.end() && prev->second.planner_name == name) {
         robot_with_score.emplace_back(
           id,
-          score_func(world_model->getOurRobot(id)) + hysterisys_func(world_model->getOurRobot(id)));
+          score_func(world_model->getOurRobot(id)) + hysteresis_func(world_model->getOurRobot(id)));
       } else {
         robot_with_score.emplace_back(id, score_func(world_model->getOurRobot(id)));
       }

--- a/session/crane_planner_plugins/include/crane_planner_plugins/attacker_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/attacker_planner.hpp
@@ -49,9 +49,13 @@ protected:
       selectable_robots_num, selectable_robots,
       [this](const std::shared_ptr<RobotInfo> & robot) {
         // ボールに近いほどスコアが高い
-        return 100.0 / std::max(world_model->getSquareDistanceFromRobotToBall(robot->id), 0.01);
+        return 100.0 - std::max(world_model->getSquareDistanceFromRobotToBall(robot->id), 0.01);
       },
-      prev_roles);
+      prev_roles,
+      [this](const std::shared_ptr<RobotInfo> & robot) {
+        // ヒステリシスは1m
+        return 1.;
+      });
   }
 };
 

--- a/session/crane_planner_plugins/include/crane_planner_plugins/attacker_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/attacker_planner.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -41,14 +42,16 @@ public:
 
 protected:
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override
   {
     return this->getSelectedRobotsByScore(
-      selectable_robots_num, selectable_robots, [this](const std::shared_ptr<RobotInfo> & robot) {
+      selectable_robots_num, selectable_robots,
+      [this](const std::shared_ptr<RobotInfo> & robot) {
         // ボールに近いほどスコアが高い
         return 100.0 / std::max(world_model->getSquareDistanceFromRobotToBall(robot->id), 0.01);
-      });
+      },
+      prev_roles);
   }
 };
 

--- a/session/crane_planner_plugins/include/crane_planner_plugins/defender_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/defender_planner.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -163,14 +164,16 @@ public:
   }
 
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override
   {
     return this->getSelectedRobotsByScore(
-      selectable_robots_num, selectable_robots, [this](const std::shared_ptr<RobotInfo> & robot) {
+      selectable_robots_num, selectable_robots,
+      [this](const std::shared_ptr<RobotInfo> & robot) {
         // x座標が自ゴールに近いほうが優先
         return 20. - std::abs(world_model->goal.x() - robot->pose.pos.x());
-      });
+      },
+      prev_roles);
   }
 };
 

--- a/session/crane_planner_plugins/include/crane_planner_plugins/formation_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/formation_planner.hpp
@@ -16,6 +16,7 @@
 #include <functional>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -40,14 +41,16 @@ public:
     const std::vector<RobotIdentifier> & robots) override;
 
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override
   {
     return this->getSelectedRobotsByScore(
-      selectable_robots_num, selectable_robots, [this](const std::shared_ptr<RobotInfo> & robot) {
+      selectable_robots_num, selectable_robots,
+      [this](const std::shared_ptr<RobotInfo> & robot) {
         // choose id smaller first
         return 15. - static_cast<double>(-robot->id);
-      });
+      },
+      prev_roles);
   }
 };
 

--- a/session/crane_planner_plugins/include/crane_planner_plugins/marker_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/marker_planner.hpp
@@ -39,8 +39,8 @@ public:
     const std::vector<RobotIdentifier> & robots) override;
 
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override;
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override;
 
 private:
   // key: ID of our robot in charge, value: ID of the enemy marked robot

--- a/session/crane_planner_plugins/include/crane_planner_plugins/our_free_kick_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/our_free_kick_planner.hpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -43,8 +44,8 @@ public:
     const std::vector<RobotIdentifier> & robots) override;
 
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override;
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override;
 };
 }  // namespace crane
 #endif  // CRANE_PLANNER_PLUGINS__OUR_FREE_KICK_PLANNER_HPP_

--- a/session/crane_planner_plugins/include/crane_planner_plugins/our_kickoff_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/our_kickoff_planner.hpp
@@ -16,6 +16,7 @@
 #include <functional>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -42,8 +43,8 @@ public:
     const std::vector<RobotIdentifier> & robots) override;
 
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override;
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override;
 };
 
 }  // namespace crane

--- a/session/crane_planner_plugins/include/crane_planner_plugins/our_penalty_kick_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/our_penalty_kick_planner.hpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -42,8 +43,8 @@ public:
     const std::vector<RobotIdentifier> & robots) override;
 
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override;
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override;
 };
 }  // namespace crane
 #endif  // CRANE_PLANNER_PLUGINS__OUR_PENALTY_KICK_PLANNER_HPP_

--- a/session/crane_planner_plugins/include/crane_planner_plugins/receive_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/receive_planner.hpp
@@ -21,6 +21,7 @@
 #include <limits>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -71,13 +72,15 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::RobotCommand>> calculateRobotCommand(
     const std::vector<RobotIdentifier> & robots) override;
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override
   {
     return this->getSelectedRobotsByScore(
-      selectable_robots_num, selectable_robots, [this](const std::shared_ptr<RobotInfo> & robot) {
+      selectable_robots_num, selectable_robots,
+      [this](const std::shared_ptr<RobotInfo> & robot) {
         return 100. / world_model->getSquareDistanceFromRobotToBall(robot->id);
-      });
+      },
+      prev_roles);
   }
 
   auto getPassResponse(const std::shared_ptr<crane_msgs::srv::PassRequest::Request> & request)

--- a/session/crane_planner_plugins/include/crane_planner_plugins/template_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/template_planner.hpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -58,14 +59,16 @@ public:
   }
 
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override
   {
     return this->getSelectedRobotsByScore(
-      selectable_robots_num, selectable_robots, [this](const std::shared_ptr<RobotInfo> & robot) {
+      selectable_robots_num, selectable_robots,
+      [this](const std::shared_ptr<RobotInfo> & robot) {
         // choose id smaller first
         return 15. - static_cast<double>(-robot->id);
-      });
+      },
+      prev_roles);
   }
 };
 

--- a/session/crane_planner_plugins/include/crane_planner_plugins/temporary/ball_placement_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/temporary/ball_placement_planner.hpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -242,14 +243,16 @@ public:
   }
 
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override
   {
     return this->getSelectedRobotsByScore(
-      selectable_robots_num, selectable_robots, [this](const std::shared_ptr<RobotInfo> & robot) {
+      selectable_robots_num, selectable_robots,
+      [this](const std::shared_ptr<RobotInfo> & robot) {
         // ボールに近いほどスコアが高い
         return 100.0 / std::max(world_model->getSquareDistanceFromRobotToBall(robot->id), 0.01);
-      });
+      },
+      prev_roles);
   }
 
 private:

--- a/session/crane_planner_plugins/include/crane_planner_plugins/their_penalty_kick_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/their_penalty_kick_planner.hpp
@@ -16,6 +16,7 @@
 #include <functional>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -69,15 +70,17 @@ public:
   }
 
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override
   {
     goalie = std::make_shared<skills::Goalie>(world_model->getOurGoalieId(), world_model);
     auto robots_sorted = this->getSelectedRobotsByScore(
-      selectable_robots_num, selectable_robots, [&](const std::shared_ptr<RobotInfo> & robot) {
+      selectable_robots_num, selectable_robots,
+      [&](const std::shared_ptr<RobotInfo> & robot) {
         // ボールに近いほうが先頭
         return 100. / robot->getDistance(world_model->ball.pos);
-      });
+      },
+      prev_roles);
     for (auto it = robots_sorted.begin(); it != robots_sorted.end(); it++) {
       if (*it != world_model->getOurGoalieId()) {
         other_robots.emplace_back(std::make_shared<RobotCommandWrapper>(*it, world_model));

--- a/session/crane_planner_plugins/include/crane_planner_plugins/tigers_goalie_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/tigers_goalie_planner.hpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -236,14 +237,16 @@ public:
   bool isBallPlaced() const { return false; }
 
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override
   {
     return this->getSelectedRobotsByScore(
-      selectable_robots_num, selectable_robots, [this](const std::shared_ptr<RobotInfo> & robot) {
+      selectable_robots_num, selectable_robots,
+      [this](const std::shared_ptr<RobotInfo> & robot) {
         // choose id smaller first
         return 15. - static_cast<double>(-robot->id);
-      });
+      },
+      prev_roles);
   }
 
   State state = State::DEFEND;

--- a/session/crane_planner_plugins/include/crane_planner_plugins/waiter_planner.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/waiter_planner.hpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -47,14 +48,16 @@ public:
   }
 
   auto getSelectedRobots(
-    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-    -> std::vector<uint8_t> override
+    uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+    const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override
   {
     return this->getSelectedRobotsByScore(
-      selectable_robots_num, selectable_robots, [this](const std::shared_ptr<RobotInfo> & robot) {
+      selectable_robots_num, selectable_robots,
+      [this](const std::shared_ptr<RobotInfo> & robot) {
         // choose id smaller first
         return 15. - static_cast<double>(-robot->id);
-      });
+      },
+      prev_roles);
   }
 
 private:

--- a/session/crane_planner_plugins/src/marker_planner.cpp
+++ b/session/crane_planner_plugins/src/marker_planner.cpp
@@ -20,8 +20,8 @@ MarkerPlanner::calculateRobotCommand(const std::vector<RobotIdentifier> & robots
   return {PlannerBase::Status::RUNNING, robot_commands};
 }
 auto MarkerPlanner::getSelectedRobots(
-  uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-  -> std::vector<uint8_t>
+  uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+  const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t>
 {
   if (selectable_robots_num >= selectable_robots.size()) {
     selectable_robots_num = selectable_robots.size();

--- a/session/crane_planner_plugins/src/our_free_kick_planner.cpp
+++ b/session/crane_planner_plugins/src/our_free_kick_planner.cpp
@@ -84,14 +84,16 @@ OurDirectFreeKickPlanner::calculateRobotCommand(const std::vector<RobotIdentifie
   return {Status::RUNNING, robot_commands};
 }
 auto OurDirectFreeKickPlanner::getSelectedRobots(
-  uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-  -> std::vector<uint8_t>
+  uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+  const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t>
 {
   auto robots_sorted = this->getSelectedRobotsByScore(
-    selectable_robots_num, selectable_robots, [&](const std::shared_ptr<RobotInfo> & robot) {
+    selectable_robots_num, selectable_robots,
+    [&](const std::shared_ptr<RobotInfo> & robot) {
       // ボールに近いほうが先頭
       return 100. / robot->getDistance(world_model->ball.pos);
-    });
+    },
+    prev_roles);
   // ゴールキーパーはキッカーに含めない(ロボットがキーパーのみの場合は除く)
   if (robots_sorted.size() > 1 && robots_sorted.front() == world_model->getOurGoalieId()) {
     robots_sorted.erase(robots_sorted.begin());

--- a/session/crane_planner_plugins/src/our_kickoff_planner.cpp
+++ b/session/crane_planner_plugins/src/our_kickoff_planner.cpp
@@ -23,8 +23,8 @@ OurKickOffPlanner::calculateRobotCommand(const std::vector<RobotIdentifier> & ro
   return {PlannerBase::Status::RUNNING, robot_commands};
 }
 auto OurKickOffPlanner::getSelectedRobots(
-  uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-  -> std::vector<uint8_t>
+  uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+  const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t>
 {
   // 一番ボールに近いロボットをkickoff attack
   auto best_attacker = std::max_element(

--- a/session/crane_planner_plugins/src/our_penalty_kick_planner.cpp
+++ b/session/crane_planner_plugins/src/our_penalty_kick_planner.cpp
@@ -32,14 +32,16 @@ OurPenaltyKickPlanner::calculateRobotCommand(const std::vector<RobotIdentifier> 
   return {Status::RUNNING, robot_commands};
 }
 auto OurPenaltyKickPlanner::getSelectedRobots(
-  uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots)
-  -> std::vector<uint8_t>
+  uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
+  const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t>
 {
   auto robots_sorted = this->getSelectedRobotsByScore(
-    selectable_robots_num, selectable_robots, [&](const std::shared_ptr<RobotInfo> & robot) {
+    selectable_robots_num, selectable_robots,
+    [&](const std::shared_ptr<RobotInfo> & robot) {
       // ボールに近いほうが先頭
       return 100. / robot->getDistance(world_model->ball.pos);
-    });
+    },
+    prev_roles);
   // ゴールキーパーはキッカーに含めない(ロボットがキーパーのみの場合は除く)
   if (robots_sorted.size() > 1 && robots_sorted.front() == world_model->getOurGoalieId()) {
     robots_sorted.erase(robots_sorted.begin());

--- a/session/crane_session_controller/src/crane_session_controller.cpp
+++ b/session/crane_session_controller/src/crane_session_controller.cpp
@@ -187,9 +187,10 @@ void SessionControllerComponent::request(
       req->selectable_robots.emplace_back(id);
     }
     try {
-      auto [response, new_planner] = [&p, &req, this]() {
+      const std::unordered_map<uint8_t, RobotRole> & prev_roles = *PlannerBase::robot_roles;
+      auto [response, new_planner] = [&]() {
         auto planner = generatePlanner(p.session_name, world_model, visualizer);
-        auto response = planner->doRobotSelect(req);
+        auto response = planner->doRobotSelect(req, prev_roles);
         return std::make_pair(response, planner);
       }();
 


### PR DESCRIPTION
プランナによってスコアの計算方法が違うので、
デフォルトでは一律のヒステリシスを付与することはせず、
自分でヒステリシス計算関数を指定する