### PR TITLE
fix: plot_kick_events.pyの型アノテーションを修正

### DIFF
--- a/crane_world_model_publisher/scripts/plot_kick_events.py
+++ b/crane_world_model_publisher/scripts/plot_kick_events.py
@@ -37,7 +37,7 @@ def load_kick_data(data_file_path: str) -> dict:
     return data
 
 
-def create_kick_plot(data: dict, output_path: str = None) -> None:
+def create_kick_plot(data: dict, output_path: str | None = None) -> str:
     """キックイベントのプロットを生成"""
     # データ抽出
     event_info = data["event_info"]


### PR DESCRIPTION
mypyテストの失敗を解決するため、create_kick_plot関数の型アノテーションを修正：
- output_pathパラメータをstr | None型に変更
- 戻り値の型をNoneからstrに修正
