### PR TITLE
fix: RVO2PlannerでNaN値処理のフォールバック機能を追加

### DIFF
--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -310,10 +310,9 @@ auto RVO2Planner::overrideTargetPosition(crane_msgs::msg::RobotCommands & msg) -
       // NaN値検証とフォールバック処理
       const Point current_pos(command.current_pose.x, command.current_pose.y);
       if (std::isnan(target_pos.x()) || std::isnan(target_pos.y())) {
-        std::cout << "[RVO2Planner] NaN detected in target_pos for robot " 
-                  << static_cast<int>(command.robot_id) 
-                  << ": target_pos(" << target_pos.x() << ", " << target_pos.y() 
-                  << "), using current position as fallback" << std::endl;
+        std::cout << "[RVO2Planner] NaN detected in target_pos for robot "
+                  << static_cast<int>(command.robot_id) << ": target_pos(" << target_pos.x() << ", "
+                  << target_pos.y() << "), using current position as fallback" << std::endl;
         target_pos = current_pos;  // フォールバック: 現在位置に設定
         command.position_target_mode.front().target_x = target_pos.x();
         command.position_target_mode.front().target_y = target_pos.y();
@@ -321,10 +320,9 @@ auto RVO2Planner::overrideTargetPosition(crane_msgs::msg::RobotCommands & msg) -
       }
 
       if (std::isnan(current_pos.x()) || std::isnan(current_pos.y())) {
-        std::cout << "[RVO2Planner] NaN detected in current_pos for robot " 
-                  << static_cast<int>(command.robot_id) 
-                  << ": current_pos(" << current_pos.x() << ", " << current_pos.y() 
-                  << "), skipping robot" << std::endl;
+        std::cout << "[RVO2Planner] NaN detected in current_pos for robot "
+                  << static_cast<int>(command.robot_id) << ": current_pos(" << current_pos.x()
+                  << ", " << current_pos.y() << "), skipping robot" << std::endl;
         continue;  // この場合は処理をスキップ
       }
 

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -307,6 +307,27 @@ auto RVO2Planner::overrideTargetPosition(crane_msgs::msg::RobotCommands & msg) -
       target_pos << command.position_target_mode.front().target_x,
         command.position_target_mode.front().target_y;
 
+      // NaN値検証とフォールバック処理
+      const Point current_pos(command.current_pose.x, command.current_pose.y);
+      if (std::isnan(target_pos.x()) || std::isnan(target_pos.y())) {
+        std::cout << "[RVO2Planner] NaN detected in target_pos for robot " 
+                  << static_cast<int>(command.robot_id) 
+                  << ": target_pos(" << target_pos.x() << ", " << target_pos.y() 
+                  << "), using current position as fallback" << std::endl;
+        target_pos = current_pos;  // フォールバック: 現在位置に設定
+        command.position_target_mode.front().target_x = target_pos.x();
+        command.position_target_mode.front().target_y = target_pos.y();
+        continue;  // この時点で早期リターン、ペナルティエリア処理をスキップ
+      }
+
+      if (std::isnan(current_pos.x()) || std::isnan(current_pos.y())) {
+        std::cout << "[RVO2Planner] NaN detected in current_pos for robot " 
+                  << static_cast<int>(command.robot_id) 
+                  << ": current_pos(" << current_pos.x() << ", " << current_pos.y() 
+                  << "), skipping robot" << std::endl;
+        continue;  // この場合は処理をスキップ
+      }
+
       bool is_near_our_penalty_area =
         (std::signbit(world_model->getOurGoalCenter().x()) == std::signbit(command.current_pose.x));
       Box penalty_area = [&]() {
@@ -422,7 +443,6 @@ auto RVO2Planner::overrideTargetPosition(crane_msgs::msg::RobotCommands & msg) -
         }
       }
 
-      const Point current_pos = Point(command.current_pose.x, command.current_pose.y);
       if (not command.local_planner_config.disable_ball_avoidance) {
         const auto & ball_pos = world_model->ball().pos;
         const double MIN_BALL_DISTANCE = [&]() {


### PR DESCRIPTION
target_posおよびcurrent_posにNaN値が検出された場合の
安全な処理ロジックを実装:

- target_posがNaNの場合は現在位置をフォールバック値として使用
- current_posがNaNの場合は該当ロボットの処理をスキップ
- 適切なログ出力でデバッグ支援を強化
- ペナルティエリア処理前の早期チェックで安全性向上

対象ファイル: crane_local_planner/src/rvo2_planner.cpp:307-329

🤖 Generated with [Claude Code](https://claude.ai/code)