### PR TITLE
refactor: world_model_publisherから未使用のdetection_frame機能を削除

### DIFF
--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -95,18 +95,6 @@ public:
 
   auto updateGeometryIfNeeded() -> void;
 
-  // detection_frame生成機能
-  [[nodiscard]] auto hasLatestDetectionFrame() const -> bool { return has_latest_detection_frame_; }
-
-  [[nodiscard]] auto getLatestDetectionFrame() const -> robocup_ssl_msgs::msg::DetectionFrame;
-
-  // 高速detection_frameパブリッシュ機能
-  auto enableDirectDetectionFramePublishing(
-    rclcpp::Publisher<robocup_ssl_msgs::msg::DetectionFrame>::SharedPtr publisher) -> void
-  {
-    direct_detection_frame_publisher_ = publisher;
-  }
-
   // Vision処理関連メソッド
   [[nodiscard]] auto getBallInfo() const -> const crane_msgs::msg::BallInfo & { return ball_info_; }
   [[nodiscard]] auto getRobotInfo(int team_index) const
@@ -148,10 +136,6 @@ private:
   double last_t_sent_;
   rclcpp::Time last_ball_detect_time_;
   rclcpp::Time last_prediction_time_;
-
-  // 高速detection_frameパブリッシャー
-  rclcpp::Publisher<robocup_ssl_msgs::msg::DetectionFrame>::SharedPtr
-    direct_detection_frame_publisher_;
 
   // ロボット位置履歴管理（速度計算用）
   struct RobotHistoryData
@@ -260,8 +244,6 @@ private:
   auto convertRobotDetection(const SSL_DetectionRobot & ssl_robot, int team_index, uint8_t robot_id)
     -> void;
   auto convertFieldGeometry(const SSL_GeometryData & ssl_geometry) -> void;
