### PR TITLE
障害物半径の計算式を速度に比例するように変更

### DIFF
--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -74,13 +74,8 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
     rvo_sim->setAgentPosition(
       command.robot_id, RVO::Vector2(command.current_pose.x, command.current_pose.y));
     rvo_sim->setAgentPrefVelocity(command.robot_id, RVO::Vector2(0.f, 0.f));
-    if (auto vel = std::hypot(command.current_velocity.x, command.current_velocity.y); vel < 0.5) {
-      rvo_sim->setAgentRadius(command.robot_id, 0.05f);
-    } else if (vel < 1.5) {
-      rvo_sim->setAgentRadius(command.robot_id, 0.09f);
-    } else {
-      rvo_sim->setAgentRadius(command.robot_id, 0.18f);
-    }
+    auto vel = std::hypot(command.current_velocity.x, command.current_velocity.y);
+    rvo_sim->setAgentRadius(command.robot_id, 0.01f + vel * 0.2f);
 
     auto robot = world_model->getOurRobot(command.robot_id);
 


### PR DESCRIPTION
半径 = 0.01 + speed * 0.2

| speed [m/s] | radius[cm] |
| -- | -- |
| 0.0 | 1 |
| 0.5 |  11 |
| 1.0 | 21 |
| 2.0 | 41 |
| 4.0 | 81 |

これ以上上げると動きがおかしくなる。
例えば、ディフェンダーが他の役割に切り替わった瞬間にペナルティーエリア内に弾きこまれたりする