### PR TITLE
🚨 fix(ci): リリースワークフローの無限ループを緊急停止

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -30,8 +30,11 @@ jobs:
     name: Version Bump and Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Merge queueによるマージは除外（バージョンバンプは実際のマージ後のみ実行）
-    if: github.actor != 'github-merge-queue[bot]'
+    # 無限ループ防止: Merge queue botとgithub-actions botによるコミットを除外
+    # ただし手動実行は許可
+    if: |
+      github.actor != 'github-merge-queue[bot]' &&
+      (github.event.head_commit.author.name != 'github-actions[bot]' || github.event_name == 'workflow_dispatch')
 
     steps:
       - name: Checkout repository
@@ -168,6 +171,8 @@ jobs:
           release: バージョン${{ steps.release.outputs.new_version }}をリリース
 
           全パッケージのバージョンを${{ steps.current_version.outputs.version }}から${{ steps.release.outputs.new_version }}に更新
+
+          [skip ci]
           EOF
           )"
 


### PR DESCRIPTION
## 🚨 緊急修正：リリースワークフローの無限ループを停止

### 現在の状況

PR #969 のマージ後、リリースワークフローが無限ループに入り、以下のリリースが連続して作成されてしまいました：

- 1.0.1
- 1.0.2
- 1.0.3
- 1.0.4
- 1.0.5
- 1.0.6

### 問題の原因

バージョンアップコミットをdevelopにpushすると、そのpushが再度リリースワークフローをトリガーし、無限ループが発生していました。

**問題のあったフロー**:
1. PRマージ → リリースワークフロー起動
2. バージョンアップコミット作成 → developへpush
3. **このpushが再度ワークフローをトリガー → 無限ループ** ❌

### 実施した対策（二重の防御）

#### 1. github-actions[bot]によるコミットを除外

```yaml
if: |
  github.actor != 'github-merge-queue[bot]' &&
  (github.event.head_commit.author.name != 'github-actions[bot]' || github.event_name == 'workflow_dispatch')
```

- github-actions[bot]によるリリースコミットはワークフローをトリガーしない
- ただし手動実行（workflow_dispatch）は許可

#### 2. コミットメッセージに [skip ci] を追加

```
release: バージョン1.0.1をリリース

全パッケージのバージョンを1.0.0から1.0.1に更新

[skip ci]
```

- GitHubの標準機能を活用
- すべてのワークフローをスキップ
- 万が一の保険として機能

### 修正後の動作フロー

1. PRがdevelopにマージ → **リリースワークフロー起動** ✅
2. バージョンアップコミット作成（`[skip ci]` 含む）
3. developへpush → **ワークフローはスキップ（無限ループ防止）** ✅
   - `[skip ci]` により他のワークフローもスキップ
   - github-actions[bot]チェックでも除外
4. タグpush → GitHub Release作成

### 優先度

**🚨 高優先度**: このPRをマージしないと、今後もPRマージのたびに無限ループが発生します。

### テスト

- [ ] マージ後、次のPRマージ時にリリースが1回だけ実行されることを確認
- [ ] 無限ループが発生しないことを確認

### 関連PR

- #967: タグ整合性チェック機能を追加
- #968: バージョンアップコミット・タグのpush処理を追加
- #969: Merge QueueとProtected Branchに対応（無限ループ発生の原因）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
