### PR TITLE
生Visionの検出情報をロボットまで伝搬する

### DIFF
--- a/consai_ros2/consai_vision_tracker/include/consai_vision_tracker/robot_tracker.hpp
+++ b/consai_ros2/consai_vision_tracker/include/consai_vision_tracker/robot_tracker.hpp
@@ -22,6 +22,7 @@
 #include <bfl/pdf/linearanalyticconditionalgaussian.h>
 
 #include <memory>
+#include <rclcpp/rclcpp.hpp>
 #include <robocup_ssl_msgs/msg/detection_robot.hpp>
 #include <robocup_ssl_msgs/msg/tracked_robot.hpp>
 #include <vector>
@@ -77,6 +78,10 @@ private:
   std::shared_ptr<Gaussian> prior;
 
   std::shared_ptr<ExtendedKalmanFilter> filter;
+
+  rclcpp::Clock clock;
+
+  rclcpp::Time last_update_time;
 };
 
 }  // namespace consai_vision_tracker

--- a/consai_ros2/consai_vision_tracker/src/robot_tracker.cpp
+++ b/consai_ros2/consai_vision_tracker/src/robot_tracker.cpp
@@ -37,6 +37,7 @@ using Vector2 = robocup_ssl_msgs::msg::Vector2;
 static const double VISIBILITY_CONTROL_VALUE = 0.005;
 
 RobotTracker::RobotTracker(const int team_color, const int id, const double dt)
