### PR TITLE
ボールフィルタの実装

### DIFF
--- a/crane_world_model_publisher/CMakeLists.txt
+++ b/crane_world_model_publisher/CMakeLists.txt
@@ -38,7 +38,7 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(test_ball_tracker test/test_ball_tracker.cpp)
-  target_link_libraries(test_ball_tracker PRIVATE
+  target_link_libraries(test_ball_tracker
     Eigen3::Eigen
     rclcpp::rclcpp
     crane_world_model_publisher_component # Links BallTracker implementation

--- a/crane_world_model_publisher/CMakeLists.txt
+++ b/crane_world_model_publisher/CMakeLists.txt
@@ -20,10 +20,11 @@ ament_auto_add_library(${PROJECT_NAME}_component SHARED
   src/world_model_publisher.cpp
   src/visualization_data_handler.cpp
   src/world_model_data_provider.cpp
+  src/ball_tracker.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}_component
-        ${robocup_ssl_msgs_LIBRARIES} ${Boost_LIBRARIES}
+        ${robocup_ssl_msgs_LIBRARIES} ${Boost_LIBRARIES} Eigen3::Eigen
 )
 
 rclcpp_components_register_nodes(${PROJECT_NAME}_component "crane::WorldModelPublisherComponent")
@@ -34,6 +35,14 @@ target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME}_component glog)
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_ball_tracker test/test_ball_tracker.cpp)
+  target_link_libraries(test_ball_tracker PRIVATE
+    Eigen3::Eigen
+    rclcpp::rclcpp
+    crane_world_model_publisher_component # Links BallTracker implementation
+  )
 endif()
 
 ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/crane_world_model_publisher/include/crane_world_model_publisher/ball_tracker.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/ball_tracker.hpp
@@ -1,0 +1,36 @@
+#ifndef CRANE_WORLD_MODEL_PUBLISHER__BALL_TRACKER_HPP_
+#define CRANE_WORLD_MODEL_PUBLISHER__BALL_TRACKER_HPP_
+
+#include <Eigen/Dense>
+#include <rclcpp/rclcpp.hpp>
+
+namespace crane {
+
+class BallTracker {
+public:
+    BallTracker();
+
+    void init(const rclcpp::Time& t_start, double initial_x, double initial_y, double initial_vx = 0.0, double initial_vy = 0.0);
+    void predict(const rclcpp::Time& t_now);
+    void update(const Eigen::Vector2d& measurement, const rclcpp::Time& t_measurement);
+
+    Eigen::Vector4d getState() const { return x_k_; } // x, y, vx, vy
+    Eigen::Matrix4d getCovariance() const { return P_k_; }
+    bool isInitialized() const { return initialized_; }
+
+private:
+    bool initialized_;
+    rclcpp::Time last_update_time_;
+
+    // Kalman Filter matrices
+    Eigen::Vector4d x_k_; // State estimate [x, y, vx, vy]'
+    Eigen::Matrix4d P_k_; // State covariance matrix
+    Eigen::Matrix4d F_k_; // State transition matrix
+    Eigen::Matrix2d R_k_; // Measurement noise covariance matrix
+    Eigen::MatrixXd H_k_; // Measurement matrix (4x2 -> 2x4)
+    Eigen::Matrix4d Q_k_; // Process noise covariance matrix
+};
+
+} // namespace crane
+
+#endif // CRANE_WORLD_MODEL_PUBLISHER__BALL_TRACKER_HPP_

--- a/crane_world_model_publisher/include/crane_world_model_publisher/ball_tracker.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/ball_tracker.hpp
@@ -4,37 +4,33 @@
 #include <Eigen/Dense>
 #include <rclcpp/rclcpp.hpp>
 
