### PR TITLE
キック速度指定機能の追加

### DIFF
--- a/crane_bringup/launch/crane.launch.py
+++ b/crane_bringup/launch/crane.launch.py
@@ -126,6 +126,8 @@ def generate_launch_description():
                                     "half_court_is_positive_side"
                                 ),
                             },
+                            {"kick_power_array": [0.0, 0.5, 1.0]},
+                            {"kick_speed_array": [0.0, 3.0, 8.0]},
                         ],
                         on_exit=default_exit_behavior,
                     ),

--- a/crane_local_planner/include/crane_local_planner/local_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/local_planner.hpp
@@ -41,9 +41,9 @@ public:
   auto initialize(rclcpp::Node & node) -> void
   {
     node.declare_parameter<std::vector<double>>("kick_power_array", {});
-    kick_power_array = get_parameter("kick_power_array").as_double_array();
+    kick_power_array = node.get_parameter("kick_power_array").as_double_array();
     node.declare_parameter<std::vector<double>>("kick_speed_array", {});
-    kick_speed_array = get_parameter("kick_speed_array").as_double_array();
+    kick_speed_array = node.get_parameter("kick_speed_array").as_double_array();
   }
 
   auto getKickPower(const crane_msgs::msg::RobotCommand & command) const -> double

--- a/crane_local_planner/include/crane_local_planner/local_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/local_planner.hpp
@@ -31,6 +31,62 @@ struct Obstacle
   float radius;
 };
 
+struct KickPowerCalculator
+{
+private:
+  std::vector<double> kick_power_array;
+  std::vector<double> kick_speed_array;
+
+public:
+  auto initialize(rclcpp::Node & node) -> void
+  {
+    node.declare_parameter<std::vector<double>>("kick_power_array", {});
+    kick_power_array = get_parameter("kick_power_array").as_double_array();
+    node.declare_parameter<std::vector<double>>("kick_speed_array", {});
+    kick_speed_array = get_parameter("kick_speed_array").as_double_array();
+  }
+
+  auto getKickPower(const crane_msgs::msg::RobotCommand & command) const -> double
+  {
+    if (not command.local_planner_config.kick_power_override) {
+      return command.kick_power;
+    }
+
+    if (kick_speed_array.size() == kick_power_array.size() && kick_power_array.size() <= 1) {
+      std::stringstream what;
+      what << "kick_speed_arrayとkick_power_arrayのサイズは等しく、2以上でなければいけません。";
+      what << "size(kick_speed_array): " << static_cast<int>(kick_speed_array.size());
+      what << ", size(kick_power_array): " << static_cast<int>(kick_power_array.size());
+      throw std::runtime_error(what.str());
+    }
+
+    double kick_speed = command.local_planner_config.target_kick_ball_speed;
+    // kick_speedが最小値より小さい場合
+    if (kick_speed <= kick_speed_array[0]) {
+      return kick_power_array[0];
+    }
+
+    // kick_speedが最大値より大きい場合
+    if (kick_speed >= kick_speed_array.back()) {
+      return kick_power_array.back();
+    }
+
+    // 線形補間
+    int idx = 0;
+    for (size_t i = 1; i < kick_speed_array.size(); ++i) {
+      if (kick_speed_array[i] > kick_speed) {
+        idx = i - 1;
+        break;
+      }
+    }
+    double kick_power_diff = kick_power_array[idx + 1] - kick_power_array[idx];
+    double kick_speed_diff = kick_speed_array[idx + 1] - kick_speed_array[idx];
+    double kick_power = kick_power_array[idx] +
+                        kick_power_diff * (kick_speed - kick_speed_array[idx]) / kick_speed_diff;
+    return kick_power;
+  }
+};
+
 class LocalPlannerComponent : public rclcpp::Node
 {
 public:
@@ -40,6 +96,8 @@ public:
   {
     declare_parameter("planner", "rvo2");
     auto planner_str = get_parameter("planner").as_string();
+
+    kick_power_calculator.initialize(*this);
 
     crane::CraneVisualizerBuffer::activate(*this);
 
@@ -87,6 +145,8 @@ private:
   std::shared_ptr<crane::LocalPlannerBase> planner = nullptr;
 
   double theta_offset = 0.;
+
+  KickPowerCalculator kick_power_calculator;
 };
 
 }  // namespace crane

