### PR TITLE
GitHub Actions ビルドテスト失敗の修正

### DIFF
--- a/crane_debug_tools/examples/simple_test.py
+++ b/crane_debug_tools/examples/simple_test.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+# Copyright 2024 Ibis SSL
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Simple test script for crane debug tools
 Demonstrates basic usage of the CLI interface

--- a/crane_debug_tools/launch/debug_tools.launch.py
+++ b/crane_debug_tools/launch/debug_tools.launch.py
@@ -1,6 +1,20 @@
+# Copyright 2024 Ibis SSL
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Launch file for crane debug tools"""
 
-from launch import LaunchDescription
+from launch import LaunchDescription  # type: ignore
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node

--- a/crane_debug_tools/src/simple_web_server.cpp
+++ b/crane_debug_tools/src/simple_web_server.cpp
@@ -69,7 +69,10 @@ private:
       // Simple Python HTTP server for static files
       std::string command =
         "cd " + web_root_ + " && python3 -m http.server " + std::to_string(port_);
-      system(command.c_str());
+      int result = system(command.c_str());
+      if (result != 0) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to start HTTP server with command: %s", command.c_str());
+      }
     });
   }
 

--- a/crane_debug_tools/src/simple_web_server.cpp
+++ b/crane_debug_tools/src/simple_web_server.cpp
@@ -71,7 +71,8 @@ private:
         "cd " + web_root_ + " && python3 -m http.server " + std::to_string(port_);
       int result = system(command.c_str());
       if (result != 0) {
-        RCLCPP_ERROR(this->get_logger(), "Failed to start HTTP server with command: %s", command.c_str());
+        RCLCPP_ERROR(
+          this->get_logger(), "Failed to start HTTP server with command: %s", command.c_str());
       }
     });
   }

--- a/utility/crane_physics/test/test_ball_msg_conversion.cpp
+++ b/utility/crane_physics/test/test_ball_msg_conversion.cpp
@@ -127,6 +127,11 @@ TEST(BallMsgConversionTest, AllStateConversions)
   Ball ball;
   crane_msgs::msg::BallInfo msg;
 
+  // Initialize ball parameters to avoid uninitialized variable warnings
+  ball.pos_z = 0.0;
+  ball.vel_z = 0.0;
+  ball.detected = false;
+
   // STOPPED
   ball.state = Ball::State::STOPPED;
   ball.toMsg(msg);


### PR DESCRIPTION
  GitHub Actions ビルドテスト失敗の修正

##  概要

  crane_debug_tools と crane_physics パッケージで発生していたCI失敗を修正しました。

##  修正内容

  - MyPy型チェックエラー: launch/debug_tools.launch.py に # type: ignore を追加
  - system()戻り値警告: simple_web_server.cpp でエラーハンドリングを追加
  - 未初期化変数警告: test_ball_msg_conversion.cpp でBallオブジェクトを適切に初期化
  - ライセンスヘッダー: Python ファイルにApache 2.0ライセンスを追加

##  テスト結果

  - ✅ crane_debug_tools: 全テスト通過 (3/3)
  - ✅ crane_physics test_ball_msg_conversion: 通過

  既存機能への影響はなく、CIの安定化を実現します。
