### PR TITLE
cpplintをアップグレード

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
         types_or: [c++, c, cuda]
 
   - repo: https://github.com/cpplint/cpplint
-    rev: 1.6.1
+    rev: 80e97a67b2a10643d764dad98cde723f8dd1f1cf # NOLINTBEGIN/NOINTENDサポート
     hooks:
       - id: cpplint
         args: [--quiet]

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -2,7 +2,7 @@
 set noparent
 linelength=100
 includeorder=standardcfirst
-filter=-build/c++11               # we do allow C++11
+filter=-build/c++20               # we do allow C++20
 filter=-build/namespaces_literals # we allow using namespace for literals
 filter=-runtime/references        # we consider passing non-const references to be ok
 filter=-whitespace/braces         # we wrap open curly braces for namespaces, classes and functions
@@ -12,4 +12,5 @@ filter=-whitespace/semicolon      # we allow the developer to decide about white
 filter=-build/header_guard        # we automatically fix the names of header guards using pre-commit
 filter=-build/include_order       # we use the custom include order
 filter=-build/include_subdir      # we allow the style of "foo.hpp"
+filter=-build/include_what_you_use # we allow the developer to decide about the includes
 filter=-readability/alt_tokens    # we want to use not instead of !

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -2,6 +2,9 @@
 set noparent
 linelength=100
 includeorder=standardcfirst
+filter=-build/c++11               # we do allow C++11
+filter=-build/c++14               # we do allow C++14
+filter=-build/c++17               # we do allow C++17
 filter=-build/c++20               # we do allow C++20
 filter=-build/namespaces_literals # we allow using namespace for literals
 filter=-runtime/references        # we consider passing non-const references to be ok


### PR DESCRIPTION
最後のcpplintのリリースである1.6.1では `NOLINTBEGIN` / `NOINTEND`がサポートされていない。
（多分Googleが公開版cpplintのメンテをやめてからリリースされていない）
pre-commitの設定にcpplintのコミットハッシュを書くことで最新版を使用できる
```
  - repo: https://github.com/cpplint/cpplint
    rev: 80e97a67b2a10643d764dad98cde723f8dd1f1cf # NOLINTBEGIN/NOINTENDサポート
    hooks:
      - id: cpplint
        args: [--quiet]
```