### PR TITLE
加速時の速度制限を撤廃

### DIFF
--- a/crane_local_planner/include/crane_local_planner/modern_orca_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/modern_orca_planner.hpp
@@ -49,7 +49,6 @@ private:
   double ORCA_TIME_HORIZON = 2.0;
   double ORCA_RADIUS = 0.05;
   double ORCA_MAX_SPEED = 4.0;
-  double ORCA_TRAPEZOIDAL_FRAME_RATE = 60.0;
 
   // デバッグ可視化パラメータ
   bool debug_visualize_constraints_ = false;

--- a/crane_local_planner/include/crane_local_planner/modern_orca_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/modern_orca_planner.hpp
@@ -43,6 +43,7 @@ private:
 
   double MAX_VEL = 4.0;
   double ACCELERATION = 4.0;
+  double STOP_STATE_MAX_VELOCITY = 1.0;
   double ORCA_TIME_STEP = 0.1;
   double ORCA_NEIGHBOR_DIST = 15.0;
   int ORCA_MAX_NEIGHBORS = 10;

--- a/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
@@ -54,8 +54,6 @@ private:
   float RVO_RADIUS = 0.09f;
   float RVO_MAX_SPEED = 10.0f;
 
-  float RVO_TRAPEZOIDAL_FRAME_RATE = 60;
-
   double MAX_VEL = 4.0;
   double ACCELERATION = 4.0;
   // 加速度は減速度の何倍にするかという係数

--- a/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
@@ -56,6 +56,7 @@ private:
 
   double MAX_VEL = 4.0;
   double ACCELERATION = 4.0;
+  double STOP_STATE_MAX_VELOCITY = 1.0;
   // 加速度は減速度の何倍にするかという係数
   ParameterWithEvent<double> acceleration_factor;
 

--- a/crane_local_planner/src/modern_orca_planner.cpp
+++ b/crane_local_planner/src/modern_orca_planner.cpp
@@ -25,6 +25,9 @@ ModernORCAPlanner::ModernORCAPlanner(rclcpp::Node & node)
   node.declare_parameter("max_acc", ACCELERATION);
   ACCELERATION = node.get_parameter("max_acc").as_double();
 
+  node.declare_parameter("stop_state_max_velocity", STOP_STATE_MAX_VELOCITY);
+  STOP_STATE_MAX_VELOCITY = node.get_parameter("stop_state_max_velocity").as_double();
+
   // Declare ORCA-specific parameters (equivalent to RVO2 parameters)
   node.declare_parameter("orca_time_step", ORCA_TIME_STEP);
   ORCA_TIME_STEP = node.get_parameter("orca_time_step").as_double();
