### PR TITLE
feat(ci): リリースワークフローをMerge QueueとProtected Branchに対応

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -30,13 +30,16 @@ jobs:
     name: Version Bump and Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Merge queueによるマージは除外（バージョンバンプは実際のマージ後のみ実行）
+    if: github.actor != 'github-merge-queue[bot]'
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Protected branchへのpushにはPATが必要
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           fetch-depth: 0
           # Protected branchへのpushにはPATが必要
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## 概要

リリースワークフローをMerge QueueとProtected Branchに対応させました。

## 背景

PR #968 でバージョンアップコミット・タグのpush処理を追加しましたが、以下の課題がありました：

1. **Protected branchへの直接push**
   - developブランチが保護されている場合、github-actions[bot]による直接pushが制限される
   - セキュリティ上、protected branchへの直接pushは推奨されない

2. **Merge queueとの非互換性**
   - Merge queue有効化後、developブランチへの直接pushは基本的に禁止
   - すべての変更はPR → Merge queue経由で行う必要がある

## 実施した対策

### 1. Merge queue botによるマージを除外

```yaml
if: github.actor != 'github-merge-queue[bot]'
```

- Merge queue内でのバージョンバンプを防止
- 実際のdevelopへのマージ後のみ、リリースワークフローを実行

### 2. Protected branchへのpush対応

```yaml
token: ${{ secrets.GH_PAT }}
```

- 既存の `GH_PAT` Secretを使用
- GITHUB_TOKENではprotected branchへのpushが制限されるため
- PATを使用することでprotected branchへのpushが可能に

## 動作フロー（Merge Queue有効化後）

1. PRがmerge queueに追加
2. Merge queue内で必須テスト実行（`merge_group` トリガー）
3. テスト成功後、developへ自動マージ
4. **マージ後、リリースワークフローが起動**（merge queue botは除外）
5. バージョンバンプ、コミット、タグ作成
6. GH_PATでdevelopへpush（protected branchでも成功）
7. GitHub Release作成

## 変更内容

### `.github/workflows/auto-release.yaml`

1. **Job条件の追加**
   - `if: github.actor != 'github-merge-queue[bot]'`
   - Merge queue botによる実行を除外

2. **Checkout tokenの変更**
   - `token: ${{ secrets.GH_PAT }}`
   - Protected branchへのpush対応

## 必要な準備

- ✅ `GH_PAT` Secretは既に設定済み
- ⏳ Merge queueの有効化（このPRマージ後に実施）
  - Settings → Branches → develop → "Require merge queue"

## テスト計画

- [ ] ドライランモードでGH_PAT認証が動作することを確認
- [ ] Merge queue有効化後、実際のマージでリリースワークフローが正常動作することを確認

## 関連PR

- #967: タグ整合性チェック機能を追加
- #968: バージョンアップコミット・タグのpush処理を追加（マージ済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
