### PR TITLE
設定・バグ修正: ball_model_calibブランチの設定・バグ修正を統合

### DIFF
--- a/crane_bringup/launch/crane.launch.py
+++ b/crane_bringup/launch/crane.launch.py
@@ -17,11 +17,21 @@ from launch.actions import DeclareLaunchArgument, GroupAction, Shutdown, Execute
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from launch.conditions import IfCondition, UnlessCondition
+from ament_index_python.packages import get_package_share_directory
+import os
 
 default_exit_behavior = Shutdown()
 
 
 def generate_launch_description():
+    # キッカー物理設定ファイルのパス
+    crane_world_model_publisher_share_dir = get_package_share_directory(
+        "crane_world_model_publisher"
+    )
+    kicker_physics_config_path = os.path.join(
+        crane_world_model_publisher_share_dir, "config", "kicker_physics.yaml"
+    )
+
     return LaunchDescription(
         [
             # Launch Arguments
@@ -124,6 +134,11 @@ def generate_launch_description():
                 default_value="5.0",
                 description="slack timeの計算などに用いられるロボットの最大速度",
             ),
+            DeclareLaunchArgument(
+                "ball_physics_config_path",
+                default_value="grsim_ball_physics.yaml",
+                description="ボール物理パラメータ設定ファイル名（configフォルダ内）",
+            ),
             Node(
                 package="crane_session_controller",
                 executable="crane_session_controller_node",
@@ -195,10 +210,8 @@ def generate_launch_description():
                                     "half_court_is_positive_side"
                                 ),
                             },
-                            {"straight_kick_power_array": [0.0, 0.25, 0.6, 0.9]},
-                            {"straight_kick_speed_array": [0.0, 2.0, 4.0, 6.0]},
-                            {"chip_kick_power_array": [0.0, 0.5, 0.75, 1.0]},
-                            {"chip_kick_distance_array": [0.0, 0.3, 1.0, 2.5]},
+                            # KickerModel統合：YAML設定ファイルから読み込み
+                            {"kicker_physics_config": kicker_physics_config_path},
                         ],
                         on_exit=default_exit_behavior,
                     ),
@@ -210,7 +223,7 @@ def generate_launch_description():
                             {"no_movement": False},
                             {"latency_ms": 0.0},
                             {"sim_mode": LaunchConfiguration("sim")},
-                            {"kick_power_limit_straight": 0.50},
+                            {"kick_power_limit_straight": 1.00},
                             {"kick_power_limit_chip": 1.0},
                             {"chip_angle_deg": 30.0},
                             {"theta_p_gain": 6.0},
@@ -237,9 +250,10 @@ def generate_launch_description():
                             {"i_saturation": 0.0},
                             {"d_gain": 4.0},
                             {"max_vel": LaunchConfiguration("max_vel")},
-                            {"max_acc": 2.2},
+                            {"max_acc": 5.0},
                             {
-                                "acceleration_factor": 1.3
+                                # "acceleration_factor": 1.3
+                                "acceleration_factor": 0.7
                             },  # 実際の加速度は3.0 * 1.5 = 4.5
                             {
                                 "half_court_practice_mode": LaunchConfiguration(
@@ -261,6 +275,7 @@ def generate_launch_description():
                     Node(
                         package="crane_sender",
                         executable="ibis_sender_node",
+                        # output="screen",
                         parameters=[
                             {"no_movement": False},
                             {"latency_ms": 100.0},
@@ -270,6 +285,7 @@ def generate_launch_description():
                             {
                                 "use_simple_velocity": False
                             },  # 速度命令でSimpleVelocityを使うかどうか。FalseならPolarVelocityになる
+                            {"acc_limit_offset": 1.0},  # 加速度制限のオフセット値
                         ],
                         on_exit=default_exit_behavior,
                     ),
@@ -354,6 +370,11 @@ def generate_launch_description():
                     {
                         "robot_max_vel_for_prediction": LaunchConfiguration(
                             "robot_max_vel_for_prediction"
+                        ),
+                    },
+                    {
+                        "ball_physics_config_path": LaunchConfiguration(
+                            "ball_physics_config_path"
                         ),
                     },
                 ],

--- a/crane_local_planner/include/crane_local_planner/local_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/local_planner.hpp
@@ -11,6 +11,7 @@
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 #include <crane_msgs/msg/robot_commands.hpp>
 #include <crane_msgs/msg/world_model.hpp>
+#include <crane_physics/kicker_model.hpp>
 #include <functional>
 // #include <grid_map_ros/grid_map_ros.hpp>
 #include <memory>
@@ -35,58 +36,31 @@ struct Obstacle
 struct KickPowerCalculator
 {
 private:
-  std::vector<double> straight_kick_power_array;
-  std::vector<double> straight_kick_speed_array;
-
-  std::vector<double> chip_kick_power_array;
-  std::vector<double> chip_kick_distance_array;
-
-  double getLinearInterpolation(
-    double x, const std::vector<double> & x_array, const std::vector<double> & y_array) const
-  {
-    if (x_array.size() != y_array.size()) {
-      std::stringstream what;
-      what << "x_arrayとy_arrayのサイズは等しい必要があります: ";
-      what << "size(x_array): " << static_cast<int>(x_array.size());
-      what << ", size(y_array): " << static_cast<int>(y_array.size());
-      throw std::runtime_error(what.str());
-    }
-
-    if (x_array.size() == 0) {
-      throw std::runtime_error("x_arrayが空です");
-    } else if (x_array.size() == 1) {
-      return y_array[0];
-    } else {
-      if (x < x_array[0]) {
-        return y_array[0];
-      } else if (x > x_array.back()) {
-        return y_array.back();
-      } else {
-        int idx = 0;
-        for (idx = 1; idx < x_array.size(); ++idx) {
-          if (x < x_array[idx]) {
-            break;
-          }
-        }
-        double x_diff = x_array[idx] - x_array[idx - 1];
-        double y_diff = y_array[idx] - y_array[idx - 1];
-        return y_array[idx - 1] + (y_diff / x_diff) * (x - x_array[idx - 1]);
-      }
-    }
-  }
+  // KickerModel統合（すべてのキック計算用）
+  std::shared_ptr<KickerModel> kicker_model;
 
 public:
   auto initialize(rclcpp::Node & node) -> void
   {
-    node.declare_parameter<std::vector<double>>("straight_kick_power_array", {});
-    straight_kick_power_array = node.get_parameter("straight_kick_power_array").as_double_array();
-    node.declare_parameter<std::vector<double>>("straight_kick_speed_array", {});
-    straight_kick_speed_array = node.get_parameter("straight_kick_speed_array").as_double_array();
+    // KickerModel初期化（YAML設定ファイルから読み込み）
+    node.declare_parameter<std::string>("kicker_physics_config", "");
+    std::string kicker_config_path = node.get_parameter("kicker_physics_config").as_string();
 
-    node.declare_parameter<std::vector<double>>("chip_kick_power_array", {});
-    chip_kick_power_array = node.get_parameter("chip_kick_power_array").as_double_array();
-    node.declare_parameter<std::vector<double>>("chip_kick_distance_array", {});
-    chip_kick_distance_array = node.get_parameter("chip_kick_distance_array").as_double_array();
+    try {
+      if (!kicker_config_path.empty()) {
+        // YAML設定ファイルからKickerModelを作成
+        kicker_model = createKickerModelFromYAML(kicker_config_path);
+        RCLCPP_INFO(
+          node.get_logger(), "KickerModel initialized from YAML: %s", kicker_config_path.c_str());
+      } else {
+        // デフォルト設定でKickerModelを作成
+        kicker_model = createDefaultKickerModel();
+        RCLCPP_INFO(node.get_logger(), "KickerModel initialized with default values");
+      }
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR(node.get_logger(), "KickerModel initialization failed: %s", e.what());
+      throw std::runtime_error("Failed to initialize KickerModel: " + std::string(e.what()));
+    }
   }
 
   auto getKickPower(const crane_msgs::msg::RobotCommand & command) const -> double
@@ -95,14 +69,21 @@ public:
       return command.kick_power;
     }
 
-    if (command.chip_enable) {
-      return getLinearInterpolation(
-        command.local_planner_config.target_chip_distance, chip_kick_distance_array,
-        chip_kick_power_array);
-    } else {
-      return getLinearInterpolation(
-        command.local_planner_config.target_kick_ball_speed, straight_kick_speed_array,
-        straight_kick_power_array);
+    // KickerModelを使用（必須）
+    if (!kicker_model) {
+      throw std::runtime_error("KickerModel is not initialized");
+    }
+
+    try {
+      if (command.chip_enable) {
+        return kicker_model->calculateChipKickPower(
+          command.local_planner_config.target_chip_distance);
+      } else {
+        return kicker_model->calculateStraightKickPower(
+          command.local_planner_config.target_kick_ball_speed);
+      }
+    } catch (const std::exception & e) {
+      throw std::runtime_error("KickerModel calculation failed: " + std::string(e.what()));
     }
   }
 };

