### PR TITLE
テスト用モーション & セッション乗っ取り機構の実装

### DIFF
--- a/crane_msgs/msg/analysis/PlaySituation.msg
+++ b/crane_msgs/msg/analysis/PlaySituation.msg
@@ -48,6 +48,9 @@ uint8 THEIR_INDIRECT_FREE = 26
 # uint8 THEIR_GOAL = 28 use halt
 uint8 THEIR_BALL_PLACEMENT = 29
 
+# セッションの注入したときのイベント
+uint8 INJECTION = 40
+
 uint8 INPLAY = 50
 uint8 OUR_INPLAY = 51
 uint8 THEIR_INPLAY = 52

--- a/crane_play_switcher/include/crane_play_switcher/play_switcher.hpp
+++ b/crane_play_switcher/include/crane_play_switcher/play_switcher.hpp
@@ -14,6 +14,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <robocup_ssl_msgs/msg/referee.hpp>
 #include <std_msgs/msg/float32.hpp>
+#include <std_msgs/msg/string.hpp>
 #include <string>
 
 #include "visibility_control.h"
@@ -35,6 +36,8 @@ private:
 
   rclcpp::Subscription<crane_msgs::msg::WorldModel>::SharedPtr world_model_sub;
 
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr session_injection_sub;
+
   void referee_callback(const robocup_ssl_msgs::msg::Referee & msg);
 
   WorldModelWrapper::SharedPtr world_model;
@@ -42,6 +45,8 @@ private:
   crane_msgs::msg::PlaySituation play_situation_msg;
 
   std::string team_name = "ibis";
+
+  bool is_injecting_session = false;
 
   struct LastCommandChangedState
   {

--- a/crane_play_switcher/include/crane_play_switcher/play_switcher.hpp
+++ b/crane_play_switcher/include/crane_play_switcher/play_switcher.hpp
@@ -46,8 +46,6 @@ private:
 
   std::string team_name = "ibis";
 
-  bool is_injecting_session = false;
-
   struct LastCommandChangedState
   {
     rclcpp::Time stamp;

--- a/crane_play_switcher/src/play_switcher.cpp
+++ b/crane_play_switcher/src/play_switcher.cpp
@@ -33,6 +33,12 @@ PlaySwitcher::PlaySwitcher(const rclcpp::NodeOptions & options)
     "/referee", 10, [this](const robocup_ssl_msgs::msg::Referee & msg) { referee_callback(msg); });
 
   last_command_changed_state.stamp = now();
+
+  session_injection_sub = create_subscription<std_msgs::msg::String>(
+    "/session_injection", 1, [&](const std_msgs::msg::String & msg) {
+      // イベント注入フラグをON（次のレフェリーイベント発生まで有効）
+      is_injecting_session = true;
+    });
 }
 
 #define NORMAL_START_MAPPING(PRE_CMD, CMD)                                        \
@@ -198,6 +204,14 @@ void PlaySwitcher::referee_callback(const robocup_ssl_msgs::msg::Referee & msg)
     // パブリッシュはコマンド更新時のみ
     play_situation_msg.header.stamp = now();
     play_situation_pub->publish(play_situation_msg);
+  }
+
+  // イベント注入フラグONのときはINJECTIONコマンドを入れてpublishする
+  if (is_injecting_session) {
+    play_situation_msg.command = PlaySituation::INJECTION;
+    play_situation_msg.header.stamp = now();
+    play_situation_pub->publish(play_situation_msg);
+    is_injecting_session = false;
   }
 
   latest_raw_referee_command = msg.command;