@@ -407,7 +410,7 @@ Vector2 ModernORCAPlanner::calculateTrapezoidalVelocityProfile(
   if (
     world_model && world_model->getMsg().play_situation.command_raw.value ==
                      robocup_ssl_msgs::msg::Referee::COMMAND_STOP) {
-    max_vel = std::min(max_vel, 1.0);
+    max_vel = std::min(max_vel, STOP_STATE_MAX_VELOCITY);
   }
 
   // Store final planned values (these will be set in the calling function)

--- a/crane_local_planner/src/modern_orca_planner.cpp
+++ b/crane_local_planner/src/modern_orca_planner.cpp
@@ -38,8 +38,6 @@ ModernORCAPlanner::ModernORCAPlanner(rclcpp::Node & node)
   ORCA_RADIUS = node.get_parameter("orca_radius").as_double();
   node.declare_parameter("orca_max_speed", ORCA_MAX_SPEED);
   ORCA_MAX_SPEED = node.get_parameter("orca_max_speed").as_double();
-  node.declare_parameter("orca_trapezoidal_frame_rate", ORCA_TRAPEZOIDAL_FRAME_RATE);
-  ORCA_TRAPEZOIDAL_FRAME_RATE = node.get_parameter("orca_trapezoidal_frame_rate").as_double();
 
   // Initialize SSL constraint manager
   ssl_constraint_manager_ = std::make_unique<modern_orca::SSLConstraintManagerForCircularAgent>();

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -38,6 +38,9 @@ RVO2Planner::RVO2Planner(rclcpp::Node & node)
   node.declare_parameter("max_acc", ACCELERATION);
   ACCELERATION = node.get_parameter("max_acc").as_double();
 
+  node.declare_parameter("stop_state_max_velocity", STOP_STATE_MAX_VELOCITY);
+  STOP_STATE_MAX_VELOCITY = node.get_parameter("stop_state_max_velocity").as_double();
+
   rvo_sim = std::make_unique<RVO::RVOSimulator>(
     RVO_TIME_STEP, RVO_NEIGHBOR_DIST, RVO_MAX_NEIGHBORS, RVO_TIME_HORIZON, RVO_TIME_HORIZON_OBST,
     RVO_RADIUS, RVO_MAX_SPEED);
@@ -58,9 +61,8 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
   if (
     world_model->getMsg().play_situation.command_raw.value ==
     robocup_ssl_msgs::msg::Referee::COMMAND_STOP) {
-    // 1.5m/sだとたまに超えるので1.0m/sにしておく
     for (int i = 0; i < 40; i++) {
-      rvo_sim->setAgentMaxSpeed(i, 1.0f);
+      rvo_sim->setAgentMaxSpeed(i, STOP_STATE_MAX_VELOCITY);
     }
   } else {
     for (int i = 0; i < 40; i++) {
@@ -168,9 +170,10 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
         if (
           world_model->getMsg().play_situation.command_raw.value ==
           robocup_ssl_msgs::msg::Referee::COMMAND_STOP) {
-          // 1.5m/sだとたまに超えるので1.0m/sにしておく
           command.local_planner_config.max_velocity_factors.emplace_back(
-            crane_msgs::msg::NamedFloat().set__name("RVO2Planner STOP制限").set__value(1.0));
+            crane_msgs::msg::NamedFloat()
+              .set__name("RVO2Planner STOP制限")
+              .set__value(STOP_STATE_MAX_VELOCITY));
         }
 
         double max_vel = resolveMaxVelocityFactors(command, MAX_VEL);

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -156,13 +156,6 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
             .set__name("RVO2Planner::max_vel_by_decel")
             .set__value(max_vel_by_decel));
 
-        // v = v0 + at
-        double max_vel_by_acc = pre_vel + max_acc * RVO_TIME_STEP;
-        command.local_planner_config.max_velocity_factors.emplace_back(
-          crane_msgs::msg::NamedFloat()
-            .set__name("RVO2Planner::max_vel_by_acc")
-            .set__value(max_vel_by_acc));
-
         command.local_planner_config.max_velocity_factors.emplace_back(
           crane_msgs::msg::NamedFloat()
             .set__name("RVO2Planner::max_vel from parameter")

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -31,8 +31,6 @@ RVO2Planner::RVO2Planner(rclcpp::Node & node)
   RVO_RADIUS = node.get_parameter("rvo_radius").as_double();
   node.declare_parameter("rvo_max_speed", RVO_MAX_SPEED);
   RVO_MAX_SPEED = node.get_parameter("rvo_max_speed").as_double();
-  node.declare_parameter("rvo_trapezoidal_frame_rate", RVO_TRAPEZOIDAL_FRAME_RATE);
-  RVO_TRAPEZOIDAL_FRAME_RATE = node.get_parameter("rvo_trapezoidal_frame_rate").as_double();
 
   node.declare_parameter("max_vel", MAX_VEL);
   MAX_VEL = node.get_parameter("max_vel").as_double();

--- a/crane_sender/src/sim_sender.cpp
+++ b/crane_sender/src/sim_sender.cpp
@@ -59,15 +59,7 @@ void SimSenderComponent::sendCommands(const crane_msgs::msg::RobotCommands & msg
           vy_controllers[command.robot_id].update(
             command.position_target_mode.front().target_y - command.current_pose.y, 1.f / 30.f);
         vel += vel.normalized() * command.local_planner_config.terminal_velocity;
-        double max_velocity = command.local_planner_config.final_planned_max_velocity.value;
-        double current_velocity =
-          std::hypot(command.current_velocity.x, command.current_velocity.y);
-        max_velocity = std::min(
-          max_velocity, current_velocity +
-                          command.local_planner_config.final_planned_max_acceleration.value * 0.1);
-        if (vel.norm() > max_velocity) {
-          vel = vel.normalized() * max_velocity;
-        }
+
         Velocity vel_local;
         vel_local << vel.x() * cos(-command.current_pose.theta) -
                        vel.y() * sin(-command.current_pose.theta),


### PR DESCRIPTION
加速時に現在速度に基づいて速度制限を行っていたが、時間遅れがある速度観測値を基に計算した制限値では必要以上に速度を制限してしまうためスムーズな加速を妨げていた。
ロボットは突然大きな指令速度を与えても無理ない範囲で加速を行うため、加速時の現在速度に基づく速度制限は撤廃することとした。