### PR TITLE
getOptimalAssignmentsの要件を弱める

### DIFF
--- a/utility/crane_basics/include/crane_basics/position_assignments.hpp
+++ b/utility/crane_basics/include/crane_basics/position_assignments.hpp
@@ -210,7 +210,7 @@ public:
 inline std::vector<int> getOptimalAssignments(
   const std::vector<Point> robot_positions, const std::vector<Point> target_positions)
 {
-  assert(robot_positions.size() == target_positions.size());
+  assert(robot_positions.size() <= target_positions.size());
   if (robot_positions.size() == 0) {
     return {};
   }


### PR DESCRIPTION
デバッグビルドのときに安全な場合でもassertを出してしまう