### PR TITLE
fix(ci): リリースワークフローにバージョンアップコミット・タグのpush処理を追加

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -146,6 +146,21 @@ jobs:
           )"
         shell: bash
 
+      - name: Create and push tag
+        run: |
+          # タグを作成してpush
+          git tag -a "${{ steps.release.outputs.new_version }}" -m "Release ${{ steps.release.outputs.new_version }}"
+          echo "Created tag ${{ steps.release.outputs.new_version }}"
+        shell: bash
+
+      - name: Push version bump commit and tag
+        run: |
+          # バージョンアップコミットとタグをpush
+          git push origin develop
+          git push origin ${{ steps.release.outputs.new_version }}
+          echo "Pushed commit and tag to remote repository"
+        shell: bash
+
       - name: Generate release notes
         id: release_notes
         run: |

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -167,13 +167,11 @@ jobs:
           全パッケージのバージョンを${{ steps.current_version.outputs.version }}から${{ steps.release.outputs.new_version }}に更新
           EOF
           )"
-        shell: bash
 
-      - name: Create and push tag
-        run: |
-          # タグを作成してpush
+          # タグを再作成（catkin_prepare_releaseが作成したタグを削除して、新しいコミットに再作成）
+          git tag -d "${{ steps.release.outputs.new_version }}"
           git tag -a "${{ steps.release.outputs.new_version }}" -m "Release ${{ steps.release.outputs.new_version }}"
-          echo "Created tag ${{ steps.release.outputs.new_version }}"
+          echo "Recreated tag ${{ steps.release.outputs.new_version }} on the amended commit"
         shell: bash
 
       - name: Push version bump commit and tag

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -12,6 +12,11 @@ on:
           - patch
           - minor
           - major
+      dry_run:
+        description: 'ドライランモード（実際のpush・リリースは行わない）'
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - develop
@@ -49,6 +54,19 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        shell: bash
+
+      - name: Display mode
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "🔍 =========================================="
+            echo "🔍   ドライランモード（DRY RUN MODE）"
+            echo "🔍 =========================================="
+            echo "🔍 実際のpush・リリースは行いません"
+            echo "🔍 =========================================="
+          else
+            echo "✅ 通常モード（実際のpush・リリースを実行）"
+          fi
         shell: bash
 
       - name: Determine bump type
@@ -105,13 +123,18 @@ jobs:
 
             if [ "$TAG_VERSION" != "$NEXT_VERSION" ]; then
               echo "❌ タグとバージョンが不一致です（タグ: $NEXT_VERSION, package.xml: $TAG_VERSION）"
-              echo "🔧 不整合なタグを削除します..."
 
-              # ローカルとリモートのタグを削除
-              git tag -d "$NEXT_VERSION"
-              git push origin --delete "$NEXT_VERSION" || echo "リモートタグの削除に失敗しましたが続行します"
-
-              echo "✅ タグを削除しました。catkin_prepare_releaseで再作成されます。"
+              if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
+                echo "🔍 [DRY RUN] 不整合なタグを削除する予定:"
+                echo "  - git tag -d $NEXT_VERSION"
+                echo "  - git push origin --delete $NEXT_VERSION"
+              else
+                echo "🔧 不整合なタグを削除します..."
+                # ローカルとリモートのタグを削除
+                git tag -d "$NEXT_VERSION"
+                git push origin --delete "$NEXT_VERSION" || echo "リモートタグの削除に失敗しましたが続行します"
+                echo "✅ タグを削除しました。catkin_prepare_releaseで再作成されます。"
+              fi
             else
               echo "✅ タグとバージョンは整合性があります。"
               echo "⚠️ しかし、このタグは既に存在するため、catkin_prepare_releaseでエラーが発生する可能性があります。"
@@ -155,10 +178,16 @@ jobs:
 
       - name: Push version bump commit and tag
         run: |