--- a/crane_play_switcher/src/play_switcher.cpp
+++ b/crane_play_switcher/src/play_switcher.cpp
@@ -36,6 +36,9 @@ PlaySwitcher::PlaySwitcher(const rclcpp::NodeOptions & options)
   session_injection_sub = create_subscription<std_msgs::msg::String>(
     "/session_injection", 1, [&](const std_msgs::msg::String & msg) {
       // イベント注入（次のレフェリーイベント発生まで有効）
+      std::stringstream ss;
+      ss << "[SESSION_INJECTION] " << msg.data;
+      RCLCPP_INFO(this->get_logger(), ss.str().c_str());
       play_situation_msg.command =
         getSituationCommandNamedInt(crane_msgs::msg::PlaySituation::INJECTION);
       play_situation_msg.header.stamp = now();

--- a/crane_robot_skills/include/crane_robot_skills/skills.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/skills.hpp
@@ -8,7 +8,9 @@
 #define CRANE_ROBOT_SKILLS__SKILLS_HPP_
 
 #include <crane_robot_skills/attacker.hpp>
+#include <crane_robot_skills/ball_calibration_data_collector.hpp>
 #include <crane_robot_skills/ball_nearby_positioner.hpp>
+#include <crane_robot_skills/center_stop_kick.hpp>
 #include <crane_robot_skills/emplace_robot.hpp>
 #include <crane_robot_skills/forward.hpp>
 #include <crane_robot_skills/freekick_saver.hpp>

--- a/crane_robot_skills/src/ball_nearby_positioner.cpp
+++ b/crane_robot_skills/src/ball_nearby_positioner.cpp
@@ -53,16 +53,15 @@ auto BallNearByPositioner::update() -> Status
         return (world_model()->getOurGoalCenter() - target).normalized();
       } else if (policy == "pass") {
         // 2番目に近いロボット
-        if (auto theirs = world_model()->theirs().getAvailableRobots(); theirs.size() > 2) {
+        if (auto theirs = world_model()->theirs().getAvailableRobots(); theirs.size() >= 2) {
           auto nearest_robot = world_model()->getNearestRobotWithDistanceFromPoint(target, theirs);
           std::erase_if(theirs, [&](const auto & r) { return r->id == nearest_robot->robot->id; });
           auto second_nearest_robot =
             world_model()->getNearestRobotWithDistanceFromPoint(target, theirs);
           return (second_nearest_robot->robot->pose.pos - target).normalized();
         } else {
-          throw std::runtime_error(
-            "[BallNearByPositioner] 「positioning policy: "
-            "pass」の計算には少なくとも2台の敵ロボットが必要です");
+          // 敵ロボットが2台未満の場合：ゴール方向をフォールバック
+          return (world_model()->getOurGoalCenter() - target).normalized();
         }
       } else {
         throw std::runtime_error(

--- a/crane_robot_skills/src/goalie.cpp
+++ b/crane_robot_skills/src/goalie.cpp
@@ -17,6 +17,7 @@ void Goalie::initialize()
   setParameter("block_distance", 0.5);
   setParameter("robot_acc_for_prediction", 2.0);
   setParameter("robot_max_vel_for_prediction", 5.0);
+  setPreUpdateFunction([&]() { command->clearSkillStates(); });
 }
 
 Status Goalie::update()

--- a/crane_robot_skills/src/single_ball_placement.cpp
+++ b/crane_robot_skills/src/single_ball_placement.cpp
@@ -18,6 +18,7 @@ void SingleBallPlacement::initialize()
 
   // マイナスするとコート内も判定される
   setParameter("コート端判定のオフセット", 0.0);
+  setPreUpdateFunction([&]() { command->clearSkillStates(); });
 
   addStateFunction(SingleBallPlacementStates::ENTRY_POINT, [this]() {
     command->stopHere();
@@ -345,19 +346,17 @@ void SingleBallPlacement::initialize()
     SingleBallPlacementStates::CONTACT_BALL, SingleBallPlacementStates::MOVE_TO_TARGET, [this]() {
       auto now = rclcpp::Clock(RCL_ROS_TIME).now();
       static int count = 0;
-      if (now.get_clock_type() == robot()->ball_sensor_stamp.get_clock_type()) {
-        if (std::abs((now - robot()->ball_sensor_stamp).seconds()) < 0.01 && robot()->ball_sensor) {
-          if (++count > 2) {
-            count = 0;
-            return true;
-          } else {
-            return false;
-          }
-        } else {
+      if (
+        robot()->getBallSensorAvailable(now, rclcpp::Duration::from_seconds(0.1)) &&
+        robot()->ball_sensor) {
+        if (++count > 2) {
           count = 0;
+          return true;
+        } else {
           return false;
         }
       } else {
+        count = 0;
         // ボールセンサが動いていないとき
         return robot()->getDistance(world_model()->ball().pos) < 0.15;
       }
@@ -429,15 +428,39 @@ void SingleBallPlacement::initialize()
       if (sleep) {
         sleep.reset();
       }
-
-      return skill_status == Status::SUCCESS;
+      Point placement_target;
+      placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
+      if (skill_status == Status::SUCCESS) {
+        return true;
+      } else if (
+        robot()->ball_sensor == true && world_model()->getMsg().ball_info.detected == false &&
+        (placement_target - robot()->kicker_center()).norm() < 0.15) {
+        // ボールセンサが動いているのにボールが見えない場合でロボットが配置位置にいる場合は成功
+        return true;
+      } else {
+        return false;
+      }
     });
-
-  // ボールが離れたら始めに戻る
   addTransition(
-    SingleBallPlacementStates::MOVE_TO_TARGET,
-    SingleBallPlacementStates::PULL_BACK_FROM_EDGE_PREPARE,
-    [this]() { return skill_status == Status::FAILURE; });
+    SingleBallPlacementStates::MOVE_TO_TARGET, SingleBallPlacementStates::ENTRY_POINT, [this]() {
+      auto now = rclcpp::Clock(RCL_ROS_TIME).now();
+      bool flag = robot()->ball_sensor_stamp.has_value() &&
+                  now.get_clock_type() == robot()->ball_sensor_stamp->get_clock_type() &&
+                  (now - *(robot()->ball_sensor_stamp)).seconds() >= 1.0;
+
+      if (flag && !robot()->ball_sensor) {
+        std::cout << "[SingleBallPlacement] Ball sensor is not working, so return to ENTRY_POINT:"
+                  << std::abs((now - *(robot()->ball_sensor_stamp)).seconds()) << "s" << std::endl;
+        return true;
+      } else {
+        return false;
+      }
+    });
+  // ボールが離れたら始めに戻る
+  // addTransition(
+  //   SingleBallPlacementStates::MOVE_TO_TARGET,
+  //   SingleBallPlacementStates::PULL_BACK_FROM_EDGE_PREPARE,
+  //   [this]() { return skill_status == Status::FAILURE; });
 
   addStateFunction(SingleBallPlacementStates::SLEEP, [this]() {
     if (not sleep) {
@@ -449,21 +472,22 @@ void SingleBallPlacement::initialize()
     command->stopHere();
     command->disableAnyAreaAvoidance();
     command->setOmegaLimit(0.0);
-    if (robot()->vel.linear.norm() < 0.05 && world_model()->ball().isStopped(0.05)) {
-      command->dribble(0.0);
-    } else {
-      command->dribble(0.3);
-    }
-
+    // if (robot()->vel.linear.norm() < 0.05 && world_model()->ball().isStopped(0.05)) {
+    //   command->dribble(0.0);
+    // } else {
+    //   command->dribble(0.3);
+    // }
+    command->dribble(0.0);
     return Status::RUNNING;
   });
 
-  addTransition(SingleBallPlacementStates::SLEEP, SingleBallPlacementStates::ENTRY_POINT, [this]() {
-    Point placement_target;
-    placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
-    // ルール 5.2 0.15m以内で認められる。再配置が必要場合のみ、 ENTRY_POINTへ移動
-    return (world_model()->ball().pos - placement_target).norm() > 0.15;
-  });
+  // addTransition(
+  //   SingleBallPlacementStates::SLEEP, SingleBallPlacementStates::ENTRY_POINT, [this]() {
+  //   Point placement_target;
+  //   placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
+  //   // ルール 5.2 0.15m以内で認められる。再配置が必要場合のみ、 ENTRY_POINTへ移動
+  //   return (world_model()->ball().pos - placement_target).norm() > 0.15;
+  // });
 
   addTransition(SingleBallPlacementStates::SLEEP, SingleBallPlacementStates::LEAVE_BALL, [this]() {
     pull_back_angle = robot()->pose.theta;
@@ -472,16 +496,22 @@ void SingleBallPlacement::initialize()
 
   addStateFunction(SingleBallPlacementStates::LEAVE_BALL, [this]() {
     // メモ：().normalized() * 0.8したらなぜかゼロベクトルが出来上がってしまう
-    Vector2 diff = (robot()->pose.pos - world_model()->ball().pos);
-    diff.normalize();
-    diff = diff * 0.8;
-    auto leave_pos = world_model()->ball().pos + diff;
+    // ボール判定15cm + ロボット判定50cm + ロボット半径10cm + マージン5com = 80cm
+    Vector2 diff = -getNormVec(robot()->pose.theta) * 0.8;
+    Point leave_pos = robot()->pose.pos + diff;
+    Point placement_target;
+    placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
 
+    if ((robot()->pose.pos - placement_target).norm() > 0.8) {
+      // 離れたならば、その場に留まる
+      leave_pos = robot()->pose.pos;
+    }
     command->setTargetTheta(pull_back_angle);
     command->setTargetPosition(leave_pos);
     command->setOmegaLimit(0.0);
     command->setMaxVelocity(1.0);
     command->disableAnyAreaAvoidance();
+    command->dribble(0.0);
     return skill_status;
   });
 
@@ -490,7 +520,9 @@ void SingleBallPlacement::initialize()
       Point placement_target;
       placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
       // ルール 5.2 0.15m以内で認められる。再配置が必要場合のみ、 ENTRY_POINTへ移動
-      return (world_model()->ball().pos - placement_target).norm() > 0.15;
+      // return (world_model()->ball().pos - placement_target).norm() > 0.15;
+      return ((world_model()->ball().pos - placement_target).norm() > 0.15) &&
+             world_model()->getMsg().ball_info.detected;
     });
 }
 

--- a/crane_sender/src/ibis_sender_node.cpp
+++ b/crane_sender/src/ibis_sender_node.cpp
@@ -5,7 +5,9 @@
 // https://opensource.org/licenses/MIT.
 
 #include <arpa/inet.h>
+#include <ifaddrs.h>
 #include <math.h>
+#include <net/if.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/udp.h>
@@ -19,8 +21,10 @@
 #include <array>
 #include <boost/asio.hpp>
 #include <class_loader/visibility_control.hpp>
+#include <cmath>
 #include <crane_msgs/msg/robot_commands.hpp>
 #include <format>
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -33,106 +37,49 @@
 
 namespace crane
 {
-// 送信方式の定義
-enum class SendMode { SIMULATION, REAL };
-enum class SendType { UNICAST, BROADCAST };
-
 // 通信設定の定数
 namespace CommConfig
 {
 constexpr int DEFAULT_PORT = 12345;
-constexpr int SIMULATION_BASE_PORT = 50100;
-constexpr const char * BROADCAST_ADDRESS = "224.5.20.255";
-constexpr const char * LOCALHOST = "localhost";
+constexpr const char * BROADCAST_ADDRESS = "192.168.20.255";
 constexpr int AI_CMD_V2_SIZE = 64;
 constexpr int AI_CMD_V2_ROBOT_NUM = 11;
 }  // namespace CommConfig
 
-class CommandSenderBase
+class BroadcastCommandSender
 {
 public:
-  CommandSenderBase(SendType type, SendMode mode) : send_type_(type), send_mode_(mode) {}
-  virtual ~CommandSenderBase() = default;
-
-protected:
-  std::string getConnectionInfo(const std::string & host, int port) const
+  explicit BroadcastCommandSender()
+  : socket(io_service, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0))
   {
-    std::string type_str = (send_type_ == SendType::UNICAST) ? "ユニキャスト" : "ブロードキャスト";
-    std::string mode_str = (send_mode_ == SendMode::SIMULATION) ? "シミュレーション" : "実機";
-    return std::format("[{}・{}] 送信先: {}:{}", type_str, mode_str, host, port);
-  }
+    try {
+      // ブロードキャスト許可フラグを設定
+      socket.set_option(boost::asio::socket_base::broadcast(true));
+      std::cout << "✓ SO_BROADCASTフラグ設定完了" << std::endl;
 
-  SendType send_type_;
-  SendMode send_mode_;
-};
+      // レゾルバでエンドポイント解決
+      boost::asio::ip::udp::resolver resolver(io_service);
+      std::string host = CommConfig::BROADCAST_ADDRESS;
+      int port = CommConfig::DEFAULT_PORT;
 
-class UnicastCommandSender : public CommandSenderBase
-{
-public:
-  explicit UnicastCommandSender(uint8_t robot_id, bool sim_mode)
-  : CommandSenderBase(SendType::UNICAST, sim_mode ? SendMode::SIMULATION : SendMode::REAL),
-    socket(io_service, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0))
-  {
-    boost::asio::ip::udp::resolver resolver(io_service);
-    endpoint = [&]() -> boost::asio::ip::udp::endpoint {
-      if (sim_mode) {
-        std::string host = CommConfig::LOCALHOST;
-        int port = CommConfig::SIMULATION_BASE_PORT + robot_id;
-        boost::asio::ip::udp::resolver::query query(host, std::to_string(port));
-        std::cout << getConnectionInfo(host, port) << " ロボット" << static_cast<int>(robot_id)
-                  << std::endl;
-        return *resolver.resolve(query);
-      } else {
-        std::string host = std::format("192.168.20.{}", 100 + robot_id);
-        int port = CommConfig::DEFAULT_PORT;
-        boost::asio::ip::udp::resolver::query query(host, std::to_string(port));
-        std::cout << getConnectionInfo(host, port) << " ロボット" << static_cast<int>(robot_id)
-                  << std::endl;
-        return *resolver.resolve(query);
-      }
-    }();
-  }
+      boost::asio::ip::udp::resolver::query query(host, std::to_string(port));
+      auto resolver_iterator = resolver.resolve(query);
+      endpoint = *resolver_iterator;
 
-  RobotCommandSerializedV2 send(RobotCommandV2 packet, int check_counter)
-  {
-    packet.check_counter = check_counter;
-    RobotCommandSerializedV2 serialized_packet;
-    RobotCommandSerializedV2_serialize(&serialized_packet, &packet);
+      // 詳細なネットワーク設定情報を表示
+      std::cout << "【実機・ブロードキャストモード初期化完了】" << std::endl;
+      std::cout << "  送信先アドレス: " << host << ":" << port << std::endl;
+      std::cout << "  解決されたエンドポイント: " << endpoint.address().to_string() << ":"
+                << endpoint.port() << std::endl;
+      std::cout << "  ローカルソケット: " << socket.local_endpoint().address().to_string() << ":"
+                << socket.local_endpoint().port() << std::endl;
 
-    uint8_t send_packet[64] = {};
-    for (int i = 0; i < 64; ++i) {
-      send_packet[i] = serialized_packet.data[i];
+      // ネットワークインターフェース情報の確認
+      checkNetworkInterfaces();
+    } catch (const std::exception & e) {
+      std::cerr << "❌ BroadcastCommandSender初期化エラー: " << e.what() << std::endl;
+      throw;
     }
-
-    socket.send_to(boost::asio::buffer(send_packet), endpoint);
-
-    return serialized_packet;
-  }
-
-protected:
-  boost::asio::io_service io_service;
-
-  boost::asio::ip::udp::endpoint endpoint;
-
-  boost::asio::ip::udp::socket socket;
-
-  int check = 0;
-};
-
-class BroadcastCommandSender : public CommandSenderBase
-{
-public:
-  explicit BroadcastCommandSender(bool sim_mode)
-  : CommandSenderBase(SendType::BROADCAST, sim_mode ? SendMode::SIMULATION : SendMode::REAL),
-    socket(io_service, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0))
-  {
-    boost::asio::ip::udp::resolver resolver(io_service);
-    std::string host = sim_mode ? CommConfig::LOCALHOST : CommConfig::BROADCAST_ADDRESS;
-    int port = CommConfig::DEFAULT_PORT;
-
-    boost::asio::ip::udp::resolver::query query(host, std::to_string(port));
-    endpoint = *resolver.resolve(query);
-    std::cout << getConnectionInfo(host, port) << std::endl;
   }
 
   void sendBroadcastPackets(
@@ -144,7 +91,7 @@ public:
     int active_robots = 0;
     for (int i = 0; i < CommConfig::AI_CMD_V2_ROBOT_NUM && i < robot_packets.size(); i++) {
       int offset = i * (CommConfig::AI_CMD_V2_SIZE + 1);
-      broadcast_buf[offset] = AF_INET;  // Orion_CM4が期待する識別子（AF_INET = 2）
+      broadcast_buf[offset] = i;
       memcpy(&broadcast_buf[offset + 1], robot_packets[i].second.data, CommConfig::AI_CMD_V2_SIZE);
 
       // 空でないパケットの数をカウント
@@ -158,17 +105,75 @@ public:
       if (!is_empty) active_robots++;
     }
 
-    socket.send_to(boost::asio::buffer(broadcast_buf, sizeof(broadcast_buf)), endpoint);
+    // パケット送信を詳細にログ出力
+    size_t total_size = sizeof(broadcast_buf);
+    try {
+      std::cout << "📦 ブロードキャストパケット送信開始:" << std::endl;
+      std::cout << "  送信先: " << endpoint.address().to_string() << ":" << endpoint.port()
+                << std::endl;
+      std::cout << "  パケットサイズ: " << total_size << " bytes" << std::endl;
+      std::cout << "  アクティブロボット数: " << active_robots << "/"
+                << CommConfig::AI_CMD_V2_ROBOT_NUM << std::endl;
 
-    // デバッグ出力（Orion_CM4の出力形式に合わせて）
-    static int last_check_counter = -1;
-    if (check_counter != last_check_counter) {
-      std::string type_str =
-        (send_type_ == SendType::BROADCAST) ? "ブロードキャスト" : "ユニキャスト";
-      std::cout << type_str << "パケット送信完了: アクティブロボット数=" << active_robots
-                << " チェックカウンタ=" << check_counter << std::endl;
-      last_check_counter = check_counter;
+      // 実際の送信処理
+      size_t sent_bytes = socket.send_to(boost::asio::buffer(broadcast_buf, total_size), endpoint);
+
+      // 送信成功ログ
+      std::cout << "✅ パケット送信成功: " << sent_bytes << " bytes 送信完了" << std::endl;
+    } catch (const boost::system::system_error & e) {
+      std::cerr << "❌ パケット送信エラー (boost): " << e.what() << std::endl;
+      std::cerr << "  エラーコード: " << e.code() << std::endl;
+      std::cerr << "  エラーメッセージ: " << e.code().message() << std::endl;
+    } catch (const std::exception & e) {
+      std::cerr << "❌ パケット送信例外: " << e.what() << std::endl;
     }
+  }
+
+private:
+  void checkNetworkInterfaces() const
+  {
+    std::cout << "🌐 利用可能なネットワークインターフェース情報:" << std::endl;
+
+    struct ifaddrs * ifaddrs_ptr;
+    if (getifaddrs(&ifaddrs_ptr) == -1) {
+      std::cerr << "❌ ネットワークインターフェース情報取得エラー" << std::endl;
+      return;
+    }
+
+    for (struct ifaddrs * ifa = ifaddrs_ptr; ifa != nullptr; ifa = ifa->ifa_next) {
+      if (ifa->ifa_addr == nullptr) continue;
+
+      // IPv4アドレスのみ表示
+      if (ifa->ifa_addr->sa_family == AF_INET) {
+        struct sockaddr_in * addr_in = reinterpret_cast<struct sockaddr_in *>(ifa->ifa_addr);
+        char ip_str[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &(addr_in->sin_addr), ip_str, INET_ADDRSTRLEN);
+
+        // ブロードキャストアドレス情報も取得
+        char broadcast_str[INET_ADDRSTRLEN] = "N/A";
+        if (ifa->ifa_flags & IFF_BROADCAST && ifa->ifa_broadaddr) {
+          struct sockaddr_in * broadcast_in =
+            reinterpret_cast<struct sockaddr_in *>(ifa->ifa_broadaddr);
+          inet_ntop(AF_INET, &(broadcast_in->sin_addr), broadcast_str, INET_ADDRSTRLEN);
+        }
+
+        std::cout << "  インターフェース: " << ifa->ifa_name << " IP: " << ip_str
+                  << " ブロードキャスト: " << broadcast_str;
+
+        // インターフェースの状態を表示
+        if (ifa->ifa_flags & IFF_UP) std::cout << " [UP]";
+        if (ifa->ifa_flags & IFF_RUNNING) std::cout << " [RUNNING]";
+        if (ifa->ifa_flags & IFF_BROADCAST) std::cout << " [BROADCAST]";
+        std::cout << std::endl;
+
+        // 設定されたブロードキャストアドレスとの照合
+        if (std::string(broadcast_str) == CommConfig::BROADCAST_ADDRESS) {
+          std::cout << "    ✅ 設定されたブロードキャストアドレスと一致!" << std::endl;
+        }
+      }
+    }
+
+    freeifaddrs(ifaddrs_ptr);
   }
 
 protected:
@@ -186,16 +191,11 @@ private:
 
   std::shared_ptr<rclcpp::ParameterCallbackHandle> parameter_callback_handle;
 
-  std::array<std::shared_ptr<UnicastCommandSender>, 20> senders;
-
   std::shared_ptr<BroadcastCommandSender> broadcast_sender;
-
-  bool sim_mode;
 
   bool use_simple_velocity;
 
-  bool use_broadcast_mode;
-  SendMode current_send_mode;
+  double acc_limit_offset;
 
 public:
   CLASS_LOADER_PUBLIC
@@ -204,16 +204,12 @@ public:
     declare_parameter("debug_id", -1);
     get_parameter("debug_id", debug_id);
 
-    declare_parameter("sim_mode", true);
-    get_parameter("sim_mode", sim_mode);
-
     declare_parameter("use_simple_velocity", false);
     get_parameter("use_simple_velocity", use_simple_velocity);
 
-    declare_parameter("use_broadcast_mode", false);
-    get_parameter("use_broadcast_mode", use_broadcast_mode);
+    declare_parameter("acc_limit_offset", 1.0);
+    get_parameter("acc_limit_offset", acc_limit_offset);
 
-    current_send_mode = sim_mode ? SendMode::SIMULATION : SendMode::REAL;
     parameter_subscriber = std::make_shared<rclcpp::ParameterEventHandler>(this);
     parameter_callback_handle =
       parameter_subscriber->add_parameter_callback("debug_id", [&](const rclcpp::Parameter & p) {
@@ -224,28 +220,102 @@ public:
         }
       });
 
-    for (std::size_t i = 0; i < senders.size(); i++) {
-      senders[i] = std::make_shared<UnicastCommandSender>(i, sim_mode);
-    }
-
-    // 送信システム初期化
-    std::string mode_str =
-      (current_send_mode == SendMode::SIMULATION) ? "シミュレーション" : "実機";
-    if (use_broadcast_mode) {
-      broadcast_sender = std::make_shared<BroadcastCommandSender>(sim_mode);
-      std::cout << "【" << mode_str << "・ブロードキャストモード】 ibis_sender_node 開始"
-                << std::endl;
-    } else {
-      std::cout << "【" << mode_str << "・ユニキャストモード】 ibis_sender_node 開始" << std::endl;
-    }
+    // ブロードキャスト送信システム初期化
+    broadcast_sender = std::make_shared<BroadcastCommandSender>();
+    std::cout << "ibis_sender_node 開始" << std::endl;
   }
 
 private:
-  RobotCommandV2 createRobotPacket(const crane_msgs::msg::RobotCommand & command, int /* counter */)
+  crane_msgs::msg::RobotCommands createTestRobotCommands() const
+  {
+    crane_msgs::msg::RobotCommands test_commands;
+    test_commands.robot_commands.clear();
+
+    static double time_offset = 0.0;
+    time_offset += 0.5;  // 固定0.5秒間隔
+
+    const int test_robot_count = 2;  // 固定2台
+    for (int i = 0; i < test_robot_count && i < CommConfig::AI_CMD_V2_ROBOT_NUM; i++) {
+      crane_msgs::msg::RobotCommand cmd;
+
+      // 基本設定
+      cmd.robot_id = i;
+
+      // 動的な位置設定（円運動パターン）
+      double angle = time_offset * 0.5 + i * (2.0 * M_PI / test_robot_count);
+      double radius = 1.0 + 0.5 * std::sin(time_offset * 0.3);
+      cmd.current_pose.x = radius * std::cos(angle);
+      cmd.current_pose.y = radius * std::sin(angle);
+      cmd.current_pose.theta = angle + M_PI / 2;  // 進行方向を向く
+
+      // 目標角度（時間に応じて回転）
+      cmd.target_theta = time_offset * 0.2 + i * M_PI / 4;
+
+      // キック・ドリブル動的設定
+      cmd.kick_power = std::abs(std::sin(time_offset + i)) * 15.0;          // 0-15の範囲
+      cmd.dribble_power = std::abs(std::cos(time_offset * 0.7 + i)) * 0.8;  // 0-0.8の範囲
+
+      // チップキックは交互に
+      cmd.chip_enable = ((static_cast<int>(time_offset) + i) % 4 == 0);
+
+      // ドリブラー上げ下げ
+      cmd.lift_up_dribbler_flag = ((static_cast<int>(time_offset * 2) + i) % 3 == 0);
+
+      // 停止フラグは基本的にfalse
+      cmd.stop_flag = false;
+
+      // 制御モード（サイクルで切り替え）
+      int mode_cycle = static_cast<int>(time_offset / 3) % 3;
+      switch (mode_cycle) {
+        case 0:  // POSITION_TARGET_MODE
+          cmd.control_mode = crane_msgs::msg::RobotCommand::POSITION_TARGET_MODE;
+          {
+            crane_msgs::msg::PositionTargetMode pos_mode;
+            pos_mode.target_x = cmd.current_pose.x + 0.5 * std::cos(time_offset);
+            pos_mode.target_y = cmd.current_pose.y + 0.5 * std::sin(time_offset);
+            cmd.position_target_mode.push_back(pos_mode);
+          }
+          break;
+        case 1:  // SIMPLE_VELOCITY_TARGET_MODE
+          cmd.control_mode = crane_msgs::msg::RobotCommand::SIMPLE_VELOCITY_TARGET_MODE;
+          {
+            crane_msgs::msg::SimpleVelocityTargetMode vel_mode;
+            vel_mode.target_vx = std::cos(time_offset + i) * 2.0;
+            vel_mode.target_vy = std::sin(time_offset + i) * 2.0;
+            cmd.simple_velocity_target_mode.push_back(vel_mode);
+          }
+          break;
+        case 2:  // POLAR_VELOCITY_TARGET_MODE
+          cmd.control_mode = crane_msgs::msg::RobotCommand::POLAR_VELOCITY_TARGET_MODE;
+          {
+            crane_msgs::msg::PolarVelocityTargetMode polar_mode;
+            polar_mode.target_velocity_r = 1.5 + 0.5 * std::sin(time_offset);
+            polar_mode.target_velocity_theta = time_offset * 0.5 + i * M_PI / 3;
+            cmd.polar_velocity_target_mode.push_back(polar_mode);
+          }
+          break;
+      }
+
+      // プランナー設定
+      cmd.local_planner_config.max_velocity = 2.0 + std::sin(time_offset) * 0.5;
+      cmd.local_planner_config.max_acceleration = 3.0 + std::cos(time_offset * 0.8) * 0.5;
+      cmd.local_planner_config.terminal_velocity = 0.1;
+      cmd.omega_limit = 5.0;
+
+      // タイミング情報
+      cmd.elapsed_time_ms_since_last_vision = static_cast<uint32_t>((time_offset * 1000)) % 100;
+
+      test_commands.robot_commands.push_back(cmd);
+    }
+
+    return test_commands;
+  }
+
+  RobotCommandV2 createRobotPacket(const crane_msgs::msg::RobotCommand & command, int counter)
   {
     RobotCommandV2 packet;
     packet.header = 0x00;
-    packet.check_counter = 0;
+    packet.check_counter = counter;
     packet.vision_global_pos[0] = command.current_pose.x;
     packet.vision_global_pos[1] = command.current_pose.y;
     packet.vision_global_theta = command.current_pose.theta;
@@ -259,11 +329,12 @@ private:
     packet.enable_chip = command.chip_enable;
     packet.lift_dribbler = command.lift_up_dribbler_flag;
     packet.stop_emergency = command.stop_flag;
-    packet.acceleration_limit = command.local_planner_config.max_acceleration + 1.0;
+    packet.acceleration_limit = command.local_planner_config.max_acceleration + acc_limit_offset;
     packet.linear_velocity_limit = command.local_planner_config.max_velocity;
     packet.angular_velocity_limit = command.omega_limit;
     packet.prioritize_move = true;
     packet.prioritize_accurate_acceleration = true;
+    packet.latency_time_ms = 100;
 
     packet.elapsed_time_ms_since_last_vision = command.elapsed_time_ms_since_last_vision;
 
@@ -349,45 +420,62 @@ public:
   void sendCommands(const crane_msgs::msg::RobotCommands & msg) override
   {
     static int counter = 0;
+    static int call_count = 0;
+    call_count++;
+
     if (++counter > 200) {
       counter = 0;
     }
 
-    if (use_broadcast_mode && broadcast_sender) {
-      // ブロードキャストモード：全ロボットのパケットを作成して一括送信
-      std::vector<std::pair<uint8_t, RobotCommandSerializedV2>> robot_packets;
+    // メソッド呼び出し確認ログ
+    std::cout << "🚀 sendCommands メソッド呼び出し #" << call_count << " (カウンタ=" << counter
+              << ")" << std::endl;
+    std::cout << "  受信したロボットコマンド数: " << msg.robot_commands.size() << std::endl;
 
-      // 全11スロット分の配列を初期化（ロボットIDでインデックス指定）
-      std::array<std::optional<RobotCommandSerializedV2>, CommConfig::AI_CMD_V2_ROBOT_NUM>
-        packet_slots;
+    // ブロードキャストモード：全ロボットのパケットを作成して一括送信
+    std::vector<std::pair<uint8_t, RobotCommandSerializedV2>> robot_packets;
 
-      for (auto command : msg.robot_commands) {
-        if (command.robot_id < CommConfig::AI_CMD_V2_ROBOT_NUM) {
-          RobotCommandV2 packet = createRobotPacket(command, counter);
-          RobotCommandSerializedV2 serialized_packet;
-          RobotCommandSerializedV2_serialize(&serialized_packet, &packet);
-          packet_slots[command.robot_id] = serialized_packet;
-        }
-      }
+    // 全11スロット分の配列を初期化（ロボットIDでインデックス指定）
+    std::array<std::optional<RobotCommandSerializedV2>, CommConfig::AI_CMD_V2_ROBOT_NUM>
+      packet_slots;
 
-      // 全スロットを順番にパケットリストに追加（空のスロットは空パケット）
-      for (int i = 0; i < CommConfig::AI_CMD_V2_ROBOT_NUM; i++) {
-        if (packet_slots[i]) {
-          robot_packets.push_back(std::make_pair(i, packet_slots[i].value()));
-        } else {
-          // 空パケットを作成
-          RobotCommandSerializedV2 empty_packet = {};
-          robot_packets.push_back(std::make_pair(i, empty_packet));
-        }
-      }
-
-      broadcast_sender->sendBroadcastPackets(robot_packets, counter);
-    } else {
-      // 個別送信モード：従来通りの処理
-      for (auto command : msg.robot_commands) {
+    int processed_commands = 0;
+    for (auto command : msg.robot_commands) {
+      if (command.robot_id < CommConfig::AI_CMD_V2_ROBOT_NUM) {
         RobotCommandV2 packet = createRobotPacket(command, counter);
-        senders[command.robot_id]->send(packet, counter);
+        RobotCommandSerializedV2 serialized_packet;
+        RobotCommandSerializedV2_serialize(&serialized_packet, &packet);
+        packet_slots[command.robot_id] = serialized_packet;
+        processed_commands++;
       }
+    }
+
+    std::cout << "  処理されたコマンド数: " << processed_commands << "/"
+              << msg.robot_commands.size() << std::endl;
+
+    // 全スロットを順番にパケットリストに追加（空のスロットは空パケット）
+    int filled_slots = 0;
+    for (int i = 0; i < CommConfig::AI_CMD_V2_ROBOT_NUM; i++) {
+      if (packet_slots[i]) {
+        robot_packets.push_back(std::make_pair(i, packet_slots[i].value()));
+        filled_slots++;
+      } else {
+        // 空パケットを作成
+        RobotCommandSerializedV2 empty_packet = {};
+        robot_packets.push_back(std::make_pair(i, empty_packet));
+      }
+    }
+
+    std::cout << "  パケットスロット使用状況: " << filled_slots << "/"
+              << CommConfig::AI_CMD_V2_ROBOT_NUM << " スロット使用中" << std::endl;
+    std::cout << "  ブロードキャスト送信準備完了 → パケット送信開始" << std::endl;
+
+    broadcast_sender->sendBroadcastPackets(robot_packets, counter);
+
+    // 定期的な詳細ログ（100回に1回）
+    if (call_count % 100 == 0) {
+      std::cout << "📈 統計情報 (100回毎): 総呼び出し=" << call_count
+                << " 平均コマンド数=" << (msg.robot_commands.size()) << std::endl;
     }
   }
 };

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -71,6 +71,43 @@ struct ProcessorConfig
   ProcessorConfig() : vision_address("224.5.23.2"), vision_port(10020), confidence_threshold(0.3) {}
 };
 
+struct BallDataQuality
+{
+  double max_position_jump = 2.0;        // 最大位置変化（m）
+  double max_velocity = 30.0;            // 最大速度（m/s）
+  double max_acceleration = 2000.0;      // 最大加速度（m/s²）（キック時の瞬間加速度を考慮）
+  double min_dt = 0.001;                 // 最小時間差（s）
+  size_t smoothing_window = 5;           // 移動平均ウィンドウサイズ
+  bool enable_outlier_rejection = true;  // 外れ値除外の有効化
+
+  // テレポート/リセット対応パラメータ
+  double teleport_threshold = 1.0;  // テレポート判定距離（m）
+  size_t stability_frames = 3;      // 安定性確認フレーム数
+  double stability_radius = 0.2;    // 安定性判定半径（m）
+  double long_gap_threshold = 0.5;  // 長時間ギャップ閾値（s）
+
+  // テレポート候補追跡
+  struct TeleportCandidate
+  {
+    Eigen::Vector3d position;
+    rclcpp::Time first_detected;
+    size_t consecutive_detections = 0;
+    bool is_stable = false;
+  } teleport_candidate;
+
+  struct Statistics
+  {
+    size_t total_detections = 0;
+    size_t outlier_rejections = 0;
+    size_t position_jumps = 0;
+    size_t velocity_outliers = 0;
+    size_t acceleration_outliers = 0;
+    size_t teleport_accepted = 0;
+    size_t teleport_rejected = 0;
+    double rejection_rate = 0.0;
+  } stats;
+};
+
 class WorldModelDataProvider
 {
 public:
@@ -160,6 +197,12 @@ private:
   static constexpr size_t MAX_ROBOT_COUNT = 20;
   std::array<std::array<RobotHistoryData, MAX_ROBOT_COUNT>, 2> robot_history_;
 
+  // ボールデータ品質管理
+  BallDataQuality ball_data_quality_;
+  std::pair<Eigen::Vector3d, rclcpp::Time> last_ball_data_;
+  std::deque<Eigen::Vector3d> velocity_history_;  // 移動平均用
+  bool ball_data_initialized_ = false;
+
   rclcpp::TimerBase::SharedPtr udp_timer;
 
   enum class Color { BLUE, YELLOW };
@@ -245,6 +288,14 @@ private:
     -> void;
   auto convertFieldGeometry(const SSL_GeometryData & ssl_geometry) -> void;
   auto reportError(const std::string & error_message) -> void;
+
+  // ボールデータ品質管理機能
+  auto validateBallPositionChange(const Eigen::Vector3d & new_pos, double dt) -> bool;
+  auto validateBallVelocity(const Eigen::Vector3d & velocity, double actual_dt) -> bool;
+  auto smoothBallVelocity(const Eigen::Vector3d & raw_velocity) -> Eigen::Vector3d;
+  auto updateQualityStatistics() -> void;
+  auto handleTeleportCandidate(const Eigen::Vector3d & new_pos, const rclcpp::Time & now) -> bool;
+  auto resetTeleportTracking() -> void;
 
   auto mergeRobotInfo(
     const crane_msgs::msg::RobotInfo & vision_robot,

--- a/crane_world_model_publisher/package.xml
+++ b/crane_world_model_publisher/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>boost</depend>
   <depend>crane_comm</depend>
   <depend>crane_geometry</depend>
@@ -22,7 +23,9 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>robocup_ssl_msgs</depend>
+  <depend>rosbag2_cpp</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>yaml-cpp</depend>
 
   <exec_depend>ament_index_python</exec_depend>

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -70,6 +70,10 @@ WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
   ball_info_.detected = false;
   ball_info_.state = crane_msgs::msg::BallInfo::STOPPED;
 
+  // ボールデータ品質管理初期化
+  last_ball_data_ = {Eigen::Vector3d::Zero(), node.get_clock()->now()};
+  velocity_history_.clear();
+
   area_mask.min_corner() << -20., -10.;
   area_mask.max_corner() << 20., 10.;
 
@@ -83,7 +87,7 @@ WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
   sub_robot_feedback = node.create_subscription<crane_msgs::msg::RobotFeedbackArray>(
     "/robot_feedback", 1, [this](const crane_msgs::msg::RobotFeedbackArray::SharedPtr msg) {
       robot_feedback = *msg;
-      auto now = rclcpp::Clock().now();
+      auto now = rclcpp::Clock(RCL_ROS_TIME).now();
     });
 
   node.declare_parameter("team_name", "ibis-ssl");
@@ -275,6 +279,27 @@ crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
 
   for (int team_idx = 0; team_idx < 2; ++team_idx) {
     auto vision_robots = robot_info_[team_idx];
+
+    // robot_feedbackデータを統合
+    for (auto & robot : vision_robots) {
+      // robot_feedbackから対応するロボットの情報を検索
+      for (const auto & feedback : robot_feedback.feedback) {
+        if (feedback.robot_id == robot.id) {
+          // feedbackデータを含むRobotInfoを作成
+          crane_msgs::msg::RobotInfo feedback_robot;
+          feedback_robot.id = feedback.robot_id;
+          feedback_robot.feedback_detected = true;
+          feedback_robot.ball_sensor = feedback.ball_sensor;
+          feedback_robot.last_ball_sensor_stamp = feedback.received_stamp;
+          feedback_robot.last_feedback_detection_stamp = feedback.received_stamp;
+
+          // visionデータとfeedbackデータを統合
+          robot = mergeRobotInfo(robot, feedback_robot);
+          break;
+        }
+      }
+    }
+
     if (team_idx == 0) {
       team_0_robots = vision_robots;
     } else {
@@ -298,7 +323,7 @@ crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
 
   // Vision遅延情報をDelayCheckpointに追加
   if (last_t_capture_ > 0.0 && last_t_sent_ > 0.0) {
-    auto now = rclcpp::Clock().now();
+    auto now = rclcpp::Clock(RCL_ROS_TIME).now();
     std::string vision_delay_info =
       DelayMonitorWrapper::formatVisionDelayInfo(last_t_capture_, last_t_sent_, now);
 
@@ -321,7 +346,7 @@ crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
     }
   }
 
-  msg.header.stamp = rclcpp::Clock().now();
+  msg.header.stamp = rclcpp::Clock(RCL_ROS_TIME).now();
   return msg;
 }
 
@@ -482,35 +507,101 @@ auto WorldModelDataProvider::convertBallDetection(const SSL_DetectionBall & ssl_
   double y = ssl_ball.y() / 1000.0;
   double z = ssl_ball.has_z() ? ssl_ball.z() / 1000.0 : 0.0;
 
-  // 位置更新
+  Eigen::Vector3d current_pos(x, y, z);
+  auto now = node.get_clock()->now();
+  double dt = (now - last_ball_data_.second).seconds();
+
+  // データ品質統計更新
+  ball_data_quality_.stats.total_detections++;
+
+  // 初回データまたは長時間の空白後はリセット
+  if (!ball_data_initialized_ || dt > 1.0) {
+    ball_data_initialized_ = true;
+    last_ball_data_ = {current_pos, now};
+    velocity_history_.clear();
+
+    // 位置のみ更新、速度は0とする
+    ball_info_.position.x = x;
+    ball_info_.position.y = y;
+    ball_info_.position.z = z;
+    ball_info_.velocity.x = 0.0;
+    ball_info_.velocity.y = 0.0;
+    ball_info_.velocity.z = 0.0;
+    ball_info_.velocity_norm = 0.0;
+
+    RCLCPP_DEBUG(node.get_logger(), "Ball tracking initialized at (%.3f, %.3f, %.3f)", x, y, z);
+
+    ball_info_.detected = true;
+    ball_info_.state = crane_msgs::msg::BallInfo::STOPPED;
+
+    // Vision情報更新
+    ball_info_.vision.stamp = now;
+    ball_info_.vision.pos.x = x;
+    ball_info_.vision.pos.y = y;
+    ball_info_.vision.pos.z = z;
+    return;
+  }
+
+  // 異常な位置変化をチェック
+  if (!validateBallPositionChange(current_pos, dt)) {
+    ball_data_quality_.stats.outlier_rejections++;
+    ball_data_quality_.stats.position_jumps++;
+
+    // テレポート候補の場合は拒否統計も更新
+    if ((current_pos - last_ball_data_.first).norm() > ball_data_quality_.teleport_threshold) {
+      ball_data_quality_.stats.teleport_rejected++;
+    }
+
+    RCLCPP_WARN(
+      node.get_logger(),
+      "Ball position jump rejected: (%.3f,%.3f,%.3f) -> (%.3f,%.3f,%.3f), dt=%.3fs",
+      last_ball_data_.first.x(), last_ball_data_.first.y(), last_ball_data_.first.z(), x, y, z, dt);
+    return;
+  }
+
+  // 速度計算（時間差が十分ある場合のみ）
+  if (dt >= ball_data_quality_.min_dt) {
+    Eigen::Vector3d raw_velocity = (current_pos - last_ball_data_.first) / dt;
+
+    // 速度妥当性チェック
+    if (!validateBallVelocity(raw_velocity, dt)) {
+      ball_data_quality_.stats.outlier_rejections++;
+      ball_data_quality_.stats.velocity_outliers++;
+
+      RCLCPP_WARN(
+        node.get_logger(), "Ball velocity outlier rejected: %.3fm/s (raw), dt=%.3fs",
+        raw_velocity.norm(), dt);
+      return;
+    }
+
+    // 速度平滑化
+    Eigen::Vector3d smoothed_velocity = smoothBallVelocity(raw_velocity);
+
+    // 速度情報更新
+    ball_info_.velocity.x = smoothed_velocity(0);
+    ball_info_.velocity.y = smoothed_velocity(1);
+    ball_info_.velocity.z = smoothed_velocity(2);
+    ball_info_.velocity_norm = smoothed_velocity.norm();
+
+    last_ball_data_ = {current_pos, now};
+  }
+
+  // 位置情報更新
   ball_info_.position.x = x;
   ball_info_.position.y = y;
   ball_info_.position.z = z;
 
   // Vision情報更新
-  ball_info_.vision.stamp = node.get_clock()->now();
+  ball_info_.vision.stamp = now;
   ball_info_.vision.pos.x = x;
   ball_info_.vision.pos.y = y;
   ball_info_.vision.pos.z = z;
 
-  // 速度計算
-  static std::pair<Eigen::Vector3d, rclcpp::Time> last_ball_data = {
-    Eigen::Vector3d::Zero(), node.get_clock()->now()};
-  auto now = node.get_clock()->now();
-  double dt = (now - last_ball_data.second).seconds();
-
-  if (dt > 0.001) {  // 1ms以上の差分のみ計算
-    Eigen::Vector3d current_pos(x, y, z);
-    Eigen::Vector3d vel = (current_pos - last_ball_data.first) / dt;
-    ball_info_.velocity.x = vel(0);
-    ball_info_.velocity.y = vel(1);
-    ball_info_.velocity.z = vel(2);
-    ball_info_.velocity_norm = vel.norm();
-    last_ball_data = {current_pos, now};
-  }
-
   ball_info_.detected = true;
   ball_info_.state = crane_msgs::msg::BallInfo::ROLLING;  // 簡易状態設定
+
+  // 統計情報定期更新
+  updateQualityStatistics();
 }
 
 auto WorldModelDataProvider::convertRobotDetection(
@@ -657,6 +748,195 @@ auto WorldModelDataProvider::convertFieldGeometry(const SSL_GeometryData & ssl_g
 auto WorldModelDataProvider::reportError(const std::string & error_message) -> void
 {
   RCLCPP_WARN(node.get_logger(), "WorldModelDataProvider error: %s", error_message.c_str());
+}
+
+auto WorldModelDataProvider::validateBallPositionChange(const Eigen::Vector3d & new_pos, double dt)
+  -> bool
+{
+  if (!ball_data_initialized_ || dt <= 0.0) {
+    resetTeleportTracking();  // 初回は追跡リセット
+    return true;              // 初回または無効な時間差は常に許可
+  }
+
+  double distance = (new_pos - last_ball_data_.first).norm();
+  double max_allowed_distance = ball_data_quality_.max_position_jump;
+
+  // 時間に応じた最大許容移動距離を計算（物理的上限速度を考慮）
+  double time_based_max_distance = ball_data_quality_.max_velocity * dt * 1.2;  // 20%のマージン
+  max_allowed_distance = std::min(max_allowed_distance, time_based_max_distance);
+
+  // 通常の物理的移動範囲内の場合
+  if (distance <= max_allowed_distance) {
+    resetTeleportTracking();  // 通常移動時は追跡リセット
+    return true;
+  }
+
+  // 大きな位置ジャンプの場合：テレポート判定
+  if (
+    distance > ball_data_quality_.teleport_threshold ||
+    dt > ball_data_quality_.long_gap_threshold) {
+    return handleTeleportCandidate(new_pos, node.get_clock()->now());
+  }
+
+  // 中程度のジャンプは拒否（ノイズの可能性）
+  return false;
+}
+
+auto WorldModelDataProvider::validateBallVelocity(
+  const Eigen::Vector3d & velocity, double actual_dt) -> bool
+{
+  double speed = velocity.norm();
+
+  // 詳細デバッグログ: 速度判定の詳細情報
+  RCLCPP_DEBUG(
+    node.get_logger(), "[VELOCITY_DEBUG] Speed check: speed=%.3fm/s, max_velocity=%.3fm/s", speed,
+    ball_data_quality_.max_velocity);
+
+  if (speed > ball_data_quality_.max_velocity) {
+    RCLCPP_WARN(
+      node.get_logger(), "[VELOCITY_REJECT] Speed limit exceeded: %.3fm/s > %.3fm/s", speed,
+      ball_data_quality_.max_velocity);
+    return false;
+  }
+
+  // 前回速度との加速度チェック（履歴がある場合）
+  if (!velocity_history_.empty() && velocity_history_.size() >= 2) {
+    Eigen::Vector3d prev_velocity = velocity_history_.back();
+
+    // 実際の時間差を使用（最小値でクランプ）
+    double dt = std::max(actual_dt, ball_data_quality_.min_dt);
+
+    double acceleration = (velocity - prev_velocity).norm() / dt;
+
+    // 詳細デバッグログ: 加速度判定の詳細情報
+    RCLCPP_DEBUG(
+      node.get_logger(),
+      "[ACCEL_DEBUG] Accel check: prev_vel=%.3fm/s, curr_vel=%.3fm/s, actual_dt=%.3fs, "
+      "used_dt=%.3fs, accel=%.1fm/s², max_accel=%.1fm/s²",
+      prev_velocity.norm(), speed, actual_dt, dt, acceleration,
+      ball_data_quality_.max_acceleration);
+
+    if (acceleration > ball_data_quality_.max_acceleration) {
+      ball_data_quality_.stats.acceleration_outliers++;
+      RCLCPP_WARN(
+        node.get_logger(),
+        "[ACCEL_REJECT] Acceleration limit exceeded: accel=%.1fm/s² > %.1fm/s² "
+        "(prev=%.3f→curr=%.3f, actual_dt=%.3f, used_dt=%.3f)",
+        acceleration, ball_data_quality_.max_acceleration, prev_velocity.norm(), speed, actual_dt,
+        dt);
+      return false;
+    }
+  }
+
+  RCLCPP_DEBUG(node.get_logger(), "[VELOCITY_ACCEPT] Velocity accepted: %.3fm/s", speed);
+  return true;
+}
+
+auto WorldModelDataProvider::smoothBallVelocity(const Eigen::Vector3d & raw_velocity)
+  -> Eigen::Vector3d
+{
+  // 移動平均フィルタ
+  velocity_history_.push_back(raw_velocity);
+
+  if (velocity_history_.size() > ball_data_quality_.smoothing_window) {
+    velocity_history_.pop_front();
+  }
+
+  if (velocity_history_.empty()) {
+    return raw_velocity;
+  }
+
+  // 平均計算
+  Eigen::Vector3d sum = Eigen::Vector3d::Zero();
+  for (const auto & vel : velocity_history_) {
+    sum += vel;
+  }
+
+  return sum / static_cast<double>(velocity_history_.size());
+}
+
+auto WorldModelDataProvider::updateQualityStatistics() -> void
+{
+  // 拒否率を定期的に計算
+  if (ball_data_quality_.stats.total_detections > 0) {
+    ball_data_quality_.stats.rejection_rate =
+      static_cast<double>(ball_data_quality_.stats.outlier_rejections) /
+      static_cast<double>(ball_data_quality_.stats.total_detections);
+  }
+
+  // 100検出ごとに統計をログ出力
+  if (ball_data_quality_.stats.total_detections % 100 == 0) {
+    // RCLCPP_INFO(
+    //   node.get_logger(),
+    //   "Ball quality stats: total=%zu, rejected=%zu (%.1f%%), pos_jumps=%zu, vel_outliers=%zu, "
+    //   "acc_outliers=%zu, teleport_ok=%zu, teleport_ng=%zu",
+    //   ball_data_quality_.stats.total_detections, ball_data_quality_.stats.outlier_rejections,
+    //   ball_data_quality_.stats.rejection_rate * 100.0, ball_data_quality_.stats.position_jumps,
+    //   ball_data_quality_.stats.velocity_outliers, ball_data_quality_.stats.acceleration_outliers,
+    //   ball_data_quality_.stats.teleport_accepted, ball_data_quality_.stats.teleport_rejected);
+  }
+}
+
+auto WorldModelDataProvider::handleTeleportCandidate(
+  const Eigen::Vector3d & new_pos, const rclcpp::Time & now) -> bool
+{
+  // 新しいテレポート候補の場合
+  if (
+    ball_data_quality_.teleport_candidate.consecutive_detections == 0 ||
+    (new_pos - ball_data_quality_.teleport_candidate.position).norm() >
+      ball_data_quality_.stability_radius) {
+    ball_data_quality_.teleport_candidate.position = new_pos;
+    ball_data_quality_.teleport_candidate.first_detected = now;
+    ball_data_quality_.teleport_candidate.consecutive_detections = 1;
+    ball_data_quality_.teleport_candidate.is_stable = false;
+
+    RCLCPP_INFO(
+      node.get_logger(), "Ball teleport candidate detected: (%.3f,%.3f,%.3f) - tracking stability",
+      new_pos.x(), new_pos.y(), new_pos.z());
+
+    return false;  // 初回は受け入れない、安定性確認待ち
+  }
+
+  // 既存候補の安定性確認
+  if (
+    (new_pos - ball_data_quality_.teleport_candidate.position).norm() <=
+    ball_data_quality_.stability_radius) {
+    ball_data_quality_.teleport_candidate.consecutive_detections++;
+
+    // 十分な連続検出で安定と判定
+    if (
+      ball_data_quality_.teleport_candidate.consecutive_detections >=
+      ball_data_quality_.stability_frames) {
+      ball_data_quality_.teleport_candidate.is_stable = true;
+      ball_data_quality_.stats.teleport_accepted++;
+
+      RCLCPP_INFO(
+        node.get_logger(),
+        "Ball teleport accepted: (%.3f,%.3f,%.3f) -> (%.3f,%.3f,%.3f) after %zu stable detections",
+        last_ball_data_.first.x(), last_ball_data_.first.y(), last_ball_data_.first.z(),
+        new_pos.x(), new_pos.y(), new_pos.z(),
+        ball_data_quality_.teleport_candidate.consecutive_detections);
+
+      resetTeleportTracking();
+      return true;  // テレポート受け入れ
+    }
+
+    return false;  // まだ安定性確認中
+  }
+
+  // 候補位置から離れた場合：新しい候補として扱う
+  ball_data_quality_.teleport_candidate.position = new_pos;
+  ball_data_quality_.teleport_candidate.first_detected = now;
+  ball_data_quality_.teleport_candidate.consecutive_detections = 1;
+  ball_data_quality_.teleport_candidate.is_stable = false;
+
+  return false;
+}
+
+auto WorldModelDataProvider::resetTeleportTracking() -> void
+{
+  ball_data_quality_.teleport_candidate.consecutive_detections = 0;
+  ball_data_quality_.teleport_candidate.is_stable = false;
 }
 
 }  // namespace crane

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -4,11 +4,14 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <crane_comm/ddps.hpp>
 #include <crane_comm/time.hpp>
 #include <crane_geometry/geometry_operations.hpp>
+#include <crane_physics/ball_physics_model.hpp>
 #include <crane_world_model_publisher/world_model_publisher.hpp>
 #include <deque>
+#include <filesystem>
 #include <robocup_ssl_msgs/msg/robot_id.hpp>
 
 namespace crane
@@ -59,6 +62,45 @@ WorldModelPublisherComponent::WorldModelPublisherComponent(const rclcpp::NodeOpt
 
   declare_parameter("robot_max_vel_for_prediction", 5.0);
   get_parameter("robot_max_vel_for_prediction", robot_max_vel_for_prediction);
+
+  // ボール物理設定ファイルパス
+  declare_parameter("ball_physics_config_path", std::string(""));
+  std::string ball_physics_config_path;
+  get_parameter("ball_physics_config_path", ball_physics_config_path);
+
+  // ボール物理モデル初期化
+  if (!ball_physics_config_path.empty()) {
+    // ファイル名だけの場合はconfigディレクトリと結合
+    std::string full_config_path = ball_physics_config_path;
+    if (!std::filesystem::path(ball_physics_config_path).is_absolute()) {
+      try {
+        std::string package_share_dir =
+          ament_index_cpp::get_package_share_directory("crane_world_model_publisher");
+        full_config_path =
+          std::filesystem::path(package_share_dir) / "config" / ball_physics_config_path;
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "パッケージディレクトリの取得に失敗しました: %s 相対パスとして扱います", e.what());
+      }
+    }
+
+    try {
+      BallPhysicsModelFactory::createWithYAMLConfig(full_config_path);
+      RCLCPP_INFO(
+        this->get_logger(), "ボール物理設定を読み込みました: %s", full_config_path.c_str());
+    } catch (const std::exception & e) {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "ボール物理設定の読み込みに失敗しました (%s): %s デフォルト設定を使用します",
+        full_config_path.c_str(), e.what());
+      // エラー時はデフォルトファクトリーインスタンスを作成
+      BallPhysicsModelFactory::getInstance();
+    }
+  } else {
+    RCLCPP_INFO(this->get_logger(), "ボール物理設定: デフォルト値を使用");
+    BallPhysicsModelFactory::getInstance();
+  }
 
   pub_process_time = create_publisher<std_msgs::msg::Float32>("~/process_time", 10);
 
@@ -320,7 +362,7 @@ auto WorldModelPublisherComponent::postProcessWorldModel(WorldModelWrapper::Shar
 
 auto WorldModelPublisherComponent::updateBallContact() -> void
 {
-  auto now = rclcpp::Clock().now();
+  auto now = rclcpp::Clock(RCL_ROS_TIME).now();
 
   // ローカルセンサーの情報でボール情報を更新
   auto friend_robots = wrapper->ours().getAvailableRobots();

--- a/docker/real/docker-compose.yaml
+++ b/docker/real/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
       - -visionAddress
       - 224.5.23.2:10006
       - -trackerAddress
-      - 224.5.23.2:11010 # not yet overridable by autoRefs
+      - 224.5.23.2:10010 # not yet overridable by autoRefs
       - -publishAddress
       - 224.5.23.1:11003
       - -address
@@ -26,18 +26,18 @@ services:
     ports:
       - 8082:8082/tcp
 
-  autoref-tigers:
-    image: tigersmannheim/auto-referee:1.2.0
-    command:
-      - --active # active mode (connect to GC)
-      - --headless
-      - --visionAddress
-      - 224.5.23.2:10006
-      - --refereeAddress
-      - 224.5.23.1:11003
-      - --trackerAddress
-      - 224.5.23.2:11010
-    network_mode: host
+#  autoref-tigers:
+#    image: tigersmannheim/auto-referee:1.2.0
+#    command:
+#      - --active # active mode (connect to GC)
+#      - --headless
+#      - --visionAddress
+#      - 224.5.23.2:10006
+#      - --refereeAddress
+#      - 224.5.23.1:11003
+#      - --trackerAddress
+#      - 224.5.23.2:10010
+#    network_mode: host
 
   voicevox:
     image: voicevox/voicevox_engine:cpu-latest

--- a/docs/ball_tracking_system.md
+++ b/docs/ball_tracking_system.md
@@ -21,6 +21,7 @@ SSL Vision UDP → VisionDataProcessor → BallTracker → world_model topic →
 3. **BallTrackerManager**: 複数トラッカーの管理
 4. **BallPhysicsModel**: 共有物理計算モデル
 5. **Ball**: 予測ユーティリティの提供
+6. **BallCalibrationDataExtractor**: Vision生データを活用したキャリブレーション
 
 ## コンポーネント詳細
 
@@ -257,6 +258,10 @@ auto estimateStateFromMeasurement(position, velocity) -> Ball::State {
 2. **可視化**: rvizでボール軌道表示
 3. **統計**: `getMahalanobisDistance()`で距離監視
 
+## キャリブレーション機能
+
+Vision生データを活用したボール物理パラメータの自動キャリブレーション機能を提供。詳細は `ball_model_calibration_guide.md` を参照。
+
 ## 今後の拡張
 
 ### 予定されている改善
@@ -264,6 +269,7 @@ auto estimateStateFromMeasurement(position, velocity) -> Ball::State {
 1. **Vision→Tracker処理**: 外部トラッカー依存の除去
 2. **機械学習統合**: 深層学習ベース状態推定
 3. **多ボール対応**: 複数ボール同時トラッキング
+4. **リアルタイムキャリブレーション**: 動的パラメータ調整機能
 
 ### API拡張
 
@@ -273,4 +279,4 @@ auto estimateStateFromMeasurement(position, velocity) -> Ball::State {
 
 ## まとめ
 
-本ボールトラッキングシステムは、EKFベースの堅牢な状態推定と物理モデルベースの予測を組み合わせることで、高精度かつリアルタイムなボール情報を提供します。モジュラー設計により、各コンポーネントが独立して機能し、将来の拡張にも対応可能な構造となっています。
+EKFベースの状態推定と物理モデル予測により高精度なボール情報を提供。モジュラー設計で拡張性も確保。

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@
 
 - EKFベース高精度ボールトラッキング
 - 3D物理モデル（重力・空気抵抗対応）
+- 自動キャリブレーション機能
 - リアルタイム60Hz更新
 
 #### [crane_robot_skills](./packages/crane_robot_skills.md)
@@ -77,6 +78,7 @@
 ### システム技術  
 
 - **[ボールトラッキング](./ball_tracking_system.md)** - EKFベース状態推定の技術仕様
+- **[ボールモデルキャリブレーション](./ball_model_calibration_guide.md)** - 物理パラメータ自動最適化
 - **[可視化システム](./visualizer.md)** - SVGベース可視化APIの使用ガイド
 - **[ネットワーク設定](./network.md)** - SSL通信とマルチキャスト設定
 

--- a/session/crane_planner_plugins/include/crane_planner_plugins/planners.hpp
+++ b/session/crane_planner_plugins/include/crane_planner_plugins/planners.hpp
@@ -31,6 +31,8 @@
 #include "skill_planner.hpp"
 #include "test_planner.hpp"
 // #include "temporary/ball_placement_planner.hpp"
+#include "ball_calibration_data_collector_planner.hpp"
+#include "center_stop_kick_planner.hpp"
 #include "emplace_robot_planner.hpp"
 #include "passable_ball_placement_planner.hpp"
 #include "sandwich_ball_placement_planner.hpp"
@@ -81,7 +83,9 @@ inline auto generatePlanner(const std::string & planner_name, Ts &&... ts) -> Pl
       {"total_defense",                             [](Ts... ts) { return std::make_shared<TotalDefensePlanner>(ts...); }},
       {"emplace_robot",                             [](Ts... ts) { return std::make_shared<EmplaceRobotPlanner>(ts...); }},
       {"forward",                                   [](Ts... ts) { return std::make_shared<ForwardPlanner>(ts...); }},
-      {"second_threat_defender",                    [](Ts... ts) { return std::make_shared<SecondThreatDefenderPlanner>(ts...); }}
+      {"second_threat_defender",                    [](Ts... ts) { return std::make_shared<SecondThreatDefenderPlanner>(ts...); }},
+      {"ball_calibration_data_collector",          [](Ts... ts) { return std::make_shared<BallCalibrationDataCollectorPlanner>(ts...); }},
+      {"center_stop_kick",                          [](Ts... ts) { return std::make_shared<CenterStopKickPlanner>(ts...); }}
       // NOLINTEND
       // clang-format on
     };

--- a/session/crane_planner_plugins/plugins.xml
+++ b/session/crane_planner_plugins/plugins.xml
@@ -20,4 +20,10 @@
 	<class type="crane::KickoffPlanner" base_class_type="crane::PlannerBase">
 		<description>a planner plugin for kickoff</description>
 	</class>
+	<class type="crane::BallCalibrationDataCollectorPlanner" base_class_type="crane::PlannerBase">
+		<description>a planner plugin for ball calibration data collection</description>
+	</class>
+	<class type="crane::CenterStopKickPlanner" base_class_type="crane::PlannerBase">
+		<description>a planner plugin for center stop kick</description>
+	</class>
 </library>

--- a/session/crane_session_controller/config/play_situation/OUR_BALL_PLACEMENT.yaml
+++ b/session/crane_session_controller/config/play_situation/OUR_BALL_PLACEMENT.yaml
@@ -3,7 +3,5 @@ description: OUR_BALL_PLACEMENT
 sessions:
   - name: ball_placement_skill
     capacity: 1
-  - name: defender
-    capacity: 2
   - name: ball_placement_avoidance
     capacity: 20

--- a/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
@@ -71,7 +71,11 @@ auto WorldModelWrapper::update(const crane_msgs::msg::WorldModel & world_model) 
       info->ball_contact.update((info->kicker_center() - ball_.pos).norm() < 0.1);
       // ボールセンサは味方だけ
       info->ball_sensor = robot.ball_sensor;
-      info->ball_sensor_stamp = robot.last_ball_sensor_stamp;
+      if (robot.last_ball_sensor_stamp.sec == 0 && robot.last_ball_sensor_stamp.nanosec == 0) {
+        info->ball_sensor_stamp = std::nullopt;
+      } else {
+        info->ball_sensor_stamp = rclcpp::Time(robot.last_ball_sensor_stamp, RCL_ROS_TIME);
+      }
     } else {
       info->ball_contact.update(false);
     }

--- a/utility/crane_physics/include/crane_physics/robot_info.hpp
+++ b/utility/crane_physics/include/crane_physics/robot_info.hpp
@@ -10,6 +10,7 @@
 #include <crane_geometry/boost_geometry.hpp>
 #include <crane_physics/ball_contact.hpp>
 #include <memory>
+#include <optional>
 #include <rclcpp/time.hpp>
 
 namespace crane
@@ -45,7 +46,7 @@ struct RobotInfo
 
   rclcpp::Time vision_detection_stamp;
 
-  rclcpp::Time ball_sensor_stamp;
+  std::optional<rclcpp::Time> ball_sensor_stamp;
 
   bool ball_sensor = false;
 
@@ -53,8 +54,18 @@ struct RobotInfo
     rclcpp::Time now, rclcpp::Duration interval = rclcpp::Duration::from_seconds(0.001)) const
     -> bool
   {
-    return now.get_clock_type() == ball_sensor_stamp.get_clock_type() &&
-           (now - ball_sensor_stamp).seconds() < interval.seconds();
+    if (
+      ball_sensor_stamp.has_value() &&
+      now.get_clock_type() == ball_sensor_stamp->get_clock_type()) {
+      auto diff = (now - *ball_sensor_stamp).seconds();
+      std::cout << "[RobotInfo] Ball sensor available: " << diff << "s" << std::endl;
+    } else {
+      std::cout << "[RobotInfo] Ball sensor not available" << std::endl;
+    }
+
+    return ball_sensor_stamp.has_value() &&
+           now.get_clock_type() == ball_sensor_stamp->get_clock_type() &&
+           (now - *ball_sensor_stamp).seconds() < interval.seconds();
   }
 
   using SharedPtr = std::shared_ptr<RobotInfo>;


### PR DESCRIPTION
ball_model_calibブランチの残り19ファイルを統合し、型互換性を修正：
- ball_sensor_stamp型をstd::optional<rclcpp::Time>に変更
- getBallSensorAvailable()メソッドをoptional型対応に更新
- プランナー設定とCMakeListsファイルを更新
- ballバッファリング設定とAPIキー設定を統合

型修正による影響:
- RobotInfo::ball_sensor_stampの型変更対応
- world_model_wrapper.cppのnullopt代入互換性確保
- #include <optional>の追加による完全なstd::optional対応

🤖 Generated with [Claude Code](https://claude.ai/code)