--- a/crane_play_switcher/src/play_switcher.cpp
+++ b/crane_play_switcher/src/play_switcher.cpp
@@ -36,8 +36,10 @@ PlaySwitcher::PlaySwitcher(const rclcpp::NodeOptions & options)
 
   session_injection_sub = create_subscription<std_msgs::msg::String>(
     "/session_injection", 1, [&](const std_msgs::msg::String & msg) {
-      // イベント注入フラグをON（次のレフェリーイベント発生まで有効）
-      is_injecting_session = true;
+      // イベント注入（次のレフェリーイベント発生まで有効）
+      play_situation_msg.command = crane_msgs::msg::PlaySituation::INJECTION;
+      play_situation_msg.header.stamp = now();
+      play_situation_pub->publish(play_situation_msg);
     });
 }
 
@@ -204,14 +206,6 @@ void PlaySwitcher::referee_callback(const robocup_ssl_msgs::msg::Referee & msg)
     // パブリッシュはコマンド更新時のみ
     play_situation_msg.header.stamp = now();
     play_situation_pub->publish(play_situation_msg);
-  }
-
-  // イベント注入フラグONのときはINJECTIONコマンドを入れてpublishする
-  if (is_injecting_session) {
-    play_situation_msg.command = PlaySituation::INJECTION;
-    play_situation_msg.header.stamp = now();
-    play_situation_pub->publish(play_situation_msg);
-    is_injecting_session = false;
   }
 
   latest_raw_referee_command = msg.command;

--- a/crane_robot_skills/include/crane_robot_skills/skills.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/skills.hpp
@@ -28,5 +28,6 @@
 #include <crane_robot_skills/steal_ball.hpp>
 #include <crane_robot_skills/sub_attacker.hpp>
 #include <crane_robot_skills/teleop.hpp>
+#include <crane_robot_skills/test_motion.hpp>
 
 #endif  // CRANE_ROBOT_SKILLS__SKILLS_HPP_

--- a/crane_robot_skills/include/crane_robot_skills/test_motion.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/test_motion.hpp
@@ -20,6 +20,7 @@ private:
   rclcpp::Time latest_section_start_time;
   rclcpp::Clock clock;
   std::unordered_map<std::string, std::function<Point(const int, const double)>> motion_functions;
+
 public:
   explicit TestMotionPosition(RobotCommandWrapperBase::SharedPtr & base)
   : SkillBase("TestMotion", base), clock(RCL_ROS_TIME)