-          # バージョンアップコミットとタグをpush
-          git push origin develop
-          git push origin ${{ steps.release.outputs.new_version }}
-          echo "Pushed commit and tag to remote repository"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "🔍 [DRY RUN] 以下のコマンドを実行する予定:"
+            echo "  - git push origin develop"
+            echo "  - git push origin ${{ steps.release.outputs.new_version }}"
+          else
+            # バージョンアップコミットとタグをpush
+            git push origin develop
+            git push origin ${{ steps.release.outputs.new_version }}
+            echo "✅ Pushed commit and tag to remote repository"
+          fi
         shell: bash
 
       - name: Generate release notes
@@ -185,7 +214,18 @@ jobs:
           fi
         shell: bash
 
+      - name: Display dry run message for release
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
+        run: |
+          echo "🔍 [DRY RUN] 以下の内容でGitHub Releaseを作成する予定:"
+          echo "  - Tag: ${{ steps.release.outputs.new_version }}"
+          echo "  - Name: Release ${{ steps.release.outputs.new_version }}"
+          echo "  - Draft: false"
+          echo "  - Prerelease: false"
+        shell: bash
+
       - name: Create GitHub Release
+        if: ${{ ! (github.event_name == 'workflow_dispatch' && inputs.dry_run == true) }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.release.outputs.new_version }}


### PR DESCRIPTION
## 概要

リリースワークフローで、バージョンアップコミットとタグが正しくリモートリポジトリにpushされるように修正しました。

## 問題の詳細

### 発生していた問題
前回のPR (#967) マージ後、以下の問題が発生していました：

1. **GitHub Release 1.0.1 は作成された**が、**package.xml のバージョンは 1.0.0 のまま**
2. タグ 1.0.1 が存在するが、そのタグが指すコミットでは package.xml は更新されていない
3. develop ブランチにバージョンアップのコミットが反映されていない

### 根本原因

```yaml
# 問題のあった処理フロー
1. catkin_prepare_release --no-push
   → バージョンアップコミット作成（ローカルのみ）
2. git commit（コミットメッセージ修正）
   → コミット修正（ローカルのみ）
3. ❌ push ステップが存在しない
4. softprops/action-gh-release
   → タグがリモートに存在しないため、現在のコミット（バージョンアップ前）にタグを作成
```

**結果**: バージョンアップコミットはローカルのみに存在し、リモートには反映されず、タグは古いコミットを指してしまう。

## 実施した修正

### 1. 即時対応（完了済み）
- 不整合なタグ 1.0.1 を削除（ローカル・リモート）
- GitHub Release 1.0.1 を削除

### 2. ワークフロー修正（本PR）

**追加した2つのステップ**:

#### ① Create and push tag
タグをローカルで作成

#### ② Push version bump commit and tag
バージョンアップコミットとタグをリモートにpush

**追加位置**: 「Amend commit with custom message」ステップの後

### 修正後の処理フロー

```yaml
1. catkin_prepare_release --no-push
   → バージョンアップコミット作成（ローカル）
2. git commit（コミットメッセージ修正）
   → コミット修正（ローカル）
3. git tag（タグ作成）
   → バージョンアップコミットにタグを作成（ローカル）
4. ✅ git push（新規追加）
   → バージョンアップコミットとタグを push
5. softprops/action-gh-release
   → 既存のタグを使用（正しいコミットを指している）
```

## 効果

✅ バージョンアップコミットが develop ブランチに正しく反映される  
✅ タグが正しいバージョンの package.xml を含むコミットを指す  
✅ GitHub Release が正しいバージョン情報を持つ  
✅ 次回以降のリリースも正しく動作する  

## テスト計画

- [ ] ワークフローの構文が正しいことを確認（CI実行）
- [ ] PRマージ後、次回のdevelopへのpush時に自動リリースが正しく動作することを確認
- [ ] バージョンアップコミットがdevelopブランチに反映されることを確認
- [ ] タグが正しいバージョンを指すことを確認

## 関連PR

- #967: タグ整合性チェック機能を追加（前回のPR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
