### PR TITLE
ローカルプランナでロボットの優先順位を考慮する

### DIFF
--- a/crane_msgs/msg/control/LocalPlannerConfig.msg
+++ b/crane_msgs/msg/control/LocalPlannerConfig.msg
@@ -8,3 +8,4 @@ float32 max_acceleration 4.0
 float32 max_velocity 6.0
 float32 max_omega 1.0
 float32 terminal_velocity 0
+uint8 priority 255

--- a/crane_msgs/msg/control/LocalPlannerConfig.msg
+++ b/crane_msgs/msg/control/LocalPlannerConfig.msg
@@ -8,4 +8,4 @@ float32 max_acceleration 4.0
 float32 max_velocity 6.0
 float32 max_omega 1.0
 float32 terminal_velocity 0
-uint8 priority 255
+uint8 priority 0

--- a/session/crane_session_controller/src/crane_session_controller.cpp
+++ b/session/crane_session_controller/src/crane_session_controller.cpp
@@ -245,6 +245,12 @@ SessionControllerComponent::SessionControllerComponent(const rclcpp::NodeOptions
           // TODO(HansRobo): プランナが成功・失敗した場合の処理
         }
       }
+
+      // ロボットの優先度を設定(値が高いほど優先度が高い)
+      uint8_t robot_priority = 100;
+      for (auto & robot_command : msg.robot_commands) {
+        robot_command.local_planner_config.priority = --robot_priority;
+      }
     } catch (const std::exception & e) {
       std::stringstream what;
       what << "An exception caught: " << e.what() << std::endl;

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
@@ -327,12 +327,12 @@ struct WorldModelWrapper : public std::enable_shared_from_this<WorldModelWrapper
     }
 
     enum class Rule {
-      EQAL_TO,
-      NOT_EQAL_TO,
+      EQUAL_TO,
+      NOT_EQUAL_TO,
       LESS_THAN,
       GREATER_THAN,
-      LESS_THAN_OR_EQAL_TO,
-      GREATER_THAN_OR_EQAL_TO,
+      LESS_THAN_OR_EQUAL_TO,
+      GREATER_THAN_OR_EQUAL_TO,
     };
 
     [[nodiscard]] bool checkDistance(
@@ -340,17 +340,17 @@ struct WorldModelWrapper : public std::enable_shared_from_this<WorldModelWrapper
     {
       double distance = (p - target).norm();
       switch (rule) {
-        case Rule::EQAL_TO:
+        case Rule::EQUAL_TO:
           return distance == threshold;
-        case Rule::NOT_EQAL_TO:
+        case Rule::NOT_EQUAL_TO:
           return distance != threshold;
         case Rule::LESS_THAN:
           return distance < threshold;
         case Rule::GREATER_THAN:
           return distance > threshold;
-        case Rule::LESS_THAN_OR_EQAL_TO:
+        case Rule::LESS_THAN_OR_EQUAL_TO:
           return distance <= threshold;
-        case Rule::GREATER_THAN_OR_EQAL_TO:
+        case Rule::GREATER_THAN_OR_EQUAL_TO:
           return distance >= threshold;
         default:
           return false;


### PR DESCRIPTION
- LocalPlannerConfigにpriorityフィールドを追加（値が大きいほど優先度が高い）
- SessionControllerで割当順に高い優先度を付与
- LocalPlannerで自分より優先度の低いロボットを無視