### PR TITLE
# RobotInfo と WorldModelDataProvider にエラー追跡機能を追加

### DIFF
--- a/crane_msgs/msg/world_model/RobotInfo.msg
+++ b/crane_msgs/msg/world_model/RobotInfo.msg
@@ -26,3 +26,12 @@ BallContact ball_contact
 
 builtin_interfaces/Time last_ball_sensor_stamp
 bool ball_sensor
+
+# ロボットのエラー情報（/robot_feedback 由来）
+# id または info が非ゼロであればエラー有りとみなす
+bool has_error
+uint16 error_id
+uint16 error_info
+float32 error_value
+builtin_interfaces/Time last_error_stamp
+float32 error_duration_sec

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -131,6 +131,16 @@ private:
   FieldGeometry field_geometry_;
   bool has_vision_updated_;
 
+  // エラー継続時間を算出するためのトラッキング用構造体
+  struct ErrorTracker
+  {
+    bool active = false;
+    uint16_t id = 0;
+    uint16_t info = 0;
+    rclcpp::Time start{};  // 現在のエラー(id, info)が開始した時刻
+  };
+  std::vector<ErrorTracker> error_tracker_[2];  // [our_team, their_team]
+
   // 最新のSSL_DetectionFrame（detection_frame生成用）
   mutable SSL_DetectionFrame latest_ssl_detection_frame_;
   mutable bool has_latest_detection_frame_;

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -77,6 +77,7 @@ WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
   // ロボット情報初期化
   for (int team = 0; team < 2; ++team) {
     robot_info_[team].resize(MAX_ROBOT_COUNT);
+    error_tracker_[team].resize(MAX_ROBOT_COUNT);
     for (size_t i = 0; i < MAX_ROBOT_COUNT; ++i) {
       auto & robot = robot_info_[team][i];
       robot.id = static_cast<uint8_t>(i);
@@ -84,6 +85,7 @@ WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
       robot.feedback_detected = false;
       robot.internal_tracker_detected = false;
       robot.detected = false;
+      // error tracker defaults are already zeroed by the struct's default members
     }
   }
 
@@ -350,6 +352,34 @@ crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
           feedback_robot.last_ball_sensor_stamp = feedback.received_stamp;
           feedback_robot.last_feedback_detection_stamp = feedback.received_stamp;
 
+          // エラー情報を転送 + 継続時間の算出
+          bool has_err = (feedback.error_id != 0 || feedback.error_info != 0);
+          feedback_robot.has_error = has_err;
+          feedback_robot.error_id = feedback.error_id;
+          feedback_robot.error_info = feedback.error_info;
+          feedback_robot.error_value = feedback.error_value;
+          feedback_robot.last_error_stamp = feedback.received_stamp;
+
+          auto & tracker = error_tracker_[team_idx][robot.id];
+          if (has_err) {
+            if (!tracker.active) {
+              // Any error started now
+              tracker.active = true;
+              tracker.start = rclcpp::Time(feedback.received_stamp);
+            }
+            // 稼働中のエラーとして種類(id/info)のみ更新（開始時刻はリセットしない）
+            tracker.id = feedback.error_id;
+            tracker.info = feedback.error_info;
+            double duration = (current_time - tracker.start).seconds();
+            if (duration < 0.0) duration = 0.0;
+            feedback_robot.error_duration_sec = static_cast<float>(duration);
+          } else {
+            tracker.active = false;
+            tracker.id = 0;
+            tracker.info = 0;
+            feedback_robot.error_duration_sec = 0.0f;
+          }
+
           // visionデータとfeedbackデータを統合
           robot = mergeRobotInfo(robot, feedback_robot);
           break;
@@ -442,6 +472,14 @@ auto WorldModelDataProvider::mergeRobotInfo(
   merged.ball_sensor = feedback_robot.ball_sensor;
   merged.last_ball_sensor_stamp = feedback_robot.last_ball_sensor_stamp;
   merged.last_feedback_detection_stamp = feedback_robot.last_feedback_detection_stamp;
+
+  // Merge error information
+  merged.has_error = feedback_robot.has_error;
+  merged.error_id = feedback_robot.error_id;
+  merged.error_info = feedback_robot.error_info;
+  merged.error_value = feedback_robot.error_value;
+  merged.last_error_stamp = feedback_robot.last_error_stamp;
+  merged.error_duration_sec = feedback_robot.error_duration_sec;
 
   // Combine detection flags
   merged.detected = merged.vision_detected || merged.feedback_detected;

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -360,23 +360,23 @@ crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
           feedback_robot.error_value = feedback.error_value;
           feedback_robot.last_error_stamp = feedback.received_stamp;
 
-          auto & tracker = error_tracker_[team_idx][robot.id];
+          auto & err_tracker = error_tracker_[team_idx][robot.id];
           if (has_err) {
-            if (!tracker.active) {
+            if (!err_tracker.active) {
               // Any error started now
-              tracker.active = true;
-              tracker.start = rclcpp::Time(feedback.received_stamp);
+              err_tracker.active = true;
+              err_tracker.start = rclcpp::Time(feedback.received_stamp);
             }
             // 稼働中のエラーとして種類(id/info)のみ更新（開始時刻はリセットしない）
-            tracker.id = feedback.error_id;
-            tracker.info = feedback.error_info;
-            double duration = (current_time - tracker.start).seconds();
+            err_tracker.id = feedback.error_id;
+            err_tracker.info = feedback.error_info;
+            double duration = (current_time - err_tracker.start).seconds();
             if (duration < 0.0) duration = 0.0;
             feedback_robot.error_duration_sec = static_cast<float>(duration);
           } else {
-            tracker.active = false;
-            tracker.id = 0;
-            tracker.info = 0;
+            err_tracker.active = false;
+            err_tracker.id = 0;
+            err_tracker.info = 0;
             feedback_robot.error_duration_sec = 0.0f;
           }
 

--- a/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
@@ -61,7 +61,8 @@ auto WorldModelWrapper::update(const crane_msgs::msg::WorldModel & world_model) 
 
   for (auto & robot : world_model.robot_info_ours) {
     auto & info = ours_.robots.at(robot.id);
-    info->available = robot.detected;
+    // エラーがないかつ検出状態なら利用可能
+    info->available = robot.detected && !robot.has_error;
     if (info->available) {
       info->id = robot.id;
       info->vision_detection_stamp = robot.vision.stamp;


### PR DESCRIPTION
- **RobotInfo.msg** にエラーの詳細を記録するためのエラー追跡用構造体を導入
- **WorldModelDataProvider** を更新し、エラー情報および継続時間の計算に対応