-  auto parseDetectionFrameFromSSL(const SSL_DetectionFrame & ssl_detection) const
-    -> robocup_ssl_msgs::msg::DetectionFrame;
   auto reportError(const std::string & error_message) -> void;
 
   auto mergeRobotInfo(

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_publisher.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_publisher.hpp
@@ -79,8 +79,6 @@ public:
 private:
   auto publishWorldModel() -> void;
 
-  auto publishDetectionFrame() -> void;
-
   auto publishVisualization(WorldModelWrapper::SharedPtr world_model) -> void;
 
   auto updateHistory(crane_msgs::msg::WorldModel & msg) -> void;
@@ -96,12 +94,6 @@ private:
   DiagnosedPublisher<crane_msgs::msg::WorldModel> pub_world_model;
 
   rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pub_process_time;
-
-  // vision_componentと同じ構造のdetection_frameパブリッシャー（比較用）
-  rclcpp::Publisher<robocup_ssl_msgs::msg::DetectionFrame>::SharedPtr pub_detection_frame_wmp;
-
-  // 高速detection_frameパブリッシャー（VisionStreamProcessorから直接パブリッシュ）
-  rclcpp::Publisher<robocup_ssl_msgs::msg::DetectionFrame>::SharedPtr pub_detection_frame_fast;
 
   rclcpp::TimerBase::SharedPtr timer;
 

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -28,8 +28,7 @@ WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
   last_t_capture_(0.0),
   last_t_sent_(0.0),
   last_ball_detect_time_(node.get_clock()->now()),
-  last_prediction_time_(node.get_clock()->now()),
-  direct_detection_frame_publisher_(nullptr)
+  last_prediction_time_(node.get_clock()->now())
 {
   using std::chrono_literals::operator""ms;
 
@@ -329,14 +328,6 @@ crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
   return msg;
 }
 
-auto WorldModelDataProvider::getLatestDetectionFrame() const
-  -> robocup_ssl_msgs::msg::DetectionFrame
-{
-  if (!has_latest_detection_frame_) {
-    return robocup_ssl_msgs::msg::DetectionFrame{};
-  }
-  return parseDetectionFrameFromSSL(latest_ssl_detection_frame_);
-}
 auto WorldModelDataProvider::setVisualizationCallbacks(
   std::function<void(const SSL_GeometryData &, bool)> geometry_callback,
   std::function<void(const robocup_ssl_msgs::msg::Referee &, double, double)> referee_callback)
@@ -370,12 +361,6 @@ auto WorldModelDataProvider::processDetectionFrame(const SSL_DetectionFrame & de
   // 最新のSSL_DetectionFrameを保存（detection_frame生成用）
   latest_ssl_detection_frame_ = detection;
   has_latest_detection_frame_ = true;
-
-  // 高速detection_frameパブリッシュ（vision_componentと同じ構造）
-  if (direct_detection_frame_publisher_) {
-    auto detection_frame_msg = parseDetectionFrameFromSSL(detection);
-    direct_detection_frame_publisher_->publish(detection_frame_msg);
-  }
 
   // タイムスタンプ更新
   last_t_capture_ = detection.t_capture();
@@ -670,95 +655,6 @@ auto WorldModelDataProvider::convertFieldGeometry(const SSL_GeometryData & ssl_g
 
   field_geometry_.center_circle_radius = 0.5;  // 標準SSL値
   field_geometry_.is_valid = true;
-}
-
-auto WorldModelDataProvider::parseDetectionFrameFromSSL(
-  const SSL_DetectionFrame & ssl_detection) const -> robocup_ssl_msgs::msg::DetectionFrame
-{
-  robocup_ssl_msgs::msg::DetectionFrame detection_frame_msg;
-
-  detection_frame_msg.frame_number = ssl_detection.frame_number();
-  detection_frame_msg.t_capture = ssl_detection.t_capture();
-  detection_frame_msg.t_sent = ssl_detection.t_sent();
-  detection_frame_msg.camera_id = ssl_detection.camera_id();
-
-  // Parse balls（vision_componentと同じ構造）
-  for (const auto & ball : ssl_detection.balls()) {
-    robocup_ssl_msgs::msg::DetectionBall ball_msg;
-    ball_msg.confidence = ball.confidence();
-    if (ball.has_area()) {
-      ball_msg.area = ball.area();
-    } else {
-      ball_msg.area = 100;  // invalid value
-    }
-    ball_msg.x = ball.x() / 1000.0;
-    ball_msg.y = ball.y() / 1000.0;
-    if (ball.has_z()) {
-      ball_msg.z = ball.z() / 1000.0;
-    } else {
-      ball_msg.z = 0.0;  // invalid value
-    }
-    ball_msg.pixel_x = ball.pixel_x();
-    ball_msg.pixel_y = ball.pixel_y();
-
-    detection_frame_msg.balls.push_back(ball_msg);
-  }
-
-  // Parse yellow robots（vision_componentと同じ構造）
-  for (const auto & robot : ssl_detection.robots_yellow()) {
-    robocup_ssl_msgs::msg::DetectionRobot robot_msg;
-    robot_msg.confidence = robot.confidence();
-    if (robot.has_robot_id()) {
-      robot_msg.robot_id = robot.robot_id();
-    } else {
-      robot_msg.robot_id = 100;  // invalid value
-    }
-    robot_msg.x = robot.x() / 1000.0;
-    robot_msg.y = robot.y() / 1000.0;
-    if (robot.has_orientation()) {
-      robot_msg.orientation = robot.orientation();
-    } else {
-      robot_msg.orientation = 0.0;  // invalid value
-    }
-    robot_msg.pixel_x = robot.pixel_x();
-    robot_msg.pixel_y = robot.pixel_y();
-    if (robot.has_height()) {
-      robot_msg.height = robot.height() / 1000.0;
-    } else {
-      robot_msg.height = 0.0;  // invalid value
-    }
-
-    detection_frame_msg.robots_yellow.push_back(robot_msg);
-  }
-
-  // Parse blue robots（vision_componentと同じ構造）
-  for (const auto & robot : ssl_detection.robots_blue()) {
-    robocup_ssl_msgs::msg::DetectionRobot robot_msg;
-    robot_msg.confidence = robot.confidence();
-    if (robot.has_robot_id()) {
-      robot_msg.robot_id = robot.robot_id();
-    } else {
-      robot_msg.robot_id = 100;  // invalid value
-    }
-    robot_msg.x = robot.x() / 1000.0;
-    robot_msg.y = robot.y() / 1000.0;
-    if (robot.has_orientation()) {
-      robot_msg.orientation = robot.orientation();
-    } else {
-      robot_msg.orientation = 0.0;  // invalid value
-    }
-    robot_msg.pixel_x = robot.pixel_x();
-    robot_msg.pixel_y = robot.pixel_y();
-    if (robot.has_height()) {
-      robot_msg.height = robot.height() / 1000.0;
-    } else {
-      robot_msg.height = 0.0;  // invalid value
-    }
-
-    detection_frame_msg.robots_blue.push_back(robot_msg);
-  }
-
-  return detection_frame_msg;
 }
 
 auto WorldModelDataProvider::reportError(const std::string & error_message) -> void

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -62,17 +62,6 @@ WorldModelPublisherComponent::WorldModelPublisherComponent(const rclcpp::NodeOpt
 
   pub_process_time = create_publisher<std_msgs::msg::Float32>("~/process_time", 10);
 
-  // vision_componentと同じ構造のdetection_frameパブリッシャー（比較用）
-  pub_detection_frame_wmp =
-    create_publisher<robocup_ssl_msgs::msg::DetectionFrame>("detection_frame_wmp", 10);
-
-  // 高速detection_frameパブリッシャー（VisionStreamProcessorから直接パブリッシュ）
-  pub_detection_frame_fast =
-    create_publisher<robocup_ssl_msgs::msg::DetectionFrame>("detection_frame_fast", 10);
-
-  // VisionStreamProcessorに高速パブリッシャーを接続
-  data_provider.enableDirectDetectionFramePublishing(pub_detection_frame_fast);
-
   // 自動/world_modelサブスクライブはOFF
   wrapper = std::make_shared<WorldModelWrapper>(*this, false);
 
@@ -81,7 +70,6 @@ WorldModelPublisherComponent::WorldModelPublisherComponent(const rclcpp::NodeOpt
     if (data_provider.available()) {
       publishWorldModel();
       publishVisualization(wrapper);
-      publishDetectionFrame();
     }
   });
 }
@@ -140,15 +128,6 @@ auto WorldModelPublisherComponent::publishWorldModel() -> void
 
   pub_world_model.publish(wrapper->getMsg());
   wrapper->addDelayCheckpoint("world_model_published", "30Hz");
-}
-
-auto WorldModelPublisherComponent::publishDetectionFrame() -> void
-{
-  // VisionStreamProcessorから最新のdetection_frameを取得してパブリッシュ
-  if (data_provider.hasLatestDetectionFrame()) {
-    auto detection_frame_msg = data_provider.getLatestDetectionFrame();
-    pub_detection_frame_wmp->publish(detection_frame_msg);
-  }
 }
 
 auto WorldModelPublisherComponent::publishVisualization(WorldModelWrapper::SharedPtr world_model)


### PR DESCRIPTION
不要なdetection_frameパブリッシュ機能とその関連実装を完全削除：

削除対象：
- WorldModelDataProvider::getLatestDetectionFrame()メソッド
- WorldModelDataProvider::parseDetectionFrameFromSSL()メソッド
- WorldModelDataProvider::enableDirectDetectionFramePublishing()メソッド
- WorldModelPublisherComponent::publishDetectionFrame()メソッド
- direct_detection_frame_publisher_メンバ変数
- pub_detection_frame_wmp、pub_detection_frame_fastパブリッシャー

影響範囲：
- world_model_publisherのコード簡素化とメモリ使用量削減
- vision_componentとの重複機能排除
- 30Hzタイマーループの処理負荷軽減

これによりworld_model_publisherの責務がworld_model配信に特化され、
システム全体のアーキテクチャがより明確になります。

🤖 Generated with [Claude Code](https://claude.ai/code)