### PR TITLE
バグ修正: crane_physicsパッケージのBall::ParabolicPhysics初期位置更新処理を修正

### DIFF
--- a/utility/crane_physics/include/crane_physics/ball_info.hpp
+++ b/utility/crane_physics/include/crane_physics/ball_info.hpp
@@ -584,6 +584,10 @@ private:
       if (point_log.size() < 2) {
         // データが不十分な場合は推定できない
         initial_velocity_ = Point3D::Zero();
+        // 1つのデータポイントがある場合は初期位置を更新
+        if (point_log.size() == 1) {
+          initial_position_ = point_log[0].position;
+        }
         return;
       }
 
@@ -595,6 +599,9 @@ private:
       // 最小時刻を基準時刻とする
       double t0 = point_log[0].time;
       Point3D p0 = point_log[0].position;
+
+      // 初期位置を更新（全てのケースで確実に実行）
+      initial_position_ = p0;
 
       // 最小二乗法で初期速度を推定
       // 放物運動の方程式: p(t) = p0 + v0*t + 0.5*g*t^2
@@ -660,9 +667,6 @@ private:
       // 最小二乗解を計算
       Point3D numerator = sum_t_dp * n_points - sum_dp * sum_t;
       initial_velocity_ = numerator / denominator;
-
-      // 初期位置も更新
-      initial_position_ = p0;
     }
 
     Point3DStamped getGroundPoint()


### PR DESCRIPTION
estimateInitialVelocityFromPointLog()メソッドで初期位置の更新が 確実に実行されるよう修正し、テスト失敗を解決。

変更内容:
- データ不足時（1点のみ）の初期位置更新を追加
- 全ケースで初期位置を早期に更新するよう変更
- 冗長な初期位置更新処理を削除

影響:
- EstimateInitialPointsFromTwoPoints テストが通過
- EstimateInitialVelocityInsufficientData テストが通過
- EstimateInitialVelocityNumericalStability テストが通過
- crane_physicsパッケージの全8テストが100%通過

🤖 Generated with [Claude Code](https://claude.ai/code)