### PR TITLE
ボールプレイスメントの修正

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/single_ball_placement.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/single_ball_placement.hpp
@@ -49,6 +49,8 @@ private:
 
   std::optional<Point> pull_back_target;
 
+  double pull_back_angle;
+
 public:
   explicit SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & base);
 

--- a/crane_robot_skills/include/crane_robot_skills/single_ball_placement.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/single_ball_placement.hpp
@@ -20,6 +20,7 @@
 namespace crane::skills
 {
 enum class SingleBallPlacementStates {
+  ENTRY_POINT,
   PULL_BACK_FROM_EDGE_PREPARE,
   PULL_BACK_FROM_EDGE_TOUCH,
   PULL_BACK_FROM_EDGE_PULL,

--- a/crane_robot_skills/src/move_with_ball.cpp
+++ b/crane_robot_skills/src/move_with_ball.cpp
@@ -24,8 +24,6 @@ MoveWithBall::MoveWithBall(RobotCommandWrapperBase::SharedPtr & base)
   setParameter("moving_direction_tolerance", 0.3);
   // この時間以上ボールが離れたら停止する
   setParameter("max_contact_lost_time", 0.3);
-  // ドリブル時の目標位置の設置距離
-  setParameter("dribble_target_horizon", 0.2);
   setParameter("ball_stabilizing_time", 0.5);
 }
 
@@ -70,8 +68,7 @@ Point MoveWithBall::getTargetPoint(const Point & target_pos)
     getAngleDiff(robot()->pose, target_theta) <
     getParameter<double>("moving_direction_tolerance")) {
     if (robot()->ball_contact.findPastContact(getParameter<double>("max_contact_lost_time"))) {
-      return robot()->pose.pos + (target_pos - robot()->pose.pos).normalized() *
-                                   getParameter<double>("dribble_target_horizon");
+      return target_pos;
     }
   }
   return robot()->pose.pos;

--- a/crane_robot_skills/src/single_ball_placement.cpp
+++ b/crane_robot_skills/src/single_ball_placement.cpp
@@ -204,7 +204,6 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
         move_with_ball->setParameter("target_x", getParameter<double>("placement_x"));
         move_with_ball->setParameter("target_y", getParameter<double>("placement_y"));
         move_with_ball->setParameter("dribble_power", 0.2);
-        move_with_ball->setParameter("dribble_target_horizon", 0.5);
       }
 
       skill_status = move_with_ball->run(visualizer);

--- a/crane_robot_skills/src/single_ball_placement.cpp
+++ b/crane_robot_skills/src/single_ball_placement.cpp
@@ -283,6 +283,7 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
     });
 
   addTransition(SingleBallPlacementStates::SLEEP, SingleBallPlacementStates::LEAVE_BALL, [this]() {
+    pull_back_angle = robot()->pose.theta;
     return skill_status == Status::SUCCESS;
   });
 
@@ -302,6 +303,7 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
       set_target_position->setParameter("y", leave_pos.y());
       set_target_position->setParameter("reach_threshold", 0.05);
 
+      command.setTargetTheta(pull_back_angle);
       command.disablePlacementAvoidance();
       command.disableBallAvoidance();
       command.disableGoalAreaAvoidance();

