### PR TITLE
シミュレーション用docker-compose.yamlにrobocupssl/ssl-status-boardを追加

### DIFF
--- a/docker/sim/docker-compose.yaml
+++ b/docker/sim/docker-compose.yaml
@@ -26,6 +26,16 @@ services:
     network_mode: host
     ports:
       - 8082:8082/tcp
+  ssl-status-board:
+    image: robocupssl/ssl-status-board:2.11.5
+    command:
+      - -address
+      - :8083
+      - --refereeAddress
+      - 224.5.23.1:11111
+    network_mode: host
+    ports:
+      - 8083:8083/tcp
 
   autoref-tigers:
     image: tigersmannheim/auto-referee:1.2.0

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -17,7 +17,7 @@ sudo chmod a+x /usr/local/lib/docker/cli-plugins/docker-compose
 ### ツール群
 
 ```bash
-cd path/to/crane/docker
+cd path/to/crane/docker/sim
 docker compose up
 ```
 
@@ -30,5 +30,3 @@ docker compose up
 - [game-controller](http://localhost:8081)
 - [vision client](http://localhost:8082)
 - [status board](http://localhost:8083)
-- [YELLOW remote control](http://localhost:8084)
-- [BLUE remote control](http://localhost:8085)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c14d2d74-a25c-4a00-91b8-d628ab33bd8d)
