### PR TITLE
機能追加: Attackerスキルでのパス判定アルゴリズム改良

### DIFF
--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -87,7 +87,16 @@ void Attacker::initialize()
     command->disableBallAvoidance();
     command->setMaxVelocity(2.0);
     if (pass_receiver_id) {
-      kick_target = world_model()->getOurRobot(pass_receiver_id.value())->pose.pos;
+      auto pass_receiver_pos = world_model()->getOurRobot(pass_receiver_id.value())->pose.pos;
+      if (pass_receiver_pos.x() * world_model()->getOurSideSign() > 0.) {
+        // 自陣にいるときは強制的に敵ゴールを目標に設定
+        kick_target = world_model()->getTheirGoalCenter();
+      } else {
+        // 敵陣に適当なロボットがいる場合はパス
+        kick_target = pass_receiver_pos;
+      }
+    } else {
+      kick_target = world_model()->getTheirGoalCenter();
     }
     kick_skill.setParameter("target", kick_target);
     Segment kick_line{world_model()->ball().pos, kick_target};

--- a/crane_robot_skills/src/center_stop_kick.cpp
+++ b/crane_robot_skills/src/center_stop_kick.cpp
@@ -343,7 +343,6 @@ void CenterStopKick::initializePhysicsModels()
     kicker_model_->setBallPhysicsModel(ball_physics_model_);
 
     RCLCPP_INFO(rclcpp::get_logger("CenterStopKick"), "物理モデル初期化完了");
-
   } catch (const std::exception & e) {
     RCLCPP_ERROR(rclcpp::get_logger("CenterStopKick"), "物理モデル初期化エラー: %s", e.what());
   }


### PR DESCRIPTION
パス相手ロボットの位置に基づくシュート・パス選択機能を追加：
- パス相手が自陣（x * side_sign > 0）にいる場合は敵ゴールへの直接シュートを実行
- パス相手が敵陣にいる場合は従来通りパスを実行
- フォールバック機能：パス相手が存在しない場合は敵ゴールへシュート

これにより攻撃戦術の柔軟性が向上し、自陣でのボール保持時に
より積極的なゴール指向の行動を取れるようになる。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>