### PR TITLE
さようなら、max_omega

### DIFF
--- a/crane_msgs/msg/control/LocalPlannerConfig.msg
+++ b/crane_msgs/msg/control/LocalPlannerConfig.msg
@@ -6,6 +6,5 @@ bool disable_rule_area_avoidance false
 
 float32 max_acceleration 4.0
 float32 max_velocity 6.0
-float32 max_omega 1.0
 float32 terminal_velocity 0
 uint8 priority 0

--- a/crane_robot_skills/include/crane_robot_skills/robot_command_as_skill.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/robot_command_as_skill.hpp
@@ -44,7 +44,6 @@ DEFINE_SKILL_COMMAND(EnableBallCenteringControl, Position);
 DEFINE_SKILL_COMMAND(EnableLocalGoalie, Position);
 DEFINE_SKILL_COMMAND(SetMaxVelocity, Position);
 DEFINE_SKILL_COMMAND(SetMaxAcceleration, Position);
-DEFINE_SKILL_COMMAND(SetMaxOmega, Position);
 DEFINE_SKILL_COMMAND(SetTerminalVelocity, Position);
 DEFINE_SKILL_COMMAND(EnableStopFlag, Position);
 DEFINE_SKILL_COMMAND(DisableStopFlag, Position);

--- a/crane_robot_skills/src/robot_command_as_skill.cpp
+++ b/crane_robot_skills/src/robot_command_as_skill.cpp
@@ -241,24 +241,6 @@ void CmdSetMaxAcceleration::print(std::ostream & os) const
   os << "[CmdSetMaxAcceleration] max_acceleration: " << getParameter<double>("max_acceleration");
 }
 
-CmdSetMaxOmega::CmdSetMaxOmega(RobotCommandWrapperBase::SharedPtr & base)
-: SkillBase("CmdSetMaxOmega", base)
-{
-  setParameter("max_omega", 0.5);
-}
-
-Status CmdSetMaxOmega::update(
-  [[maybe_unused]] const ConsaiVisualizerWrapper::SharedPtr & visualizer)
-{
-  command.setMaxOmega(getParameter<double>("max_omega"));
-  return Status::SUCCESS;
-}
-
-void CmdSetMaxOmega::print(std::ostream & os) const
-{
-  os << "[CmdSetMaxOmega] max_omega: " << getParameter<double>("max_omega");
-}
-
 CmdSetTerminalVelocity::CmdSetTerminalVelocity(RobotCommandWrapperBase::SharedPtr & base)
 : SkillBase("CmdSetTerminalVelocity", base)
 {

--- a/crane_sender/src/ibis_sender_node.cpp
+++ b/crane_sender/src/ibis_sender_node.cpp
@@ -152,7 +152,7 @@ public:
       packet.stop_emergency = command.stop_flag;
       packet.acceleration_limit = command.local_planner_config.max_acceleration;
       packet.linear_velocity_limit = command.local_planner_config.max_velocity;
-      packet.angular_velocity_limit = command.local_planner_config.max_omega;
+      packet.angular_velocity_limit = command.omega_limit;
       packet.prioritize_move = true;
       packet.prioritize_accurate_acceleration = true;
 

--- a/crane_sender/src/ibis_velocity_sender_node.cpp
+++ b/crane_sender/src/ibis_velocity_sender_node.cpp
@@ -196,7 +196,7 @@ public:
       packet.stop_emergency = command.stop_flag;
       packet.acceleration_limit = command.local_planner_config.max_acceleration;
       packet.linear_velocity_limit = command.local_planner_config.max_velocity;
-      packet.angular_velocity_limit = command.local_planner_config.max_omega;
+      packet.angular_velocity_limit = command.omega_limit;
       packet.prioritize_move = true;
       packet.prioritize_accurate_acceleration = true;
 

--- a/crane_simple_ai/src/crane_commander.cpp
+++ b/crane_simple_ai/src/crane_commander.cpp
@@ -63,7 +63,6 @@ CraneCommander::CraneCommander(QWidget * parent) : QMainWindow(parent), ui(new U
   setUpSkillDictionary<skills::CmdSetMaxVelocity>();
   setUpSkillDictionary<skills::Attacker>();
   //  setUpSkillDictionary<skills::CmdSetMaxAcceleration>();
-  //  setUpSkillDictionary<skills::CmdSetMaxOmega>();
   //  setUpSkillDictionary<skills::CmdSetTerminalVelocity>();
   setUpSkillDictionary<skills::CmdEnableStopFlag>();
   setUpSkillDictionary<skills::CmdDisableStopFlag>();

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
@@ -214,12 +214,6 @@ public:
     return static_cast<T &>(*this);
   }
 
-  T & setMaxOmega(double max_omega)
-  {
-    command->latest_msg.local_planner_config.max_omega = max_omega;
-    return static_cast<T &>(*this);
-  }
-
   T & setOmegaLimit(double omega_limit)
   {
     command->latest_msg.omega_limit = omega_limit;


### PR DESCRIPTION
max_omega / omega_limitと同じ役割の変数が同時に存在していて、バグの原因となった。
max_omegaには引退して、omega_limitに統一する