--- a/crane_local_planner/src/crane_local_planner.cpp
+++ b/crane_local_planner/src/crane_local_planner.cpp
@@ -46,6 +46,7 @@ auto LocalPlannerComponent::callbackRobotCommands(const crane_msgs::msg::RobotCo
     }
   }
 
+  // 各種制御モードをメッセージの内容を照合
   crane_msgs::msg::RobotCommands commands;
   for (const auto & raw_command : msg.robot_commands) {
     bool is_valid = true;
@@ -113,6 +114,7 @@ auto LocalPlannerComponent::callbackRobotCommands(const crane_msgs::msg::RobotCo
         RCLCPP_ERROR(get_logger(), what.str().c_str());
         break;
     }
+    // 一致しなかったらエラーメッセージ＆ロボットを待機状態にする
     if (is_valid) {
       crane_msgs::msg::RobotCommand command = raw_command;
       auto robot = world_model->getOurRobot(command.robot_id);
@@ -125,6 +127,11 @@ auto LocalPlannerComponent::callbackRobotCommands(const crane_msgs::msg::RobotCo
       command.target_theta += theta_offset;
       commands.robot_commands.push_back(command);
     }
+  }
+
+  // キックパワーの調整
+  for (auto & command : commands.robot_commands) {
+    command.kick_power = kick_power_calculator.getKickPower(command);
   }
 
   auto pub_msg = planner->calculateRobotCommand(commands, theta_offset);

--- a/crane_msgs/msg/control/LocalPlannerConfig.msg
+++ b/crane_msgs/msg/control/LocalPlannerConfig.msg
@@ -12,3 +12,6 @@ float32 theta_tolerance 0.0
 
 float32 final_planned_max_acceleration -1.0
 float32 final_planned_max_velocity -1.0
+
+bool kick_power_override false
+float target_kick_ball_speed 0.0

--- a/crane_msgs/msg/control/LocalPlannerConfig.msg
+++ b/crane_msgs/msg/control/LocalPlannerConfig.msg
@@ -14,4 +14,4 @@ float32 final_planned_max_acceleration -1.0
 float32 final_planned_max_velocity -1.0
 
 bool kick_power_override false
-float target_kick_ball_speed 0.0
+float32 target_kick_ball_speed 0.0

--- a/crane_robot_skills/include/crane_robot_skills/kick.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/kick.hpp
@@ -49,6 +49,10 @@ public:
 
 private:
   void initialize();
+
+  void kickWithChip();
+
+  void kickStraight();
 };
 }  // namespace crane::skills
 #endif  // CRANE_ROBOT_SKILLS__KICK_HPP_

--- a/crane_robot_skills/src/goal_kick.cpp
+++ b/crane_robot_skills/src/goal_kick.cpp
@@ -12,7 +12,9 @@ namespace crane::skills
 void GoalKick::initialize()
 {
   setParameter("キック角度の最低要求精度[deg]", 1.0);
-  kick_skill.setParameter("kick_power", 0.8);
+  // kick_skill.setParameter("kick_power", 0.8);
+  kick_skill.setParameter("use_target_kick_speed", true);
+  kick_skill.setParameter("target_kick_speed", 6.0);
   kick_skill.setParameter("chip_kick", false);
   kick_skill.setParameter("with_dribble", false);
 }