+: clock(RCL_ROS_TIME)
 {
   prev_tracked_robot.robot_id.team_color = team_color;
   prev_tracked_robot.robot_id.id = id;
@@ -222,6 +223,7 @@ TrackedRobot RobotTracker::update()
     }
 
   } else {
+    last_update_time = clock.now();
     // 観測値があればvisibilityをn倍のレートで上げる
     //    prev_tracked_robot.visibility[0] += VISIBILITY_CONTROL_VALUE * 5.0;
     // NOTE: JapanOpen2024でビジョンの点滅がロボット制御に影響を与えたと思われるため、
@@ -269,6 +271,8 @@ TrackedRobot RobotTracker::update()
   prev_tracked_robot.vel[0].x = expected_value(4);
   prev_tracked_robot.vel[0].y = expected_value(5);
   prev_tracked_robot.vel_angular[0] = expected_value(6);
+
+  prev_tracked_robot.stamp = last_update_time;
 
   // 次の状態を予測する
   // 例えば、ロボットの加速度が入力値になる

--- a/consai_ros2/robocup_ssl_msgs/CMakeLists.txt
+++ b/consai_ros2/robocup_ssl_msgs/CMakeLists.txt
@@ -100,7 +100,6 @@ set(msg_files
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   DEPENDENCIES std_msgs
-  ADD_LINTER_TESTS
 )
 
 if(BUILD_TESTING)

--- a/consai_ros2/robocup_ssl_msgs/msg/detection_tracked/TrackedRobot.msg
+++ b/consai_ros2/robocup_ssl_msgs/msg/detection_tracked/TrackedRobot.msg
@@ -3,6 +3,8 @@
 
 # A single tracked robot
 
+builtin_interfaces/Time stamp
+
 RobotId robot_id
 
 # The position [m] in the ssl-vision coordinate system

--- a/consai_ros2/robocup_ssl_msgs/package.xml
+++ b/consai_ros2/robocup_ssl_msgs/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <depend>builtin_interfaces</depend>
   <depend>protobuf-dev</depend>
   <depend>std_msgs</depend>
 

--- a/crane_msgs/msg/world_model/RobotInfoOurs.msg
+++ b/crane_msgs/msg/world_model/RobotInfoOurs.msg
@@ -1,5 +1,9 @@
 bool disappeared
 uint8 id
+
+# Latest vision detection time
+builtin_interfaces/Time detection_stamp
+
 geometry_msgs/Pose2D pose
 geometry_msgs/Pose2D velocity
 

--- a/crane_msgs/msg/world_model/RobotInfoTheirs.msg
+++ b/crane_msgs/msg/world_model/RobotInfoTheirs.msg
@@ -1,5 +1,9 @@
 bool disappeared
 uint8 id
+
+# Latest vision detection time
+builtin_interfaces/Time detection_stamp
+
 geometry_msgs/Pose2D pose
 geometry_msgs/Pose2D velocity
 

--- a/crane_sender/CMakeLists.txt
+++ b/crane_sender/CMakeLists.txt
@@ -26,7 +26,7 @@ add_backward(ibis_sender_node)
 if (BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
-  ament_add_gtest(test_robot_packet test/test_robot_packet.cpp)
+  ament_auto_add_gtest(test_robot_packet test/test_robot_packet.cpp)
   target_link_libraries(test_robot_packet sim_sender_component)
 endif ()
 

--- a/crane_sender/include/crane_sender/robot_packet.hpp
+++ b/crane_sender/include/crane_sender/robot_packet.hpp
@@ -41,6 +41,7 @@ struct RobotCommand
   float BALL_GLOBAL_X;
   float BALL_GLOBAL_Y;
   float TARGET_GLOBAL_THETA;
+  int ELAPSED_TIME_MS_SINCE_LAST_VISION;
 
   bool LOCAL_FEEDBACK_ENABLE;
   bool LOCAL_KEEPER_MODE_ENABLE;
@@ -66,6 +67,8 @@ struct RobotCommandSerialized
     VISION_GLOBAL_THETA_LOW,
     TARGET_GLOBAL_THETA_HIGH,
     TARGET_GLOBAL_THETA_LOW,
+    ELAPSED_TIME_MS_SINCE_LAST_VISION_HIGH,
+    ELAPSED_TIME_MS_SINCE_LAST_VISION_LOW,
     KICK_POWER,
     DRIBBLE_POWER,
     LOCAL_FLAGS,
@@ -108,6 +111,9 @@ struct RobotCommandSerialized
     FLOAT_FROM_2BYTE(BALL_GLOBAL_X, 32.767);
     FLOAT_FROM_2BYTE(BALL_GLOBAL_Y, 32.767);
     FLOAT_FROM_2BYTE(TARGET_GLOBAL_THETA, M_PI);
+    packet.ELAPSED_TIME_MS_SINCE_LAST_VISION =
+      data[static_cast<int>(Address::ELAPSED_TIME_MS_SINCE_LAST_VISION_HIGH)] << 8 |
+      data[static_cast<int>(Address::ELAPSED_TIME_MS_SINCE_LAST_VISION_LOW)];
     const uint8_t kick_raw = data[static_cast<int>(Address::KICK_POWER)];
     if (kick_raw >= 101) {
       packet.CHIP_ENABLE = true;
@@ -162,6 +168,12 @@ RobotCommand::operator RobotCommandSerialized() const
   FLOAT_TO_2BYTE(BALL_GLOBAL_X, 32.767);
   FLOAT_TO_2BYTE(BALL_GLOBAL_Y, 32.767);
   FLOAT_TO_2BYTE(TARGET_GLOBAL_THETA, M_PI);
+  serialized.data[static_cast<int>(
+    RobotCommandSerialized::Address::ELAPSED_TIME_MS_SINCE_LAST_VISION_HIGH)] =
+    ELAPSED_TIME_MS_SINCE_LAST_VISION >> 8;
+  serialized.data[static_cast<int>(
+    RobotCommandSerialized::Address::ELAPSED_TIME_MS_SINCE_LAST_VISION_LOW)] =
+    ELAPSED_TIME_MS_SINCE_LAST_VISION & 0xFF;
   serialized.data[static_cast<int>(RobotCommandSerialized::Address::DRIBBLE_POWER)] =
     static_cast<uint8_t>(DRIBBLE_POWER * 20);
   serialized.data[static_cast<int>(RobotCommandSerialized::Address::KICK_POWER)] =

--- a/crane_sender/src/ibis_sender_node.cpp
+++ b/crane_sender/src/ibis_sender_node.cpp
@@ -95,9 +95,12 @@ private:
 
   bool sim_mode;
 
+  rclcpp::Clock clock;
+
 public:
   CLASS_LOADER_PUBLIC
-  explicit IbisSenderNode(const rclcpp::NodeOptions & options) : SenderBase("ibis_sender", options)
+  explicit IbisSenderNode(const rclcpp::NodeOptions & options)
+  : SenderBase("ibis_sender", options), clock(RCL_ROS_TIME)
   {
     declare_parameter("debug_id", -1);
     get_parameter("debug_id", debug_id);
@@ -137,6 +140,8 @@ public:
     if (not world_model->hasUpdated()) {
       return;
     }
+
+    auto now = clock.now();
 
     auto normalize_angle = [](float angle_rad) -> float {
       if (fabs(angle_rad) > M_PI) {
@@ -180,6 +185,9 @@ public:
       packet.VISION_GLOBAL_X = command.current_pose.x;
       packet.VISION_GLOBAL_Y = command.current_pose.y;
       packet.VISION_GLOBAL_THETA = command.current_pose.theta;
+
+      auto elapsed_time = now - world_model->getOurRobot(command.robot_id)->detection_stamp;
+      packet.ELAPSED_TIME_MS_SINCE_LAST_VISION = elapsed_time.nanoseconds() / 1e6;
 
       packet.BALL_GLOBAL_X = command.current_ball_x;
       packet.BALL_GLOBAL_Y = command.current_ball_y;

--- a/crane_sender/test/test_robot_packet.cpp
+++ b/crane_sender/test/test_robot_packet.cpp
@@ -37,6 +37,7 @@ TEST(RobotPacket, ENcodeDecode)
   packet.BALL_GLOBAL_X = dist_32(gen);
   packet.BALL_GLOBAL_Y = dist_32(gen);
   packet.TARGET_GLOBAL_THETA = dist_pi(gen);
+  packet.ELAPSED_TIME_MS_SINCE_LAST_VISION = 100;
   packet.LOCAL_FEEDBACK_ENABLE = static_cast<bool>(dist_0_1_int(gen));
   packet.LOCAL_KEEPER_MODE_ENABLE = static_cast<bool>(dist_0_1_int(gen));
   packet.IS_ID_VISIBLE = static_cast<bool>(dist_0_1_int(gen));
@@ -55,6 +56,9 @@ TEST(RobotPacket, ENcodeDecode)
   EXPECT_NEAR(packet.VISION_GLOBAL_X, deserialized_packet.VISION_GLOBAL_X, MAX_ERROR_32);
   EXPECT_NEAR(packet.VISION_GLOBAL_Y, deserialized_packet.VISION_GLOBAL_Y, MAX_ERROR_32);
   EXPECT_NEAR(packet.VISION_GLOBAL_THETA, deserialized_packet.VISION_GLOBAL_THETA, MAX_ERROR_PI);
+  EXPECT_EQ(
+    packet.ELAPSED_TIME_MS_SINCE_LAST_VISION,
+    deserialized_packet.ELAPSED_TIME_MS_SINCE_LAST_VISION);
   EXPECT_NEAR(packet.TARGET_GLOBAL_X, deserialized_packet.TARGET_GLOBAL_X, MAX_ERROR_32);
   EXPECT_NEAR(packet.TARGET_GLOBAL_Y, deserialized_packet.TARGET_GLOBAL_Y, MAX_ERROR_32);
   EXPECT_NEAR(packet.BALL_GLOBAL_X, deserialized_packet.BALL_GLOBAL_X, MAX_ERROR_32);

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -180,6 +180,7 @@ void WorldModelPublisherComponent::visionDetectionsCallback(
     each_robot_info.pose.x = robot.pos.x;
     each_robot_info.pose.y = robot.pos.y;
     each_robot_info.pose.theta = robot.orientation;
+    each_robot_info.detection_stamp = robot.stamp;
     if (not robot.vel.empty()) {
       each_robot_info.velocity.x = robot.vel.front().x;
       each_robot_info.velocity.y = robot.vel.front().y;
@@ -303,6 +304,7 @@ void WorldModelPublisherComponent::publishWorldModel()
     crane_msgs::msg::RobotInfoOurs info;
     info.id = robot.robot_id;
     info.disappeared = !robot.detected;
+    info.detection_stamp = robot.detection_stamp;
     info.pose = robot.pose;
     info.velocity = robot.velocity;
     info.ball_contact = robot.ball_contact;
@@ -312,6 +314,7 @@ void WorldModelPublisherComponent::publishWorldModel()
     crane_msgs::msg::RobotInfoTheirs info;
     info.id = robot.robot_id;
     info.disappeared = !robot.detected;
+    info.detection_stamp = robot.detection_stamp;
     info.pose = robot.pose;
     info.velocity = robot.velocity;
     info.ball_contact = robot.ball_contact;

--- a/utility/crane_basics/CMakeLists.txt
+++ b/utility/crane_basics/CMakeLists.txt
@@ -25,7 +25,7 @@ ament_export_include_directories(
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
-  ament_add_gtest(test_geometry test/test.cpp)
+  ament_auto_add_gtest(test_geometry test/test.cpp)
   target_include_directories(test_geometry PUBLIC include)
   target_include_directories(test_geometry PUBLIC ${EIGEN3_INCLUDE_DIRS})
   target_include_directories(test_geometry PUBLIC ${closest_point_vendor_INCLUDE_DIRS})

--- a/utility/crane_basics/include/crane_basics/robot_info.hpp
+++ b/utility/crane_basics/include/crane_basics/robot_info.hpp
@@ -10,6 +10,7 @@
 #include <crane_basics/ball_contact.hpp>
 #include <crane_basics/boost_geometry.hpp>
 #include <memory>
+#include <rclcpp/time.hpp>
 
 namespace crane
 {
@@ -38,6 +39,8 @@ struct RobotInfo
   Velocity2D vel;
 
   bool available = false;
+
+  rclcpp::Time detection_stamp;
 
   using SharedPtr = std::shared_ptr<RobotInfo>;
 

--- a/utility/crane_basics/package.xml
+++ b/utility/crane_basics/package.xml
@@ -19,6 +19,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>crane_lint_common</test_depend>
+  <test_depend>rclcpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
@@ -98,6 +98,7 @@ void WorldModelWrapper::update(const crane_msgs::msg::WorldModel & world_model)
     info->available = !robot.disappeared;
     if (info->available) {
       info->id = robot.id;
+      info->detection_stamp = robot.detection_stamp;
       info->pose.pos << robot.pose.x, robot.pose.y;
       info->pose.theta = robot.pose.theta;
       info->vel.linear << robot.velocity.x, robot.velocity.y;


### PR DESCRIPTION
ロボット側で生Visionが検知状況を知るために上流から下流まで検出情報を伝搬する