### PR TITLE
自動再実行スクリプトを追加

### DIFF
--- a/scripts/auto_restart.bash
+++ b/scripts/auto_restart.bash
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-COMMAND="source ~/workspace/ibis_ws/install/setup.bash && ros2 launch crane_bringup crane.launch.py"
+# スクリプトの位置を取得
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# workspace のルートディレクトリを計算（scripts から3階層上がる）
+WORKSPACE_DIR="$(dirname "$(dirname "$(dirname "$SCRIPT_DIR")")")"
+
+# setup.bash のパスを構築
+SETUP_BASH="${WORKSPACE_DIR}/install/setup.bash"
+
+COMMAND="source ${SETUP_BASH} && ros2 launch crane_bringup crane.launch.py"
 
 echo "コマンドを実行します: ${COMMAND}"
 

--- a/scripts/auto_restart.bash
+++ b/scripts/auto_restart.bash
@@ -5,17 +5,17 @@ COMMAND="source ~/workspace/ibis_ws/install/setup.bash && ros2 launch crane_brin
 echo "コマンドを実行します: ${COMMAND}"
 
 while true; do
-  # コマンドを実行
-  bash -c "${COMMAND}"
+    # コマンドを実行
+    bash -c "${COMMAND}"
 
-  # コマンドの終了ステータスを取得
-  EXIT_STATUS=$?
+    # コマンドの終了ステータスを取得
+    EXIT_STATUS=$?
 
-  echo "コマンドがコード $EXIT_STATUS で終了しました。"
-  echo "ros関連プロセスをクリーンアップします"
-  ps aux | grep ros | grep -v grep | awk '{ print "kill -9 " $2 }' | sh
-  echo "2秒待ってリスタートします。リスタートする前にCtrl+Cを実行すると終了できます"
-  sleep 2
+    echo "コマンドがコード $EXIT_STATUS で終了しました。"
+    echo "ros関連プロセスをクリーンアップします"
+    ps aux | grep ros | grep -v grep | awk '{ print "kill -9 " $2 }' | sh
+    echo "2秒待ってリスタートします。リスタートする前にCtrl+Cを実行すると終了できます"
+    sleep 2
 done
 
 echo "自動再実行スクリプトを終了します"

--- a/scripts/auto_restart.bash
+++ b/scripts/auto_restart.bash
@@ -13,7 +13,7 @@ while true; do
 
     echo "コマンドがコード $EXIT_STATUS で終了しました。"
     echo "ros関連プロセスをクリーンアップします"
-    ps aux | grep ros | grep -v grep | awk '{ print "kill -9 " $2 }' | sh
+  ps aux | pgrep ros | grep -v grep | awk '{ print "kill -9 " $2 }' | sh
     echo "2秒待ってリスタートします。リスタートする前にCtrl+Cを実行すると終了できます"
     sleep 2
 done

--- a/scripts/auto_restart.bash
+++ b/scripts/auto_restart.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+COMMAND="source ~/workspace/ibis_ws/install/setup.bash && ros2 launch crane_bringup crane.launch.py"
+
+echo "コマンドを実行します: ${COMMAND}"
+
+while true; do
+  # コマンドを実行
+  bash -c "${COMMAND}"
+
+  # コマンドの終了ステータスを取得
+  EXIT_STATUS=$?
+
+  echo "コマンドがコード $EXIT_STATUS で終了しました。"
+  echo "ros関連プロセスをクリーンアップします"
+  ps aux | grep ros | grep -v grep | awk '{ print "kill -9 " $2 }' | sh
+  echo "2秒待ってリスタートします。リスタートする前にCtrl+Cを実行すると終了できます"
+  sleep 2
+done
+
+echo "自動再実行スクリプトを終了します"

--- a/scripts/auto_restart.bash
+++ b/scripts/auto_restart.bash
@@ -13,7 +13,7 @@ while true; do
 
     echo "コマンドがコード $EXIT_STATUS で終了しました。"
     echo "ros関連プロセスをクリーンアップします"
-  ps aux | pgrep ros | grep -v grep | awk '{ print "kill -9 " $2 }' | sh
+    ps aux | pgrep ros | grep -v grep | awk '{ print "kill -9 " $2 }' | sh
     echo "2秒待ってリスタートします。リスタートする前にCtrl+Cを実行すると終了できます"
     sleep 2
 done


### PR DESCRIPTION
```bash
$ cd path/to/ibis_ws
$ ./src/crane/scripts/auto_restart.bash
コマンドを実行します: source ~/workspace/ibis_ws/install/setup.bash && ros2 launch crane_bringup crane.launch.py
...
中略
...
コマンドが終了コード 0 で終了しました。
ros関連プロセスをクリーンアップします
2秒待ってリスタートします。リスタートする前にCtrl+Cを実行すると終了できます
```
