### PR TITLE
refactor: システム全体のログ出力を削減と改善

### DIFF
--- a/crane_bringup/launch/crane.launch.py
+++ b/crane_bringup/launch/crane.launch.py
@@ -445,7 +445,7 @@ def generate_launch_description():
                         ]
                     },
                 ],
-                output="log",
+                # output="log",
                 on_exit=default_exit_behavior,
             ),
         ]

--- a/crane_robot_receiver/src/robot_receiver_node.cpp
+++ b/crane_robot_receiver/src/robot_receiver_node.cpp
@@ -125,7 +125,6 @@ public:
           inet_ntop(
             AF_INET, &(reinterpret_cast<struct sockaddr_in *>(ifa->ifa_addr)->sin_addr), ip,
             INET_ADDRSTRLEN);
-          std::cout << "マルチキャスト: " << ifa->ifa_name << ": " << ip << std::endl;
           boost::asio::ip::detail::socket_option::multicast_request<
             IPPROTO_IP, IP_ADD_MEMBERSHIP, IPPROTO_IPV6, IPV6_JOIN_GROUP>
             join_device(addr.to_v4(), boost::asio::ip::address::from_string(ip).to_v4());
@@ -340,8 +339,6 @@ public:
     for (int i = 0; i < robot_num; i++) {
       auto config = makeConfig(i);
       receivers.push_back(std::make_shared<MulticastReceiver>(config.ip, config.port));
-      std::cout << "make robot receiver for id: " << static_cast<int>(i) << ", ip: " << config.ip
-                << ", port: " << config.port << std::endl;
     }
 
     using std::chrono::operator""ms;

--- a/session/crane_session_controller/src/crane_session_controller.cpp
+++ b/session/crane_session_controller/src/crane_session_controller.cpp
@@ -46,8 +46,6 @@ SessionControllerComponent::SessionControllerComponent(const rclcpp::NodeOptions
     if (config_file.extension() != ".yaml") {
       return;
     } else {
-      RCLCPP_INFO(
-        get_logger(), "セッション設定を読み込みます : %s", config_file.filename().string().c_str());
       auto config = YAML::LoadFile(config_file.c_str());
       std::stringstream ss;
       ss << "NAME : " << config["name"] << std::endl;
@@ -68,7 +66,6 @@ SessionControllerComponent::SessionControllerComponent(const rclcpp::NodeOptions
     }
   };
 
-  std::cout << "----------------------------------------" << std::endl;
   using std::filesystem::directory_iterator;
   for (auto & path : directory_iterator(session_config_dir)) {
     if (path.is_directory()) {
@@ -90,9 +87,7 @@ SessionControllerComponent::SessionControllerComponent(const rclcpp::NodeOptions
     path(ament_index_cpp::get_package_share_directory("crane_session_controller")) / "config" /
     event_config_file_name;
   auto event_config = YAML::LoadFile(event_config_path.c_str());
-  std::cout << "----------------------------------------" << std::endl;
   for (auto event_node : event_config["events"]) {
-    std::cout << "イベント「" << event_node["event"] << "」の設定を読み込みます" << std::endl;
     event_map[event_node["event"].as<std::string>()] = event_node["session"].as<std::string>();
   }
 
@@ -131,7 +126,7 @@ SessionControllerComponent::SessionControllerComponent(const rclcpp::NodeOptions
           ofs << what.str() << std::endl;
           ofs.close();
         }
-        std::cout << what.str() << std::endl;
+        RCLCPP_ERROR(get_logger(), "%s", what.str().c_str());
       }
     }
   });
@@ -253,7 +248,7 @@ auto SessionControllerComponent::assign(const std::string & session_name) -> voi
         ofs << what.str() << std::endl;
         ofs.close();
       }
-      std::cout << what.str() << std::endl;
+      RCLCPP_ERROR(get_logger(), "%s", what.str().c_str());
     }
   } else {
     RCLCPP_ERROR(


### PR DESCRIPTION
開発時のデバッグ情報過多を解決し、本番環境での可読性を向上
- crane_bringup: launch時のlog出力をコメントアウトしてコンソール表示に変更
- crane_robot_receiver: マルチキャスト設定とロボット受信機初期化の冗長な std::cout を削除
- crane_session_controller: エラーハンドリングを std::cout から RCLCPP_ERROR に統一
- 不要なセッション読み込み確認メッセージとデバッグ区切り線を削除

これにより実行時の出力が整理され、重要なエラー情報が埋もれることを防止

🤖 Generated with [Claude Code](https://claude.ai/code)