### PR TITLE
Toggle unity build

### DIFF
--- a/crane_planner_plugins/CMakeLists.txt
+++ b/crane_planner_plugins/CMakeLists.txt
@@ -33,9 +33,6 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 target_link_libraries(${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
 
 # Enable Unity Build for faster compilation
-# set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
-# set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD_BATCH_SIZE 6)
-
 option(CRANE_UNITY_BUILD "Enable unity build" ON)
 if(CRANE_UNITY_BUILD)
   set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)

--- a/crane_planner_plugins/CMakeLists.txt
+++ b/crane_planner_plugins/CMakeLists.txt
@@ -33,8 +33,14 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 target_link_libraries(${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
 
 # Enable Unity Build for faster compilation
-set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
-set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD_BATCH_SIZE 6)
+# set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
+# set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD_BATCH_SIZE 6)
+
+option(CRANE_UNITY_BUILD "Enable unity build" ON)
+if(CRANE_UNITY_BUILD)
+  set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
+  set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD_BATCH_SIZE 6)
+endif()
 
 target_precompile_headers(${PROJECT_NAME}
   PUBLIC


### PR DESCRIPTION
UNITY_BUILDされると、build_commands.jsonから消えてしまって補完が死んじゃうのでトグル可能にした。

```colcon build --symlink-install --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release -DCRANE_UNITY_BUILD=OFF```

「DCRANE_UNITY_BUILD=OFF」でOFF可能基本ONのはず