@@ -55,16 +56,19 @@ public:
     const double section_time = getParameter<double>("section_time");
     const double sleep_time = getParameter<double>("sleep_time");
     if (auto motion = motion_functions.find(motion_name); motion != motion_functions.end()) {
-      if ( clock.now() - latest_section_start_time >= rclcpp::Duration::from_seconds(section_time + sleep_time)) {
+      if (
+        clock.now() - latest_section_start_time >=
+        rclcpp::Duration::from_seconds(section_time + sleep_time)) {
         latest_section_start_time = clock.now();
         current_section++;
       }
       const double parameter = (clock.now() - latest_section_start_time).seconds() / section_time;
       const Point position = motion->second(current_section, parameter);
       command.setTargetPosition(position);
-    }else {
+    } else {
       std::stringstream what;
-      what << "TestMotionPositionでサポートされていないモーション \"" << motion_name << "\"が指定されています。";
+      what << "TestMotionPositionでサポートされていないモーション \"" << motion_name
+           << "\"が指定されています。";
       what << "有効なのは [";
       for (const auto & motion : motion_functions) {
         what << motion.first << ", ";

--- a/crane_robot_skills/include/crane_robot_skills/test_motion.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/test_motion.hpp
@@ -25,7 +25,7 @@ public:
   : SkillBase("TestMotion", base), clock(RCL_ROS_TIME)
   {
     // segment / square / circle
-    setParameter("motion", "segment");
+    setParameter("motion", std::string("segment"));
     setParameter("origin", Point::Zero());
     setParameter("section_time", 5.);
     setParameter("sleep_time", 1.);

--- a/crane_robot_skills/include/crane_robot_skills/test_motion.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/test_motion.hpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2023 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_ROBOT_SKILLS__TEST_MOTION_HPP_
+#define CRANE_ROBOT_SKILLS__TEST_MOTION_HPP_
+
+#include <crane_basics/eigen_adapter.hpp>
+#include <crane_robot_skills/skill_base.hpp>
+#include <memory>
+
+namespace crane::skills
+{
+class TestMotionPosition : public SkillBase<RobotCommandWrapperPosition>
+{
+public:
+  explicit TestMotionPosition(RobotCommandWrapperBase::SharedPtr & base)
+  : SkillBase("TestMotion", base)
+  {
+    setParameter("motion", "一文字");
+    setParameter("origin", Point::Zero());
+    setParameter("section_time", 5.);
+    setParameter("sleep_time", 1.);
+    setParameter("distance", 1.);
+  }
+
+  Status update() override
+  {
+    command.stopHere();
+    return Status::RUNNING;
+  }
+
+  // 往復
+  Point getPositionA(const int section, const double parameter) const
+  {
+    const double distance = getParameter<double>("distance");
+    const Point origin = getParameter<Point>("origin");
+    switch (section) {
+      case 0:
+        return origin + Point(distance * (parameter - 0.5), 0);
+      case 1:
+        return origin + Point(distance * (0.5 - parameter), 0);
+      default:
+        throw std::runtime_error("Invalid section");
+    }
+  }
+
+  // 四角
+  Point getPositionB(const int section, const double parameter) const
+  {
+    const double distance = getParameter<double>("distance");
+    const Point origin = getParameter<Point>("origin");
+
+    const double up = distance * (parameter - 0.5);
+    const double down = distance * (0.5 - parameter);
+
+    switch (section) {
+      case 0:
+        // x : minus -> plus, y: plus
+        return origin + Point(up, distance * 0.5);
+      case 1:
+        // x : plus, y: plus -> minus
+        return origin + Point(distance * 0.5, down, 0);
+      case 2:
+        // x: plus -> minus, y: minus
+        return origin + Point(down, -distance * 0.5);
+      case 3:
+        // x: minus, y: minus -> plus
+        return origin + Point(-distance * 0.5, up, 0);
+      default:
+        throw std::runtime_error("Invalid section");
+    }
+  }
+
+  // 円
+  Point getPositionC(const double parameter) const
+  {
+    const double distance = getParameter<double>("distance");
+    const Point origin = getParameter<Point>("origin");
+    const double radius = distance * 0.5;
+    const double theta = 2.0 * M_PI * parameter;
+    return origin + getNormVec(theta) * radius;
+  }
+
+  void print(std::ostream & os) const override { os << "[Idle]"; }
+};
+}  // namespace crane::skills
+#endif  // CRANE_ROBOT_SKILLS__TEST_MOTION_HPP_

--- a/crane_robot_skills/include/crane_robot_skills/test_motion.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/test_motion.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 ibis-ssl
+// Copyright (c) 2024 ibis-ssl
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
@@ -15,29 +15,72 @@ namespace crane::skills
 {
 class TestMotionPosition : public SkillBase<RobotCommandWrapperPosition>
 {
+private:
+  int current_section = 0;
+  rclcpp::Time latest_section_start_time;
+  rclcpp::Clock clock;
+  std::unordered_map<std::string, std::function<Point(const int, const double)>> motion_functions;
 public:
   explicit TestMotionPosition(RobotCommandWrapperBase::SharedPtr & base)
-  : SkillBase("TestMotion", base)
+  : SkillBase("TestMotion", base), clock(RCL_ROS_TIME)
   {
-    setParameter("motion", "一文字");
+    // segment / square / circle
+    setParameter("motion", "segment");
     setParameter("origin", Point::Zero());
     setParameter("section_time", 5.);
     setParameter("sleep_time", 1.);
     setParameter("distance", 1.);
+    latest_section_start_time = clock.now();
+    motion_functions["segment"] = [&](const int section, const double parameter) {
+      return getPositionSegment(section, parameter);
+    };
+    motion_functions["square"] = [&](const int section, const double parameter) {
+      return getPositionSquare(section, parameter);
+    };
+    motion_functions["circle"] = [&](const int section, const double parameter) {
+      return getPositionCircle(section, parameter);
+    };
+  }
+
+  void reset(const std::string & motion)
+  {
+    setParameter("motion", motion);
+    current_section = 0;
+    latest_section_start_time = clock.now();
   }
 
   Status update() override
   {
-    command.stopHere();
+    const std::string motion_name = getParameter<std::string>("motion");
+    const double section_time = getParameter<double>("section_time");
+    const double sleep_time = getParameter<double>("sleep_time");
+    if (auto motion = motion_functions.find(motion_name); motion != motion_functions.end()) {
+      if ( clock.now() - latest_section_start_time >= rclcpp::Duration::from_seconds(section_time + sleep_time)) {
+        latest_section_start_time = clock.now();
+        current_section++;
+      }
+      const double parameter = (clock.now() - latest_section_start_time).seconds() / section_time;
+      const Point position = motion->second(current_section, parameter);
+      command.setTargetPosition(position);
+    }else {
+      std::stringstream what;
+      what << "TestMotionPositionでサポートされていないモーション \"" << motion_name << "\"が指定されています。";
+      what << "有効なのは [";
+      for (const auto & motion : motion_functions) {
+        what << motion.first << ", ";
+      }
+      what << "] です。";
+      throw std::runtime_error(what.str());
+    }
     return Status::RUNNING;
   }
 
   // 往復
-  Point getPositionA(const int section, const double parameter) const
+  Point getPositionSegment(const int section, const double parameter) const
   {
     const double distance = getParameter<double>("distance");
     const Point origin = getParameter<Point>("origin");
-    switch (section) {
+    switch (section % 2) {
       case 0:
         return origin + Point(distance * (parameter - 0.5), 0);
       case 1:
@@ -48,7 +91,7 @@ public:
   }
 
   // 四角
-  Point getPositionB(const int section, const double parameter) const
+  Point getPositionSquare(const int section, const double parameter) const
   {
     const double distance = getParameter<double>("distance");
     const Point origin = getParameter<Point>("origin");
@@ -56,7 +99,7 @@ public:
     const double up = distance * (parameter - 0.5);
     const double down = distance * (0.5 - parameter);
 
-    switch (section) {
+    switch (section % 4) {
       case 0:
         // x : minus -> plus, y: plus
         return origin + Point(up, distance * 0.5);
@@ -75,7 +118,7 @@ public:
   }
 
   // 円
-  Point getPositionC(const double parameter) const
+  Point getPositionCircle([[maybe_unused]] const int section, const double parameter) const
   {
     const double distance = getParameter<double>("distance");
     const Point origin = getParameter<Point>("origin");

--- a/crane_robot_skills/include/crane_robot_skills/test_motion.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/test_motion.hpp
@@ -131,7 +131,7 @@ public:
     return origin + getNormVec(theta) * radius;
   }
 
-  void print(std::ostream & os) const override { os << "[Idle]"; }
+  void print(std::ostream & os) const override { os << "[TestMotionPosition]"; }
 };
 }  // namespace crane::skills
 #endif  // CRANE_ROBOT_SKILLS__TEST_MOTION_HPP_

--- a/crane_robot_skills/include/crane_robot_skills/test_motion.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/test_motion.hpp
@@ -62,13 +62,13 @@ public:
         return origin + Point(up, distance * 0.5);
       case 1:
         // x : plus, y: plus -> minus
-        return origin + Point(distance * 0.5, down, 0);
+        return origin + Point(distance * 0.5, down);
       case 2:
         // x: plus -> minus, y: minus
         return origin + Point(down, -distance * 0.5);
       case 3:
         // x: minus, y: minus -> plus
-        return origin + Point(-distance * 0.5, up, 0);
+        return origin + Point(-distance * 0.5, up);
       default:
         throw std::runtime_error("Invalid section");
     }

--- a/crane_simple_ai/src/crane_commander.cpp
+++ b/crane_simple_ai/src/crane_commander.cpp
@@ -83,6 +83,7 @@ CraneCommander::CraneCommander(QWidget * parent) : QMainWindow(parent), ui(new U
   setUpSkillDictionary<skills::SimpleKickOff>();
   setUpSkillDictionary<skills::StealBall>();
   setUpSkillDictionary<skills::SubAttacker>();
+  setUpSkillDictionary<skills::TestMotionPosition>();
   setUpSkillDictionary<skills::Marker>();
   setUpSkillDictionary<skills::SingleBallPlacement>();
   //  setUpSkillDictionary<skills::KickoffAttack>();

--- a/session/crane_session_controller/config/normal.yaml
+++ b/session/crane_session_controller/config/normal.yaml
@@ -39,3 +39,5 @@ events:
     session: THEIR_FREE_KICK
   - event: formation
     session: formation
+  - event: INJECTION
+    session: HALT

--- a/session/crane_session_controller/include/crane_session_controller/session_controller.hpp
+++ b/session/crane_session_controller/include/crane_session_controller/session_controller.hpp
@@ -21,6 +21,7 @@
 #include <optional>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/float32.hpp>
+#include <std_msgs/msg/string.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -62,6 +63,8 @@ private:
   rclcpp::Subscription<crane_msgs::msg::GameAnalysis>::SharedPtr game_analysis_sub;
 
   rclcpp::Subscription<crane_msgs::msg::PlaySituation>::SharedPtr play_situation_sub;
+
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr session_injection_sub;
 
   rclcpp::Publisher<crane_msgs::msg::RobotCommands>::SharedPtr robot_commands_pub;
 

--- a/session/crane_session_controller/src/crane_session_controller.cpp
+++ b/session/crane_session_controller/src/crane_session_controller.cpp
@@ -12,6 +12,7 @@
 #include <crane_planner_plugins/planners.hpp>
 #include <filesystem>
 #include <fstream>
+#include <std_msgs/msg/string.hpp>
 
 #include "crane_session_controller/session_controller.hpp"
 
@@ -209,6 +210,10 @@ SessionControllerComponent::SessionControllerComponent(const rclcpp::NodeOptions
     robot_commands_pub->publish(msg);
     ConsaiVisualizerBuffer::publish();
   });
+
+  session_injection_sub = create_subscription<std_msgs::msg::String>(
+    "/session_injection", 1,
+    [&](const std_msgs::msg::String & msg) { event_map["INJECTION"] = msg.data; });
 }
 
 void SessionControllerComponent::assign(const std::string & session_name)

--- a/utility/crane_msg_wrappers/src/play_situation_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/play_situation_wrapper.cpp
@@ -56,6 +56,7 @@ static std::map<int, std::string> situation_command_map = {
   CMD_STRING_MAPPING(crane_msgs::msg::PlaySituation, THEIR_INDIRECT_FREE),
   CMD_STRING_MAPPING(crane_msgs::msg::PlaySituation, OUR_BALL_PLACEMENT),
   CMD_STRING_MAPPING(crane_msgs::msg::PlaySituation, THEIR_BALL_PLACEMENT),
+  CMD_STRING_MAPPING(crane_msgs::msg::PlaySituation, INJECTION),
   CMD_STRING_MAPPING(crane_msgs::msg::PlaySituation, INPLAY),
   CMD_STRING_MAPPING(crane_msgs::msg::PlaySituation, OUR_INPLAY),
   CMD_STRING_MAPPING(crane_msgs::msg::PlaySituation, THEIR_INPLAY),


### PR DESCRIPTION
- テスト用モーション
	- 往復
	- 四角
	- 円 
- `/session_injection`トピックに所望のセッション名を入れることで、一時的にsession_controllerを上書きする