-namespace crane
-{
+namespace crane {
 
-class BallTracker
-{
+class BallTracker {
 public:
-  BallTracker();
+    BallTracker();
 
-  void init(
-    const rclcpp::Time & t_start, double initial_x, double initial_y, double initial_vx = 0.0,
-    double initial_vy = 0.0);
-  void predict(const rclcpp::Time & t_now);
-  void update(const Eigen::Vector2d & measurement, const rclcpp::Time & t_measurement);
+    void init(const rclcpp::Time& t_start, double initial_x, double initial_y, double initial_vx = 0.0, double initial_vy = 0.0);
+    void predict(const rclcpp::Time& t_now);
+    void update(const Eigen::Vector2d& measurement, const rclcpp::Time& t_measurement);
 
-  Eigen::Vector4d getState() const { return x_k_; }  // x, y, vx, vy
-  Eigen::Matrix4d getCovariance() const { return P_k_; }
-  bool isInitialized() const { return initialized_; }
+    Eigen::Vector4d getState() const { return x_k_; } // x, y, vx, vy
+    Eigen::Matrix4d getCovariance() const { return P_k_; }
+    bool isInitialized() const { return initialized_; }
 
 private:
-  bool initialized_;
-  rclcpp::Time last_update_time_;
+    bool initialized_;
+    rclcpp::Time last_update_time_;
 
-  // Kalman Filter matrices
-  Eigen::Vector4d x_k_;  // State estimate [x, y, vx, vy]'
-  Eigen::Matrix4d P_k_;  // State covariance matrix
-  Eigen::Matrix4d F_k_;  // State transition matrix
-  Eigen::Matrix2d R_k_;  // Measurement noise covariance matrix
-  Eigen::MatrixXd H_k_;  // Measurement matrix (4x2 -> 2x4)
-  Eigen::Matrix4d Q_k_;  // Process noise covariance matrix
+    // Kalman Filter matrices
+    Eigen::Vector4d x_k_; // State estimate [x, y, vx, vy]'
+    Eigen::Matrix4d P_k_; // State covariance matrix
+    Eigen::Matrix4d F_k_; // State transition matrix
+    Eigen::Matrix2d R_k_; // Measurement noise covariance matrix
+    Eigen::MatrixXd H_k_; // Measurement matrix (4x2 -> 2x4)
+    Eigen::Matrix4d Q_k_; // Process noise covariance matrix
 };
 
-}  // namespace crane
+} // namespace crane
 
-#endif  // CRANE_WORLD_MODEL_PUBLISHER__BALL_TRACKER_HPP_
+#endif // CRANE_WORLD_MODEL_PUBLISHER__BALL_TRACKER_HPP_

--- a/crane_world_model_publisher/include/crane_world_model_publisher/ball_tracker.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/ball_tracker.hpp
@@ -4,33 +4,37 @@
 #include <Eigen/Dense>
 #include <rclcpp/rclcpp.hpp>
 
-namespace crane {
+namespace crane
+{
 
-class BallTracker {
+class BallTracker
+{
 public:
-    BallTracker();
+  BallTracker();
 
-    void init(const rclcpp::Time& t_start, double initial_x, double initial_y, double initial_vx = 0.0, double initial_vy = 0.0);
-    void predict(const rclcpp::Time& t_now);
-    void update(const Eigen::Vector2d& measurement, const rclcpp::Time& t_measurement);
+  void init(
+    const rclcpp::Time & t_start, double initial_x, double initial_y, double initial_vx = 0.0,
+    double initial_vy = 0.0);
+  void predict(const rclcpp::Time & t_now);
+  void update(const Eigen::Vector2d & measurement, const rclcpp::Time & t_measurement);
 
-    Eigen::Vector4d getState() const { return x_k_; } // x, y, vx, vy
-    Eigen::Matrix4d getCovariance() const { return P_k_; }
-    bool isInitialized() const { return initialized_; }
+  Eigen::Vector4d getState() const { return x_k_; }  // x, y, vx, vy
+  Eigen::Matrix4d getCovariance() const { return P_k_; }
+  bool isInitialized() const { return initialized_; }
 
 private:
-    bool initialized_;
-    rclcpp::Time last_update_time_;
+  bool initialized_;
+  rclcpp::Time last_update_time_;
 
-    // Kalman Filter matrices
-    Eigen::Vector4d x_k_; // State estimate [x, y, vx, vy]'
-    Eigen::Matrix4d P_k_; // State covariance matrix
-    Eigen::Matrix4d F_k_; // State transition matrix
-    Eigen::Matrix2d R_k_; // Measurement noise covariance matrix
-    Eigen::MatrixXd H_k_; // Measurement matrix (4x2 -> 2x4)
-    Eigen::Matrix4d Q_k_; // Process noise covariance matrix
+  // Kalman Filter matrices
+  Eigen::Vector4d x_k_;  // State estimate [x, y, vx, vy]'
+  Eigen::Matrix4d P_k_;  // State covariance matrix
+  Eigen::Matrix4d F_k_;  // State transition matrix
+  Eigen::Matrix2d R_k_;  // Measurement noise covariance matrix
+  Eigen::MatrixXd H_k_;  // Measurement matrix (4x2 -> 2x4)
+  Eigen::Matrix4d Q_k_;  // Process noise covariance matrix
 };
 
-} // namespace crane
+}  // namespace crane
 
-#endif // CRANE_WORLD_MODEL_PUBLISHER__BALL_TRACKER_HPP_
+#endif  // CRANE_WORLD_MODEL_PUBLISHER__BALL_TRACKER_HPP_

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -12,6 +12,7 @@
 #include <robocup_ssl_msgs/ssl_vision_wrapper.pb.h>
 
 #include <Eigen/Dense>
+#include "crane_world_model_publisher/ball_tracker.hpp"  // Added this line
 #include <crane_basics/multicast.hpp>
 #include <crane_msgs/msg/play_situation.hpp>
 #include <crane_msgs/msg/robot_feedback_array.hpp>
@@ -24,43 +25,38 @@
 #include <string>
 #include <vector>
 
-#include "crane_world_model_publisher/ball_tracker.hpp"  // Added this line
-
 namespace crane
 {
 
 // Moved ActiveBallTrack struct definition here to be self-contained before WorldModelDataProvider
-struct ActiveBallTrack
-{
-  std::unique_ptr<BallTracker> tracker;
-  rclcpp::Time last_measurement_time;
-  // bool currently_detected_in_frame; // Removed
-  bool vision_updated_this_frame;  // Added
-  bool sensor_updated_this_frame;  // Added
-  double last_measured_z;
-  double last_measured_vz;
-  int track_id;  // Unique ID for this track
+struct ActiveBallTrack {
+    std::unique_ptr<BallTracker> tracker;
+    rclcpp::Time last_measurement_time;
+    // bool currently_detected_in_frame; // Removed
+    bool vision_updated_this_frame;    // Added
+    bool sensor_updated_this_frame;    // Added
+    double last_measured_z;
+    double last_measured_vz;
+    int track_id; // Unique ID for this track
 
-  ActiveBallTrack(int id)
-  : tracker(std::make_unique<BallTracker>()),
-    vision_updated_this_frame(false),  // Added init
-    sensor_updated_this_frame(false),  // Added init
-    last_measured_z(0.0),
-    last_measured_vz(0.0),
-    track_id(id)
-  {
-  }
+    ActiveBallTrack(int id) :
+        tracker(std::make_unique<BallTracker>()),
+        vision_updated_this_frame(false), // Added init
+        sensor_updated_this_frame(false), // Added init
+        last_measured_z(0.0),
+        last_measured_vz(0.0),
+        track_id(id) {}
 
-  // Add a copy constructor and copy assignment operator for vector operations if needed,
-  // or ensure they are implicitly deleted/disabled due to unique_ptr if copies are not intended.
-  // For std::vector::emplace_back, move semantics will be used if available.
-  // Explicitly defining move constructor and assignment for clarity:
-  ActiveBallTrack(ActiveBallTrack && other) noexcept = default;
-  ActiveBallTrack & operator=(ActiveBallTrack && other) noexcept = default;
+    // Add a copy constructor and copy assignment operator for vector operations if needed,
+    // or ensure they are implicitly deleted/disabled due to unique_ptr if copies are not intended.
+    // For std::vector::emplace_back, move semantics will be used if available.
+    // Explicitly defining move constructor and assignment for clarity:
+    ActiveBallTrack(ActiveBallTrack&& other) noexcept = default;
+    ActiveBallTrack& operator=(ActiveBallTrack&& other) noexcept = default;
 
-  // Prevent copying due to unique_ptr member
-  ActiveBallTrack(const ActiveBallTrack &) = delete;
-  ActiveBallTrack & operator=(const ActiveBallTrack &) = delete;
+    // Prevent copying due to unique_ptr member
+    ActiveBallTrack(const ActiveBallTrack&) = delete;
+    ActiveBallTrack& operator=(const ActiveBallTrack&) = delete;
 };
 
 class WorldModelDataProvider
@@ -133,7 +129,7 @@ private:
     std::vector<crane_msgs::msg::RobotInfo> robot_info[2];
 
     // crane_msgs::msg::BallInfo ball_info; // Removed
-    std::vector<crane_msgs::msg::BallInfo> balls_info;  // Added
+    std::vector<crane_msgs::msg::BallInfo> balls_info; // Added
 
     std::vector<bool> ball_sensor_detected;
   } data;
@@ -195,12 +191,12 @@ private:
   // double last_detected_ball_z_; // Removed
   // double last_detected_ball_vz_; // Removed
 
-  std::vector<ActiveBallTrack> active_ball_tracks_;                        // Added
-  int next_ball_track_id_ = 0;                                             // Added
-  static constexpr double BALL_ASSOCIATION_THRESHOLD_DISTANCE = 0.3;       // Kept
-  static constexpr double BALL_DISAPPEARED_THRESHOLD_SECONDS = 1.0;        // Kept
-  static constexpr double ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD = 0.5;  // Added
-  static constexpr double ROBOT_BALL_HOLDING_OFFSET = 0.1;                 // Added
+  std::vector<ActiveBallTrack> active_ball_tracks_; // Added
+  int next_ball_track_id_ = 0; // Added
+  static constexpr double BALL_ASSOCIATION_THRESHOLD_DISTANCE = 0.3; // Kept
+  static constexpr double BALL_DISAPPEARED_THRESHOLD_SECONDS = 1.0; // Kept
+  static constexpr double ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD = 0.5; // Added
+  static constexpr double ROBOT_BALL_HOLDING_OFFSET = 0.1; // Added
 
   auto trackerCallback(const TrackedFrame & tracked_frame) -> void;
 

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -11,7 +11,8 @@
 #include <robocup_ssl_msgs/ssl_vision_geometry.pb.h>
 #include <robocup_ssl_msgs/ssl_vision_wrapper.pb.h>
 
-#include <Eigen/Dense>  // Add this line
+#include <Eigen/Dense>
+#include "crane_world_model_publisher/ball_tracker.hpp"  // Added this line
 #include <crane_basics/multicast.hpp>
 #include <crane_msgs/msg/play_situation.hpp>
 #include <crane_msgs/msg/robot_feedback_array.hpp>
@@ -26,6 +27,38 @@
 
 namespace crane
 {
+
+// Moved ActiveBallTrack struct definition here to be self-contained before WorldModelDataProvider
+struct ActiveBallTrack {
+    std::unique_ptr<BallTracker> tracker;
+    rclcpp::Time last_measurement_time;
+    // bool currently_detected_in_frame; // Removed
+    bool vision_updated_this_frame;    // Added
+    bool sensor_updated_this_frame;    // Added
+    double last_measured_z;
+    double last_measured_vz;
+    int track_id; // Unique ID for this track
+
+    ActiveBallTrack(int id) :
+        tracker(std::make_unique<BallTracker>()),
+        vision_updated_this_frame(false), // Added init
+        sensor_updated_this_frame(false), // Added init
+        last_measured_z(0.0),
+        last_measured_vz(0.0),
+        track_id(id) {}
+
+    // Add a copy constructor and copy assignment operator for vector operations if needed,
+    // or ensure they are implicitly deleted/disabled due to unique_ptr if copies are not intended.
+    // For std::vector::emplace_back, move semantics will be used if available.
+    // Explicitly defining move constructor and assignment for clarity:
+    ActiveBallTrack(ActiveBallTrack&& other) noexcept = default;
+    ActiveBallTrack& operator=(ActiveBallTrack&& other) noexcept = default;
+
+    // Prevent copying due to unique_ptr member
+    ActiveBallTrack(const ActiveBallTrack&) = delete;
+    ActiveBallTrack& operator=(const ActiveBallTrack&) = delete;
+};
+
 class WorldModelDataProvider
 {
 public:
@@ -95,7 +128,8 @@ private:
 
     std::vector<crane_msgs::msg::RobotInfo> robot_info[2];
 
-    crane_msgs::msg::BallInfo ball_info;
+    // crane_msgs::msg::BallInfo ball_info; // Removed
+    std::vector<crane_msgs::msg::BallInfo> balls_info; // Added
 
     std::vector<bool> ball_sensor_detected;
   } data;
@@ -150,6 +184,19 @@ private:
   std::vector<uint8_t> robot_ids_mask;
 
   Box area_mask;
+
+  // std::unique_ptr<BallTracker> ball_tracker_; // Removed
+  // rclcpp::Time last_ball_tracker_measurement_time_; // Removed
+  // bool ball_seen_by_tracker_at_least_once_; // Removed
+  // double last_detected_ball_z_; // Removed
+  // double last_detected_ball_vz_; // Removed
+
+  std::vector<ActiveBallTrack> active_ball_tracks_; // Added
+  int next_ball_track_id_ = 0; // Added
+  static constexpr double BALL_ASSOCIATION_THRESHOLD_DISTANCE = 0.3; // Kept
+  static constexpr double BALL_DISAPPEARED_THRESHOLD_SECONDS = 1.0; // Kept
+  static constexpr double ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD = 0.5; // Added
+  static constexpr double ROBOT_BALL_HOLDING_OFFSET = 0.1; // Added
 
   auto trackerCallback(const TrackedFrame & tracked_frame) -> void;
 

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -12,7 +12,6 @@
 #include <robocup_ssl_msgs/ssl_vision_wrapper.pb.h>
 
 #include <Eigen/Dense>
-#include "crane_world_model_publisher/ball_tracker.hpp"  // Added this line
 #include <crane_basics/multicast.hpp>
 #include <crane_msgs/msg/play_situation.hpp>
 #include <crane_msgs/msg/robot_feedback_array.hpp>
@@ -25,38 +24,43 @@
 #include <string>
 #include <vector>
 
+#include "crane_world_model_publisher/ball_tracker.hpp"  // Added this line
+
 namespace crane
 {
 
 // Moved ActiveBallTrack struct definition here to be self-contained before WorldModelDataProvider
-struct ActiveBallTrack {
-    std::unique_ptr<BallTracker> tracker;
-    rclcpp::Time last_measurement_time;
-    // bool currently_detected_in_frame; // Removed
-    bool vision_updated_this_frame;    // Added
-    bool sensor_updated_this_frame;    // Added
-    double last_measured_z;
-    double last_measured_vz;
-    int track_id; // Unique ID for this track
+struct ActiveBallTrack
+{
+  std::unique_ptr<BallTracker> tracker;
+  rclcpp::Time last_measurement_time;
+  // bool currently_detected_in_frame; // Removed
+  bool vision_updated_this_frame;  // Added
+  bool sensor_updated_this_frame;  // Added
+  double last_measured_z;
+  double last_measured_vz;
+  int track_id;  // Unique ID for this track
 
-    ActiveBallTrack(int id) :
-        tracker(std::make_unique<BallTracker>()),
-        vision_updated_this_frame(false), // Added init
-        sensor_updated_this_frame(false), // Added init
-        last_measured_z(0.0),
-        last_measured_vz(0.0),
-        track_id(id) {}
+  ActiveBallTrack(int id)
+  : tracker(std::make_unique<BallTracker>()),
+    vision_updated_this_frame(false),  // Added init
+    sensor_updated_this_frame(false),  // Added init
+    last_measured_z(0.0),
+    last_measured_vz(0.0),
+    track_id(id)
+  {
+  }
 
-    // Add a copy constructor and copy assignment operator for vector operations if needed,
-    // or ensure they are implicitly deleted/disabled due to unique_ptr if copies are not intended.
-    // For std::vector::emplace_back, move semantics will be used if available.
-    // Explicitly defining move constructor and assignment for clarity:
-    ActiveBallTrack(ActiveBallTrack&& other) noexcept = default;
-    ActiveBallTrack& operator=(ActiveBallTrack&& other) noexcept = default;
+  // Add a copy constructor and copy assignment operator for vector operations if needed,
+  // or ensure they are implicitly deleted/disabled due to unique_ptr if copies are not intended.
+  // For std::vector::emplace_back, move semantics will be used if available.
+  // Explicitly defining move constructor and assignment for clarity:
+  ActiveBallTrack(ActiveBallTrack && other) noexcept = default;
+  ActiveBallTrack & operator=(ActiveBallTrack && other) noexcept = default;
 
-    // Prevent copying due to unique_ptr member
-    ActiveBallTrack(const ActiveBallTrack&) = delete;
-    ActiveBallTrack& operator=(const ActiveBallTrack&) = delete;
+  // Prevent copying due to unique_ptr member
+  ActiveBallTrack(const ActiveBallTrack &) = delete;
+  ActiveBallTrack & operator=(const ActiveBallTrack &) = delete;
 };
 
 class WorldModelDataProvider
@@ -129,7 +133,7 @@ private:
     std::vector<crane_msgs::msg::RobotInfo> robot_info[2];
 
     // crane_msgs::msg::BallInfo ball_info; // Removed
-    std::vector<crane_msgs::msg::BallInfo> balls_info; // Added
+    std::vector<crane_msgs::msg::BallInfo> balls_info;  // Added
 
     std::vector<bool> ball_sensor_detected;
   } data;
@@ -191,12 +195,12 @@ private:
   // double last_detected_ball_z_; // Removed
   // double last_detected_ball_vz_; // Removed
 
-  std::vector<ActiveBallTrack> active_ball_tracks_; // Added
-  int next_ball_track_id_ = 0; // Added
-  static constexpr double BALL_ASSOCIATION_THRESHOLD_DISTANCE = 0.3; // Kept
-  static constexpr double BALL_DISAPPEARED_THRESHOLD_SECONDS = 1.0; // Kept
-  static constexpr double ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD = 0.5; // Added
-  static constexpr double ROBOT_BALL_HOLDING_OFFSET = 0.1; // Added
+  std::vector<ActiveBallTrack> active_ball_tracks_;                        // Added
+  int next_ball_track_id_ = 0;                                             // Added
+  static constexpr double BALL_ASSOCIATION_THRESHOLD_DISTANCE = 0.3;       // Kept
+  static constexpr double BALL_DISAPPEARED_THRESHOLD_SECONDS = 1.0;        // Kept
+  static constexpr double ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD = 0.5;  // Added
+  static constexpr double ROBOT_BALL_HOLDING_OFFSET = 0.1;                 // Added
 
   auto trackerCallback(const TrackedFrame & tracked_frame) -> void;
 

--- a/crane_world_model_publisher/src/ball_tracker.cpp
+++ b/crane_world_model_publisher/src/ball_tracker.cpp
@@ -1,117 +1,129 @@
 #include "crane_world_model_publisher/ball_tracker.hpp"
 
-namespace crane {
+namespace crane
+{
 
-BallTracker::BallTracker() : initialized_(false) {
-    // Initialize matrices (dimensions)
-    x_k_ = Eigen::Vector4d::Zero();
-    P_k_ = Eigen::Matrix4d::Identity(); // Initial uncertainty
-    F_k_ = Eigen::Matrix4d::Identity();
-    H_k_ = Eigen::MatrixXd::Zero(2, 4);
-    Q_k_ = Eigen::Matrix4d::Identity();
-    R_k_ = Eigen::Matrix2d::Identity();
+BallTracker::BallTracker() : initialized_(false)
+{
+  // Initialize matrices (dimensions)
+  x_k_ = Eigen::Vector4d::Zero();
+  P_k_ = Eigen::Matrix4d::Identity();  // Initial uncertainty
+  F_k_ = Eigen::Matrix4d::Identity();
+  H_k_ = Eigen::MatrixXd::Zero(2, 4);
+  Q_k_ = Eigen::Matrix4d::Identity();
+  R_k_ = Eigen::Matrix2d::Identity();
 
-    // Measurement matrix H_k_ (maps state to measurement [x, y])
-    H_k_(0, 0) = 1.0; // x = x
-    H_k_(1, 1) = 1.0; // y = y
+  // Measurement matrix H_k_ (maps state to measurement [x, y])
+  H_k_(0, 0) = 1.0;  // x = x
+  H_k_(1, 1) = 1.0;  // y = y
 
-    // Initial Process Noise Covariance Q_k_ (tune these values)
-    // Assumes some uncertainty in constant velocity model
-    double q_pos = 0.05; // position variance
-    double q_vel = 0.1;  // velocity variance
-    Q_k_ << q_pos, 0, 0, 0,
-            0, q_pos, 0, 0,
-            0, 0, q_vel, 0,
-            0, 0, 0, q_vel;
+  // Initial Process Noise Covariance Q_k_ (tune these values)
+  // Assumes some uncertainty in constant velocity model
+  double q_pos = 0.05;  // position variance
+  double q_vel = 0.1;   // velocity variance
+  Q_k_ << q_pos, 0, 0, 0, 0, q_pos, 0, 0, 0, 0, q_vel, 0, 0, 0, 0, q_vel;
 
-    // Initial Measurement Noise Covariance R_k_ (tune these values)
-    // Depends on sensor accuracy
-    double r_pos = 0.1; // measurement variance for position
-    R_k_ << r_pos, 0,
-            0, r_pos;
+  // Initial Measurement Noise Covariance R_k_ (tune these values)
+  // Depends on sensor accuracy
+  double r_pos = 0.1;  // measurement variance for position
+  R_k_ << r_pos, 0, 0, r_pos;
 }
 
-void BallTracker::init(const rclcpp::Time& t_start, double initial_x, double initial_y, double initial_vx, double initial_vy) {
-    x_k_ << initial_x, initial_y, initial_vx, initial_vy;
+void BallTracker::init(
+  const rclcpp::Time & t_start, double initial_x, double initial_y, double initial_vx,
+  double initial_vy)
+{
+  x_k_ << initial_x, initial_y, initial_vx, initial_vy;
 
-    // Set initial covariance. Large if initial state is uncertain, smaller if more certain.
-    P_k_ = Eigen::Matrix4d::Identity() * 0.1; // Example: moderate initial uncertainty
-    P_k_(2,2) = 1.0; // Higher uncertainty for initial velocities if not measured
-    P_k_(3,3) = 1.0;
+  // Set initial covariance. Large if initial state is uncertain, smaller if more certain.
+  P_k_ = Eigen::Matrix4d::Identity() * 0.1;  // Example: moderate initial uncertainty
+  P_k_(2, 2) = 1.0;  // Higher uncertainty for initial velocities if not measured
+  P_k_(3, 3) = 1.0;
 
-    last_update_time_ = t_start;
-    initialized_ = true;
-    RCLCPP_INFO(rclcpp::get_logger("BallTracker"), "Kalman Filter initialized at t=%.4f with x=%.2f, y=%.2f, vx=%.2f, vy=%.2f",
-                t_start.seconds(), initial_x, initial_y, initial_vx, initial_vy);
+  last_update_time_ = t_start;
+  initialized_ = true;
+  RCLCPP_INFO(
+    rclcpp::get_logger("BallTracker"),
+    "Kalman Filter initialized at t=%.4f with x=%.2f, y=%.2f, vx=%.2f, vy=%.2f", t_start.seconds(),
+    initial_x, initial_y, initial_vx, initial_vy);
 }
 
-void BallTracker::predict(const rclcpp::Time& t_now) {
-    if (!initialized_) {
-        RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Predict called before initialization.");
-        return;
-    }
+void BallTracker::predict(const rclcpp::Time & t_now)
+{
+  if (!initialized_) {
+    RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Predict called before initialization.");
+    return;
+  }
 
-    double dt = (t_now - last_update_time_).seconds();
-    if (dt < 0) {
-        RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Negative dt (%.4f) in predict. Skipping.", dt);
-        dt = 0; // Or handle as an error
-    }
+  double dt = (t_now - last_update_time_).seconds();
+  if (dt < 0) {
+    RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Negative dt (%.4f) in predict. Skipping.", dt);
+    dt = 0;  // Or handle as an error
+  }
 
-    // Update State Transition Matrix F_k_ for current dt
-    F_k_ = Eigen::Matrix4d::Identity();
-    F_k_(0, 2) = dt; // x = x_prev + vx_prev * dt
-    F_k_(1, 3) = dt; // y = y_prev + vy_prev * dt
+  // Update State Transition Matrix F_k_ for current dt
+  F_k_ = Eigen::Matrix4d::Identity();
+  F_k_(0, 2) = dt;  // x = x_prev + vx_prev * dt
+  F_k_(1, 3) = dt;  // y = y_prev + vy_prev * dt
 
-    // Predict state: x_k = F_k * x_k_{k-1}
-    x_k_ = F_k_ * x_k_;
-    // Predict covariance: P_k = F_k * P_{k-1} * F_k' + Q_k
-    P_k_ = F_k_ * P_k_ * F_k_.transpose() + Q_k_;
+  // Predict state: x_k = F_k * x_k_{k-1}
+  x_k_ = F_k_ * x_k_;
+  // Predict covariance: P_k = F_k * P_{k-1} * F_k' + Q_k
+  P_k_ = F_k_ * P_k_ * F_k_.transpose() + Q_k_;
 
-    last_update_time_ = t_now; // Update time for next prediction or update
+  last_update_time_ = t_now;  // Update time for next prediction or update
 }
 
-void BallTracker::update(const Eigen::Vector2d& measurement, const rclcpp::Time& t_measurement) {
-    if (!initialized_) {
-        RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Update called before initialization. Initializing with this measurement.");
-        // If not initialized, use this measurement to initialize (optional, could also require explicit init)
-        // init(t_measurement, measurement(0), measurement(1));
-        // For now, let's assume init must be called first.
-        return;
-    }
+void BallTracker::update(const Eigen::Vector2d & measurement, const rclcpp::Time & t_measurement)
+{
+  if (!initialized_) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("BallTracker"),
+      "Update called before initialization. Initializing with this measurement.");
+    // If not initialized, use this measurement to initialize (optional, could also require explicit init)
+    // init(t_measurement, measurement(0), measurement(1));
+    // For now, let's assume init must be called first.
+    return;
+  }
 
-    // If t_measurement is older than last_update_time_, it could be an old packet.
-    // A more robust system might handle out-of-order measurements.
-    // For simplicity, we can predict up to t_measurement if it's newer than last_update_time_
-    // but not if predict() was just called with a t_now equal to t_measurement.
-    // This check ensures we don't double-predict or use stale data.
-    if ((t_measurement - last_update_time_).seconds() > 1e-9) { // if t_measurement is significantly newer
-         //RCLCPP_INFO(rclcpp::get_logger("BallTracker"), "Update time is newer, predicting up to measurement time.");
-         predict(t_measurement); // Predict up to the measurement time
-    } else if ((t_measurement - last_update_time_).seconds() < -1e-9) { // if t_measurement is significantly older
-        RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Received old measurement (%.4fs older). Skipping update.", (last_update_time_ - t_measurement).seconds());
-        return;
-    }
+  // If t_measurement is older than last_update_time_, it could be an old packet.
+  // A more robust system might handle out-of-order measurements.
+  // For simplicity, we can predict up to t_measurement if it's newer than last_update_time_
+  // but not if predict() was just called with a t_now equal to t_measurement.
+  // This check ensures we don't double-predict or use stale data.
+  if (
+    (t_measurement - last_update_time_).seconds() >
+    1e-9) {  // if t_measurement is significantly newer
+    //RCLCPP_INFO(rclcpp::get_logger("BallTracker"), "Update time is newer, predicting up to measurement time.");
+    predict(t_measurement);  // Predict up to the measurement time
+  } else if (
+    (t_measurement - last_update_time_).seconds() <
+    -1e-9) {  // if t_measurement is significantly older
+    RCLCPP_WARN(
+      rclcpp::get_logger("BallTracker"), "Received old measurement (%.4fs older). Skipping update.",
+      (last_update_time_ - t_measurement).seconds());
+    return;
+  }
 
+  // Measurement residual (innovation): y_k = z_k - H_k * x_k_predicted
+  Eigen::Vector2d y_k = measurement - H_k_ * x_k_;
 
-    // Measurement residual (innovation): y_k = z_k - H_k * x_k_predicted
-    Eigen::Vector2d y_k = measurement - H_k_ * x_k_;
+  // Residual (innovation) covariance: S_k = H_k * P_k_predicted * H_k' + R_k
+  Eigen::Matrix2d S_k = H_k_ * P_k_ * H_k_.transpose() + R_k_;
 
-    // Residual (innovation) covariance: S_k = H_k * P_k_predicted * H_k' + R_k
-    Eigen::Matrix2d S_k = H_k_ * P_k_ * H_k_.transpose() + R_k_;
+  // Optimal Kalman gain: K_k = P_k_predicted * H_k' * S_k^-1
+  Eigen::MatrixXd K_k = P_k_ * H_k_.transpose() * S_k.inverse();
 
-    // Optimal Kalman gain: K_k = P_k_predicted * H_k' * S_k^-1
-    Eigen::MatrixXd K_k = P_k_ * H_k_.transpose() * S_k.inverse();
+  // Update state estimate: x_k = x_k_predicted + K_k * y_k
+  x_k_ = x_k_ + K_k * y_k;
 
-    // Update state estimate: x_k = x_k_predicted + K_k * y_k
-    x_k_ = x_k_ + K_k * y_k;
+  // Update state covariance: P_k = (I - K_k * H_k) * P_k_predicted
+  Eigen::Matrix4d I = Eigen::Matrix4d::Identity();
+  P_k_ = (I - K_k * H_k_) * P_k_;
 
-    // Update state covariance: P_k = (I - K_k * H_k) * P_k_predicted
-    Eigen::Matrix4d I = Eigen::Matrix4d::Identity();
-    P_k_ = (I - K_k * H_k_) * P_k_;
-
-    // last_update_time_ was already updated in predict if called, or should be t_measurement if predict wasn't called.
-    // Ensure last_update_time_ reflects the time of this data.
-    last_update_time_ = t_measurement;
+  // last_update_time_ was already updated in predict if called, or should be t_measurement if predict wasn't called.
+  // Ensure last_update_time_ reflects the time of this data.
+  last_update_time_ = t_measurement;
 }
 
-} // namespace crane
+}  // namespace crane

--- a/crane_world_model_publisher/src/ball_tracker.cpp
+++ b/crane_world_model_publisher/src/ball_tracker.cpp
@@ -1,0 +1,117 @@
+#include "crane_world_model_publisher/ball_tracker.hpp"
+
+namespace crane {
+
+BallTracker::BallTracker() : initialized_(false) {
+    // Initialize matrices (dimensions)
+    x_k_ = Eigen::Vector4d::Zero();
+    P_k_ = Eigen::Matrix4d::Identity(); // Initial uncertainty
+    F_k_ = Eigen::Matrix4d::Identity();
+    H_k_ = Eigen::MatrixXd::Zero(2, 4);
+    Q_k_ = Eigen::Matrix4d::Identity();
+    R_k_ = Eigen::Matrix2d::Identity();
+
+    // Measurement matrix H_k_ (maps state to measurement [x, y])
+    H_k_(0, 0) = 1.0; // x = x
+    H_k_(1, 1) = 1.0; // y = y
+
+    // Initial Process Noise Covariance Q_k_ (tune these values)
+    // Assumes some uncertainty in constant velocity model
+    double q_pos = 0.05; // position variance
+    double q_vel = 0.1;  // velocity variance
+    Q_k_ << q_pos, 0, 0, 0,
+            0, q_pos, 0, 0,
+            0, 0, q_vel, 0,
+            0, 0, 0, q_vel;
+
+    // Initial Measurement Noise Covariance R_k_ (tune these values)
+    // Depends on sensor accuracy
+    double r_pos = 0.1; // measurement variance for position
+    R_k_ << r_pos, 0,
+            0, r_pos;
+}
+
+void BallTracker::init(const rclcpp::Time& t_start, double initial_x, double initial_y, double initial_vx, double initial_vy) {
+    x_k_ << initial_x, initial_y, initial_vx, initial_vy;
+
+    // Set initial covariance. Large if initial state is uncertain, smaller if more certain.
+    P_k_ = Eigen::Matrix4d::Identity() * 0.1; // Example: moderate initial uncertainty
+    P_k_(2,2) = 1.0; // Higher uncertainty for initial velocities if not measured
+    P_k_(3,3) = 1.0;
+
+    last_update_time_ = t_start;
+    initialized_ = true;
+    RCLCPP_INFO(rclcpp::get_logger("BallTracker"), "Kalman Filter initialized at t=%.4f with x=%.2f, y=%.2f, vx=%.2f, vy=%.2f",
+                t_start.seconds(), initial_x, initial_y, initial_vx, initial_vy);
+}
+
+void BallTracker::predict(const rclcpp::Time& t_now) {
+    if (!initialized_) {
+        RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Predict called before initialization.");
+        return;
+    }
+
+    double dt = (t_now - last_update_time_).seconds();
+    if (dt < 0) {
+        RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Negative dt (%.4f) in predict. Skipping.", dt);
+        dt = 0; // Or handle as an error
+    }
+
+    // Update State Transition Matrix F_k_ for current dt
+    F_k_ = Eigen::Matrix4d::Identity();
+    F_k_(0, 2) = dt; // x = x_prev + vx_prev * dt
+    F_k_(1, 3) = dt; // y = y_prev + vy_prev * dt
+
+    // Predict state: x_k = F_k * x_k_{k-1}
+    x_k_ = F_k_ * x_k_;
+    // Predict covariance: P_k = F_k * P_{k-1} * F_k' + Q_k
+    P_k_ = F_k_ * P_k_ * F_k_.transpose() + Q_k_;
+
+    last_update_time_ = t_now; // Update time for next prediction or update
+}
+
+void BallTracker::update(const Eigen::Vector2d& measurement, const rclcpp::Time& t_measurement) {
+    if (!initialized_) {
+        RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Update called before initialization. Initializing with this measurement.");
+        // If not initialized, use this measurement to initialize (optional, could also require explicit init)
+        // init(t_measurement, measurement(0), measurement(1));
+        // For now, let's assume init must be called first.
+        return;
+    }
+
+    // If t_measurement is older than last_update_time_, it could be an old packet.
+    // A more robust system might handle out-of-order measurements.
+    // For simplicity, we can predict up to t_measurement if it's newer than last_update_time_
+    // but not if predict() was just called with a t_now equal to t_measurement.
+    // This check ensures we don't double-predict or use stale data.
+    if ((t_measurement - last_update_time_).seconds() > 1e-9) { // if t_measurement is significantly newer
+         //RCLCPP_INFO(rclcpp::get_logger("BallTracker"), "Update time is newer, predicting up to measurement time.");
+         predict(t_measurement); // Predict up to the measurement time
+    } else if ((t_measurement - last_update_time_).seconds() < -1e-9) { // if t_measurement is significantly older
+        RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Received old measurement (%.4fs older). Skipping update.", (last_update_time_ - t_measurement).seconds());
+        return;
+    }
+
+
+    // Measurement residual (innovation): y_k = z_k - H_k * x_k_predicted
+    Eigen::Vector2d y_k = measurement - H_k_ * x_k_;
+
+    // Residual (innovation) covariance: S_k = H_k * P_k_predicted * H_k' + R_k
+    Eigen::Matrix2d S_k = H_k_ * P_k_ * H_k_.transpose() + R_k_;
+
+    // Optimal Kalman gain: K_k = P_k_predicted * H_k' * S_k^-1
+    Eigen::MatrixXd K_k = P_k_ * H_k_.transpose() * S_k.inverse();
+
+    // Update state estimate: x_k = x_k_predicted + K_k * y_k
+    x_k_ = x_k_ + K_k * y_k;
+
+    // Update state covariance: P_k = (I - K_k * H_k) * P_k_predicted
+    Eigen::Matrix4d I = Eigen::Matrix4d::Identity();
+    P_k_ = (I - K_k * H_k_) * P_k_;
+
+    // last_update_time_ was already updated in predict if called, or should be t_measurement if predict wasn't called.
+    // Ensure last_update_time_ reflects the time of this data.
+    last_update_time_ = t_measurement;
+}
+
+} // namespace crane

--- a/crane_world_model_publisher/src/ball_tracker.cpp
+++ b/crane_world_model_publisher/src/ball_tracker.cpp
@@ -1,129 +1,117 @@
 #include "crane_world_model_publisher/ball_tracker.hpp"
 
-namespace crane
-{
+namespace crane {
 
-BallTracker::BallTracker() : initialized_(false)
-{
-  // Initialize matrices (dimensions)
-  x_k_ = Eigen::Vector4d::Zero();
-  P_k_ = Eigen::Matrix4d::Identity();  // Initial uncertainty
-  F_k_ = Eigen::Matrix4d::Identity();
-  H_k_ = Eigen::MatrixXd::Zero(2, 4);
-  Q_k_ = Eigen::Matrix4d::Identity();
-  R_k_ = Eigen::Matrix2d::Identity();
+BallTracker::BallTracker() : initialized_(false) {
+    // Initialize matrices (dimensions)
+    x_k_ = Eigen::Vector4d::Zero();
+    P_k_ = Eigen::Matrix4d::Identity(); // Initial uncertainty
+    F_k_ = Eigen::Matrix4d::Identity();
+    H_k_ = Eigen::MatrixXd::Zero(2, 4);
+    Q_k_ = Eigen::Matrix4d::Identity();
+    R_k_ = Eigen::Matrix2d::Identity();
 
-  // Measurement matrix H_k_ (maps state to measurement [x, y])
-  H_k_(0, 0) = 1.0;  // x = x
-  H_k_(1, 1) = 1.0;  // y = y
+    // Measurement matrix H_k_ (maps state to measurement [x, y])
+    H_k_(0, 0) = 1.0; // x = x
+    H_k_(1, 1) = 1.0; // y = y
 
-  // Initial Process Noise Covariance Q_k_ (tune these values)
-  // Assumes some uncertainty in constant velocity model
-  double q_pos = 0.05;  // position variance
-  double q_vel = 0.1;   // velocity variance
-  Q_k_ << q_pos, 0, 0, 0, 0, q_pos, 0, 0, 0, 0, q_vel, 0, 0, 0, 0, q_vel;
+    // Initial Process Noise Covariance Q_k_ (tune these values)
+    // Assumes some uncertainty in constant velocity model
+    double q_pos = 0.05; // position variance
+    double q_vel = 0.1;  // velocity variance
+    Q_k_ << q_pos, 0, 0, 0,
+            0, q_pos, 0, 0,
+            0, 0, q_vel, 0,
+            0, 0, 0, q_vel;
 
-  // Initial Measurement Noise Covariance R_k_ (tune these values)
-  // Depends on sensor accuracy
-  double r_pos = 0.1;  // measurement variance for position
-  R_k_ << r_pos, 0, 0, r_pos;
+    // Initial Measurement Noise Covariance R_k_ (tune these values)
+    // Depends on sensor accuracy
+    double r_pos = 0.1; // measurement variance for position
+    R_k_ << r_pos, 0,
+            0, r_pos;
 }
 
-void BallTracker::init(
-  const rclcpp::Time & t_start, double initial_x, double initial_y, double initial_vx,
-  double initial_vy)
-{
-  x_k_ << initial_x, initial_y, initial_vx, initial_vy;
+void BallTracker::init(const rclcpp::Time& t_start, double initial_x, double initial_y, double initial_vx, double initial_vy) {
+    x_k_ << initial_x, initial_y, initial_vx, initial_vy;
 
-  // Set initial covariance. Large if initial state is uncertain, smaller if more certain.
-  P_k_ = Eigen::Matrix4d::Identity() * 0.1;  // Example: moderate initial uncertainty
-  P_k_(2, 2) = 1.0;  // Higher uncertainty for initial velocities if not measured
-  P_k_(3, 3) = 1.0;
+    // Set initial covariance. Large if initial state is uncertain, smaller if more certain.
+    P_k_ = Eigen::Matrix4d::Identity() * 0.1; // Example: moderate initial uncertainty
+    P_k_(2,2) = 1.0; // Higher uncertainty for initial velocities if not measured
+    P_k_(3,3) = 1.0;
 
-  last_update_time_ = t_start;
-  initialized_ = true;
-  RCLCPP_INFO(
-    rclcpp::get_logger("BallTracker"),
-    "Kalman Filter initialized at t=%.4f with x=%.2f, y=%.2f, vx=%.2f, vy=%.2f", t_start.seconds(),
-    initial_x, initial_y, initial_vx, initial_vy);
+    last_update_time_ = t_start;
+    initialized_ = true;
+    RCLCPP_INFO(rclcpp::get_logger("BallTracker"), "Kalman Filter initialized at t=%.4f with x=%.2f, y=%.2f, vx=%.2f, vy=%.2f",
+                t_start.seconds(), initial_x, initial_y, initial_vx, initial_vy);
 }
 
-void BallTracker::predict(const rclcpp::Time & t_now)
-{
-  if (!initialized_) {
-    RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Predict called before initialization.");
-    return;
-  }
+void BallTracker::predict(const rclcpp::Time& t_now) {
+    if (!initialized_) {
+        RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Predict called before initialization.");
+        return;
+    }
 
-  double dt = (t_now - last_update_time_).seconds();
-  if (dt < 0) {
-    RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Negative dt (%.4f) in predict. Skipping.", dt);
-    dt = 0;  // Or handle as an error
-  }
+    double dt = (t_now - last_update_time_).seconds();
+    if (dt < 0) {
+        RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Negative dt (%.4f) in predict. Skipping.", dt);
+        dt = 0; // Or handle as an error
+    }
 
-  // Update State Transition Matrix F_k_ for current dt
-  F_k_ = Eigen::Matrix4d::Identity();
-  F_k_(0, 2) = dt;  // x = x_prev + vx_prev * dt
-  F_k_(1, 3) = dt;  // y = y_prev + vy_prev * dt
+    // Update State Transition Matrix F_k_ for current dt
+    F_k_ = Eigen::Matrix4d::Identity();
+    F_k_(0, 2) = dt; // x = x_prev + vx_prev * dt
+    F_k_(1, 3) = dt; // y = y_prev + vy_prev * dt
 
-  // Predict state: x_k = F_k * x_k_{k-1}
-  x_k_ = F_k_ * x_k_;
-  // Predict covariance: P_k = F_k * P_{k-1} * F_k' + Q_k
-  P_k_ = F_k_ * P_k_ * F_k_.transpose() + Q_k_;
+    // Predict state: x_k = F_k * x_k_{k-1}
+    x_k_ = F_k_ * x_k_;
+    // Predict covariance: P_k = F_k * P_{k-1} * F_k' + Q_k
+    P_k_ = F_k_ * P_k_ * F_k_.transpose() + Q_k_;
 
-  last_update_time_ = t_now;  // Update time for next prediction or update
+    last_update_time_ = t_now; // Update time for next prediction or update
 }
 
-void BallTracker::update(const Eigen::Vector2d & measurement, const rclcpp::Time & t_measurement)
-{
-  if (!initialized_) {
-    RCLCPP_WARN(
-      rclcpp::get_logger("BallTracker"),
-      "Update called before initialization. Initializing with this measurement.");
-    // If not initialized, use this measurement to initialize (optional, could also require explicit init)
-    // init(t_measurement, measurement(0), measurement(1));
-    // For now, let's assume init must be called first.
-    return;
-  }
+void BallTracker::update(const Eigen::Vector2d& measurement, const rclcpp::Time& t_measurement) {
+    if (!initialized_) {
+        RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Update called before initialization. Initializing with this measurement.");
+        // If not initialized, use this measurement to initialize (optional, could also require explicit init)
+        // init(t_measurement, measurement(0), measurement(1));
+        // For now, let's assume init must be called first.
+        return;
+    }
 
-  // If t_measurement is older than last_update_time_, it could be an old packet.
-  // A more robust system might handle out-of-order measurements.
-  // For simplicity, we can predict up to t_measurement if it's newer than last_update_time_
-  // but not if predict() was just called with a t_now equal to t_measurement.
-  // This check ensures we don't double-predict or use stale data.
-  if (
-    (t_measurement - last_update_time_).seconds() >
-    1e-9) {  // if t_measurement is significantly newer
-    //RCLCPP_INFO(rclcpp::get_logger("BallTracker"), "Update time is newer, predicting up to measurement time.");
-    predict(t_measurement);  // Predict up to the measurement time
-  } else if (
-    (t_measurement - last_update_time_).seconds() <
-    -1e-9) {  // if t_measurement is significantly older
-    RCLCPP_WARN(
-      rclcpp::get_logger("BallTracker"), "Received old measurement (%.4fs older). Skipping update.",
-      (last_update_time_ - t_measurement).seconds());
-    return;
-  }
+    // If t_measurement is older than last_update_time_, it could be an old packet.
+    // A more robust system might handle out-of-order measurements.
+    // For simplicity, we can predict up to t_measurement if it's newer than last_update_time_
+    // but not if predict() was just called with a t_now equal to t_measurement.
+    // This check ensures we don't double-predict or use stale data.
+    if ((t_measurement - last_update_time_).seconds() > 1e-9) { // if t_measurement is significantly newer
+         //RCLCPP_INFO(rclcpp::get_logger("BallTracker"), "Update time is newer, predicting up to measurement time.");
+         predict(t_measurement); // Predict up to the measurement time
+    } else if ((t_measurement - last_update_time_).seconds() < -1e-9) { // if t_measurement is significantly older
+        RCLCPP_WARN(rclcpp::get_logger("BallTracker"), "Received old measurement (%.4fs older). Skipping update.", (last_update_time_ - t_measurement).seconds());
+        return;
+    }
 
-  // Measurement residual (innovation): y_k = z_k - H_k * x_k_predicted
-  Eigen::Vector2d y_k = measurement - H_k_ * x_k_;
 
-  // Residual (innovation) covariance: S_k = H_k * P_k_predicted * H_k' + R_k
-  Eigen::Matrix2d S_k = H_k_ * P_k_ * H_k_.transpose() + R_k_;
+    // Measurement residual (innovation): y_k = z_k - H_k * x_k_predicted
+    Eigen::Vector2d y_k = measurement - H_k_ * x_k_;
 
-  // Optimal Kalman gain: K_k = P_k_predicted * H_k' * S_k^-1
-  Eigen::MatrixXd K_k = P_k_ * H_k_.transpose() * S_k.inverse();
+    // Residual (innovation) covariance: S_k = H_k * P_k_predicted * H_k' + R_k
+    Eigen::Matrix2d S_k = H_k_ * P_k_ * H_k_.transpose() + R_k_;
 
-  // Update state estimate: x_k = x_k_predicted + K_k * y_k
-  x_k_ = x_k_ + K_k * y_k;
+    // Optimal Kalman gain: K_k = P_k_predicted * H_k' * S_k^-1
+    Eigen::MatrixXd K_k = P_k_ * H_k_.transpose() * S_k.inverse();
 
-  // Update state covariance: P_k = (I - K_k * H_k) * P_k_predicted
-  Eigen::Matrix4d I = Eigen::Matrix4d::Identity();
-  P_k_ = (I - K_k * H_k_) * P_k_;
+    // Update state estimate: x_k = x_k_predicted + K_k * y_k
+    x_k_ = x_k_ + K_k * y_k;
 
-  // last_update_time_ was already updated in predict if called, or should be t_measurement if predict wasn't called.
-  // Ensure last_update_time_ reflects the time of this data.
-  last_update_time_ = t_measurement;
+    // Update state covariance: P_k = (I - K_k * H_k) * P_k_predicted
+    Eigen::Matrix4d I = Eigen::Matrix4d::Identity();
+    P_k_ = (I - K_k * H_k_) * P_k_;
+
+    // last_update_time_ was already updated in predict if called, or should be t_measurement if predict wasn't called.
+    // Ensure last_update_time_ reflects the time of this data.
+    last_update_time_ = t_measurement;
 }
 
-}  // namespace crane
+} // namespace crane

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -47,12 +47,13 @@ auto createTransformMatrix(bool enable, bool is_positive_side, double field_widt
 }
 
 WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
-: node(node), vis_data_handler(node)
-// active_ball_tracks_ is default constructed
-// next_ball_track_id_ is initialized in the header or here
+: node(node),
+  vis_data_handler(node)
+  // active_ball_tracks_ is default constructed
+  // next_ball_track_id_ is initialized in the header or here
 {
-  next_ball_track_id_ = 0;      // Explicitly initialize here
-  active_ball_tracks_.clear();  // Clear any default constructed elements, though likely empty
+  next_ball_track_id_ = 0; // Explicitly initialize here
+  active_ball_tracks_.clear(); // Clear any default constructed elements, though likely empty
   using std::chrono_literals::operator""ms;
   node.declare_parameter("tracker_address", "224.5.23.2");
   node.declare_parameter("tracker_port", 11010);
@@ -382,7 +383,8 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
     }
 
     int best_detection_idx = -1;
-    double min_dist_sq = BALL_ASSOCIATION_THRESHOLD_DISTANCE * BALL_ASSOCIATION_THRESHOLD_DISTANCE;
+    double min_dist_sq =
+      BALL_ASSOCIATION_THRESHOLD_DISTANCE * BALL_ASSOCIATION_THRESHOLD_DISTANCE;
 
     Eigen::Vector4d predicted_state = track.tracker->getState();
     Eigen::Vector2d predicted_pos(predicted_state(0), predicted_state(1));
@@ -408,7 +410,8 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
       track.last_measurement_time = current_time;
       track.vision_updated_this_frame = true;
       track.last_measured_z = matched_detection.pos().z();
-      track.last_measured_vz = matched_detection.has_vel() ? matched_detection.vel().z() : 0.0;
+      track.last_measured_vz =
+        matched_detection.has_vel() ? matched_detection.vel().z() : 0.0;
       detection_assigned[best_detection_idx] = true;
     }
   }
@@ -416,21 +419,18 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
   // C. Robot Sensor Compensation (Snap existing predicted tracks)
   uint8_t our_team_color_idx = static_cast<uint8_t>(game_data.our_color);
   for (const auto & robot : data.robot_info[our_team_color_idx]) {
-    if (
-      robot.ball_sensor && robot.detected &&  // ensure robot itself is detected
-      (current_time - robot.last_ball_sensor_stamp).seconds() < 0.5) {
+    if (robot.ball_sensor && robot.detected && // ensure robot itself is detected
+        (current_time - robot.last_ball_sensor_stamp).seconds() < 0.5) {
       Eigen::Vector2d ball_pos_at_robot_eigen(
         robot.pose.x + std::cos(robot.pose.theta) * ROBOT_BALL_HOLDING_OFFSET,
         robot.pose.y + std::sin(robot.pose.theta) * ROBOT_BALL_HOLDING_OFFSET);
 
       ActiveBallTrack * best_track_to_snap = nullptr;
-      double min_dist_sq_sensor =
-        ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD * ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD;
+      double min_dist_sq_sensor = ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD * ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD;
 
       for (auto & track_candidate : active_ball_tracks_) {
-        if (
-          !track_candidate.vision_updated_this_frame &&  // Don't snap if just updated by vision
-          track_candidate.tracker->isInitialized()) {
+        if (!track_candidate.vision_updated_this_frame && // Don't snap if just updated by vision
+            track_candidate.tracker->isInitialized()) {
           Eigen::Vector4d kf_predicted_state = track_candidate.tracker->getState();
           Eigen::Vector2d kf_predicted_pos(kf_predicted_state(0), kf_predicted_state(1));
           double dist_sq = (kf_predicted_pos - ball_pos_at_robot_eigen).squaredNorm();
@@ -448,10 +448,9 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
           best_track_to_snap->track_id, robot.id);
         best_track_to_snap->tracker->update(ball_pos_at_robot_eigen, current_time);
         best_track_to_snap->sensor_updated_this_frame = true;
-        best_track_to_snap->last_measured_z = 0.0;  // Ball on ground when held
+        best_track_to_snap->last_measured_z = 0.0; // Ball on ground when held
         best_track_to_snap->last_measured_vz = 0.0;
-        best_track_to_snap->last_measurement_time =
-          current_time;  // Treat sensor update as a measurement
+        best_track_to_snap->last_measurement_time = current_time; // Treat sensor update as a measurement
       }
     }
   }
@@ -464,29 +463,24 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
     const auto & new_detected_ball = tracked_frame.balls(i);
     // Ensure this ball isn't already effectively handled by a sensor-snapped track
     bool already_handled_by_sensor_snap = false;
-    if (
-      new_detected_ball.balls_size() >
-      0) {  // Check if balls_size() can be called on new_detected_ball
-      Eigen::Vector2d new_ball_vision_pos(new_detected_ball.pos().x(), new_detected_ball.pos().y());
-      for (const auto & track : active_ball_tracks_) {
-        if (track.sensor_updated_this_frame) {
-          Eigen::Vector4d sensor_updated_state = track.tracker->getState();
-          Eigen::Vector2d sensor_updated_pos(sensor_updated_state(0), sensor_updated_state(1));
-          if (
-            (new_ball_vision_pos - sensor_updated_pos).squaredNorm() <
-            (BALL_ASSOCIATION_THRESHOLD_DISTANCE * BALL_ASSOCIATION_THRESHOLD_DISTANCE)) {
-            already_handled_by_sensor_snap = true;
-            break;
-          }
+    if (new_detected_ball.balls_size() > 0) { // Check if balls_size() can be called on new_detected_ball
+        Eigen::Vector2d new_ball_vision_pos(new_detected_ball.pos().x(), new_detected_ball.pos().y());
+        for (const auto& track : active_ball_tracks_) {
+            if (track.sensor_updated_this_frame) {
+                Eigen::Vector4d sensor_updated_state = track.tracker->getState();
+                Eigen::Vector2d sensor_updated_pos(sensor_updated_state(0), sensor_updated_state(1));
+                if ((new_ball_vision_pos - sensor_updated_pos).squaredNorm() < (BALL_ASSOCIATION_THRESHOLD_DISTANCE * BALL_ASSOCIATION_THRESHOLD_DISTANCE)) {
+                    already_handled_by_sensor_snap = true;
+                    break;
+                }
+            }
         }
-      }
     }
 
+
     if (already_handled_by_sensor_snap) {
-      RCLCPP_DEBUG(
-        node.get_logger(),
-        "Skipping new vision track creation for ball near sensor-snapped track.");
-      continue;
+        RCLCPP_DEBUG(node.get_logger(), "Skipping new vision track creation for ball near sensor-snapped track.");
+        continue;
     }
 
     active_ball_tracks_.emplace_back(next_ball_track_id_++);
@@ -496,10 +490,12 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
       new_detected_ball.has_vel() ? new_detected_ball.vel().x() : 0.0,
       new_detected_ball.has_vel() ? new_detected_ball.vel().y() : 0.0);
     new_track.last_measurement_time = current_time;
-    new_track.vision_updated_this_frame = true;  // Mark as vision updated
+    new_track.vision_updated_this_frame = true; // Mark as vision updated
     new_track.last_measured_z = new_detected_ball.pos().z();
-    new_track.last_measured_vz = new_detected_ball.has_vel() ? new_detected_ball.vel().z() : 0.0;
-    RCLCPP_DEBUG(node.get_logger(), "Created new ball track ID %d from vision", new_track.track_id);
+    new_track.last_measured_vz =
+      new_detected_ball.has_vel() ? new_detected_ball.vel().z() : 0.0;
+    RCLCPP_DEBUG(
+      node.get_logger(), "Created new ball track ID %d from vision", new_track.track_id);
   }
 
   // E. Final Track Maintenance & Populate data.balls_info
@@ -518,31 +514,30 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
       ball_msg.velocity.x = state(2);
       ball_msg.velocity.y = state(3);
 
-      if (track.vision_updated_this_frame) {  // Prefer vision Z if available this frame
+      if (track.vision_updated_this_frame) { // Prefer vision Z if available this frame
         ball_msg.position.z = track.last_measured_z;
         ball_msg.velocity.z = track.last_measured_vz;
-      } else {  // Sensor update or purely predicted (but sensor was the trigger for "is_currently_considered_detected")
-        ball_msg.position.z = 0.0;  // Ball on ground if snapped by sensor
+      } else { // Sensor update or purely predicted (but sensor was the trigger for "is_currently_considered_detected")
+        ball_msg.position.z = 0.0; // Ball on ground if snapped by sensor
         ball_msg.velocity.z = 0.0;
       }
       ball_msg.velocity_norm = std::hypot(ball_msg.velocity.x, ball_msg.velocity.y);
       ball_msg.detected = true;
       data.balls_info.push_back(ball_msg);
       next_active_ball_tracks.push_back(std::move(track));
-    } else {  // Only predicted, not updated by vision or sensor this frame
-      if (
-        (current_time - track.last_measurement_time).seconds() <
-        BALL_DISAPPEARED_THRESHOLD_SECONDS) {
+    } else { // Only predicted, not updated by vision or sensor this frame
+      if ((current_time - track.last_measurement_time).seconds() <
+          BALL_DISAPPEARED_THRESHOLD_SECONDS) {
         crane_msgs::msg::BallInfo ball_msg;
         Eigen::Vector4d state = track.tracker->getState();
         ball_msg.position.x = state(0);
         ball_msg.position.y = state(1);
-        ball_msg.position.z = 0.0;  // Predicted, assume on ground
+        ball_msg.position.z = 0.0; // Predicted, assume on ground
         ball_msg.velocity.x = state(2);
         ball_msg.velocity.y = state(3);
-        ball_msg.velocity.z = 0.0;  // Predicted, assume no Z velocity
+        ball_msg.velocity.z = 0.0; // Predicted, assume no Z velocity
         ball_msg.velocity_norm = std::hypot(ball_msg.velocity.x, ball_msg.velocity.y);
-        ball_msg.detected = true;  // Still considered detected via prediction
+        ball_msg.detected = true; // Still considered detected via prediction
         data.balls_info.push_back(ball_msg);
         next_active_ball_tracks.push_back(std::move(track));
       } else {
@@ -766,7 +761,7 @@ crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
 
   // msg.ball_info = data.ball_info; // Old single ball info
   if (!data.balls_info.empty()) {
-    msg.ball_info = data.balls_info.front();  // Use the first ball for the singular msg.ball_info
+    msg.ball_info = data.balls_info.front(); // Use the first ball for the singular msg.ball_info
   } else {
     crane_msgs::msg::BallInfo default_ball;
     default_ball.detected = false;

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -47,13 +47,12 @@ auto createTransformMatrix(bool enable, bool is_positive_side, double field_widt
 }
 
 WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
-: node(node),
-  vis_data_handler(node)
-  // active_ball_tracks_ is default constructed
-  // next_ball_track_id_ is initialized in the header or here
+: node(node), vis_data_handler(node)
+// active_ball_tracks_ is default constructed
+// next_ball_track_id_ is initialized in the header or here
 {
-  next_ball_track_id_ = 0; // Explicitly initialize here
-  active_ball_tracks_.clear(); // Clear any default constructed elements, though likely empty
+  next_ball_track_id_ = 0;      // Explicitly initialize here
+  active_ball_tracks_.clear();  // Clear any default constructed elements, though likely empty
   using std::chrono_literals::operator""ms;
   node.declare_parameter("tracker_address", "224.5.23.2");
   node.declare_parameter("tracker_port", 11010);
@@ -383,8 +382,7 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
     }
 
     int best_detection_idx = -1;
-    double min_dist_sq =
-      BALL_ASSOCIATION_THRESHOLD_DISTANCE * BALL_ASSOCIATION_THRESHOLD_DISTANCE;
+    double min_dist_sq = BALL_ASSOCIATION_THRESHOLD_DISTANCE * BALL_ASSOCIATION_THRESHOLD_DISTANCE;
 
     Eigen::Vector4d predicted_state = track.tracker->getState();
     Eigen::Vector2d predicted_pos(predicted_state(0), predicted_state(1));
@@ -410,8 +408,7 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
       track.last_measurement_time = current_time;
       track.vision_updated_this_frame = true;
       track.last_measured_z = matched_detection.pos().z();
-      track.last_measured_vz =
-        matched_detection.has_vel() ? matched_detection.vel().z() : 0.0;
+      track.last_measured_vz = matched_detection.has_vel() ? matched_detection.vel().z() : 0.0;
       detection_assigned[best_detection_idx] = true;
     }
   }
@@ -419,18 +416,21 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
   // C. Robot Sensor Compensation (Snap existing predicted tracks)
   uint8_t our_team_color_idx = static_cast<uint8_t>(game_data.our_color);
   for (const auto & robot : data.robot_info[our_team_color_idx]) {
-    if (robot.ball_sensor && robot.detected && // ensure robot itself is detected
-        (current_time - robot.last_ball_sensor_stamp).seconds() < 0.5) {
+    if (
+      robot.ball_sensor && robot.detected &&  // ensure robot itself is detected
+      (current_time - robot.last_ball_sensor_stamp).seconds() < 0.5) {
       Eigen::Vector2d ball_pos_at_robot_eigen(
         robot.pose.x + std::cos(robot.pose.theta) * ROBOT_BALL_HOLDING_OFFSET,
         robot.pose.y + std::sin(robot.pose.theta) * ROBOT_BALL_HOLDING_OFFSET);
 
       ActiveBallTrack * best_track_to_snap = nullptr;
-      double min_dist_sq_sensor = ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD * ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD;
+      double min_dist_sq_sensor =
+        ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD * ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD;
 
       for (auto & track_candidate : active_ball_tracks_) {
-        if (!track_candidate.vision_updated_this_frame && // Don't snap if just updated by vision
-            track_candidate.tracker->isInitialized()) {
+        if (
+          !track_candidate.vision_updated_this_frame &&  // Don't snap if just updated by vision
+          track_candidate.tracker->isInitialized()) {
           Eigen::Vector4d kf_predicted_state = track_candidate.tracker->getState();
           Eigen::Vector2d kf_predicted_pos(kf_predicted_state(0), kf_predicted_state(1));
           double dist_sq = (kf_predicted_pos - ball_pos_at_robot_eigen).squaredNorm();
@@ -448,9 +448,10 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
           best_track_to_snap->track_id, robot.id);
         best_track_to_snap->tracker->update(ball_pos_at_robot_eigen, current_time);
         best_track_to_snap->sensor_updated_this_frame = true;
-        best_track_to_snap->last_measured_z = 0.0; // Ball on ground when held
+        best_track_to_snap->last_measured_z = 0.0;  // Ball on ground when held
         best_track_to_snap->last_measured_vz = 0.0;
-        best_track_to_snap->last_measurement_time = current_time; // Treat sensor update as a measurement
+        best_track_to_snap->last_measurement_time =
+          current_time;  // Treat sensor update as a measurement
       }
     }
   }
@@ -463,24 +464,29 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
     const auto & new_detected_ball = tracked_frame.balls(i);
     // Ensure this ball isn't already effectively handled by a sensor-snapped track
     bool already_handled_by_sensor_snap = false;
-    if (new_detected_ball.balls_size() > 0) { // Check if balls_size() can be called on new_detected_ball
-        Eigen::Vector2d new_ball_vision_pos(new_detected_ball.pos().x(), new_detected_ball.pos().y());
-        for (const auto& track : active_ball_tracks_) {
-            if (track.sensor_updated_this_frame) {
-                Eigen::Vector4d sensor_updated_state = track.tracker->getState();
-                Eigen::Vector2d sensor_updated_pos(sensor_updated_state(0), sensor_updated_state(1));
-                if ((new_ball_vision_pos - sensor_updated_pos).squaredNorm() < (BALL_ASSOCIATION_THRESHOLD_DISTANCE * BALL_ASSOCIATION_THRESHOLD_DISTANCE)) {
-                    already_handled_by_sensor_snap = true;
-                    break;
-                }
-            }
+    if (
+      new_detected_ball.balls_size() >
+      0) {  // Check if balls_size() can be called on new_detected_ball
+      Eigen::Vector2d new_ball_vision_pos(new_detected_ball.pos().x(), new_detected_ball.pos().y());
+      for (const auto & track : active_ball_tracks_) {
+        if (track.sensor_updated_this_frame) {
+          Eigen::Vector4d sensor_updated_state = track.tracker->getState();
+          Eigen::Vector2d sensor_updated_pos(sensor_updated_state(0), sensor_updated_state(1));
+          if (
+            (new_ball_vision_pos - sensor_updated_pos).squaredNorm() <
+            (BALL_ASSOCIATION_THRESHOLD_DISTANCE * BALL_ASSOCIATION_THRESHOLD_DISTANCE)) {
+            already_handled_by_sensor_snap = true;
+            break;
+          }
         }
+      }
     }
 
-
     if (already_handled_by_sensor_snap) {
-        RCLCPP_DEBUG(node.get_logger(), "Skipping new vision track creation for ball near sensor-snapped track.");
-        continue;
+      RCLCPP_DEBUG(
+        node.get_logger(),
+        "Skipping new vision track creation for ball near sensor-snapped track.");
+      continue;
     }
 
     active_ball_tracks_.emplace_back(next_ball_track_id_++);
@@ -490,12 +496,10 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
       new_detected_ball.has_vel() ? new_detected_ball.vel().x() : 0.0,
       new_detected_ball.has_vel() ? new_detected_ball.vel().y() : 0.0);
     new_track.last_measurement_time = current_time;
-    new_track.vision_updated_this_frame = true; // Mark as vision updated
+    new_track.vision_updated_this_frame = true;  // Mark as vision updated
     new_track.last_measured_z = new_detected_ball.pos().z();
-    new_track.last_measured_vz =
-      new_detected_ball.has_vel() ? new_detected_ball.vel().z() : 0.0;
-    RCLCPP_DEBUG(
-      node.get_logger(), "Created new ball track ID %d from vision", new_track.track_id);
+    new_track.last_measured_vz = new_detected_ball.has_vel() ? new_detected_ball.vel().z() : 0.0;
+    RCLCPP_DEBUG(node.get_logger(), "Created new ball track ID %d from vision", new_track.track_id);
   }
 
   // E. Final Track Maintenance & Populate data.balls_info
@@ -514,30 +518,31 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
       ball_msg.velocity.x = state(2);
       ball_msg.velocity.y = state(3);
 
-      if (track.vision_updated_this_frame) { // Prefer vision Z if available this frame
+      if (track.vision_updated_this_frame) {  // Prefer vision Z if available this frame
         ball_msg.position.z = track.last_measured_z;
         ball_msg.velocity.z = track.last_measured_vz;
-      } else { // Sensor update or purely predicted (but sensor was the trigger for "is_currently_considered_detected")
-        ball_msg.position.z = 0.0; // Ball on ground if snapped by sensor
+      } else {  // Sensor update or purely predicted (but sensor was the trigger for "is_currently_considered_detected")
+        ball_msg.position.z = 0.0;  // Ball on ground if snapped by sensor
         ball_msg.velocity.z = 0.0;
       }
       ball_msg.velocity_norm = std::hypot(ball_msg.velocity.x, ball_msg.velocity.y);
       ball_msg.detected = true;
       data.balls_info.push_back(ball_msg);
       next_active_ball_tracks.push_back(std::move(track));
-    } else { // Only predicted, not updated by vision or sensor this frame
-      if ((current_time - track.last_measurement_time).seconds() <
-          BALL_DISAPPEARED_THRESHOLD_SECONDS) {
+    } else {  // Only predicted, not updated by vision or sensor this frame
+      if (
+        (current_time - track.last_measurement_time).seconds() <
+        BALL_DISAPPEARED_THRESHOLD_SECONDS) {
         crane_msgs::msg::BallInfo ball_msg;
         Eigen::Vector4d state = track.tracker->getState();
         ball_msg.position.x = state(0);
         ball_msg.position.y = state(1);
-        ball_msg.position.z = 0.0; // Predicted, assume on ground
+        ball_msg.position.z = 0.0;  // Predicted, assume on ground
         ball_msg.velocity.x = state(2);
         ball_msg.velocity.y = state(3);
-        ball_msg.velocity.z = 0.0; // Predicted, assume no Z velocity
+        ball_msg.velocity.z = 0.0;  // Predicted, assume no Z velocity
         ball_msg.velocity_norm = std::hypot(ball_msg.velocity.x, ball_msg.velocity.y);
-        ball_msg.detected = true; // Still considered detected via prediction
+        ball_msg.detected = true;  // Still considered detected via prediction
         data.balls_info.push_back(ball_msg);
         next_active_ball_tracks.push_back(std::move(track));
       } else {
@@ -761,7 +766,7 @@ crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
 
   // msg.ball_info = data.ball_info; // Old single ball info
   if (!data.balls_info.empty()) {
-    msg.ball_info = data.balls_info.front(); // Use the first ball for the singular msg.ball_info
+    msg.ball_info = data.balls_info.front();  // Use the first ball for the singular msg.ball_info
   } else {
     crane_msgs::msg::BallInfo default_ball;
     default_ball.detected = false;

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -47,8 +47,13 @@ auto createTransformMatrix(bool enable, bool is_positive_side, double field_widt
 }
 
 WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
-: node(node), vis_data_handler(node)
+: node(node),
+  vis_data_handler(node)
+  // active_ball_tracks_ is default constructed
+  // next_ball_track_id_ is initialized in the header or here
 {
+  next_ball_track_id_ = 0; // Explicitly initialize here
+  active_ball_tracks_.clear(); // Clear any default constructed elements, though likely empty
   using std::chrono_literals::operator""ms;
   node.declare_parameter("tracker_address", "224.5.23.2");
   node.declare_parameter("tracker_port", 11010);
@@ -336,33 +341,212 @@ auto WorldModelDataProvider::trackerCallback(const TrackedFrame & tracked_frame)
     }
   }
 
-  if (not tracked_frame.balls().empty()) {
-    auto ball = [&]() {
-      for (const auto & tracked_ball : tracked_frame.balls()) {
-        Eigen::Vector3d position{tracked_ball.pos().x(), tracked_ball.pos().y(), 1.0};
-        Eigen::Vector3d transformed_pos = transform_matrix * position;
-        if (isInBox(area_mask, {transformed_pos.x(), transformed_pos.y()})) {
-          return tracked_ball;
-        }
-      }
-      // 範囲内のボールがないときは仕方なく範囲外のものを参照
-      return *tracked_frame.balls().begin();
-    }();
+  // --- Start of new multi-ball logic placeholder in trackerCallback ---
+  // Clear previous frame's ball data
+  data.balls_info.clear();
 
-    // トラッカーコールバックではアフィン変換は適用せず、そのまま値を設定
-    // 後でgetMsgで一括変換するようにする
-    data.ball_info.position.x = ball.pos().x();
-    data.ball_info.position.y = ball.pos().y();
-    data.ball_info.position.z = ball.pos().z();
+  // The actual multi-ball tracking logic (association, new track creation, prediction, update)
+  // will be implemented in the next subtask.
+  // For now, this callback will be mostly empty regarding ball processing,
+  // or it might process the first ball using the old single-ball logic
+  // temporarily if we want to keep some functionality.
+  // However, the subtask asks to modify structures, so we'll assume the old logic is
+  // effectively removed from here and will be replaced.
 
-    if (ball.has_vel()) {
-      data.ball_info.velocity.x = ball.vel().x();
-      data.ball_info.velocity.y = ball.vel().y();
-      data.ball_info.velocity.z = ball.vel().z();
-      data.ball_info.velocity_norm =
-        std::hypot(data.ball_info.velocity.x, data.ball_info.velocity.y);
+  // --- End of new multi-ball logic placeholder ---
+
+  // Example: For now, to ensure data.balls_info is populated for getMsg,
+  // we can add a dummy ball if needed, or ensure getMsg handles empty data.balls_info.
+  // The current getMsg handles empty data.balls_info by creating a default ball.
+  // So, no specific action is needed here for this subtask if trackerCallback's detailed
+  // logic for multi-ball is deferred.
+
+  // Old single ball KF logic is removed as per plan.
+  // The new multi-ball logic will be added in the next subtask.
+  // For this subtask, we ensure the structure is changed and compiles.
+
+  // A. Predict Step
+  for (auto & track : active_ball_tracks_) {
+    track.vision_updated_this_frame = false;
+    track.sensor_updated_this_frame = false;
+    if (track.tracker->isInitialized()) {
+      track.tracker->predict(current_time);
     }
   }
+
+  std::vector<bool> detection_assigned(tracked_frame.balls_size(), false);
+
+  // B. Vision-based Association & Update
+  for (auto & track : active_ball_tracks_) {
+    if (!track.tracker->isInitialized()) {
+      continue;
+    }
+
+    int best_detection_idx = -1;
+    double min_dist_sq =
+      BALL_ASSOCIATION_THRESHOLD_DISTANCE * BALL_ASSOCIATION_THRESHOLD_DISTANCE;
+
+    Eigen::Vector4d predicted_state = track.tracker->getState();
+    Eigen::Vector2d predicted_pos(predicted_state(0), predicted_state(1));
+
+    for (int i = 0; i < tracked_frame.balls_size(); ++i) {
+      if (detection_assigned[i]) {
+        continue;
+      }
+      const auto & detected_ball = tracked_frame.balls(i);
+      Eigen::Vector2d measured_pos(detected_ball.pos().x(), detected_ball.pos().y());
+      double dist_sq = (measured_pos - predicted_pos).squaredNorm();
+
+      if (dist_sq < min_dist_sq) {
+        min_dist_sq = dist_sq;
+        best_detection_idx = i;
+      }
+    }
+
+    if (best_detection_idx != -1) {
+      const auto & matched_detection = tracked_frame.balls(best_detection_idx);
+      Eigen::Vector2d measurement(matched_detection.pos().x(), matched_detection.pos().y());
+      track.tracker->update(measurement, current_time);
+      track.last_measurement_time = current_time;
+      track.vision_updated_this_frame = true;
+      track.last_measured_z = matched_detection.pos().z();
+      track.last_measured_vz =
+        matched_detection.has_vel() ? matched_detection.vel().z() : 0.0;
+      detection_assigned[best_detection_idx] = true;
+    }
+  }
+
+  // C. Robot Sensor Compensation (Snap existing predicted tracks)
+  uint8_t our_team_color_idx = static_cast<uint8_t>(game_data.our_color);
+  for (const auto & robot : data.robot_info[our_team_color_idx]) {
+    if (robot.ball_sensor && robot.detected && // ensure robot itself is detected
+        (current_time - robot.last_ball_sensor_stamp).seconds() < 0.5) {
+      Eigen::Vector2d ball_pos_at_robot_eigen(
+        robot.pose.x + std::cos(robot.pose.theta) * ROBOT_BALL_HOLDING_OFFSET,
+        robot.pose.y + std::sin(robot.pose.theta) * ROBOT_BALL_HOLDING_OFFSET);
+
+      ActiveBallTrack * best_track_to_snap = nullptr;
+      double min_dist_sq_sensor = ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD * ROBOT_POSSESSION_SNAP_DISTANCE_THRESHOLD;
+
+      for (auto & track_candidate : active_ball_tracks_) {
+        if (!track_candidate.vision_updated_this_frame && // Don't snap if just updated by vision
+            track_candidate.tracker->isInitialized()) {
+          Eigen::Vector4d kf_predicted_state = track_candidate.tracker->getState();
+          Eigen::Vector2d kf_predicted_pos(kf_predicted_state(0), kf_predicted_state(1));
+          double dist_sq = (kf_predicted_pos - ball_pos_at_robot_eigen).squaredNorm();
+
+          if (dist_sq < min_dist_sq_sensor) {
+            min_dist_sq_sensor = dist_sq;
+            best_track_to_snap = &track_candidate;
+          }
+        }
+      }
+
+      if (best_track_to_snap) {
+        RCLCPP_DEBUG(
+          node.get_logger(), "Snapping track ID %d to robot %d by sensor.",
+          best_track_to_snap->track_id, robot.id);
+        best_track_to_snap->tracker->update(ball_pos_at_robot_eigen, current_time);
+        best_track_to_snap->sensor_updated_this_frame = true;
+        best_track_to_snap->last_measured_z = 0.0; // Ball on ground when held
+        best_track_to_snap->last_measured_vz = 0.0;
+        best_track_to_snap->last_measurement_time = current_time; // Treat sensor update as a measurement
+      }
+    }
+  }
+
+  // D. New Vision Track Creation
+  for (int i = 0; i < tracked_frame.balls_size(); ++i) {
+    if (detection_assigned[i]) {
+      continue;
+    }
+    const auto & new_detected_ball = tracked_frame.balls(i);
+    // Ensure this ball isn't already effectively handled by a sensor-snapped track
+    bool already_handled_by_sensor_snap = false;
+    if (new_detected_ball.balls_size() > 0) { // Check if balls_size() can be called on new_detected_ball
+        Eigen::Vector2d new_ball_vision_pos(new_detected_ball.pos().x(), new_detected_ball.pos().y());
+        for (const auto& track : active_ball_tracks_) {
+            if (track.sensor_updated_this_frame) {
+                Eigen::Vector4d sensor_updated_state = track.tracker->getState();
+                Eigen::Vector2d sensor_updated_pos(sensor_updated_state(0), sensor_updated_state(1));
+                if ((new_ball_vision_pos - sensor_updated_pos).squaredNorm() < (BALL_ASSOCIATION_THRESHOLD_DISTANCE * BALL_ASSOCIATION_THRESHOLD_DISTANCE)) {
+                    already_handled_by_sensor_snap = true;
+                    break;
+                }
+            }
+        }
+    }
+
+
+    if (already_handled_by_sensor_snap) {
+        RCLCPP_DEBUG(node.get_logger(), "Skipping new vision track creation for ball near sensor-snapped track.");
+        continue;
+    }
+
+    active_ball_tracks_.emplace_back(next_ball_track_id_++);
+    auto & new_track = active_ball_tracks_.back();
+    new_track.tracker->init(
+      current_time, new_detected_ball.pos().x(), new_detected_ball.pos().y(),
+      new_detected_ball.has_vel() ? new_detected_ball.vel().x() : 0.0,
+      new_detected_ball.has_vel() ? new_detected_ball.vel().y() : 0.0);
+    new_track.last_measurement_time = current_time;
+    new_track.vision_updated_this_frame = true; // Mark as vision updated
+    new_track.last_measured_z = new_detected_ball.pos().z();
+    new_track.last_measured_vz =
+      new_detected_ball.has_vel() ? new_detected_ball.vel().z() : 0.0;
+    RCLCPP_DEBUG(
+      node.get_logger(), "Created new ball track ID %d from vision", new_track.track_id);
+  }
+
+  // E. Final Track Maintenance & Populate data.balls_info
+  std::vector<ActiveBallTrack> next_active_ball_tracks;
+  next_active_ball_tracks.reserve(active_ball_tracks_.size());
+
+  for (auto & track : active_ball_tracks_) {
+    bool is_currently_considered_detected =
+      track.vision_updated_this_frame || track.sensor_updated_this_frame;
+
+    if (is_currently_considered_detected) {
+      crane_msgs::msg::BallInfo ball_msg;
+      Eigen::Vector4d state = track.tracker->getState();
+      ball_msg.position.x = state(0);
+      ball_msg.position.y = state(1);
+      ball_msg.velocity.x = state(2);
+      ball_msg.velocity.y = state(3);
+
+      if (track.vision_updated_this_frame) { // Prefer vision Z if available this frame
+        ball_msg.position.z = track.last_measured_z;
+        ball_msg.velocity.z = track.last_measured_vz;
+      } else { // Sensor update or purely predicted (but sensor was the trigger for "is_currently_considered_detected")
+        ball_msg.position.z = 0.0; // Ball on ground if snapped by sensor
+        ball_msg.velocity.z = 0.0;
+      }
+      ball_msg.velocity_norm = std::hypot(ball_msg.velocity.x, ball_msg.velocity.y);
+      ball_msg.detected = true;
+      data.balls_info.push_back(ball_msg);
+      next_active_ball_tracks.push_back(std::move(track));
+    } else { // Only predicted, not updated by vision or sensor this frame
+      if ((current_time - track.last_measurement_time).seconds() <
+          BALL_DISAPPEARED_THRESHOLD_SECONDS) {
+        crane_msgs::msg::BallInfo ball_msg;
+        Eigen::Vector4d state = track.tracker->getState();
+        ball_msg.position.x = state(0);
+        ball_msg.position.y = state(1);
+        ball_msg.position.z = 0.0; // Predicted, assume on ground
+        ball_msg.velocity.x = state(2);
+        ball_msg.velocity.y = state(3);
+        ball_msg.velocity.z = 0.0; // Predicted, assume no Z velocity
+        ball_msg.velocity_norm = std::hypot(ball_msg.velocity.x, ball_msg.velocity.y);
+        ball_msg.detected = true; // Still considered detected via prediction
+        data.balls_info.push_back(ball_msg);
+        next_active_ball_tracks.push_back(std::move(track));
+      } else {
+        RCLCPP_DEBUG(
+          node.get_logger(), "Removed ball track ID %d due to disappearance.", track.track_id);
+      }
+    }
+  }
+  active_ball_tracks_ = std::move(next_active_ball_tracks);
 }
 
 auto WorldModelDataProvider::visionGeometryCallback(const SSL_GeometryData & geometry_data) -> void
@@ -575,7 +759,15 @@ crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
   msg.our_max_allowed_bots = game_data.our_max_allowed_bots;
   msg.their_max_allowed_bots = game_data.their_max_allowed_bots;
 
-  msg.ball_info = data.ball_info;
+  // msg.ball_info = data.ball_info; // Old single ball info
+  if (!data.balls_info.empty()) {
+    msg.ball_info = data.balls_info.front(); // Use the first ball for the singular msg.ball_info
+  } else {
+    crane_msgs::msg::BallInfo default_ball;
+    default_ball.detected = false;
+    // default_ball.position, velocity etc will be zero-initialized
+    msg.ball_info = default_ball;
+  }
 
   for (auto & robot : data.robot_info[0]) {
     robot.detected = robot.vision_detected or robot.feedback_detected;

--- a/crane_world_model_publisher/test/test_ball_tracker.cpp
+++ b/crane_world_model_publisher/test/test_ball_tracker.cpp
@@ -1,157 +1,145 @@
 #include <gtest/gtest.h>
-
-#include <rclcpp/rclcpp.hpp>  // For rclcpp::Time
-
 #include "crane_world_model_publisher/ball_tracker.hpp"
+#include <rclcpp/rclcpp.hpp> // For rclcpp::Time
 
 // Test fixture for BallTracker tests
-class BallTrackerTest : public ::testing::Test
-{
+class BallTrackerTest : public ::testing::Test {
 protected:
-  crane::BallTracker tracker;
-  rclcpp::Time t0;
-  rclcpp::Clock ros_clock;  // Member to ensure lifetime
+    crane::BallTracker tracker;
+    rclcpp::Time t0;
+    rclcpp::Clock ros_clock; // Member to ensure lifetime
 
-  BallTrackerTest() : t0(0, 0, RCL_ROS_TIME), ros_clock(RCL_ROS_TIME)
-  {
-    // It's good practice to initialize rclcpp if it's not already,
-    // especially when using rclcpp::Time.
-    // However, in a gtest environment, rclcpp::init might be called by the test runner
-    // if it's an ament_add_gtest target.
-    t0 = ros_clock.now();
-  }
-
-  // Helper to compare Eigen matrices/vectors with a tolerance
-  void expect_eigen_almost_equal(
-    const Eigen::MatrixXd & actual, const Eigen::MatrixXd & expected, double tolerance = 1e-5)
-  {
-    ASSERT_EQ(actual.rows(), expected.rows());
-    ASSERT_EQ(actual.cols(), expected.cols());
-    for (int i = 0; i < actual.rows(); ++i) {
-      for (int j = 0; j < actual.cols(); ++j) {
-        EXPECT_NEAR(actual(i, j), expected(i, j), tolerance);
-      }
+    BallTrackerTest() : t0(0, 0, RCL_ROS_TIME), ros_clock(RCL_ROS_TIME) {
+         // It's good practice to initialize rclcpp if it's not already,
+         // especially when using rclcpp::Time.
+         // However, in a gtest environment, rclcpp::init might be called by the test runner
+         // if it's an ament_add_gtest target.
+        t0 = ros_clock.now();
     }
-  }
+
+    // Helper to compare Eigen matrices/vectors with a tolerance
+    void expect_eigen_almost_equal(const Eigen::MatrixXd& actual, const Eigen::MatrixXd& expected, double tolerance = 1e-5) {
+        ASSERT_EQ(actual.rows(), expected.rows());
+        ASSERT_EQ(actual.cols(), expected.cols());
+        for (int i = 0; i < actual.rows(); ++i) {
+            for (int j = 0; j < actual.cols(); ++j) {
+                EXPECT_NEAR(actual(i, j), expected(i, j), tolerance);
+            }
+        }
+    }
 };
 
-TEST_F(BallTrackerTest, Initialization)
-{
-  tracker.init(t0, 1.0, 2.0, 0.5, -0.5);
-  ASSERT_TRUE(tracker.isInitialized());
-  Eigen::Vector4d expected_state;
-  expected_state << 1.0, 2.0, 0.5, -0.5;
-  expect_eigen_almost_equal(tracker.getState(), expected_state);
+TEST_F(BallTrackerTest, Initialization) {
+    tracker.init(t0, 1.0, 2.0, 0.5, -0.5);
+    ASSERT_TRUE(tracker.isInitialized());
+    Eigen::Vector4d expected_state;
+    expected_state << 1.0, 2.0, 0.5, -0.5;
+    expect_eigen_almost_equal(tracker.getState(), expected_state);
 
-  // Check that initial covariance is not zero (P_k_ is set in init)
-  ASSERT_GT(tracker.getCovariance()(0, 0), 0.0);
+    // Check that initial covariance is not zero (P_k_ is set in init)
+    ASSERT_GT(tracker.getCovariance()(0,0), 0.0);
 }
 
-TEST_F(BallTrackerTest, PredictConstantVelocity)
-{
-  tracker.init(t0, 0.0, 0.0, 1.0, 2.0);  // vx=1, vy=2
+TEST_F(BallTrackerTest, PredictConstantVelocity) {
+    tracker.init(t0, 0.0, 0.0, 1.0, 2.0); // vx=1, vy=2
 
-  rclcpp::Time t1 = t0 + rclcpp::Duration(1, 0);  // 1 second later
-  tracker.predict(t1);
+    rclcpp::Time t1 = t0 + rclcpp::Duration(1, 0); // 1 second later
+    tracker.predict(t1);
 
-  Eigen::Vector4d predicted_state = tracker.getState();
-  // Expected: x = 0 + 1*1 = 1, y = 0 + 2*1 = 2, vx=1, vy=2
-  Eigen::Vector4d expected_state;
-  expected_state << 1.0, 2.0, 1.0, 2.0;
-  // Increased tolerance due to process noise Q_k effect over 1s
-  expect_eigen_almost_equal(predicted_state, expected_state, 0.2);
+    Eigen::Vector4d predicted_state = tracker.getState();
+    // Expected: x = 0 + 1*1 = 1, y = 0 + 2*1 = 2, vx=1, vy=2
+    Eigen::Vector4d expected_state;
+    expected_state << 1.0, 2.0, 1.0, 2.0;
+    // Increased tolerance due to process noise Q_k effect over 1s
+    expect_eigen_almost_equal(predicted_state, expected_state, 0.2);
 }
 
-TEST_F(BallTrackerTest, PredictIncreasesCovariance)
-{
-  tracker.init(t0, 0.0, 0.0, 0.0, 0.0);
-  Eigen::Matrix4d P0 = tracker.getCovariance();
+TEST_F(BallTrackerTest, PredictIncreasesCovariance) {
+    tracker.init(t0, 0.0, 0.0, 0.0, 0.0);
+    Eigen::Matrix4d P0 = tracker.getCovariance();
 
-  rclcpp::Time t1 = t0 + rclcpp::Duration(1, 0);
-  tracker.predict(t1);
-  Eigen::Matrix4d P1 = tracker.getCovariance();
+    rclcpp::Time t1 = t0 + rclcpp::Duration(1, 0);
+    tracker.predict(t1);
+    Eigen::Matrix4d P1 = tracker.getCovariance();
 
-  // P_k = F_k * P_{k-1} * F_k' + Q_k
-  // Since Q_k is positive semi-definite and non-zero, trace of P should increase.
-  ASSERT_GT(P1.trace(), P0.trace() - 1e-5);  // trace(P1) should be > trace(P0)
+    // P_k = F_k * P_{k-1} * F_k' + Q_k
+    // Since Q_k is positive semi-definite and non-zero, trace of P should increase.
+    ASSERT_GT(P1.trace(), P0.trace() - 1e-5); // trace(P1) should be > trace(P0)
 }
 
-TEST_F(BallTrackerTest, UpdateReducesCovariance)
-{
-  tracker.init(t0, 0.0, 0.0, 1.0, 0.0);  // Moving along x-axis
 
-  rclcpp::Time t_predict = t0 + rclcpp::Duration(1, 0);  // Predict 1s
-  tracker.predict(t_predict);
-  Eigen::Matrix4d P_predicted = tracker.getCovariance();
+TEST_F(BallTrackerTest, UpdateReducesCovariance) {
+    tracker.init(t0, 0.0, 0.0, 1.0, 0.0); // Moving along x-axis
 
-  Eigen::Vector2d measurement(0.9, 0.1);   // Measurement slightly off from prediction (1.0, 0.0)
-  rclcpp::Time t_measurement = t_predict;  // Measurement at the same time as prediction
-  tracker.update(measurement, t_measurement);
-  Eigen::Matrix4d P_updated = tracker.getCovariance();
+    rclcpp::Time t_predict = t0 + rclcpp::Duration(1,0); // Predict 1s
+    tracker.predict(t_predict);
+    Eigen::Matrix4d P_predicted = tracker.getCovariance();
 
-  // Sum of diagonal elements (trace) should typically decrease after update with reasonable R
-  ASSERT_LT(P_updated.trace(), P_predicted.trace() + 1e-5);
+    Eigen::Vector2d measurement(0.9, 0.1); // Measurement slightly off from prediction (1.0, 0.0)
+    rclcpp::Time t_measurement = t_predict; // Measurement at the same time as prediction
+    tracker.update(measurement, t_measurement);
+    Eigen::Matrix4d P_updated = tracker.getCovariance();
+
+    // Sum of diagonal elements (trace) should typically decrease after update with reasonable R
+    ASSERT_LT(P_updated.trace(), P_predicted.trace() + 1e-5);
 }
 
-TEST_F(BallTrackerTest, StateConvergesWithUpdates)
-{
-  // Initialize tracker with a somewhat off state
-  tracker.init(t0, 0.1, -0.1, 0.1, 0.1);
+TEST_F(BallTrackerTest, StateConvergesWithUpdates) {
+    // Initialize tracker with a somewhat off state
+    tracker.init(t0, 0.1, -0.1, 0.1, 0.1);
 
-  Eigen::Vector2d true_ball_pos(0.0, 0.0);
-  double true_vx = 0.5;  // m/s
-  double true_vy = 0.2;  // m/s
-  double dt_secs = 0.1;  // 100ms per step
-  rclcpp::Duration dt_duration = rclcpp::Duration::from_seconds(dt_secs);
+    Eigen::Vector2d true_ball_pos(0.0, 0.0);
+    double true_vx = 0.5; // m/s
+    double true_vy = 0.2; // m/s
+    double dt_secs = 0.1;   // 100ms per step
+    rclcpp::Duration dt_duration = rclcpp::Duration::from_seconds(dt_secs);
 
-  rclcpp::Time current_tracker_time = t0;
+    rclcpp::Time current_tracker_time = t0;
 
-  // Simulate a few steps
-  for (int i = 0; i < 20; ++i) {  // Increased steps for convergence
-    current_tracker_time = t0 + rclcpp::Duration::from_seconds(i * dt_secs);
+    // Simulate a few steps
+    for (int i = 0; i < 20; ++i) { // Increased steps for convergence
+        current_tracker_time = t0 + rclcpp::Duration::from_seconds(i * dt_secs);
 
-    true_ball_pos(0) += true_vx * dt_secs;
-    true_ball_pos(1) += true_vy * dt_secs;
+        true_ball_pos(0) += true_vx * dt_secs;
+        true_ball_pos(1) += true_vy * dt_secs;
 
-    Eigen::Vector2d measurement = true_ball_pos;
+        Eigen::Vector2d measurement = true_ball_pos;
 
-    // Predict to current measurement time, then update.
-    // BallTracker's update method internally calls predict if time has advanced.
-    tracker.update(measurement, current_tracker_time);
-  }
+        // Predict to current measurement time, then update.
+        // BallTracker's update method internally calls predict if time has advanced.
+        tracker.update(measurement, current_tracker_time);
+    }
 
-  Eigen::Vector4d final_state = tracker.getState();
-  EXPECT_NEAR(final_state(0), true_ball_pos(0), 0.15);  // Check X pos
-  EXPECT_NEAR(final_state(1), true_ball_pos(1), 0.15);  // Check Y pos
-  EXPECT_NEAR(final_state(2), true_vx, 0.15);           // Check Vx
-  EXPECT_NEAR(final_state(3), true_vy, 0.15);           // Check Vy
+    Eigen::Vector4d final_state = tracker.getState();
+    EXPECT_NEAR(final_state(0), true_ball_pos(0), 0.15); // Check X pos
+    EXPECT_NEAR(final_state(1), true_ball_pos(1), 0.15); // Check Y pos
+    EXPECT_NEAR(final_state(2), true_vx, 0.15);           // Check Vx
+    EXPECT_NEAR(final_state(3), true_vy, 0.15);           // Check Vy
 }
 
-TEST_F(BallTrackerTest, PredictWithNegativeDt)
-{
-  tracker.init(t0, 1.0, 2.0, 0.5, -0.5);
-  Eigen::Vector4d initial_state = tracker.getState();
-  Eigen::Matrix4d initial_covariance = tracker.getCovariance();
+TEST_F(BallTrackerTest, PredictWithNegativeDt) {
+    tracker.init(t0, 1.0, 2.0, 0.5, -0.5);
+    Eigen::Vector4d initial_state = tracker.getState();
+    Eigen::Matrix4d initial_covariance = tracker.getCovariance();
 
-  rclcpp::Time t_minus_1 = t0 - rclcpp::Duration(1, 0);
-  tracker.predict(t_minus_1);
+    rclcpp::Time t_minus_1 = t0 - rclcpp::Duration(1,0);
+    tracker.predict(t_minus_1);
 
-  Eigen::Vector4d state_after_neg_dt = tracker.getState();
-  Eigen::Matrix4d cov_after_neg_dt = tracker.getCovariance();
+    Eigen::Vector4d state_after_neg_dt = tracker.getState();
+    Eigen::Matrix4d cov_after_neg_dt = tracker.getCovariance();
 
-  // Expect state and covariance to be unchanged as dt will be clamped to 0
-  expect_eigen_almost_equal(state_after_neg_dt, initial_state, 1e-5);
-  expect_eigen_almost_equal(cov_after_neg_dt, initial_covariance, 1e-5);
+    // Expect state and covariance to be unchanged as dt will be clamped to 0
+    expect_eigen_almost_equal(state_after_neg_dt, initial_state, 1e-5);
+    expect_eigen_almost_equal(cov_after_neg_dt, initial_covariance, 1e-5);
 }
 
 // Main function for running tests (needed for GTest)
-int main(int argc, char ** argv)
-{
-  rclcpp::init(0, nullptr);  // Initialize rclcpp for rclcpp::Time
-  ::testing::InitGoogleTest(&argc, argv);
-  int result = RUN_ALL_TESTS();
-  rclcpp::shutdown();
-  return result;
+int main(int argc, char **argv) {
+    rclcpp::init(0, nullptr); // Initialize rclcpp for rclcpp::Time
+    ::testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    rclcpp::shutdown();
+    return result;
 }
 
 ```

--- a/crane_world_model_publisher/test/test_ball_tracker.cpp
+++ b/crane_world_model_publisher/test/test_ball_tracker.cpp
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+#include "crane_world_model_publisher/ball_tracker.hpp"
+#include <rclcpp/rclcpp.hpp> // For rclcpp::Time
+
+// Test fixture for BallTracker tests
+class BallTrackerTest : public ::testing::Test {
+protected:
+    crane::BallTracker tracker;
+    rclcpp::Time t0;
+    rclcpp::Clock ros_clock; // Member to ensure lifetime
+
+    BallTrackerTest() : t0(0, 0, RCL_ROS_TIME), ros_clock(RCL_ROS_TIME) {
+         // It's good practice to initialize rclcpp if it's not already,
+         // especially when using rclcpp::Time.
+         // However, in a gtest environment, rclcpp::init might be called by the test runner
+         // if it's an ament_add_gtest target.
+        t0 = ros_clock.now();
+    }
+
+    // Helper to compare Eigen matrices/vectors with a tolerance
+    void expect_eigen_almost_equal(const Eigen::MatrixXd& actual, const Eigen::MatrixXd& expected, double tolerance = 1e-5) {
+        ASSERT_EQ(actual.rows(), expected.rows());
+        ASSERT_EQ(actual.cols(), expected.cols());
+        for (int i = 0; i < actual.rows(); ++i) {
+            for (int j = 0; j < actual.cols(); ++j) {
+                EXPECT_NEAR(actual(i, j), expected(i, j), tolerance);
+            }
+        }
+    }
+};
+
+TEST_F(BallTrackerTest, Initialization) {
+    tracker.init(t0, 1.0, 2.0, 0.5, -0.5);
+    ASSERT_TRUE(tracker.isInitialized());
+    Eigen::Vector4d expected_state;
+    expected_state << 1.0, 2.0, 0.5, -0.5;
+    expect_eigen_almost_equal(tracker.getState(), expected_state);
+
+    // Check that initial covariance is not zero (P_k_ is set in init)
+    ASSERT_GT(tracker.getCovariance()(0,0), 0.0);
+}
+
+TEST_F(BallTrackerTest, PredictConstantVelocity) {
+    tracker.init(t0, 0.0, 0.0, 1.0, 2.0); // vx=1, vy=2
+
+    rclcpp::Time t1 = t0 + rclcpp::Duration(1, 0); // 1 second later
+    tracker.predict(t1);
+
+    Eigen::Vector4d predicted_state = tracker.getState();
+    // Expected: x = 0 + 1*1 = 1, y = 0 + 2*1 = 2, vx=1, vy=2
+    Eigen::Vector4d expected_state;
+    expected_state << 1.0, 2.0, 1.0, 2.0;
+    // Increased tolerance due to process noise Q_k effect over 1s
+    expect_eigen_almost_equal(predicted_state, expected_state, 0.2);
+}
+
+TEST_F(BallTrackerTest, PredictIncreasesCovariance) {
+    tracker.init(t0, 0.0, 0.0, 0.0, 0.0);
+    Eigen::Matrix4d P0 = tracker.getCovariance();
+
+    rclcpp::Time t1 = t0 + rclcpp::Duration(1, 0);
+    tracker.predict(t1);
+    Eigen::Matrix4d P1 = tracker.getCovariance();
+
+    // P_k = F_k * P_{k-1} * F_k' + Q_k
+    // Since Q_k is positive semi-definite and non-zero, trace of P should increase.
+    ASSERT_GT(P1.trace(), P0.trace() - 1e-5); // trace(P1) should be > trace(P0)
+}
+
+
+TEST_F(BallTrackerTest, UpdateReducesCovariance) {
+    tracker.init(t0, 0.0, 0.0, 1.0, 0.0); // Moving along x-axis
+
+    rclcpp::Time t_predict = t0 + rclcpp::Duration(1,0); // Predict 1s
+    tracker.predict(t_predict);
+    Eigen::Matrix4d P_predicted = tracker.getCovariance();
+
+    Eigen::Vector2d measurement(0.9, 0.1); // Measurement slightly off from prediction (1.0, 0.0)
+    rclcpp::Time t_measurement = t_predict; // Measurement at the same time as prediction
+    tracker.update(measurement, t_measurement);
+    Eigen::Matrix4d P_updated = tracker.getCovariance();
+
+    // Sum of diagonal elements (trace) should typically decrease after update with reasonable R
+    ASSERT_LT(P_updated.trace(), P_predicted.trace() + 1e-5);
+}
+
+TEST_F(BallTrackerTest, StateConvergesWithUpdates) {
+    // Initialize tracker with a somewhat off state
+    tracker.init(t0, 0.1, -0.1, 0.1, 0.1);
+
+    Eigen::Vector2d true_ball_pos(0.0, 0.0);
+    double true_vx = 0.5; // m/s
+    double true_vy = 0.2; // m/s
+    double dt_secs = 0.1;   // 100ms per step
+    rclcpp::Duration dt_duration = rclcpp::Duration::from_seconds(dt_secs);
+
+    rclcpp::Time current_tracker_time = t0;
+
+    // Simulate a few steps
+    for (int i = 0; i < 20; ++i) { // Increased steps for convergence
+        current_tracker_time = t0 + rclcpp::Duration::from_seconds(i * dt_secs);
+
+        true_ball_pos(0) += true_vx * dt_secs;
+        true_ball_pos(1) += true_vy * dt_secs;
+
+        Eigen::Vector2d measurement = true_ball_pos;
+
+        // Predict to current measurement time, then update.
+        // BallTracker's update method internally calls predict if time has advanced.
+        tracker.update(measurement, current_tracker_time);
+    }
+
+    Eigen::Vector4d final_state = tracker.getState();
+    EXPECT_NEAR(final_state(0), true_ball_pos(0), 0.15); // Check X pos
+    EXPECT_NEAR(final_state(1), true_ball_pos(1), 0.15); // Check Y pos
+    EXPECT_NEAR(final_state(2), true_vx, 0.15);           // Check Vx
+    EXPECT_NEAR(final_state(3), true_vy, 0.15);           // Check Vy
+}
+
+TEST_F(BallTrackerTest, PredictWithNegativeDt) {
+    tracker.init(t0, 1.0, 2.0, 0.5, -0.5);
+    Eigen::Vector4d initial_state = tracker.getState();
+    Eigen::Matrix4d initial_covariance = tracker.getCovariance();
+
+    rclcpp::Time t_minus_1 = t0 - rclcpp::Duration(1,0);
+    tracker.predict(t_minus_1);
+
+    Eigen::Vector4d state_after_neg_dt = tracker.getState();
+    Eigen::Matrix4d cov_after_neg_dt = tracker.getCovariance();
+
+    // Expect state and covariance to be unchanged as dt will be clamped to 0
+    expect_eigen_almost_equal(state_after_neg_dt, initial_state, 1e-5);
+    expect_eigen_almost_equal(cov_after_neg_dt, initial_covariance, 1e-5);
+}
+
+// Main function for running tests (needed for GTest)
+int main(int argc, char **argv) {
+    rclcpp::init(0, nullptr); // Initialize rclcpp for rclcpp::Time
+    ::testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    rclcpp::shutdown();
+    return result;
+}
+
+```

--- a/crane_world_model_publisher/test/test_ball_tracker.cpp
+++ b/crane_world_model_publisher/test/test_ball_tracker.cpp
@@ -1,145 +1,157 @@
 #include <gtest/gtest.h>
+
+#include <rclcpp/rclcpp.hpp>  // For rclcpp::Time
+
 #include "crane_world_model_publisher/ball_tracker.hpp"
-#include <rclcpp/rclcpp.hpp> // For rclcpp::Time
 
 // Test fixture for BallTracker tests
-class BallTrackerTest : public ::testing::Test {
+class BallTrackerTest : public ::testing::Test
+{
 protected:
-    crane::BallTracker tracker;
-    rclcpp::Time t0;
-    rclcpp::Clock ros_clock; // Member to ensure lifetime
+  crane::BallTracker tracker;
+  rclcpp::Time t0;
+  rclcpp::Clock ros_clock;  // Member to ensure lifetime
 
-    BallTrackerTest() : t0(0, 0, RCL_ROS_TIME), ros_clock(RCL_ROS_TIME) {
-         // It's good practice to initialize rclcpp if it's not already,
-         // especially when using rclcpp::Time.
-         // However, in a gtest environment, rclcpp::init might be called by the test runner
-         // if it's an ament_add_gtest target.
-        t0 = ros_clock.now();
-    }
+  BallTrackerTest() : t0(0, 0, RCL_ROS_TIME), ros_clock(RCL_ROS_TIME)
+  {
+    // It's good practice to initialize rclcpp if it's not already,
+    // especially when using rclcpp::Time.
+    // However, in a gtest environment, rclcpp::init might be called by the test runner
+    // if it's an ament_add_gtest target.
+    t0 = ros_clock.now();
+  }
 
-    // Helper to compare Eigen matrices/vectors with a tolerance
-    void expect_eigen_almost_equal(const Eigen::MatrixXd& actual, const Eigen::MatrixXd& expected, double tolerance = 1e-5) {
-        ASSERT_EQ(actual.rows(), expected.rows());
-        ASSERT_EQ(actual.cols(), expected.cols());
-        for (int i = 0; i < actual.rows(); ++i) {
-            for (int j = 0; j < actual.cols(); ++j) {
-                EXPECT_NEAR(actual(i, j), expected(i, j), tolerance);
-            }
-        }
+  // Helper to compare Eigen matrices/vectors with a tolerance
+  void expect_eigen_almost_equal(
+    const Eigen::MatrixXd & actual, const Eigen::MatrixXd & expected, double tolerance = 1e-5)
+  {
+    ASSERT_EQ(actual.rows(), expected.rows());
+    ASSERT_EQ(actual.cols(), expected.cols());
+    for (int i = 0; i < actual.rows(); ++i) {
+      for (int j = 0; j < actual.cols(); ++j) {
+        EXPECT_NEAR(actual(i, j), expected(i, j), tolerance);
+      }
     }
+  }
 };
 
-TEST_F(BallTrackerTest, Initialization) {
-    tracker.init(t0, 1.0, 2.0, 0.5, -0.5);
-    ASSERT_TRUE(tracker.isInitialized());
-    Eigen::Vector4d expected_state;
-    expected_state << 1.0, 2.0, 0.5, -0.5;
-    expect_eigen_almost_equal(tracker.getState(), expected_state);
+TEST_F(BallTrackerTest, Initialization)
+{
+  tracker.init(t0, 1.0, 2.0, 0.5, -0.5);
+  ASSERT_TRUE(tracker.isInitialized());
+  Eigen::Vector4d expected_state;
+  expected_state << 1.0, 2.0, 0.5, -0.5;
+  expect_eigen_almost_equal(tracker.getState(), expected_state);
 
-    // Check that initial covariance is not zero (P_k_ is set in init)
-    ASSERT_GT(tracker.getCovariance()(0,0), 0.0);
+  // Check that initial covariance is not zero (P_k_ is set in init)
+  ASSERT_GT(tracker.getCovariance()(0, 0), 0.0);
 }
 
-TEST_F(BallTrackerTest, PredictConstantVelocity) {
-    tracker.init(t0, 0.0, 0.0, 1.0, 2.0); // vx=1, vy=2
+TEST_F(BallTrackerTest, PredictConstantVelocity)
+{
+  tracker.init(t0, 0.0, 0.0, 1.0, 2.0);  // vx=1, vy=2
 
-    rclcpp::Time t1 = t0 + rclcpp::Duration(1, 0); // 1 second later
-    tracker.predict(t1);
+  rclcpp::Time t1 = t0 + rclcpp::Duration(1, 0);  // 1 second later
+  tracker.predict(t1);
 
-    Eigen::Vector4d predicted_state = tracker.getState();
-    // Expected: x = 0 + 1*1 = 1, y = 0 + 2*1 = 2, vx=1, vy=2
-    Eigen::Vector4d expected_state;
-    expected_state << 1.0, 2.0, 1.0, 2.0;
-    // Increased tolerance due to process noise Q_k effect over 1s
-    expect_eigen_almost_equal(predicted_state, expected_state, 0.2);
+  Eigen::Vector4d predicted_state = tracker.getState();
+  // Expected: x = 0 + 1*1 = 1, y = 0 + 2*1 = 2, vx=1, vy=2
+  Eigen::Vector4d expected_state;
+  expected_state << 1.0, 2.0, 1.0, 2.0;
+  // Increased tolerance due to process noise Q_k effect over 1s
+  expect_eigen_almost_equal(predicted_state, expected_state, 0.2);
 }
 
-TEST_F(BallTrackerTest, PredictIncreasesCovariance) {
-    tracker.init(t0, 0.0, 0.0, 0.0, 0.0);
-    Eigen::Matrix4d P0 = tracker.getCovariance();
+TEST_F(BallTrackerTest, PredictIncreasesCovariance)
+{
+  tracker.init(t0, 0.0, 0.0, 0.0, 0.0);
+  Eigen::Matrix4d P0 = tracker.getCovariance();
 
-    rclcpp::Time t1 = t0 + rclcpp::Duration(1, 0);
-    tracker.predict(t1);
-    Eigen::Matrix4d P1 = tracker.getCovariance();
+  rclcpp::Time t1 = t0 + rclcpp::Duration(1, 0);
+  tracker.predict(t1);
+  Eigen::Matrix4d P1 = tracker.getCovariance();
 
-    // P_k = F_k * P_{k-1} * F_k' + Q_k
-    // Since Q_k is positive semi-definite and non-zero, trace of P should increase.
-    ASSERT_GT(P1.trace(), P0.trace() - 1e-5); // trace(P1) should be > trace(P0)
+  // P_k = F_k * P_{k-1} * F_k' + Q_k
+  // Since Q_k is positive semi-definite and non-zero, trace of P should increase.
+  ASSERT_GT(P1.trace(), P0.trace() - 1e-5);  // trace(P1) should be > trace(P0)
 }
 
+TEST_F(BallTrackerTest, UpdateReducesCovariance)
+{
+  tracker.init(t0, 0.0, 0.0, 1.0, 0.0);  // Moving along x-axis
 
-TEST_F(BallTrackerTest, UpdateReducesCovariance) {
-    tracker.init(t0, 0.0, 0.0, 1.0, 0.0); // Moving along x-axis
+  rclcpp::Time t_predict = t0 + rclcpp::Duration(1, 0);  // Predict 1s
+  tracker.predict(t_predict);
+  Eigen::Matrix4d P_predicted = tracker.getCovariance();
 
-    rclcpp::Time t_predict = t0 + rclcpp::Duration(1,0); // Predict 1s
-    tracker.predict(t_predict);
-    Eigen::Matrix4d P_predicted = tracker.getCovariance();
+  Eigen::Vector2d measurement(0.9, 0.1);   // Measurement slightly off from prediction (1.0, 0.0)
+  rclcpp::Time t_measurement = t_predict;  // Measurement at the same time as prediction
+  tracker.update(measurement, t_measurement);
+  Eigen::Matrix4d P_updated = tracker.getCovariance();
 
-    Eigen::Vector2d measurement(0.9, 0.1); // Measurement slightly off from prediction (1.0, 0.0)
-    rclcpp::Time t_measurement = t_predict; // Measurement at the same time as prediction
-    tracker.update(measurement, t_measurement);
-    Eigen::Matrix4d P_updated = tracker.getCovariance();
-
-    // Sum of diagonal elements (trace) should typically decrease after update with reasonable R
-    ASSERT_LT(P_updated.trace(), P_predicted.trace() + 1e-5);
+  // Sum of diagonal elements (trace) should typically decrease after update with reasonable R
+  ASSERT_LT(P_updated.trace(), P_predicted.trace() + 1e-5);
 }
 
-TEST_F(BallTrackerTest, StateConvergesWithUpdates) {
-    // Initialize tracker with a somewhat off state
-    tracker.init(t0, 0.1, -0.1, 0.1, 0.1);
+TEST_F(BallTrackerTest, StateConvergesWithUpdates)
+{
+  // Initialize tracker with a somewhat off state
+  tracker.init(t0, 0.1, -0.1, 0.1, 0.1);
 
-    Eigen::Vector2d true_ball_pos(0.0, 0.0);
-    double true_vx = 0.5; // m/s
-    double true_vy = 0.2; // m/s
-    double dt_secs = 0.1;   // 100ms per step
-    rclcpp::Duration dt_duration = rclcpp::Duration::from_seconds(dt_secs);
+  Eigen::Vector2d true_ball_pos(0.0, 0.0);
+  double true_vx = 0.5;  // m/s
+  double true_vy = 0.2;  // m/s
+  double dt_secs = 0.1;  // 100ms per step
+  rclcpp::Duration dt_duration = rclcpp::Duration::from_seconds(dt_secs);
 
-    rclcpp::Time current_tracker_time = t0;
+  rclcpp::Time current_tracker_time = t0;
 
-    // Simulate a few steps
-    for (int i = 0; i < 20; ++i) { // Increased steps for convergence
-        current_tracker_time = t0 + rclcpp::Duration::from_seconds(i * dt_secs);
+  // Simulate a few steps
+  for (int i = 0; i < 20; ++i) {  // Increased steps for convergence
+    current_tracker_time = t0 + rclcpp::Duration::from_seconds(i * dt_secs);
 
-        true_ball_pos(0) += true_vx * dt_secs;
-        true_ball_pos(1) += true_vy * dt_secs;
+    true_ball_pos(0) += true_vx * dt_secs;
+    true_ball_pos(1) += true_vy * dt_secs;
 
-        Eigen::Vector2d measurement = true_ball_pos;
+    Eigen::Vector2d measurement = true_ball_pos;
 
-        // Predict to current measurement time, then update.
-        // BallTracker's update method internally calls predict if time has advanced.
-        tracker.update(measurement, current_tracker_time);
-    }
+    // Predict to current measurement time, then update.
+    // BallTracker's update method internally calls predict if time has advanced.
+    tracker.update(measurement, current_tracker_time);
+  }
 
-    Eigen::Vector4d final_state = tracker.getState();
-    EXPECT_NEAR(final_state(0), true_ball_pos(0), 0.15); // Check X pos
-    EXPECT_NEAR(final_state(1), true_ball_pos(1), 0.15); // Check Y pos
-    EXPECT_NEAR(final_state(2), true_vx, 0.15);           // Check Vx
-    EXPECT_NEAR(final_state(3), true_vy, 0.15);           // Check Vy
+  Eigen::Vector4d final_state = tracker.getState();
+  EXPECT_NEAR(final_state(0), true_ball_pos(0), 0.15);  // Check X pos
+  EXPECT_NEAR(final_state(1), true_ball_pos(1), 0.15);  // Check Y pos
+  EXPECT_NEAR(final_state(2), true_vx, 0.15);           // Check Vx
+  EXPECT_NEAR(final_state(3), true_vy, 0.15);           // Check Vy
 }
 
-TEST_F(BallTrackerTest, PredictWithNegativeDt) {
-    tracker.init(t0, 1.0, 2.0, 0.5, -0.5);
-    Eigen::Vector4d initial_state = tracker.getState();
-    Eigen::Matrix4d initial_covariance = tracker.getCovariance();
+TEST_F(BallTrackerTest, PredictWithNegativeDt)
+{
+  tracker.init(t0, 1.0, 2.0, 0.5, -0.5);
+  Eigen::Vector4d initial_state = tracker.getState();
+  Eigen::Matrix4d initial_covariance = tracker.getCovariance();
 
-    rclcpp::Time t_minus_1 = t0 - rclcpp::Duration(1,0);
-    tracker.predict(t_minus_1);
+  rclcpp::Time t_minus_1 = t0 - rclcpp::Duration(1, 0);
+  tracker.predict(t_minus_1);
 
-    Eigen::Vector4d state_after_neg_dt = tracker.getState();
-    Eigen::Matrix4d cov_after_neg_dt = tracker.getCovariance();
+  Eigen::Vector4d state_after_neg_dt = tracker.getState();
+  Eigen::Matrix4d cov_after_neg_dt = tracker.getCovariance();
 
-    // Expect state and covariance to be unchanged as dt will be clamped to 0
-    expect_eigen_almost_equal(state_after_neg_dt, initial_state, 1e-5);
-    expect_eigen_almost_equal(cov_after_neg_dt, initial_covariance, 1e-5);
+  // Expect state and covariance to be unchanged as dt will be clamped to 0
+  expect_eigen_almost_equal(state_after_neg_dt, initial_state, 1e-5);
+  expect_eigen_almost_equal(cov_after_neg_dt, initial_covariance, 1e-5);
 }
 
 // Main function for running tests (needed for GTest)
-int main(int argc, char **argv) {
-    rclcpp::init(0, nullptr); // Initialize rclcpp for rclcpp::Time
-    ::testing::InitGoogleTest(&argc, argv);
-    int result = RUN_ALL_TESTS();
-    rclcpp::shutdown();
-    return result;
+int main(int argc, char ** argv)
+{
+  rclcpp::init(0, nullptr);  // Initialize rclcpp for rclcpp::Time
+  ::testing::InitGoogleTest(&argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }
 
 ```


### PR DESCRIPTION
…nsation

I've implemented a new BallTracker system for crane_world_model_publisher.

Key features include:

1.  **Kalman Filter for Ball Tracking**:
    *   A new `BallTracker` class uses a Kalman filter (Eigen-based) to estimate ball state (x, y, vx, vy).
    *   Unit tests for `BallTracker` cover initialization, prediction, update, and state convergence.

2.  **Multi-Ball Tracking Framework**:
    *   `WorldModelDataProvider` now manages multiple `ActiveBallTrack` instances.
    *   Includes logic for data association (greedy nearest neighbor), creation of new tracks for new ball detections, and removal of stale tracks.

3.  **Vision Packet Callback Update**:
    *   The `trackerCallback` in `WorldModelDataProvider` now processes `TrackedFrame` data to update the multi-ball Kalman filters.

4.  **Dead Zone (Blind Spot) Compensation**:
    *   Kalman filter predictions provide ball state estimates when direct vision is lost for short periods.
    *   Robot ball sensor data is integrated: if a robot's sensor indicates ball possession, nearby predicted ball tracks (not updated by vision in the current frame) can be "snapped" to the robot's location, improving accuracy during dead zones.

5.  **Kick Event Detection Enhancement**:
    *   `KickEventDetector` now implicitly uses the filtered state of the primary tracked ball, potentially improving detection reliability due to smoother input data.

The system now internally tracks multiple balls, though `WorldModelDataProvider::getMsg()` still publishes only the primary ball's information in `msg.ball_info` due to the current message definition. This provides a robust foundation for future multi-ball capabilities in higher-level modules.