### PR TITLE
自動バージョニング・リリースシステムの導入

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -1,0 +1,139 @@
+name: Auto Version Bump and Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'バージョンバンプタイプ'
+        required: true
+        type: choice
+        default: 'patch'
+        options:
+          - patch
+          - minor
+          - major
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  version-bump-release:
+    name: Version Bump and Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install bloom and dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -yqq python3-pip python3-catkin-pkg
+          pip3 install bloom
+        shell: bash
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        shell: bash
+
+      - name: Determine bump type
+        id: bump_type
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "type=${{ inputs.bump_type }}" >> $GITHUB_OUTPUT
+          else
+            echo "type=patch" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - name: Get current version
+        id: current_version
+        run: |
+          # 最初のpackage.xmlからバージョンを取得
+          VERSION=$(grep -m1 '<version>' $(find . -name package.xml | head -1) | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $VERSION"
+        shell: bash
+
+      - name: Run catkin_prepare_release
+        id: release
+        run: |
+          # バージョンバンプを実行
+          catkin_prepare_release --bump ${{ steps.bump_type.outputs.type }} --no-push -y
+
+          # 新しいバージョンを取得
+          NEW_VERSION=$(grep -m1 '<version>' $(find . -name package.xml | head -1) | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION"
+        shell: bash
+
+      - name: Amend commit with custom message
+        run: |
+          # catkin_prepare_releaseが作成したコミットを修正して日本語メッセージに変更
+          git reset --soft HEAD~1
+          git add .
+          git commit -m "$(cat <<'EOF'
+          release: バージョン${{ steps.release.outputs.new_version }}をリリース
+
+          全パッケージのバージョンを${{ steps.current_version.outputs.version }}から${{ steps.release.outputs.new_version }}に更新
+          EOF
+          )"
+        shell: bash
+
+      - name: Create and push tag
+        run: |
+          git tag -a "${{ steps.release.outputs.new_version }}" -m "Release ${{ steps.release.outputs.new_version }}"
+          git push origin develop
+          git push origin "${{ steps.release.outputs.new_version }}"
+        shell: bash
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          # 前回のタグを取得
+          PREVIOUS_TAG=$(git tag --sort=-creatordate | sed -n '2p')
+
+          if [ -z "$PREVIOUS_TAG" ]; then
+            # 最初のリリースの場合
+            echo "notes=🎉 crane v${{ steps.release.outputs.new_version }}の初回リリースです。" >> $GITHUB_OUTPUT
+          else
+            # 変更履歴を生成
+            CHANGES=$(git log --pretty=format:"- %s" ${PREVIOUS_TAG}..${{ steps.release.outputs.new_version }})
+            echo "notes<<EOF" >> $GITHUB_OUTPUT
+            echo "## 変更内容" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "$CHANGES" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "---" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...${{ steps.release.outputs.new_version }}" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release.outputs.new_version }}
+          name: Release ${{ steps.release.outputs.new_version }}
+          body: ${{ steps.release_notes.outputs.notes }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/3rdparty/closest_point_vendor/package.xml
+++ b/3rdparty/closest_point_vendor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>closest_point_vendor</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="pythagora.yoshimoto@gmail.com">hans</maintainer>
   <license>TODO: License declaration</license>

--- a/3rdparty/matplotlib_cpp_17_vendor/package.xml
+++ b/3rdparty/matplotlib_cpp_17_vendor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>matplotlib_cpp_17_vendor</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="pythagora.yoshimoto@gmail.com">groundstation</maintainer>
   <license>TODO: License declaration</license>

--- a/3rdparty/modern_orca/package.xml
+++ b/3rdparty/modern_orca/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>modern_orca</name>
-  <version>0.1.0</version>
+  <version>1.0.0</version>
   <description>Modern C++ ORCA Library with Extensible Constraints</description>
 
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>

--- a/3rdparty/rvo2_vendor/package.xml
+++ b/3rdparty/rvo2_vendor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rvo2_vendor</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="pythagora.yoshimoto@gmail.com">groundstation</maintainer>
   <license>TODO: License declaration</license>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,45 @@ FILTER_BRANCH_SQUELCH_WARNING=1 git filter-branch --force --index-filter \
   --prune-empty HEAD~20..HEAD
 ```
 
+## バージョニングとリリース管理
+
+このプロジェクトは自動バージョニング・リリースシステムを採用しています。
+
+### 自動バージョンアップ
+
+developブランチへのマージ時に、GitHub Actionsが自動的にpatchバージョンをインクリメントします。
+
+**フロー**:
+1. 機能開発ブランチでの作業
+2. PRレビュー・承認
+3. developへのマージ → 自動的に `X.Y.Z` → `X.Y.Z+1`
+4. GitHub Releaseが自動作成される
+
+### 手動バージョンアップ
+
+minor/majorバージョンアップが必要な場合は、GitHub ActionsのUIから手動実行します。
+
+**手順**:
+1. GitHub Actions → `Auto Version Bump and Release` を選択
+2. `workflow_dispatch` を実行
+3. バージョンバンプタイプを選択:
+   - `patch`: X.Y.Z → X.Y.Z+1（デフォルト）
+   - `minor`: X.Y.Z → X.Y+1.0
+   - `major`: X.Y.Z → X+1.0.0
+
+### バージョン管理ポリシー
+
+- **全パッケージ統一**: 32個の全パッケージを同一バージョンで管理
+- **セマンティックバージョニング**: メジャー.マイナー.パッチ形式
+- **Gitタグ**: 各バージョンにタグを付与（例: `1.0.0`）
+- **リリースノート**: GitHub Releaseで自動生成
+
+### AIエージェントへの指示
+
+- バージョン番号は手動で変更しないこと
+- package.xmlのバージョンは自動管理されていることを認識すること
+- リリースはGitHub Actionsに任せること
+
 ## コミット規約
 
 ### 言語ポリシー

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,7 @@ FILTER_BRANCH_SQUELCH_WARNING=1 git filter-branch --force --index-filter \
 developブランチへのマージ時に、GitHub Actionsが自動的にpatchバージョンをインクリメントします。
 
 **フロー**:
+
 1. 機能開発ブランチでの作業
 2. PRレビュー・承認
 3. developへのマージ → 自動的に `X.Y.Z` → `X.Y.Z+1`
@@ -297,6 +298,7 @@ developブランチへのマージ時に、GitHub Actionsが自動的にpatchバ
 minor/majorバージョンアップが必要な場合は、GitHub ActionsのUIから手動実行します。
 
 **手順**:
+
 1. GitHub Actions → `Auto Version Bump and Release` を選択
 2. `workflow_dispatch` を実行
 3. バージョンバンプタイプを選択:

--- a/consai_ros2/robocup_ssl_comm/package.xml
+++ b/consai_ros2/robocup_ssl_comm/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robocup_ssl_comm</name>
-  <version>0.1.0</version>
+  <version>1.0.0</version>
   <description>This package provides components that communicate with RoboCup SSL official software.</description>
   <maintainer email="macakasit@gmail.com">shotaak</maintainer>
   <license>Apache License 2.0</license>

--- a/consai_ros2/robocup_ssl_msgs/package.xml
+++ b/consai_ros2/robocup_ssl_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robocup_ssl_msgs</name>
-  <version>0.1.0</version>
+  <version>1.0.0</version>
   <description>robocup_ssl_msgs contains message types that express RoboCup SSL official protocols in ROS system.</description>
   <maintainer email="macakasit@gmail.com">shotaak</maintainer>
   <license>Apache License 2.0</license>

--- a/crane_bringup/package.xml
+++ b/crane_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_bringup</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="pythagora.yoshimoto@gmail.com">hans</maintainer>
   <license>TODO: License declaration</license>

--- a/crane_debug_tools/package.xml
+++ b/crane_debug_tools/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_debug_tools</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Modern debugging tools for crane robot skills</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>

--- a/crane_description/package.xml
+++ b/crane_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_description</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="macakasit@gmail.com">akshota</maintainer>
   <license>MIT</license>

--- a/crane_game_analyzer/package.xml
+++ b/crane_game_analyzer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_game_analyzer</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Analyze ssl game from vision and referee command</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
   <license>MIT</license>

--- a/crane_gui/package.xml
+++ b/crane_gui/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_gui</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="taiga202500@gmail.com">ibis</maintainer>
   <license>TODO: License declaration</license>

--- a/crane_local_planner/package.xml
+++ b/crane_local_planner/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_local_planner</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Facilitate pass between robots</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
   <license>MIT</license>

--- a/crane_msgs/package.xml
+++ b/crane_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_msgs</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Crane</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>

--- a/crane_play_switcher/package.xml
+++ b/crane_play_switcher/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_play_switcher</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Extract facts from vision and referee command</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
   <license>MIT</license>

--- a/crane_robot_receiver/package.xml
+++ b/crane_robot_receiver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_robot_receiver</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Receive sensor data from real robot</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>

--- a/crane_robot_skills/package.xml
+++ b/crane_robot_skills/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_robot_skills</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>crane_robot_skills</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>

--- a/crane_sender/package.xml
+++ b/crane_sender/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_sender</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Send commands to real robot</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>

--- a/crane_speaker/package.xml
+++ b/crane_speaker/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_speaker</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>crane_speaker</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
   <license>MIT</license>

--- a/crane_visualization_interfaces/package.xml
+++ b/crane_visualization_interfaces/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_visualization_interfaces</name>
-  <version>0.1.0</version>
+  <version>1.0.0</version>
   <description>Message types for CON-SAI visualization</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
   <license>MIT</license>

--- a/crane_world_model_publisher/package.xml
+++ b/crane_world_model_publisher/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_world_model_publisher</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>crane_world_model_publisher</description>
   <maintainer email="macakasit@gmail.com">akshota</maintainer>
   <license>MIT</license>

--- a/session/crane_planner_plugins/package.xml
+++ b/session/crane_planner_plugins/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_planner_plugins</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>planner collection</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
   <license>MIT</license>

--- a/session/crane_session_controller/package.xml
+++ b/session/crane_session_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_session_controller</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>control robot sessions and their planners</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
   <license>MIT</license>

--- a/utility/crane_clock_publisher/package.xml
+++ b/utility/crane_clock_publisher/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_clock_publisher</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>

--- a/utility/crane_comm/package.xml
+++ b/utility/crane_comm/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_comm</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Communication and ROS 2 utilities for crane robotics system</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>

--- a/utility/crane_geometry/package.xml
+++ b/utility/crane_geometry/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_geometry</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Core geometry and mathematical utilities for crane robotics system</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>

--- a/utility/crane_grsim_operator/package.xml
+++ b/utility/crane_grsim_operator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_grsim_operator</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Operate ball and robots in GrSim for debugging.</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
   <license>MIT</license>

--- a/utility/crane_lint_common/package.xml
+++ b/utility/crane_lint_common/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_lint_common</name>
-  <version>0.0.1</version>
+  <version>1.0.0</version>
   <description>common linter settings for crane packages</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
   <license>Apache 2.0</license>

--- a/utility/crane_msg_wrappers/package.xml
+++ b/utility/crane_msg_wrappers/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_msg_wrappers</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>utility</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>

--- a/utility/crane_physics/package.xml
+++ b/utility/crane_physics/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_physics</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Physics simulation and robot modeling utilities for crane robotics system</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>

--- a/utility/crane_teleop/package.xml
+++ b/utility/crane_teleop/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_teleop</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="macakasit@gmail.com">akshota</maintainer>
   <license>TODO: License declaration</license>

--- a/utility/crane_utils/package.xml
+++ b/utility/crane_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_utils</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Common utility functions and helpers for crane robotics system</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>

--- a/utility/crane_visualization_aggregator/package.xml
+++ b/utility/crane_visualization_aggregator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_visualization_aggregator</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>crane_visualization_aggregator</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>


### PR DESCRIPTION
## 概要
craneシステムに自動バージョニングとリリース管理システムを導入します。

## 変更内容
- **GitHub Actionsワークフロー追加**: `.github/workflows/auto-release.yaml`
  - developブランチへのマージ時に自動的にpatchバージョンアップ（1.0.X → 1.0.X+1）
  - 手動トリガー（workflow_dispatch）でminor/majorバージョンアップも可能
  - GitHub Releaseの自動作成
- **全パッケージバージョン統一**: 全32パッケージを1.0.0に統一

## リリースフロー
### 通常運用（自動）
1. 機能開発ブランチでの作業
2. PRレビュー・承認
3. developへのマージ → **自動的にpatchバージョンアップ**
4. GitHub Releaseが自動作成

### minor/majorバージョンアップ（手動）
- GitHub ActionsのUIから`workflow_dispatch`を実行
- バージョンバンプタイプを選択（patch/minor/major）

## 技術詳細
- **ツール**: catkin_prepare_release（bloom）
- **バージョン管理**: 全パッケージ統一管理（モノレポ構成）
- **権限**: GITHUB_TOKEN（追加設定不要）
- **コミット規約**: 日本語コミットメッセージ

## 注意事項
⚠️ **このPRがマージされると、自動的にバージョン1.0.1へアップデートされます**

初回リリースv1.0.0を維持したい場合は、マージ前に以下のいずれかの対応が必要です：
1. auto-release.yamlのpushトリガーを一時的に無効化
2. マージ後に手動で1.0.1を1.0.0に戻す

## テスト
- [ ] ワークフロー構文チェック（pre-commit）
- [ ] 全パッケージのバージョン整合性確認
- [ ] タグ1.0.0の作成確認