--- a/crane_robot_skills/src/kick.cpp
+++ b/crane_robot_skills/src/kick.cpp
@@ -241,7 +241,7 @@ auto Kick::getBallExitPointFromField(const double offset) -> Point
 
 auto Kick::kickWithChip() -> void
 {
-  if (getParameter<double>("use_target_kick_speed")) {
+  if (getParameter<bool>("use_target_kick_speed")) {
     command->setKickWithChipTargetSpeed(getParameter<double>("target_kick_speed"));
   } else {
     command->kickWithChip(getParameter<double>("kick_power"));
@@ -250,7 +250,7 @@ auto Kick::kickWithChip() -> void
 
 auto Kick::kickStraight() -> void
 {
-  if (getParameter<double>("use_target_kick_speed")) {
+  if (getParameter<bool>("use_target_kick_speed")) {
     command->setKickStraightTargetSpeed(getParameter<double>("target_kick_speed"));
   } else {
     command->kickStraight(getParameter<double>("kick_power"));

--- a/crane_robot_skills/src/kick.cpp
+++ b/crane_robot_skills/src/kick.cpp
@@ -14,6 +14,8 @@ void Kick::initialize()
   command->usePositionMode();
   setParameter("target", Point(0, 0));
   setParameter("kick_power", 0.7f);
+  setParameter("use_target_kick_speed", false);
+  setParameter("target_kick_speed", 2.0);
   setParameter("chip_kick", false);
   setParameter("with_dribble", false);
   setParameter("dribble_power", 0.3f);
@@ -67,6 +69,7 @@ void Kick::initialize()
         }
       }();
       command->setDribblerTargetPosition(target_pos);
+      // TODO(HansRobo): 速度指定対応
       command->kickStraight(0.3);
       command->disableBallAvoidance();
     } else {
@@ -189,9 +192,9 @@ void Kick::initialize()
           getAngleDiff(getAngle(target - ball_pos), getAngle(ball_pos - robot()->pose.pos))) <
         20. * degree<double>()) {
         if (getParameter<bool>("chip_kick")) {
-          command->kickWithChip(getParameter<double>("kick_power"));
+          kickWithChip();
         } else {
-          command->kickStraight(getParameter<double>("kick_power"));
+          kickStraight();
         }
       } else {
         command->kickStraight(0.0);
@@ -234,5 +237,23 @@ auto Kick::getBallExitPointFromField(const double offset) -> Point
     }
   }
   return world_model()->ball.pos;
+}
+
+auto Kick::kickWithChip() -> void
+{
+  if (getParameter<double>("use_target_kick_speed")) {
+    command->setKickWithChipTargetSpeed(getParameter<double>("target_kick_speed"));
+  } else {
+    command->kickWithChip(getParameter<double>("kick_power"));
+  }
+}
+
+auto Kick::kickStraight() -> void
+{
+  if (getParameter<double>("use_target_kick_speed")) {
+    command->setKickStraightTargetSpeed(getParameter<double>("target_kick_speed"));
+  } else {
+    command->kickStraight(getParameter<double>("kick_power"));
+  }
 }
 }  // namespace crane::skills

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
@@ -104,6 +104,7 @@ public:
 
   auto kickWithChip(double power) -> RobotCommandWrapper &
   {
+    latest_msg.local_planner_config.kick_power_override = false;
     latest_msg.chip_enable = true;
     latest_msg.kick_power = power;
     return *this;
@@ -111,8 +112,25 @@ public:
 
   auto kickStraight(double power) -> RobotCommandWrapper &
   {
+    latest_msg.local_planner_config.kick_power_override = false;
     latest_msg.chip_enable = false;
     latest_msg.kick_power = power;
+    return *this;
+  }
+
+  auto setKickStraightTargetSpeed(double speed_mps) -> RobotCommandWrapper &
+  {
+    latest_msg.local_planner_config.kick_power_override = true;
+    latest_msg.chip_enable = false;
+    latest_msg.local_planner_config.target_kick_ball_speed = speed_mps;
+    return *this;
+  }
+
+  auto setKickWithChipTargetSpeed(double speed_mps) -> RobotCommandWrapper &
+  {
+    latest_msg.local_planner_config.kick_power_override = true;
+    latest_msg.chip_enable = true;
+    latest_msg.local_planner_config.target_kick_ball_speed = speed_mps;
     return *this;
   }
 


### PR DESCRIPTION
以下のようにパワーと速度の組を設定することで出したい速度に応じて必要なキックパワーを線形補間で計算してくれるイメージ。

```
- kick_power: [0.0, 0.5, 1.0]
- kick_speed: [0.0, 3.0, 7.0]
```


ボールとの相対速度や正面じゃない方向から転がってくるボールなどに対する調整は別途になるかもしれない。

- [x] コマンドに設定欄の追加
- [x] RobotCommandWrapperの対応
- [x] 速度パラメータ調整インタフェースの追加（ros paramのfloat32[]?）
- [x] 速度->キックパワー変換のアルゴリズム実装（線形補間？）
- [x] Kickスキルの対応