--- a/crane_robot_skills/src/single_ball_placement.cpp
+++ b/crane_robot_skills/src/single_ball_placement.cpp
@@ -22,7 +22,8 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
   // 端にある場合、コート側からアプローチする
   addStateFunction(
     SingleBallPlacementStates::PULL_BACK_FROM_EDGE_PREPARE,
-    [this]([[maybe_unused]] const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+    [this](const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+      visualizer->addPoint(robot()->pose.pos, 0, "white", 1.0, state_string);
       if (not pull_back_target) {
         pull_back_target = world_model()->ball.pos;
         const auto offset = getParameter<double>("コート端判定のオフセット");
@@ -77,7 +78,8 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
   // PULL_BACK_FROM_EDGE_TOUCH
   addStateFunction(
     SingleBallPlacementStates::PULL_BACK_FROM_EDGE_TOUCH,
-    [this]([[maybe_unused]] const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+    [this](const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+      visualizer->addPoint(robot()->pose.pos, 0, "white", 1.0, state_string);
       //      if (not get_ball_contact) {
       //        get_ball_contact = std::make_shared<GetBallContact>(robot()->id, world_model);
       //        get_ball_contact->setCommander(command);
@@ -120,7 +122,8 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
   // PULL_BACK_FROM_EDGE_PULL
   addStateFunction(
     SingleBallPlacementStates::PULL_BACK_FROM_EDGE_PULL,
-    [this]([[maybe_unused]] const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+    [this](const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+      visualizer->addPoint(robot()->pose.pos, 0, "white", 1.0, state_string);
       command.setDribblerTargetPosition(pull_back_target.value());
       // 角度はそのまま引っ張りたいので指定はしない
       command.dribble(0.2);
@@ -146,7 +149,8 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
 
   addStateFunction(
     SingleBallPlacementStates::GO_OVER_BALL,
-    [this]([[maybe_unused]] const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+    [this](const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+      visualizer->addPoint(robot()->pose.pos, 0, "white", 1.0, state_string);
       command.setMaxVelocity(1.5);
       Point placement_target;
       placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
@@ -179,7 +183,8 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
 
   addStateFunction(
     SingleBallPlacementStates::CONTACT_BALL,
-    [this]([[maybe_unused]] const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+    [this](const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+      visualizer->addPoint(robot()->pose.pos, 0, "white", 1.0, state_string);
       if (not get_ball_contact) {
         get_ball_contact = std::make_shared<GetBallContact>(command_base);
       }
@@ -198,7 +203,8 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
 
   addStateFunction(
     SingleBallPlacementStates::MOVE_TO_TARGET,
-    [this]([[maybe_unused]] const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+    [this](const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+      visualizer->addPoint(robot()->pose.pos, 0, "white", 1.0, state_string);
       if (not move_with_ball) {
         move_with_ball = std::make_shared<MoveWithBall>(command_base);
         move_with_ball->setParameter("target_x", getParameter<double>("placement_x"));
@@ -227,7 +233,8 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
 
   addStateFunction(
     SingleBallPlacementStates::PLACE_BALL,
-    [this]([[maybe_unused]] const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+    [this](const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+      visualizer->addPoint(robot()->pose.pos, 0, "white", 1.0, state_string);
       if (not sleep) {
         sleep = std::make_shared<Sleep>(command_base);
         sleep->setParameter("duration", 1.0);
@@ -242,7 +249,8 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
 
   addStateFunction(
     SingleBallPlacementStates::SLEEP,
-    [this]([[maybe_unused]] const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+    [this](const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+      visualizer->addPoint(robot()->pose.pos, 0, "white", 1.0, state_string);
       if (not sleep) {
         sleep = std::make_shared<Sleep>(command_base);
         sleep->setParameter("duration", 1.0);
@@ -262,7 +270,8 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
 
   addStateFunction(
     SingleBallPlacementStates::LEAVE_BALL,
-    [this]([[maybe_unused]] const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+    [this](const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
+      visualizer->addPoint(robot()->pose.pos, 0, "white", 1.0, state_string);
       if (not set_target_position) {
         set_target_position = std::make_shared<CmdSetTargetPosition>(command_base);
       }

--- a/crane_robot_skills/src/single_ball_placement.cpp
+++ b/crane_robot_skills/src/single_ball_placement.cpp
@@ -240,7 +240,7 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
     });
 
   addTransition(
-    SingleBallPlacementStates::MOVE_TO_TARGET, SingleBallPlacementStates::PLACE_BALL,
+    SingleBallPlacementStates::MOVE_TO_TARGET, SingleBallPlacementStates::SLEEP,
     [this]() { return skill_status == Status::SUCCESS; });
 
   // ボールが離れたら始めに戻る
@@ -248,22 +248,6 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
     SingleBallPlacementStates::MOVE_TO_TARGET,
     SingleBallPlacementStates::PULL_BACK_FROM_EDGE_PREPARE,
     [this]() { return skill_status == Status::FAILURE; });
-
-  addStateFunction(
-    SingleBallPlacementStates::PLACE_BALL,
-    [this](const ConsaiVisualizerWrapper::SharedPtr & visualizer) -> Status {
-      visualizer->addPoint(robot()->pose.pos, 0, "white", 1.0, state_string);
-      if (not sleep) {
-        sleep = std::make_shared<Sleep>(command_base);
-        sleep->setParameter("duration", 1.0);
-      }
-      skill_status = sleep->run(visualizer);
-      return Status::RUNNING;
-    });
-
-  addTransition(SingleBallPlacementStates::PLACE_BALL, SingleBallPlacementStates::SLEEP, [this]() {
-    return skill_status == Status::SUCCESS;
-  });
 
   addStateFunction(
     SingleBallPlacementStates::SLEEP,
@@ -325,9 +309,6 @@ void SingleBallPlacement::print(std::ostream & os) const
       break;
     case SingleBallPlacementStates::MOVE_TO_TARGET:
       move_with_ball->print(os);
-      break;
-    case SingleBallPlacementStates::PLACE_BALL:
-      os << " PLACE_BALL";
       break;
     case SingleBallPlacementStates::SLEEP:
       sleep->print(os);

--- a/crane_robot_skills/src/single_ball_placement.cpp
+++ b/crane_robot_skills/src/single_ball_placement.cpp
@@ -209,7 +209,8 @@ SingleBallPlacement::SingleBallPlacement(RobotCommandWrapperBase::SharedPtr & ba
         move_with_ball = std::make_shared<MoveWithBall>(command_base);
         move_with_ball->setParameter("target_x", getParameter<double>("placement_x"));
         move_with_ball->setParameter("target_y", getParameter<double>("placement_y"));
-        move_with_ball->setParameter("dribble_power", 0.2);
+        move_with_ball->setParameter("dribble_power", 0.5);
+        move_with_ball->setParameter("ball_stabilizing_time", 1.5);
       }
 
       skill_status = move_with_ball->run(visualizer);

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
@@ -245,8 +245,6 @@ struct WorldModelWrapper
 
   Point goal;
 
-  std::optional<Point> ball_placement_target = std::nullopt;
-
   Ball ball;
 
   PlaySituationWrapper play_situation;


### PR DESCRIPTION
- ボールプレイスメントが終了していない場合、必ずリトライする
- ボールプレイスメント終了後にボールが離れるときに角度が変わらないようにした
- 配置時に勢い余ってボールを転がしてしまわないようにした