### PR TITLE
Optimize GitHub Actions workflow caching

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Generate rosdep keys file
         run: |
+          sudo rosdep init || true
+          rosdep update
           colcon list -p --base-paths . dependency_ws > packages.txt
           rosdep keys --from-paths $(cat packages.txt) --rosdistro ${{ matrix.rosdistro }} > rosdep_keys.txt
         shell: bash

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -58,13 +58,45 @@ jobs:
           vcs import dependency_ws < dependency_${{ matrix.rosdistro }}.repos
         shell: bash
 
+      - name: Generate rosdep keys file
+        run: |
+          colcon list -p --base-paths . dependency_ws > packages.txt
+          rosdep keys --from-paths $(cat packages.txt) --rosdistro ${{ matrix.rosdistro }} > rosdep_keys.txt
+        shell: bash
+
+      - name: Cache dependency_ws
+        uses: actions/cache@v4
+        with:
+          path: dependency_ws
+          key: dependency_ws-${{ matrix.rosdistro }}-${{ hashFiles('dependency_${{ matrix.rosdistro }}.repos') }}
+          restore-keys: |
+            dependency_ws-${{ matrix.rosdistro }}-
+
       - name: Run rosdep install
         run: |
-          package_paths=$(colcon list -p --base-paths . dependency_ws)
           sudo apt-get -yqq update
-          rosdep update
-          DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths . --ignore-src --rosdistro ${{ matrix.rosdistro }}
+          if [[ "${{ steps.cache-rosdep.outputs.cache-hit }}" == "true" ]]; then
+            echo "Rosdep cache hit. Skipping rosdep update and install."
+            # rosdep updateはキャッシュされているので不要だが、念のため実行しても良いかもしれない
+            # rosdep update
+            # rosdep install はキャッシュされている前提なのでスキップ
+          else
+            echo "Rosdep cache miss. Running rosdep update and install."
+            rosdep update
+            DEBIAN_FRONTEND=noninteractive rosdep install -yqq --from-paths . dependency_ws --ignore-src --rosdistro ${{ matrix.rosdistro }}
+          fi
         shell: bash
+
+      - name: Cache rosdep
+        id: cache-rosdep
+        uses: actions/cache@v4
+        with:
+          path: |
+            /var/lib/apt/lists
+            /home/runner/.ros/rosdep
+          key: rosdep-${{ matrix.rosdistro }}-${{ runner.os }}-${{ hashFiles('rosdep_keys.txt') }}
+          restore-keys: |
+            rosdep-${{ matrix.rosdistro }}-${{ runner.os }}-
 
       - name: Set up colcon-mixin
         run: |
@@ -86,7 +118,9 @@ jobs:
           path: |
             ./build
             ./install
-          key: build-${{ matrix.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          key: build-${{ matrix.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake', '**/package.xml') }}
+          restore-keys: |
+            build-${{ matrix.rosdistro }}-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Test
         run: |


### PR DESCRIPTION
This commit implements several changes to the build_test.yaml workflow to improve caching efficiency and reduce runtime:

- Modified cache keys for rosdep, colcon build, and dependency_ws to be more resilient to unrelated changes.
- Introduced restore-keys for more flexible cache matching.
- Generated a rosdep_keys.txt file to accurately capture rosdep dependencies for caching.
- Conditional execution for `rosdep install`:
  - Skips `rosdep update` and `rosdep install` if a valid rosdep cache is found.
  - Ensures `apt-get update` runs to keep package lists current.

These changes aim to significantly speed up the workflow, especially for subsequent runs on the same branch or with similar dependencies.