### PR TITLE
ロボット割当アルゴリズムをハンガリアン法による全体最適化に移行

### DIFF
--- a/crane_planner_plugins/include/crane_planner_plugins/attacker_skill_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/attacker_skill_tactic.hpp
@@ -98,6 +98,16 @@ public:
       return {selected_robots.front()};
     }
   }
+
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    // ボールに近いロボットを優先（距離が小さいほど適している）
+    auto wm = world_model;  // shared_ptrをコピー
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      return robot->getDistance(wm->ball().pos);
+    };
+  }
 };
 
 }  // namespace crane

--- a/crane_planner_plugins/include/crane_planner_plugins/attacker_skill_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/attacker_skill_tactic.hpp
@@ -41,37 +41,41 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override
   {
-    if (not skill) {
+    // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
+    if (robots.empty()) {
       return {TacticBase::Status::RUNNING, {}};
-    } else {
-      std::string state_name(magic_enum::enum_name(skill->getCurrentState()));
-      {
-        visualizer->circle()
-          .center(skill->commander()->getRobot()->pose.pos)
-          .radius(0.3)
-          .stroke("red")
-          .strokeWidth(20)
-          .build();
-      }
-      if (world_model->ball().isMoving()) {
-        {
-          auto polyline_builder = visualizer->polyline();
-          for (auto [point, distance] : world_model->getBallSequence(2.0, 0.1)) {
-            polyline_builder.addPoint(point);
-          }
-          polyline_builder.stroke("orange", 0.3).strokeWidth(100).build();
-        }
-      }
-      auto status = skill->run();
-      if (skill->getID() != robots.front().id) {
-        std::stringstream ss;
-        ss << "スキルのIDは" << static_cast<int>(skill->getID())
-           << "ですが、選択されたロボットのIDは" << static_cast<int>(robots.front().id) << "です。";
-        ss << "スキルのStateは" << magic_enum::enum_name(skill->getCurrentState()) << "です。";
-        std::cout << ss.str() << std::endl;
-      }
-      return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};
     }
+    if (not skill) {
+      skill = std::make_shared<skills::Attacker>("attacker", robots.front().id, world_model);
+    }
+
+    std::string state_name(magic_enum::enum_name(skill->getCurrentState()));
+    {
+      visualizer->circle()
+        .center(skill->commander()->getRobot()->pose.pos)
+        .radius(0.3)
+        .stroke("red")
+        .strokeWidth(20)
+        .build();
+    }
+    if (world_model->ball().isMoving()) {
+      {
+        auto polyline_builder = visualizer->polyline();
+        for (auto [point, distance] : world_model->getBallSequence(2.0, 0.1)) {
+          polyline_builder.addPoint(point);
+        }
+        polyline_builder.stroke("orange", 0.3).strokeWidth(100).build();
+      }
+    }
+    auto status = skill->run();
+    if (skill->getID() != robots.front().id) {
+      std::stringstream ss;
+      ss << "スキルのIDは" << static_cast<int>(skill->getID()) << "ですが、選択されたロボットのIDは"
+         << static_cast<int>(robots.front().id) << "です。";
+      ss << "スキルのStateは" << magic_enum::enum_name(skill->getCurrentState()) << "です。";
+      RCLCPP_WARN(rclcpp::get_logger("AttackerSkillTactic"), "%s", ss.str().c_str());
+    }
+    return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};
   }
 
   auto getSelectedRobots(
@@ -104,9 +108,8 @@ public:
   {
     // ボールに近いロボットを優先（距離が小さいほど適している）
     auto wm = world_model;  // shared_ptrをコピー
-    return [wm](const std::shared_ptr<RobotInfo> & robot) {
-      return robot->getDistance(wm->ball().pos);
-    };
+    return
+      [wm](const std::shared_ptr<RobotInfo> & robot) { return robot->getDistance(wm->ball().pos); };
   }
 };
 

--- a/crane_planner_plugins/include/crane_planner_plugins/defender_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/defender_tactic.hpp
@@ -62,6 +62,22 @@ public:
 
     return selected;
   }
+
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    // 守備ライン位置に近いロボットを優先
+    auto wm = world_model;  // shared_ptrをコピー
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      Segment ball_line{wm->goal(), wm->ball().pos};
+      auto parameter = getDefenseLinePointParameter(ball_line, wm);
+      if (not parameter) {
+        return 1000.0;  // パラメータが無効な場合は大きなコスト
+      }
+      const auto defense_point = getDefenseLinePoint(parameter.value(), wm);
+      return robot->getDistance(defense_point);
+    };
+  }
 };
 
 }  // namespace crane

--- a/crane_planner_plugins/include/crane_planner_plugins/emplace_robot_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/emplace_robot_tactic.hpp
@@ -47,8 +47,11 @@ public:
   auto getRobotSuitabilityFunc() const
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {
-    // キーパーIDを優先（通常は0番）
-    return [](const std::shared_ptr<RobotInfo> & robot) { return static_cast<double>(robot->id); };
+    // ゴールキーパーだけ退場させにくくする
+    auto wm = world_model;  // shared_ptrをコピー
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      return (robot->id == wm->getOurGoalieId()) ? 100.0 : 0.0;
+    };
   }
 
 private:

--- a/crane_planner_plugins/include/crane_planner_plugins/emplace_robot_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/emplace_robot_tactic.hpp
@@ -42,6 +42,15 @@ public:
     [[maybe_unused]] uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
     const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override;
 
+  bool isHardConstraint() const override { return true; }
+
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    // キーパーIDを優先（通常は0番）
+    return [](const std::shared_ptr<RobotInfo> & robot) { return static_cast<double>(robot->id); };
+  }
+
 private:
   std::unordered_map<uint8_t, std::shared_ptr<skills::EmplaceRobot>> m_skill_map;
 };

--- a/crane_planner_plugins/include/crane_planner_plugins/forward_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/forward_tactic.hpp
@@ -39,6 +39,17 @@ public:
     uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
     const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    // フォワードライン（敵ゴール前）に近いロボットを優先
+    auto wm = world_model;  // shared_ptrをコピー
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      // 敵ゴール位置に近いほど適している
+      return robot->getDistance(wm->getTheirGoalCenter());
+    };
+  }
+
   std::vector<std::shared_ptr<skills::Forward>> forward_skills;
 };
 }  // namespace crane

--- a/crane_planner_plugins/include/crane_planner_plugins/marker_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/marker_tactic.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <crane_msg_wrappers/position_command_wrapper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_planner_plugins/marker_functions.hpp>
 #include <crane_planner_plugins/tactic_base.hpp>
 #include <crane_robot_skills/marker.hpp>
 #include <functional>
@@ -39,6 +40,27 @@ public:
   auto getSelectedRobots(
     uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
     const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override;
+
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    // 危険な敵ロボットの中心位置に近いロボットを優先
+    auto wm = world_model;  // shared_ptrをコピー
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      auto danger_enemies = getDangerEnemies(wm);
+      if (danger_enemies.empty()) {
+        // 敵がいない場合はフィールド中央への距離を返す
+        return robot->getDistance(Point(0.0, 0.0));
+      }
+      // 危険な敵ロボットの平均位置を計算
+      Point center(0.0, 0.0);
+      for (const auto & [enemy, score] : danger_enemies) {
+        center += enemy->pose.pos;
+      }
+      center /= static_cast<double>(danger_enemies.size());
+      return robot->getDistance(center);
+    };
+  }
 
 private:
   auto assignMarkingTarget(

--- a/crane_planner_plugins/include/crane_planner_plugins/pass_receiver_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/pass_receiver_tactic.hpp
@@ -44,8 +44,14 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override
   {
-    if (!receive_skill) {
+    // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
+    if (robots.empty()) {
       return {TacticBase::Status::RUNNING, {}};
+    }
+    if (!receive_skill) {
+      receive_skill =
+        std::make_shared<skills::Receive>("pass_receiver", robots.front().id, world_model);
+      receive_skill->setParameter("policy", std::string("closest"));
     }
 
     // If a kick is ongoing by our team or ball is moving sufficiently, actively receive

--- a/crane_planner_plugins/include/crane_planner_plugins/second_threat_defender_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/second_threat_defender_tactic.hpp
@@ -39,6 +39,18 @@ public:
     uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
     const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    // セカンド脅威守備位置に近いロボットを優先
+    auto wm = world_model;  // shared_ptrをコピー
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      constexpr double offset = 0.3;
+      auto target = skills::SecondThreatDefender::getDefaultPoint(wm, offset);
+      return robot->getDistance(target);
+    };
+  }
+
 private:
   std::shared_ptr<skills::SecondThreatDefender> skill;
 };

--- a/crane_planner_plugins/include/crane_planner_plugins/simple_placer_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/simple_placer_tactic.hpp
@@ -292,9 +292,7 @@ public:
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {
     // ID番号の小さいロボットを優先（通常の割当順序を維持）
-    return [](const std::shared_ptr<RobotInfo> & robot) {
-      return static_cast<double>(robot->id);
-    };
+    return [](const std::shared_ptr<RobotInfo> & robot) { return static_cast<double>(robot->id); };
   }
 
   auto getSelectedRobots(

--- a/crane_planner_plugins/include/crane_planner_plugins/simple_placer_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/simple_placer_tactic.hpp
@@ -288,6 +288,15 @@ public:
     return area_points;
   }
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    // ID番号の小さいロボットを優先（通常の割当順序を維持）
+    return [](const std::shared_ptr<RobotInfo> & robot) {
+      return static_cast<double>(robot->id);
+    };
+  }
+
   auto getSelectedRobots(
     [[maybe_unused]] uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
     const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override

--- a/crane_planner_plugins/include/crane_planner_plugins/skill_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/skill_tactic.hpp
@@ -40,13 +40,15 @@ namespace crane
     std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(    \
       const std::vector<RobotIdentifier> & robots) override                                       \
     {                                                                                             \
-      if (not skill) {                                                                            \
+      if (robots.empty()) {                                                                       \
         return {TacticBase::Status::RUNNING, {}};                                                 \
-      } else {                                                                                    \
-        std::vector<crane_msgs::msg::PositionCommand> robot_commands;                             \
-        auto status = skill->run();                                                               \
-        return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};             \
       }                                                                                           \
+      if (not skill) {                                                                            \
+        skill = std::make_shared<skills::CLASS_NAME>(robots.front().id, world_model);             \
+      }                                                                                           \
+      std::vector<crane_msgs::msg::PositionCommand> robot_commands;                               \
+      auto status = skill->run();                                                                 \
+      return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};               \
     }                                                                                             \
     auto getSelectedRobots(                                                                       \
       uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,              \

--- a/crane_planner_plugins/include/crane_planner_plugins/tactic_base.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/tactic_base.hpp
@@ -140,6 +140,30 @@ public:
 
   bool hasTacticParameter(const std::string & key) const { return tactic_params_.contains(key); }
 
+  /**
+   * @brief ロボット適性評価関数を取得（GlobalRobotAllocator用）
+   *
+   * 各Tacticに適したロボットを評価するための関数を返す。
+   * 返される関数は、ロボット情報を受け取り、適性コスト（小さいほど適している）を返す。
+   *
+   * @return ロボット適性評価関数
+   */
+  virtual auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)>
+  {
+    // デフォルト実装: すべてのロボットを等価とみなす（コスト0）
+    return [](const std::shared_ptr<RobotInfo> &) { return 0.0; };
+  }
+
+  /**
+   * @brief ハード制約Tacticかどうかを返す
+   *
+   * trueを返すTacticは優先的にロボットが割り当てられる（キーパーなど）。
+   *
+   * @return ハード制約の場合true
+   */
+  virtual bool isHardConstraint() const { return false; }
+
 protected:
   virtual auto getSelectedRobots(
     uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,

--- a/crane_planner_plugins/include/crane_planner_plugins/tactic_base.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/tactic_base.hpp
@@ -73,6 +73,22 @@ public:
     return selected_robots;
   }
 
+  /**
+   * @brief GlobalRobotAllocatorが選択したロボットを直接設定する
+   *
+   * 既存のgetSelectedRobotsをバイパスして、外部で決定されたロボットIDを直接設定する。
+   *
+   * @param robot_ids 割り当てられたロボットIDリスト
+   */
+  void setAllocatedRobots(const std::vector<uint8_t> & robot_ids)
+  {
+    robots.clear();
+    for (auto id : robot_ids) {
+      RobotIdentifier robot_id{true, id};
+      robots.emplace_back(robot_id);
+    }
+  }
+
   auto getPositionCommands() -> crane_msgs::msg::PositionCommands
   {
     auto [latest_status, position_commands] = calculatePositionCommand(robots);

--- a/crane_planner_plugins/include/crane_planner_plugins/total_defense_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/total_defense_tactic.hpp
@@ -59,6 +59,23 @@ public:
   auto getSelectedRobots(
     uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
     const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override;
+
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    // 守備位置に近いロボットを優先
+    auto wm = world_model;  // shared_ptrをコピー
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      Segment ball_line{wm->goal(), wm->ball().pos};
+      auto parameter = getDefenseLinePointParameter(ball_line, wm);
+      if (not parameter) {
+        // パラメータが取得できない場合はゴール位置への距離を使用
+        return robot->getDistance(wm->getOurGoalCenter());
+      }
+      const auto defense_point = getDefenseLinePoint(parameter.value(), wm);
+      return robot->getDistance(defense_point);
+    };
+  }
 };
 
 }  // namespace crane

--- a/crane_planner_plugins/include/crane_planner_plugins/waiter_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/waiter_tactic.hpp
@@ -41,9 +41,7 @@ public:
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {
     // ID番号の小さいロボットを優先（待機ロボットとして低IDを使用）
-    return [](const std::shared_ptr<RobotInfo> & robot) {
-      return static_cast<double>(robot->id);
-    };
+    return [](const std::shared_ptr<RobotInfo> & robot) { return static_cast<double>(robot->id); };
   }
 
 private:

--- a/crane_planner_plugins/include/crane_planner_plugins/waiter_tactic.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/waiter_tactic.hpp
@@ -37,6 +37,15 @@ public:
     uint8_t selectable_robots_num, const std::vector<uint8_t> & selectable_robots,
     const std::unordered_map<uint8_t, RobotRole> & prev_roles) -> std::vector<uint8_t> override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    // ID番号の小さいロボットを優先（待機ロボットとして低IDを使用）
+    return [](const std::shared_ptr<RobotInfo> & robot) {
+      return static_cast<double>(robot->id);
+    };
+  }
+
 private:
   std::unordered_map<uint8_t, Pose2D> stop_poses;
 };

--- a/crane_planner_plugins/src/emplace_robot_tactic.cpp
+++ b/crane_planner_plugins/src/emplace_robot_tactic.cpp
@@ -9,8 +9,28 @@
 namespace crane
 {
 std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
-EmplaceRobotTactic::calculatePositionCommand(const std::vector<RobotIdentifier> &)
+EmplaceRobotTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
 {
+  // GlobalRobotAllocator対応: robotsが変更されたらスキルマップを再生成
+  if (m_skill_map.size() != robots.size()) {
+    m_skill_map.clear();
+
+    int select_num = robots.size();
+    int selected_robots_index = 0;
+    for (const auto & robot_id : robots) {
+      m_skill_map.try_emplace(
+        robot_id.id, std::make_shared<skills::EmplaceRobot>(robot_id.id, world_model));
+
+      m_skill_map[robot_id.id]->setParameter("total_robot_number", select_num);
+      m_skill_map[robot_id.id]->setParameter("current_robot_index", selected_robots_index);
+
+      // どちら側に退場するか
+      m_skill_map[robot_id.id]->setParameter(
+        "emplace_line_positive", world_model->isEmplacePositiveSide());
+      ++selected_robots_index;
+    }
+  }
+
   std::vector<crane_msgs::msg::PositionCommand> robot_commands;
 
   for (auto & [id, skill] : m_skill_map) {

--- a/crane_planner_plugins/src/forward_tactic.cpp
+++ b/crane_planner_plugins/src/forward_tactic.cpp
@@ -50,10 +50,37 @@ auto ForwardTactic::createForwardLines() const -> std::vector<Segment>
   return forward_lines;
 }
 
-auto ForwardTactic::calculatePositionCommand(
-  [[maybe_unused]] const std::vector<RobotIdentifier> & robots)
+auto ForwardTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
   -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>>
 {
+  // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
+  if (forward_skills.size() != robots.size()) {
+    forward_skills.clear();
+
+    auto forward_lines = createForwardLines();
+    if (forward_lines.size() > robots.size()) {
+      forward_lines.resize(robots.size());
+    }
+
+    std::vector<Point> robot_positions =
+      robots | ranges::views::transform([this](const auto & robot_id) -> Point {
+        return world_model->getRobot(robot_id)->pose.pos;
+      }) |
+      ranges::to<std::vector>;
+
+    auto solution = getOptimalAssignments(robot_positions, forward_lines);
+
+    for (const auto & [index, robot_id] : robots | ranges::views::enumerate) {
+      auto skill = std::make_shared<skills::Forward>(robot_id.id, world_model);
+      auto line = forward_lines[solution[index]];
+      skill->setParameter("front_point", line.second);
+      skill->setParameter("back_point", line.first);
+      skill->setParameter("max_vel", 1.5);
+      skill->planner_visualizer = visualizer;
+      forward_skills.emplace_back(skill);
+    }
+  }
+
   std::vector<crane_msgs::msg::PositionCommand> robot_commands;
   for (auto forward_skill : forward_skills) {
     forward_skill->run();

--- a/crane_planner_plugins/src/simple_ai_tactic.cpp
+++ b/crane_planner_plugins/src/simple_ai_tactic.cpp
@@ -65,18 +65,23 @@ SimpleAITactic::SimpleAITactic(WorldModelWrapper::SharedPtr & world_model, rclcp
     // ゴール（通常の指令）のコールバック
     [&](const rclcpp_action::GoalUUID, std::shared_ptr<const SkillExecution::Goal> goal)
       -> rclcpp_action::GoalResponse {
-      std::cout << "Received goal: " << goal->name << std::endl;
+      RCLCPP_INFO(action_node->get_logger(), "Received goal: %s", goal->name.c_str());
       if (running_skill) {
         running_skill.reset();
       }
       if (auto skill_generator = skill_generators.find(goal->name);
           skill_generator != skill_generators.end()) {
-        std::cout << "Start executing skill: " << goal->name << " for robot "
-                  << static_cast<int>(goal->robot_id) << std::endl;
+        RCLCPP_INFO(
+          action_node->get_logger(), "Start executing skill: %s for robot %d", goal->name.c_str(),
+          static_cast<int>(goal->robot_id));
         robot_id = goal->robot_id;
-        std::cout << "Skill: " << std::hex << running_skill.get() << std::endl;
+        RCLCPP_DEBUG(
+          action_node->get_logger(), "Skill pointer (before): %p",
+          static_cast<void *>(running_skill.get()));
         running_skill = skill_generator->second(goal->name, goal->robot_id, this->world_model);
-        std::cout << "Skill: " << std::hex << running_skill.get() << std::endl;
+        RCLCPP_DEBUG(
+          action_node->get_logger(), "Skill pointer (after): %p",
+          static_cast<void *>(running_skill.get()));
         skill_status = skills::Status::RUNNING;
         parameters.clear();
 
@@ -104,14 +109,14 @@ SimpleAITactic::SimpleAITactic(WorldModelWrapper::SharedPtr & world_model, rclcp
         }
         return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
       } else {
-        std::cerr << "No skill found: " << goal->name << std::endl;
+        RCLCPP_ERROR(action_node->get_logger(), "No skill found: %s", goal->name.c_str());
         return rclcpp_action::GoalResponse::REJECT;
       }
     },
     // キャンセルのコールバック
     [&](const std::shared_ptr<rclcpp_action::ServerGoalHandle<SkillExecution>> &)
       -> rclcpp_action::CancelResponse {
-      std::cout << "Canceling goal: " << std::endl;
+      RCLCPP_INFO(action_node->get_logger(), "Canceling goal");
       skill_execution_goal_handle.reset();
       if (running_skill) {
         running_skill.reset();
@@ -122,7 +127,7 @@ SimpleAITactic::SimpleAITactic(WorldModelWrapper::SharedPtr & world_model, rclcp
     [this](
       const std::shared_ptr<rclcpp_action::ServerGoalHandle<SkillExecution>> goal_handle) -> void {
       skill_execution_goal_handle = goal_handle;
-      std::cout << "accept goal callback" << std::endl;
+      RCLCPP_INFO(action_node->get_logger(), "Accept goal callback");
     });
 
   action_sync_timer = action_node->create_wall_timer(std::chrono::milliseconds(200), [this]() {

--- a/crane_planner_plugins/src/skill_planners.cpp
+++ b/crane_planner_plugins/src/skill_planners.cpp
@@ -10,32 +10,39 @@
 
 namespace crane
 {
-auto GoalieSkillTactic::calculatePositionCommand(
-  [[maybe_unused]] const std::vector<RobotIdentifier> & robots)
+auto GoalieSkillTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
   -> std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
 {
-  if (not skill) {
+  // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
+  if (robots.empty()) {
     return {TacticBase::Status::RUNNING, {}};
-  } else {
-    auto status = skill->run();
-    return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};
   }
+  if (not skill) {
+    skill = std::make_shared<skills::Goalie>("goalie", robots.front().id, world_model);
+  }
+
+  auto status = skill->run();
+  return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};
 }
 
-auto BallPlacementSkillTactic::calculatePositionCommand(
-  [[maybe_unused]] const std::vector<RobotIdentifier> & robots)
+auto BallPlacementSkillTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
   -> std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
 {
-  if (not skill) {
+  // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
+  if (robots.empty()) {
     return {TacticBase::Status::RUNNING, {}};
-  } else {
-    if (auto target = world_model->getBallPlacementTarget(); target.has_value()) {
-      skill->setParameter("placement_x", target->x());
-      skill->setParameter("placement_y", target->y());
-    }
-    auto status = skill->run();
-    return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};
   }
+  if (not skill) {
+    skill = std::make_shared<skills::SingleBallPlacement>(
+      "ball_placement_skill_planner", robots.front().id, world_model);
+  }
+
+  if (auto target = world_model->getBallPlacementTarget(); target.has_value()) {
+    skill->setParameter("placement_x", target->x());
+    skill->setParameter("placement_y", target->y());
+  }
+  auto status = skill->run();
+  return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};
 }
 
 auto BallPlacementSkillTactic::getSelectedRobots(
@@ -69,16 +76,20 @@ auto BallPlacementSkillTactic::getSelectedRobots(
   }
 }
 
-auto SubAttackerSkillTactic::calculatePositionCommand(
-  [[maybe_unused]] const std::vector<RobotIdentifier> & robots)
+auto SubAttackerSkillTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
   -> std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
 {
-  if (not skill) {
+  // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
+  if (robots.empty()) {
     return {TacticBase::Status::RUNNING, {}};
-  } else {
-    auto status = skill->run();
-    return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};
   }
+  if (not skill) {
+    skill = std::make_shared<skills::SubAttacker>(
+      "sub_attacker_skill_planner", robots.front().id, world_model);
+  }
+
+  auto status = skill->run();
+  return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};
 }
 
 auto SubAttackerSkillTactic::getSelectedRobots(
@@ -115,16 +126,20 @@ auto SubAttackerSkillTactic::getSelectedRobots(
   }
 }
 
-auto SimpleKickOffSkillTactic::calculatePositionCommand(
-  [[maybe_unused]] const std::vector<RobotIdentifier> & robots)
+auto SimpleKickOffSkillTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
   -> std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
 {
-  if (not skill) {
+  // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
+  if (robots.empty()) {
     return {TacticBase::Status::RUNNING, {}};
-  } else {
-    auto status = skill->run();
-    return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};
   }
+  if (not skill) {
+    skill = std::make_shared<skills::SimpleKickOff>(
+      "simple_kick_off_skill_planner", robots.front().id, world_model);
+  }
+
+  auto status = skill->run();
+  return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};
 }
 
 auto SimpleKickOffSkillTactic::getSelectedRobots(
@@ -148,9 +163,27 @@ auto SimpleKickOffSkillTactic::getSelectedRobots(
 }
 
 auto BallNearByPositionerSkillTactic::calculatePositionCommand(
-  [[maybe_unused]] const std::vector<RobotIdentifier> & robots)
+  const std::vector<RobotIdentifier> & robots)
   -> std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
 {
+  // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
+  if (skills.size() != robots.size()) {
+    skills.clear();
+
+    int index = 0;
+    for (const auto & robot_id : robots) {
+      skills.emplace_back(
+        std::make_shared<skills::BallNearByPositioner>(
+          "ball_near_by_positioner_skill_planner", robot_id.id, world_model));
+      skills.back()->setParameter("total_robot_number", static_cast<int>(robots.size()));
+      skills.back()->setParameter("current_robot_index", index++);
+      skills.back()->setParameter("line_policy", std::string("arc"));
+      skills.back()->setParameter("positioning_policy", std::string("auto"));
+      skills.back()->setParameter("robot_interval", 0.35);
+      skills.back()->setParameter("margin_distance", 0.8);
+    }
+  }
+
   auto robot_commands = skills | ranges::views::transform([this](const auto & skill) {
                           skill->run();
                           return skill->getRobotCommand();
@@ -192,9 +225,27 @@ auto BallNearByPositionerSkillTactic::getSelectedRobots(
 }
 
 auto PlacementTargetNearByPositionerSkillTactic::calculatePositionCommand(
-  [[maybe_unused]] const std::vector<RobotIdentifier> & robots)
+  const std::vector<RobotIdentifier> & robots)
   -> std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
 {
+  // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
+  if (skills.size() != robots.size()) {
+    skills.clear();
+
+    int index = 0;
+    for (const auto & robot_id : robots) {
+      skills.emplace_back(
+        std::make_shared<skills::BallNearByPositioner>(
+          "ball_near_by_positioner_skill_planner", robot_id.id, world_model));
+      skills.back()->setParameter("total_robot_number", static_cast<int>(robots.size()));
+      skills.back()->setParameter("current_robot_index", index++);
+      skills.back()->setParameter("line_policy", std::string("arc"));
+      skills.back()->setParameter("positioning_policy", std::string("goal"));
+      skills.back()->setParameter("robot_interval", 0.35);
+      skills.back()->setParameter("margin_distance", 0.8);
+    }
+  }
+
   auto target = world_model->getBallPlacementTarget().value_or(world_model->ball().pos);
   auto robot_commands = skills | ranges::views::transform([&](const auto & skill) {
                           skill->setParameter("alternative_target_mode", true);

--- a/crane_planner_plugins/src/test_tactic.cpp
+++ b/crane_planner_plugins/src/test_tactic.cpp
@@ -60,14 +60,14 @@ TestTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots
   auto now = rclcpp::Clock().now();
   if (command->getTargetDistance() < 0.05) {
     if (not sleep_until.has_value()) {
-      std::cout << "[TestTactic] 到着" << std::endl;
+      RCLCPP_INFO(rclcpp::get_logger("TestTactic"), "Arrived");
       sleep_until = now + rclcpp::Duration::from_seconds(default_sleep_sec);
     } else if (now >= *sleep_until) {
       sleep_until.reset();
       current_index = (current_index + 1) % waypoints.size();
       auto next_wp = waypoints.at(current_index).pos;
-      std::cout << "[TestTactic] 次のポイントへ: " << next_wp.x() << ", " << next_wp.y()
-                << std::endl;
+      RCLCPP_INFO(
+        rclcpp::get_logger("TestTactic"), "Next waypoint: %f, %f", next_wp.x(), next_wp.y());
     }
   }
   robot_commands.emplace_back(command->getMsg());

--- a/crane_session_controller/CMakeLists.txt
+++ b/crane_session_controller/CMakeLists.txt
@@ -23,12 +23,15 @@ ament_auto_add_library(${PROJECT_NAME}_component SHARED
   src/diagnostics_reporter.cpp
   src/command_aggregator.cpp
   src/robot_allocator.cpp
+  src/global_robot_allocator.cpp
   include/crane_session_controller/tactic_coordinator.hpp
   include/crane_session_controller/configuration_manager.hpp
   include/crane_session_controller/tactic_registry.hpp
   include/crane_session_controller/diagnostics_reporter.hpp
   include/crane_session_controller/command_aggregator.hpp
-  include/crane_session_controller/robot_allocator.hpp)
+  include/crane_session_controller/robot_allocator.hpp
+  include/crane_session_controller/global_robot_allocator.hpp
+  include/crane_session_controller/allocation_state.hpp)
 target_link_libraries(${PROJECT_NAME}_component ${YAML_CPP_LIBRARIES})
 
 target_precompile_headers(${PROJECT_NAME}_component

--- a/crane_session_controller/include/crane_session_controller/allocation_state.hpp
+++ b/crane_session_controller/include/crane_session_controller/allocation_state.hpp
@@ -67,7 +67,8 @@ public:
    * @param tactic_name 割り当てられたTactic名
    * @param target_position ターゲット位置
    */
-  void updateAssignment(uint8_t robot_id, const std::string & tactic_name, const Point & target_position)
+  void updateAssignment(
+    uint8_t robot_id, const std::string & tactic_name, const Point & target_position)
   {
     // Tactic割当を更新
     bool same_tactic = wasAssignedTo(robot_id, tactic_name);

--- a/crane_session_controller/include/crane_session_controller/allocation_state.hpp
+++ b/crane_session_controller/include/crane_session_controller/allocation_state.hpp
@@ -1,0 +1,162 @@
+// Copyright (c) 2024 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_SESSION_CONTROLLER__ALLOCATION_STATE_HPP_
+#define CRANE_SESSION_CONTROLLER__ALLOCATION_STATE_HPP_
+
+#include <crane_geometry/boost_geometry.hpp>
+#include <string>
+#include <unordered_map>
+
+namespace crane
+{
+
+/**
+ * @brief ロボット割当の状態管理クラス
+ *
+ * フレーム間でのロボット割当状態を追跡し、ヒステリシス制御に必要な情報を提供する。
+ */
+class AllocationState
+{
+public:
+  AllocationState() = default;
+
+  /**
+   * @brief 前フレームで指定のロボットが指定のTacticに割り当てられていたかを確認
+   * @param robot_id ロボットID
+   * @param tactic_name Tactic名
+   * @return 割り当てられていた場合true
+   */
+  [[nodiscard]] auto wasAssignedTo(uint8_t robot_id, const std::string & tactic_name) const -> bool
+  {
+    auto it = robot_to_tactic_.find(robot_id);
+    return it != robot_to_tactic_.end() && it->second == tactic_name;
+  }
+
+  /**
+   * @brief 指定のロボットの前フレームのターゲット位置を取得
+   * @param robot_id ロボットID
+   * @return ターゲット位置（存在しない場合はnullopt）
+   */
+  [[nodiscard]] auto getPrevTarget(uint8_t robot_id) const -> std::optional<Point>
+  {
+    auto it = robot_to_position_.find(robot_id);
+    if (it != robot_to_position_.end()) {
+      return it->second;
+    }
+    return std::nullopt;
+  }
+
+  /**
+   * @brief 指定のロボットの割当継続フレーム数を取得
+   * @param robot_id ロボットID
+   * @return 継続フレーム数（未割当の場合は0）
+   */
+  [[nodiscard]] auto getAssignmentDuration(uint8_t robot_id) const -> int
+  {
+    auto it = assignment_duration_.find(robot_id);
+    return it != assignment_duration_.end() ? it->second : 0;
+  }
+
+  /**
+   * @brief 割当状態を更新
+   * @param robot_id ロボットID
+   * @param tactic_name 割り当てられたTactic名
+   * @param target_position ターゲット位置
+   */
+  void updateAssignment(uint8_t robot_id, const std::string & tactic_name, const Point & target_position)
+  {
+    // Tactic割当を更新
+    bool same_tactic = wasAssignedTo(robot_id, tactic_name);
+    robot_to_tactic_[robot_id] = tactic_name;
+    robot_to_position_[robot_id] = target_position;
+
+    // 継続フレーム数を更新
+    if (same_tactic) {
+      assignment_duration_[robot_id]++;
+    } else {
+      assignment_duration_[robot_id] = 1;
+    }
+  }
+
+  /**
+   * @brief 指定のロボットの割当状態をクリア
+   * @param robot_id ロボットID
+   */
+  void clearAssignment(uint8_t robot_id)
+  {
+    robot_to_tactic_.erase(robot_id);
+    robot_to_position_.erase(robot_id);
+    assignment_duration_.erase(robot_id);
+  }
+
+  /**
+   * @brief 全ロボットの割当状態をクリア
+   */
+  void clearAll()
+  {
+    robot_to_tactic_.clear();
+    robot_to_position_.clear();
+    assignment_duration_.clear();
+  }
+
+  /**
+   * @brief 現在割り当てられているロボットIDの一覧を取得
+   * @return ロボットIDのベクター
+   */
+  [[nodiscard]] auto getAllAssignedRobots() const -> std::vector<uint8_t>
+  {
+    std::vector<uint8_t> robots;
+    robots.reserve(robot_to_tactic_.size());
+    for (const auto & [robot_id, _] : robot_to_tactic_) {
+      robots.push_back(robot_id);
+    }
+    return robots;
+  }
+
+  /**
+   * @brief 指定のTacticに割り当てられているロボットIDの一覧を取得
+   * @param tactic_name Tactic名
+   * @return ロボットIDのベクター
+   */
+  [[nodiscard]] auto getRobotsAssignedTo(const std::string & tactic_name) const
+    -> std::vector<uint8_t>
+  {
+    std::vector<uint8_t> robots;
+    for (const auto & [robot_id, assigned_tactic] : robot_to_tactic_) {
+      if (assigned_tactic == tactic_name) {
+        robots.push_back(robot_id);
+      }
+    }
+    return robots;
+  }
+
+  /**
+   * @brief デバッグ用文字列を生成
+   * @return 割当状態の文字列表現
+   */
+  [[nodiscard]] auto toString() const -> std::string
+  {
+    std::stringstream ss;
+    ss << "AllocationState: ";
+    for (const auto & [robot_id, tactic_name] : robot_to_tactic_) {
+      ss << "[" << static_cast<int>(robot_id) << "->" << tactic_name << "("
+         << getAssignmentDuration(robot_id) << ")] ";
+    }
+    return ss.str();
+  }
+
+private:
+  // 前フレームの割当情報
+  std::unordered_map<uint8_t, std::string> robot_to_tactic_;  // robot_id -> tactic_name
+  std::unordered_map<uint8_t, Point> robot_to_position_;      // robot_id -> target_position
+
+  // 割当継続フレーム数
+  std::unordered_map<uint8_t, int> assignment_duration_;  // robot_id -> frames
+};
+
+}  // namespace crane
+#endif  // CRANE_SESSION_CONTROLLER__ALLOCATION_STATE_HPP_

--- a/crane_session_controller/include/crane_session_controller/global_robot_allocator.hpp
+++ b/crane_session_controller/include/crane_session_controller/global_robot_allocator.hpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2024 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_SESSION_CONTROLLER__GLOBAL_ROBOT_ALLOCATOR_HPP_
+#define CRANE_SESSION_CONTROLLER__GLOBAL_ROBOT_ALLOCATOR_HPP_
+
+#include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_physics/allocation_cost.hpp>
+#include <crane_physics/position_assignments.hpp>
+#include <crane_physics/robot_info.hpp>
+#include <crane_session_controller/allocation_state.hpp>
+#include <functional>
+#include <memory>
+#include <rclcpp/logger.hpp>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace crane
+{
+
+/**
+ * @brief Tacticのロボット要求情報
+ */
+struct TacticRequirement
+{
+  // Tactic名
+  std::string name;
+
+  // 優先度（数値が小さいほど優先度が高い、0が最高優先度）
+  int priority;
+
+  // 必要最小ロボット数
+  int min_robots;
+
+  // 必要最大ロボット数
+  int max_robots;
+
+  // ロボット適性評価関数（ロボット→コストを返す、小さいほど適している）
+  std::function<double(const std::shared_ptr<RobotInfo> &)> suitability_func;
+
+  // ハード制約フラグ（trueの場合、優先的に確保される）
+  bool is_hard_constraint = false;
+
+  TacticRequirement(
+    std::string n, int p, int min_r, int max_r,
+    std::function<double(const std::shared_ptr<RobotInfo> &)> func, bool hard = false)
+  : name(std::move(n)),
+    priority(p),
+    min_robots(min_r),
+    max_robots(max_r),
+    suitability_func(std::move(func)),
+    is_hard_constraint(hard)
+  {
+  }
+};
+
+/**
+ * @brief 全体最適化ロボット割当クラス
+ *
+ * 複数のTacticからの要求を統一的に処理し、ハンガリアン法で全体最適な割当を行う。
+ */
+class GlobalRobotAllocator
+{
+public:
+  explicit GlobalRobotAllocator(rclcpp::Logger logger) : logger_(logger) {}
+
+  /**
+   * @brief 全体最適化によるロボット割当
+   *
+   * @param requirements Tacticごとの要求リスト
+   * @param available_robots 利用可能なロボットIDリスト
+   * @param world_model ワールドモデル
+   * @param prev_state 前フレームの割当状態
+   * @param config コスト計算設定
+   * @return Tactic名→割り当てられたロボットIDリストのマップ
+   */
+  auto allocate(
+    const std::vector<TacticRequirement> & requirements,
+    const std::vector<uint8_t> & available_robots, WorldModelWrapper::SharedPtr & world_model,
+    const AllocationState & prev_state, const AllocationCostConfig & config)
+    -> std::unordered_map<std::string, std::vector<uint8_t>>;
+
+private:
+  rclcpp::Logger logger_;
+
+  /**
+   * @brief ハード制約Tacticを先に処理
+   */
+  auto allocateHardConstraints(
+    const std::vector<TacticRequirement> & hard_requirements,
+    std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
+    const AllocationState & prev_state, const AllocationCostConfig & config,
+    std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void;
+
+  /**
+   * @brief ソフト制約Tacticをハンガリアン法で処理
+   */
+  auto allocateSoftConstraints(
+    const std::vector<TacticRequirement> & soft_requirements,
+    const std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
+    const AllocationState & prev_state, const AllocationCostConfig & config,
+    std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void;
+
+  /**
+   * @brief 仮想ターゲット（Tactic-Robot ペア）を生成
+   */
+  struct VirtualTarget
+  {
+    std::string tactic_name;
+    int tactic_priority;
+    size_t robot_index;
+    std::function<double(const std::shared_ptr<RobotInfo> &)> suitability_func;
+  };
+
+  /**
+   * @brief コスト行列を構築
+   */
+  auto buildCostMatrix(
+    const std::vector<uint8_t> & robots, const std::vector<VirtualTarget> & targets,
+    WorldModelWrapper::SharedPtr & world_model, const AllocationState & prev_state,
+    const AllocationCostConfig & config)
+    -> std::function<double(size_t robot_idx, size_t target_idx)>;
+};
+
+}  // namespace crane
+#endif  // CRANE_SESSION_CONTROLLER__GLOBAL_ROBOT_ALLOCATOR_HPP_

--- a/crane_session_controller/include/crane_session_controller/global_robot_allocator.hpp
+++ b/crane_session_controller/include/crane_session_controller/global_robot_allocator.hpp
@@ -113,7 +113,7 @@ private:
     std::string tactic_name;
     int tactic_priority;
     size_t robot_index;
-    std::function<double(const std::shared_ptr<RobotInfo> &)> suitability_func;
+    std::shared_ptr<std::function<double(const std::shared_ptr<RobotInfo> &)>> suitability_func;
   };
 
   /**

--- a/crane_session_controller/include/crane_session_controller/robot_allocator.hpp
+++ b/crane_session_controller/include/crane_session_controller/robot_allocator.hpp
@@ -75,10 +75,7 @@ public:
   {
     allocation_cost_config_ = config;
   }
-  const AllocationCostConfig & getAllocationCostConfig() const
-  {
-    return allocation_cost_config_;
-  }
+  const AllocationCostConfig & getAllocationCostConfig() const { return allocation_cost_config_; }
 
 private:
   std::shared_ptr<ConfigurationManager> config_manager_;

--- a/crane_session_controller/include/crane_session_controller/robot_allocator.hpp
+++ b/crane_session_controller/include/crane_session_controller/robot_allocator.hpp
@@ -15,7 +15,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include "allocation_state.hpp"
 #include "configuration_manager.hpp"
+#include "global_robot_allocator.hpp"
 #include "tactic_registry.hpp"
 
 namespace crane
@@ -66,22 +68,30 @@ public:
    */
   auto logAssignmentIfChanged(const std::string & current_assignment) -> void;
 
-private:
   /**
-   * @brief プランナーへのロボット割り当てを試行（エラーハンドリング含む）
+   * @brief コスト設定を取得/設定
    */
-  auto tryAssignRobotToPlanner(
-    const TacticSlot & session_capacity, std::vector<uint8_t> & selectable_robot_ids,
-    const std::vector<TacticBase::SharedPtr> & prev_available_planners,
-    WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node,
-    crane_msgs::msg::RobotSelectResults & results) -> bool;
+  void setAllocationCostConfig(const AllocationCostConfig & config)
+  {
+    allocation_cost_config_ = config;
+  }
+  const AllocationCostConfig & getAllocationCostConfig() const
+  {
+    return allocation_cost_config_;
+  }
 
+private:
   std::shared_ptr<ConfigurationManager> config_manager_;
   std::shared_ptr<TacticRegistry> tactic_registry_;
   rclcpp::Logger logger_;
 
   std::unordered_map<uint8_t, RobotRole> prev_robot_roles_;
   std::string prev_assignment_log_;
+
+  // 全体最適化用メンバ
+  std::unique_ptr<GlobalRobotAllocator> global_allocator_;
+  AllocationState allocation_state_;
+  AllocationCostConfig allocation_cost_config_;
 };
 
 }  // namespace crane

--- a/crane_session_controller/src/command_aggregator.cpp
+++ b/crane_session_controller/src/command_aggregator.cpp
@@ -28,7 +28,17 @@ auto CommandAggregator::collectCommands(
 
   // 全プランナーからコマンドを収集
   for (const auto & tactic : tactic_registry_->getAllPlanners()) {
+    auto robot_count = tactic->getRobots().size();
     auto commands_msg = tactic->getPositionCommands();
+    auto command_count = commands_msg.robot_commands.size();
+
+    if (robot_count > 0 && command_count == 0) {
+      // ロボットは割り当てられているがコマンドが生成されていない
+      std::cerr << "[CommandAggregator] 警告: Tactic「" << tactic->name << "」にロボット "
+                << robot_count << " 台が割り当てられていますが、"
+                << "コマンドが0件生成されました" << std::endl;
+    }
+
     // Note: tactic_name フィールドはメッセージ定義にないためコメントアウト
     // ranges::for_each(
     //   commands_msg.robot_commands, [&](crane_msgs::msg::PositionCommand & position_command) {

--- a/crane_session_controller/src/crane_tactic_coordinator.cpp
+++ b/crane_session_controller/src/crane_tactic_coordinator.cpp
@@ -43,7 +43,7 @@ TacticCoordinatorComponent::TacticCoordinatorComponent(const rclcpp::NodeOptions
   declare_parameter<std::string>("session_config_file_name", "unified_session_config.yaml");
   auto session_config_file_name = get_parameter("session_config_file_name").as_string();
   config_manager_ = std::make_shared<ConfigurationManager>(
-    ament_index_cpp::get_package_share_directory("crane_tactic_coordinator"),
+    ament_index_cpp::get_package_share_directory("crane_session_controller"),
     session_config_file_name, get_logger());
 
   // プランナー管理の初期化

--- a/crane_session_controller/src/global_robot_allocator.cpp
+++ b/crane_session_controller/src/global_robot_allocator.cpp
@@ -1,0 +1,241 @@
+// Copyright (c) 2024 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "crane_session_controller/global_robot_allocator.hpp"
+
+#include <algorithm>
+#include <crane_utils/stream.hpp>
+#include <limits>
+#include <sstream>
+
+namespace crane
+{
+
+auto GlobalRobotAllocator::allocate(
+  const std::vector<TacticRequirement> & requirements,
+  const std::vector<uint8_t> & available_robots, WorldModelWrapper::SharedPtr & world_model,
+  const AllocationState & prev_state, const AllocationCostConfig & config)
+  -> std::unordered_map<std::string, std::vector<uint8_t>>
+{
+  std::unordered_map<std::string, std::vector<uint8_t>> result;
+
+  if (available_robots.empty()) {
+    RCLCPP_DEBUG(logger_, "GlobalRobotAllocator: 利用可能なロボットがありません");
+    return result;
+  }
+
+  // ハード制約とソフト制約に分類
+  std::vector<TacticRequirement> hard_requirements;
+  std::vector<TacticRequirement> soft_requirements;
+
+  for (const auto & req : requirements) {
+    if (req.is_hard_constraint) {
+      hard_requirements.push_back(req);
+    } else {
+      soft_requirements.push_back(req);
+    }
+  }
+
+  // ハード制約を優先度順にソート
+  std::ranges::sort(hard_requirements, [](const auto & a, const auto & b) {
+    return a.priority < b.priority;
+  });
+
+  // ソフト制約も優先度順にソート
+  std::ranges::sort(soft_requirements, [](const auto & a, const auto & b) {
+    return a.priority < b.priority;
+  });
+
+  auto remaining_robots = available_robots;
+
+  // Phase 1: ハード制約Tacticを先に処理
+  allocateHardConstraints(
+    hard_requirements, remaining_robots, world_model, prev_state, config, result);
+
+  // Phase 2: 残りのロボットでソフト制約Tacticをハンガリアン法で処理
+  allocateSoftConstraints(
+    soft_requirements, remaining_robots, world_model, prev_state, config, result);
+
+  return result;
+}
+
+auto GlobalRobotAllocator::allocateHardConstraints(
+  const std::vector<TacticRequirement> & hard_requirements,
+  std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
+  const AllocationState & prev_state, const AllocationCostConfig & config,
+  std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void
+{
+  for (const auto & req : hard_requirements) {
+    if (remaining_robots.empty()) {
+      RCLCPP_WARN(
+        logger_, "ハード制約Tactic「%s」に割り当てるロボットが不足しています", req.name.c_str());
+      break;
+    }
+
+    // 適性評価でロボットをソート
+    std::vector<std::pair<uint8_t, double>> robot_scores;
+    for (const auto & robot_id : remaining_robots) {
+      auto robot = world_model->getOurRobot(robot_id);
+      double score = req.suitability_func(robot);
+      robot_scores.emplace_back(robot_id, score);
+    }
+
+    std::ranges::sort(robot_scores, [](const auto & a, const auto & b) {
+      return a.second < b.second;  // コストが小さい順
+    });
+
+    // 必要数だけロボットを割り当て
+    int num_to_allocate = std::min(req.max_robots, static_cast<int>(remaining_robots.size()));
+    num_to_allocate = std::max(req.min_robots, num_to_allocate);
+
+    std::vector<uint8_t> assigned_robots;
+    for (int i = 0; i < num_to_allocate && i < robot_scores.size(); ++i) {
+      assigned_robots.push_back(robot_scores[i].first);
+    }
+
+    result[req.name] = assigned_robots;
+
+    // 割り当てたロボットをremaining_robotsから削除
+    for (const auto & robot_id : assigned_robots) {
+      auto it = std::find(remaining_robots.begin(), remaining_robots.end(), robot_id);
+      if (it != remaining_robots.end()) {
+        remaining_robots.erase(it);
+      }
+    }
+
+    RCLCPP_DEBUG(
+      logger_, "ハード制約Tactic「%s」に%luロボットを割り当て: %s", req.name.c_str(),
+      assigned_robots.size(), [&]() {
+        std::stringstream ss;
+        for (const auto & id : assigned_robots) {
+          ss << static_cast<int>(id) << " ";
+        }
+        return ss.str();
+      }()
+                     .c_str());
+  }
+}
+
+auto GlobalRobotAllocator::allocateSoftConstraints(
+  const std::vector<TacticRequirement> & soft_requirements,
+  const std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
+  const AllocationState & prev_state, const AllocationCostConfig & config,
+  std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void
+{
+  if (remaining_robots.empty() || soft_requirements.empty()) {
+    return;
+  }
+
+  // 仮想ターゲットを生成（各Tacticが必要とするロボット数分）
+  std::vector<VirtualTarget> virtual_targets;
+  for (const auto & req : soft_requirements) {
+    int num_targets = std::min(req.max_robots, static_cast<int>(remaining_robots.size()));
+    for (int i = 0; i < num_targets; ++i) {
+      virtual_targets.push_back(
+        {req.name, req.priority, static_cast<size_t>(i), req.suitability_func});
+    }
+  }
+
+  if (virtual_targets.empty()) {
+    return;
+  }
+
+  // ロボット数 ≤ ターゲット数 を保証
+  if (remaining_robots.size() > virtual_targets.size()) {
+    RCLCPP_WARN(
+      logger_,
+      "GlobalRobotAllocator: ロボット数(%lu)がターゲット数(%lu)を超えています。一部のロボットは割り当てられません",
+      remaining_robots.size(), virtual_targets.size());
+    // ハンガリアン法は robots <= targets を要求するため、
+    // ダミーターゲットを追加する必要があるが、ここでは単純に警告を出す
+  }
+
+  // コスト関数を構築
+  auto cost_func = buildCostMatrix(remaining_robots, virtual_targets, world_model, prev_state, config);
+
+  // ハンガリアン法で最適割当を計算
+  auto assignment = getOptimalAssignmentsWithCost(
+    remaining_robots.size(), virtual_targets.size(), cost_func);
+
+  // 割当結果を集計
+  std::unordered_map<std::string, std::vector<uint8_t>> tactic_assignments;
+  for (size_t robot_idx = 0; robot_idx < assignment.size(); ++robot_idx) {
+    int target_idx = assignment[robot_idx];
+    if (target_idx < 0 || target_idx >= virtual_targets.size()) {
+      continue;
+    }
+
+    const auto & target = virtual_targets[target_idx];
+    uint8_t robot_id = remaining_robots[robot_idx];
+    tactic_assignments[target.tactic_name].push_back(robot_id);
+  }
+
+  // min_robotsの制約を満たしているか確認
+  for (const auto & req : soft_requirements) {
+    auto it = tactic_assignments.find(req.name);
+    if (it != tactic_assignments.end()) {
+      if (it->second.size() < req.min_robots) {
+        RCLCPP_WARN(
+          logger_, "Tactic「%s」の最小ロボット数(%d)を満たせませんでした（実際: %lu）",
+          req.name.c_str(), req.min_robots, it->second.size());
+      }
+    } else if (req.min_robots > 0) {
+      RCLCPP_WARN(
+        logger_, "Tactic「%s」にロボットを割り当てられませんでした（最小要求: %d）",
+        req.name.c_str(), req.min_robots);
+    }
+  }
+
+  // 結果をマージ
+  for (const auto & [tactic_name, robots] : tactic_assignments) {
+    result[tactic_name] = robots;
+    RCLCPP_DEBUG(
+      logger_, "ソフト制約Tactic「%s」に%luロボットを割り当て: %s", tactic_name.c_str(),
+      robots.size(), [&]() {
+        std::stringstream ss;
+        for (const auto & id : robots) {
+          ss << static_cast<int>(id) << " ";
+        }
+        return ss.str();
+      }()
+                     .c_str());
+  }
+}
+
+auto GlobalRobotAllocator::buildCostMatrix(
+  const std::vector<uint8_t> & robots, const std::vector<VirtualTarget> & targets,
+  WorldModelWrapper::SharedPtr & world_model, const AllocationState & prev_state,
+  const AllocationCostConfig & config) -> std::function<double(size_t, size_t)>
+{
+  return [&robots, &targets, &world_model, &prev_state, &config](
+           size_t robot_idx, size_t target_idx) -> double {
+    uint8_t robot_id = robots[robot_idx];
+    const auto & target = targets[target_idx];
+    auto robot = world_model->getOurRobot(robot_id);
+
+    // 基本コスト: ロボットとTacticの適性（ダミーターゲット位置を使用しないため、スコアのみ）
+    // ここでは、各Tacticの suitability_func を直接呼び出すことはできないため、
+    // 簡易的に優先度コストのみを使用
+    double base_cost = 0.0;
+
+    // ヒステリシスコンテキストを構築
+    AssignmentContext context;
+    context.was_assigned_to_same_tactic = prev_state.wasAssignedTo(robot_id, target.tactic_name);
+    context.tactic_priority = target.tactic_priority;
+
+    // 簡易コスト計算（位置ベースではなく優先度ベース）
+    double priority_cost = context.tactic_priority * config.priority_cost_multiplier;
+    double hysteresis_bonus = context.was_assigned_to_same_tactic ? config.hysteresis_bonus : 0.0;
+    double velocity_hysteresis = 0.0;
+    if (context.was_assigned_to_same_tactic) {
+      velocity_hysteresis = robot->vel.linear.norm() * config.velocity_hysteresis_factor;
+    }
+
+    return base_cost + priority_cost - hysteresis_bonus + velocity_hysteresis;
+  };
+}
+
+}  // namespace crane

--- a/crane_session_controller/src/global_robot_allocator.cpp
+++ b/crane_session_controller/src/global_robot_allocator.cpp
@@ -7,6 +7,7 @@
 #include "crane_session_controller/global_robot_allocator.hpp"
 
 #include <algorithm>
+#include <crane_physics/position_assignments.hpp>
 #include <crane_utils/stream.hpp>
 #include <limits>
 #include <sstream>
@@ -22,8 +23,12 @@ auto GlobalRobotAllocator::allocate(
 {
   std::unordered_map<std::string, std::vector<uint8_t>> result;
 
+  RCLCPP_INFO(
+    logger_, "[GlobalRobotAllocator] 割当開始: %lu Tactics, %lu ロボット", requirements.size(),
+    available_robots.size());
+
   if (available_robots.empty()) {
-    RCLCPP_DEBUG(logger_, "GlobalRobotAllocator: 利用可能なロボットがありません");
+    RCLCPP_WARN(logger_, "[GlobalRobotAllocator] 利用可能なロボットがありません");
     return result;
   }
 
@@ -40,32 +45,39 @@ auto GlobalRobotAllocator::allocate(
   }
 
   // ハード制約を優先度順にソート
-  std::ranges::sort(hard_requirements, [](const auto & a, const auto & b) {
-    return a.priority < b.priority;
-  });
+  std::ranges::sort(
+    hard_requirements, [](const auto & a, const auto & b) { return a.priority < b.priority; });
 
   // ソフト制約も優先度順にソート
-  std::ranges::sort(soft_requirements, [](const auto & a, const auto & b) {
-    return a.priority < b.priority;
-  });
+  std::ranges::sort(
+    soft_requirements, [](const auto & a, const auto & b) { return a.priority < b.priority; });
 
   auto remaining_robots = available_robots;
+
+  RCLCPP_INFO(
+    logger_, "[GlobalRobotAllocator] ハード制約: %lu, ソフト制約: %lu", hard_requirements.size(),
+    soft_requirements.size());
 
   // Phase 1: ハード制約Tacticを先に処理
   allocateHardConstraints(
     hard_requirements, remaining_robots, world_model, prev_state, config, result);
 
+  RCLCPP_INFO(
+    logger_, "[GlobalRobotAllocator] ハード制約処理後の残りロボット: %lu", remaining_robots.size());
+
   // Phase 2: 残りのロボットでソフト制約Tacticをハンガリアン法で処理
   allocateSoftConstraints(
     soft_requirements, remaining_robots, world_model, prev_state, config, result);
+
+  RCLCPP_INFO(logger_, "[GlobalRobotAllocator] 割当完了: %lu Tactics", result.size());
 
   return result;
 }
 
 auto GlobalRobotAllocator::allocateHardConstraints(
-  const std::vector<TacticRequirement> & hard_requirements,
-  std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
-  const AllocationState & prev_state, const AllocationCostConfig & config,
+  const std::vector<TacticRequirement> & hard_requirements, std::vector<uint8_t> & remaining_robots,
+  WorldModelWrapper::SharedPtr & world_model, const AllocationState & prev_state,
+  const AllocationCostConfig & config,
   std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void
 {
   for (const auto & req : hard_requirements) {
@@ -108,14 +120,15 @@ auto GlobalRobotAllocator::allocateHardConstraints(
 
     RCLCPP_DEBUG(
       logger_, "ハード制約Tactic「%s」に%luロボットを割り当て: %s", req.name.c_str(),
-      assigned_robots.size(), [&]() {
+      assigned_robots.size(),
+      [&]() {
         std::stringstream ss;
         for (const auto & id : assigned_robots) {
           ss << static_cast<int>(id) << " ";
         }
         return ss.str();
       }()
-                     .c_str());
+        .c_str());
   }
 }
 
@@ -133,9 +146,11 @@ auto GlobalRobotAllocator::allocateSoftConstraints(
   std::vector<VirtualTarget> virtual_targets;
   for (const auto & req : soft_requirements) {
     int num_targets = std::min(req.max_robots, static_cast<int>(remaining_robots.size()));
+    // 適性関数をshared_ptrでラップ（コピーコストを削減しライフタイムを管理）
+    auto func_ptr = std::make_shared<std::function<double(const std::shared_ptr<RobotInfo> &)>>(
+      req.suitability_func);
     for (int i = 0; i < num_targets; ++i) {
-      virtual_targets.push_back(
-        {req.name, req.priority, static_cast<size_t>(i), req.suitability_func});
+      virtual_targets.push_back({req.name, req.priority, static_cast<size_t>(i), func_ptr});
     }
   }
 
@@ -146,31 +161,115 @@ auto GlobalRobotAllocator::allocateSoftConstraints(
   // ロボット数 ≤ ターゲット数 を保証
   if (remaining_robots.size() > virtual_targets.size()) {
     RCLCPP_WARN(
-      logger_,
-      "GlobalRobotAllocator: ロボット数(%lu)がターゲット数(%lu)を超えています。一部のロボットは割り当てられません",
+      logger_, "[allocateSoftConstraints] ロボット数(%lu)がターゲット数(%lu)を超えています",
       remaining_robots.size(), virtual_targets.size());
     // ハンガリアン法は robots <= targets を要求するため、
     // ダミーターゲットを追加する必要があるが、ここでは単純に警告を出す
   }
 
   // コスト関数を構築
-  auto cost_func = buildCostMatrix(remaining_robots, virtual_targets, world_model, prev_state, config);
+  auto cost_func =
+    buildCostMatrix(remaining_robots, virtual_targets, world_model, prev_state, config);
+
+  // Hungarian実装は U >= V を要求するため、robots < targets の場合は転置する
+  bool needs_transpose = remaining_robots.size() < virtual_targets.size();
+  size_t matrix_rows = needs_transpose ? virtual_targets.size() : remaining_robots.size();
+  size_t matrix_cols = needs_transpose ? remaining_robots.size() : virtual_targets.size();
+
+  std::vector<std::vector<double>> cost_matrix(matrix_rows, std::vector<double>(matrix_cols));
+
+  if (needs_transpose) {
+    // 転置: cost_matrix[target][robot] = cost(robot, target)
+    for (size_t i = 0; i < remaining_robots.size(); ++i) {
+      for (size_t j = 0; j < virtual_targets.size(); ++j) {
+        cost_matrix[j][i] = cost_func(i, j);
+      }
+    }
+  } else {
+    // 通常: cost_matrix[robot][target] = cost(robot, target)
+    for (size_t i = 0; i < remaining_robots.size(); ++i) {
+      for (size_t j = 0; j < virtual_targets.size(); ++j) {
+        cost_matrix[i][j] = cost_func(i, j);
+      }
+    }
+  }
+
+  // コスト行列の検証と正規化
+  double min_cost = std::numeric_limits<double>::max();
+  double max_cost = std::numeric_limits<double>::lowest();
+  bool has_invalid = false;
+
+  for (size_t i = 0; i < matrix_rows; ++i) {
+    for (size_t j = 0; j < matrix_cols; ++j) {
+      if (std::isnan(cost_matrix[i][j]) || std::isinf(cost_matrix[i][j])) {
+        RCLCPP_ERROR(
+          logger_, "[allocateSoftConstraints] 不正なコスト値: cost[%lu][%lu]=%f", i, j,
+          cost_matrix[i][j]);
+        has_invalid = true;
+      } else {
+        min_cost = std::min(min_cost, cost_matrix[i][j]);
+        max_cost = std::max(max_cost, cost_matrix[i][j]);
+      }
+    }
+  }
+
+  if (has_invalid) {
+    RCLCPP_ERROR(logger_, "[allocateSoftConstraints] コスト行列に不正な値が含まれています");
+    return;
+  }
+
+  // Hungarian法は非負のコスト行列を要求するため、負の値がある場合はオフセットを追加
+  if (min_cost < 0.0) {
+    RCLCPP_WARN(
+      logger_, "[allocateSoftConstraints] 負のコスト値を検出: %f。オフセットを追加します",
+      min_cost);
+    double offset = -min_cost + 1.0;
+    for (size_t i = 0; i < matrix_rows; ++i) {
+      for (size_t j = 0; j < matrix_cols; ++j) {
+        cost_matrix[i][j] += offset;
+      }
+    }
+  }
 
   // ハンガリアン法で最適割当を計算
-  auto assignment = getOptimalAssignmentsWithCost(
-    remaining_robots.size(), virtual_targets.size(), cost_func);
+  std::vector<int> assignment;
+
+  try {
+    math::Hungarian<double> hungarian_solver(cost_matrix);
+    auto [cost, solution_index] = hungarian_solver.solve();
+    assignment = std::move(solution_index);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(logger_, "[allocateSoftConstraints] ハンガリアン法で例外発生: %s", e.what());
+    return;
+  }
 
   // 割当結果を集計
   std::unordered_map<std::string, std::vector<uint8_t>> tactic_assignments;
-  for (size_t robot_idx = 0; robot_idx < assignment.size(); ++robot_idx) {
-    int target_idx = assignment[robot_idx];
-    if (target_idx < 0 || target_idx >= virtual_targets.size()) {
-      continue;
-    }
 
-    const auto & target = virtual_targets[target_idx];
-    uint8_t robot_id = remaining_robots[robot_idx];
-    tactic_assignments[target.tactic_name].push_back(robot_id);
+  if (needs_transpose) {
+    // 転置モード: assignment[target_idx] = robot_idx
+    for (size_t target_idx = 0; target_idx < assignment.size(); ++target_idx) {
+      int robot_idx = assignment[target_idx];
+      if (robot_idx < 0 || robot_idx >= remaining_robots.size()) {
+        continue;
+      }
+
+      const auto & target = virtual_targets[target_idx];
+      uint8_t robot_id = remaining_robots[robot_idx];
+      tactic_assignments[target.tactic_name].push_back(robot_id);
+    }
+  } else {
+    // 通常モード: assignment[robot_idx] = target_idx
+    for (size_t robot_idx = 0; robot_idx < assignment.size(); ++robot_idx) {
+      int target_idx = assignment[robot_idx];
+      if (target_idx < 0 || target_idx >= virtual_targets.size()) {
+        continue;
+      }
+
+      const auto & target = virtual_targets[target_idx];
+      uint8_t robot_id = remaining_robots[robot_idx];
+      tactic_assignments[target.tactic_name].push_back(robot_id);
+    }
   }
 
   // min_robotsの制約を満たしているか確認
@@ -194,14 +293,15 @@ auto GlobalRobotAllocator::allocateSoftConstraints(
     result[tactic_name] = robots;
     RCLCPP_DEBUG(
       logger_, "ソフト制約Tactic「%s」に%luロボットを割り当て: %s", tactic_name.c_str(),
-      robots.size(), [&]() {
+      robots.size(),
+      [&]() {
         std::stringstream ss;
         for (const auto & id : robots) {
           ss << static_cast<int>(id) << " ";
         }
         return ss.str();
       }()
-                     .c_str());
+        .c_str());
   }
 }
 
@@ -210,28 +310,42 @@ auto GlobalRobotAllocator::buildCostMatrix(
   WorldModelWrapper::SharedPtr & world_model, const AllocationState & prev_state,
   const AllocationCostConfig & config) -> std::function<double(size_t, size_t)>
 {
-  return [&robots, &targets, &world_model, &prev_state, &config](
-           size_t robot_idx, size_t target_idx) -> double {
-    uint8_t robot_id = robots[robot_idx];
-    const auto & target = targets[target_idx];
-    auto robot = world_model->getOurRobot(robot_id);
+  // 必要な情報を値キャプチャしてライフタイムを保証
+  // ただし、VirtualTargetは軽量なので直接コピー
+  auto robots_copy = robots;
+  auto targets_copy = targets;
+  auto wm = world_model;
+  auto state_copy = prev_state;
+  auto config_copy = config;
 
-    // 基本コスト: ロボットとTacticの適性（ダミーターゲット位置を使用しないため、スコアのみ）
-    // ここでは、各Tacticの suitability_func を直接呼び出すことはできないため、
-    // 簡易的に優先度コストのみを使用
+  return [robots_copy, targets_copy, wm, state_copy, config_copy](
+           size_t robot_idx, size_t target_idx) -> double {
+    if (robot_idx >= robots_copy.size() || target_idx >= targets_copy.size()) {
+      return std::numeric_limits<double>::max();
+    }
+
+    uint8_t robot_id = robots_copy[robot_idx];
+    const auto & target = targets_copy[target_idx];
+    auto robot = wm->getOurRobot(robot_id);
+
+    // 基本コスト: shared_ptr経由で適性関数を呼び出す
     double base_cost = 0.0;
+    if (target.suitability_func) {
+      base_cost = (*target.suitability_func)(robot);
+    }
 
     // ヒステリシスコンテキストを構築
     AssignmentContext context;
-    context.was_assigned_to_same_tactic = prev_state.wasAssignedTo(robot_id, target.tactic_name);
+    context.was_assigned_to_same_tactic = state_copy.wasAssignedTo(robot_id, target.tactic_name);
     context.tactic_priority = target.tactic_priority;
 
-    // 簡易コスト計算（位置ベースではなく優先度ベース）
-    double priority_cost = context.tactic_priority * config.priority_cost_multiplier;
-    double hysteresis_bonus = context.was_assigned_to_same_tactic ? config.hysteresis_bonus : 0.0;
+    // 総コスト計算
+    double priority_cost = context.tactic_priority * config_copy.priority_cost_multiplier;
+    double hysteresis_bonus =
+      context.was_assigned_to_same_tactic ? config_copy.hysteresis_bonus : 0.0;
     double velocity_hysteresis = 0.0;
     if (context.was_assigned_to_same_tactic) {
-      velocity_hysteresis = robot->vel.linear.norm() * config.velocity_hysteresis_factor;
+      velocity_hysteresis = robot->vel.linear.norm() * config_copy.velocity_hysteresis_factor;
     }
 
     return base_cost + priority_cost - hysteresis_bonus + velocity_hysteresis;

--- a/crane_session_controller/src/global_robot_allocator.cpp
+++ b/crane_session_controller/src/global_robot_allocator.cpp
@@ -23,10 +23,6 @@ auto GlobalRobotAllocator::allocate(
 {
   std::unordered_map<std::string, std::vector<uint8_t>> result;
 
-  RCLCPP_INFO(
-    logger_, "[GlobalRobotAllocator] 割当開始: %lu Tactics, %lu ロボット", requirements.size(),
-    available_robots.size());
-
   if (available_robots.empty()) {
     RCLCPP_WARN(logger_, "[GlobalRobotAllocator] 利用可能なロボットがありません");
     return result;
@@ -54,22 +50,13 @@ auto GlobalRobotAllocator::allocate(
 
   auto remaining_robots = available_robots;
 
-  RCLCPP_INFO(
-    logger_, "[GlobalRobotAllocator] ハード制約: %lu, ソフト制約: %lu", hard_requirements.size(),
-    soft_requirements.size());
-
   // Phase 1: ハード制約Tacticを先に処理
   allocateHardConstraints(
     hard_requirements, remaining_robots, world_model, prev_state, config, result);
 
-  RCLCPP_INFO(
-    logger_, "[GlobalRobotAllocator] ハード制約処理後の残りロボット: %lu", remaining_robots.size());
-
   // Phase 2: 残りのロボットでソフト制約Tacticをハンガリアン法で処理
   allocateSoftConstraints(
     soft_requirements, remaining_robots, world_model, prev_state, config, result);
-
-  RCLCPP_INFO(logger_, "[GlobalRobotAllocator] 割当完了: %lu Tactics", result.size());
 
   return result;
 }

--- a/crane_session_controller/src/robot_allocator.cpp
+++ b/crane_session_controller/src/robot_allocator.cpp
@@ -20,7 +20,10 @@ namespace crane
 RobotAllocator::RobotAllocator(
   std::shared_ptr<ConfigurationManager> config_manager,
   std::shared_ptr<TacticRegistry> tactic_registry, rclcpp::Logger logger)
-: config_manager_(config_manager), tactic_registry_(tactic_registry), logger_(logger)
+: config_manager_(config_manager),
+  tactic_registry_(tactic_registry),
+  logger_(logger),
+  global_allocator_(std::make_unique<GlobalRobotAllocator>(logger))
 {
 }
 
@@ -33,8 +36,7 @@ auto RobotAllocator::allocate(
   if (!session_capacities_opt.has_value()) {
     RCLCPP_ERROR(
       logger_,
-      "\t「%"
-      "s」というSituationに対してロボット割当リクエストが発行されましたが，見つかりませんでした",
+      "\t「%s」というSituationに対してロボット割当リクエストが発行されましたが，見つかりませんでした",
       session_name.c_str());
     return crane_msgs::msg::RobotSelectResults{};
   }
@@ -44,25 +46,79 @@ auto RobotAllocator::allocate(
   // 前回のプランナーリストを保存し、新しいリストをクリア
   auto prev_available_planners = tactic_registry_->getAllPlanners();
   tactic_registry_->clear();
-  prev_robot_roles_.clear();
 
-  crane_msgs::msg::RobotSelectResults results;
-
-  // 優先順位が高いPlannerから順にロボットを割り当てる
+  // TacticRequirementリストを構築
+  std::vector<TacticRequirement> requirements;
+  int priority = 0;
   for (const auto & session_capacity : session_capacities) {
-    if (!tryAssignRobotToPlanner(
-          session_capacity, selectable_robot_ids, prev_available_planners, world_model, node,
-          results)) {
-      // エラーが発生した場合はループを抜ける
-      break;
+    if (session_capacity.selectable_robot_num <= 0) {
+      continue;
     }
+
+    // プランナー生成
+    auto tactic = tactic_registry_->getOrCreatePlanner(
+      session_capacity.session_name, world_model, node, prev_available_planners,
+      session_capacity.params);
+
+    // 適性関数とハード制約フラグを取得
+    auto suitability_func = tactic->getRobotSuitabilityFunc();
+    bool is_hard = tactic->isHardConstraint();
+
+    requirements.emplace_back(
+      session_capacity.session_name, priority++, 1,  // min_robots
+      session_capacity.selectable_robot_num,         // max_robots
+      suitability_func, is_hard);
   }
 
-  // 割り当てられなかったロボットを待機状態にする
-  if (not selectable_robot_ids.empty()) {
-    TacticSlot waiter_session{"waiter", static_cast<int>(selectable_robot_ids.size()), {}};
-    tryAssignRobotToPlanner(
-      waiter_session, selectable_robot_ids, prev_available_planners, world_model, node, results);
+  // GlobalRobotAllocatorで割当を実行
+  auto allocation = global_allocator_->allocate(
+    requirements, selectable_robot_ids, world_model, allocation_state_,
+    allocation_cost_config_);
+
+  // 割当結果を適用
+  crane_msgs::msg::RobotSelectResults results;
+  for (const auto & [tactic_name, robot_ids] : allocation) {
+    // Tacticを取得または再生成
+    auto tactic_it = std::find_if(
+      tactic_registry_->getAllPlanners().begin(), tactic_registry_->getAllPlanners().end(),
+      [&tactic_name](const auto & t) { return t->name == tactic_name; });
+
+    TacticBase::SharedPtr tactic;
+    if (tactic_it != tactic_registry_->getAllPlanners().end()) {
+      tactic = *tactic_it;
+    } else {
+      // 見つからない場合は新規生成（通常はここには来ない）
+      auto session_it = std::find_if(
+        session_capacities.begin(), session_capacities.end(),
+        [&tactic_name](const auto & s) { return s.session_name == tactic_name; });
+      if (session_it != session_capacities.end()) {
+        tactic = tactic_registry_->getOrCreatePlanner(
+          tactic_name, world_model, node, prev_available_planners, session_it->params);
+      }
+    }
+
+    if (tactic) {
+      // ロボット割当をTacticに反映
+      // selectRobots()を呼び出してロボットを割り当てる
+      // ただし、GlobalRobotAllocatorが既に選択済みなので、直接渡す
+      tactic->selectRobots(robot_ids, robot_ids.size(), prev_robot_roles_);
+
+      // レジストリに追加
+      if (tactic_it == tactic_registry_->getAllPlanners().end()) {
+        tactic_registry_->addPlanner(tactic);
+      }
+
+      // AllocationStateを更新（ターゲット位置は現時点では不明なのでロボット位置を使用）
+      for (auto id : robot_ids) {
+        auto robot = world_model->getOurRobot(id);
+        allocation_state_.updateAssignment(id, tactic_name, robot->pose.pos);
+        prev_robot_roles_.insert_or_assign(id, RobotRole{tactic_name, ""});
+      }
+
+      RCLCPP_DEBUG_STREAM(
+        logger_, "\tグローバルアロケータ: セッション「" << tactic_name << "」のロボット割当："
+                                                        << robot_ids);
+    }
   }
 
   return results;
@@ -131,62 +187,6 @@ auto RobotAllocator::logAssignmentIfChanged(const std::string & current_assignme
       RCLCPP_DEBUG(logger_, "ロボット割当: %s", current_assignment.c_str());
     }
     prev_assignment_log_ = current_assignment;
-  }
-}
-
-auto RobotAllocator::tryAssignRobotToPlanner(
-  const TacticSlot & session_capacity, std::vector<uint8_t> & selectable_robot_ids,
-  const std::vector<TacticBase::SharedPtr> & prev_available_planners,
-  WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node,
-  crane_msgs::msg::RobotSelectResults & results) -> bool
-{
-  // 割り当て可能なロボットがない場合はスキップ
-  if (session_capacity.selectable_robot_num <= 0 || selectable_robot_ids.empty()) {
-    return true;
-  }
-
-  crane_msgs::msg::RobotSelectResult result;
-  result.name = session_capacity.session_name;
-  result.selectable_robots_num = session_capacity.selectable_robot_num;
-  std::ranges::copy(selectable_robot_ids, std::back_inserter(result.selectable_robots));
-
-  try {
-    // プランナー生成とロボット選択
-    // TacticRegistryを使ってプランナーを取得または生成
-    auto tactic = tactic_registry_->getOrCreatePlanner(
-      session_capacity.session_name, world_model, node, prev_available_planners,
-      session_capacity.params);
-
-    auto selected_robots = tactic->selectRobots(
-      selectable_robot_ids, session_capacity.selectable_robot_num, prev_robot_roles_);
-    results.results.push_back(result);
-
-    // プランナーをレジストリに登録
-    tactic_registry_->addPlanner(tactic);
-
-    if (not selectable_robot_ids.empty()) {
-      RCLCPP_DEBUG_STREAM(
-        logger_, "\tセッション「" << session_capacity.session_name << "」のロボット選択："
-                                  << selectable_robot_ids << " -> " << selected_robots);
-    }
-
-    // 割当依頼結果の反映
-    for (auto selected_robot_id : selected_robots) {
-      // 割当されたロボットを利用可能ロボットリストから削除
-      selectable_robot_ids.erase(
-        remove(selectable_robot_ids.begin(), selectable_robot_ids.end(), selected_robot_id),
-        selectable_robot_ids.end());
-      // 割当されたロボットをロールマップに追加(この情報は他のプランナにも共有される)
-      prev_robot_roles_.insert_or_assign(
-        selected_robot_id, RobotRole{session_capacity.session_name, ""});
-    }
-
-    return true;
-  } catch (std::exception & e) {
-    RCLCPP_ERROR(
-      logger_, "\t「%s」というプランナを呼び出した時に例外が発生しました : %s",
-      session_capacity.session_name.c_str(), e.what());
-    return false;
   }
 }
 

--- a/crane_session_controller/src/robot_allocator.cpp
+++ b/crane_session_controller/src/robot_allocator.cpp
@@ -36,7 +36,8 @@ auto RobotAllocator::allocate(
   if (!session_capacities_opt.has_value()) {
     RCLCPP_ERROR(
       logger_,
-      "\t「%s」というSituationに対してロボット割当リクエストが発行されましたが，見つかりませんでした",
+      "\t「%"
+      "s」というSituationに対してロボット割当リクエストが発行されましたが，見つかりませんでした",
       session_name.c_str());
     return crane_msgs::msg::RobotSelectResults{};
   }
@@ -72,8 +73,7 @@ auto RobotAllocator::allocate(
 
   // GlobalRobotAllocatorで割当を実行
   auto allocation = global_allocator_->allocate(
-    requirements, selectable_robot_ids, world_model, allocation_state_,
-    allocation_cost_config_);
+    requirements, selectable_robot_ids, world_model, allocation_state_, allocation_cost_config_);
 
   // 割当結果を適用
   crane_msgs::msg::RobotSelectResults results;
@@ -99,9 +99,13 @@ auto RobotAllocator::allocate(
 
     if (tactic) {
       // ロボット割当をTacticに反映
-      // selectRobots()を呼び出してロボットを割り当てる
-      // ただし、GlobalRobotAllocatorが既に選択済みなので、直接渡す
-      tactic->selectRobots(robot_ids, robot_ids.size(), prev_robot_roles_);
+      // GlobalRobotAllocatorが選択したロボットを直接設定（getSelectedRobotsをバイパス）
+      tactic->setAllocatedRobots(robot_ids);
+
+      // 設定後のロボット数を確認
+      RCLCPP_INFO(
+        logger_, "\tTactic「%s」のロボット設定: 設定前=%lu, 設定後=%lu", tactic_name.c_str(),
+        tactic->getRobots().size() - robot_ids.size(), tactic->getRobots().size());
 
       // レジストリに追加
       if (tactic_it == tactic_registry_->getAllPlanners().end()) {
@@ -115,9 +119,9 @@ auto RobotAllocator::allocate(
         prev_robot_roles_.insert_or_assign(id, RobotRole{tactic_name, ""});
       }
 
-      RCLCPP_DEBUG_STREAM(
-        logger_, "\tグローバルアロケータ: セッション「" << tactic_name << "」のロボット割当："
-                                                        << robot_ids);
+      RCLCPP_INFO_STREAM(
+        logger_,
+        "\tグローバルアロケータ: セッション「" << tactic_name << "」のロボット割当：" << robot_ids);
     }
   }
 

--- a/utility/crane_physics/include/crane_physics/allocation_cost.hpp
+++ b/utility/crane_physics/include/crane_physics/allocation_cost.hpp
@@ -1,0 +1,156 @@
+// Copyright (c) 2024 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_PHYSICS__ALLOCATION_COST_HPP_
+#define CRANE_PHYSICS__ALLOCATION_COST_HPP_
+
+#include <crane_geometry/boost_geometry.hpp>
+#include <crane_physics/robot_info.hpp>
+#include <memory>
+
+namespace crane
+{
+
+/**
+ * @brief ロボット割当コスト計算の設定パラメータ
+ */
+struct AllocationCostConfig
+{
+  // 距離コスト係数（1.0 = 1メートルあたりのコスト）
+  double distance_weight = 1.0;
+
+  // 速度アライメント係数（目標方向への速度を評価）
+  // 例: 0.3 なら、速度1m/sで0.3mの距離に相当
+  double velocity_alignment_weight = 0.3;
+
+  // 到達時間係数（台形速度プロファイルでの到達時間を評価）
+  // 例: 0.5 なら、1秒で0.5mの距離に相当
+  double travel_time_weight = 0.5;
+
+  // ヒステリシスボーナス（同一Tactic継続時のコスト減少）[m]
+  double hysteresis_bonus = 0.5;
+
+  // 速度ベースヒステリシス係数（高速移動中の再割当抑制）
+  // 例: 0.2 なら、速度1m/sで0.2mのペナルティ
+  double velocity_hysteresis_factor = 0.2;
+
+  // Tactic優先度によるコスト調整（優先度差1あたりのコスト増加）[m]
+  double priority_cost_multiplier = 10.0;
+
+  // 最大加速度 [m/s^2]（到達時間計算用）
+  double max_acceleration = 3.0;
+
+  // 最大速度 [m/s]（到達時間計算用）
+  double max_velocity = 3.0;
+
+  // デフォルトコンストラクタ
+  AllocationCostConfig() = default;
+};
+
+/**
+ * @brief 割当コンテキスト情報
+ */
+struct AssignmentContext
+{
+  // 前回同じTacticに割り当てられていたか
+  bool was_assigned_to_same_tactic = false;
+
+  // 前回のターゲット位置（ヒステリシス計算用）
+  std::optional<Point> prev_target_position;
+
+  // Tactic優先度（数値が小さいほど優先度が高い）
+  int tactic_priority = 100;
+
+  // デフォルトコンストラクタ
+  AssignmentContext() = default;
+};
+
+/**
+ * @brief ロボット割当の統合コスト関数
+ *
+ * 距離、速度、ヒステリシス、優先度を考慮した総合的なコストを計算する。
+ *
+ * @param robot ロボット情報
+ * @param target ターゲット位置
+ * @param context 割当コンテキスト
+ * @param config コスト計算設定
+ * @return 総合コスト値（小さいほど良い）
+ */
+inline double calculateAllocationCost(
+  const RobotInfo & robot, const Point & target, const AssignmentContext & context,
+  const AllocationCostConfig & config = AllocationCostConfig())
+{
+  // 基本コスト: ユークリッド距離
+  Vector2 to_target = target - robot.pose.pos;
+  double distance = to_target.norm();
+  double distance_cost = distance * config.distance_weight;
+
+  // 速度考慮コスト: 目標方向への速度成分を評価
+  double velocity_cost = 0.0;
+  if (distance > 1e-6) {  // ゼロ除算回避
+    Vector2 to_target_normalized = to_target.normalized();
+    double velocity_alignment = robot.vel.linear.dot(to_target_normalized);
+    // 目標方向への速度があればコスト減少、逆方向ならコスト増加
+    velocity_cost = -velocity_alignment * config.velocity_alignment_weight;
+  }
+
+  // 到達時間ベースコスト（より正確な評価）
+  double time_cost = 0.0;
+  if (config.travel_time_weight > 0.0) {
+    double travel_time = getTravelTimeTrapezoidal(
+      robot.pose.pos, robot.vel.linear, target, config.max_acceleration, config.max_velocity);
+    time_cost = travel_time * config.travel_time_weight;
+  }
+
+  // ヒステリシスボーナス（同じTacticに継続割当の場合コスト減少）
+  double hysteresis_bonus = 0.0;
+  if (context.was_assigned_to_same_tactic) {
+    hysteresis_bonus = config.hysteresis_bonus;
+  }
+
+  // 速度ベースヒステリシス（Sumatra参考）
+  // 高速移動中のロボットの再割当にペナルティを課す
+  double velocity_hysteresis = 0.0;
+  if (context.was_assigned_to_same_tactic) {
+    double robot_speed = robot.vel.linear.norm();
+    velocity_hysteresis = robot_speed * config.velocity_hysteresis_factor;
+  }
+
+  // 優先度コスト（優先度の低いTacticへの割当はコスト増加）
+  double priority_cost = context.tactic_priority * config.priority_cost_multiplier;
+
+  // 総合コスト
+  // ボーナスは負の値として減算される
+  return distance_cost + velocity_cost + time_cost - hysteresis_bonus + velocity_hysteresis +
+         priority_cost;
+}
+
+/**
+ * @brief 簡易版コスト関数（距離のみ）
+ *
+ * 後方互換性のための関数。既存コードとの互換性を保つ。
+ *
+ * @param robot_pos ロボット位置
+ * @param target ターゲット位置
+ * @return 距離コスト
+ */
+inline double calculateSimpleDistanceCost(const Point & robot_pos, const Point & target)
+{
+  return (target - robot_pos).norm();
+}
+
+/**
+ * @brief SharedPtr版のコスト関数（WorldModelWrapper互換用）
+ */
+inline double calculateAllocationCost(
+  const std::shared_ptr<RobotInfo> & robot, const Point & target,
+  const AssignmentContext & context, const AllocationCostConfig & config = AllocationCostConfig())
+{
+  return calculateAllocationCost(*robot, target, context, config);
+}
+
+}  // namespace crane
+#endif  // CRANE_PHYSICS__ALLOCATION_COST_HPP_

--- a/utility/crane_physics/include/crane_physics/allocation_cost.hpp
+++ b/utility/crane_physics/include/crane_physics/allocation_cost.hpp
@@ -146,8 +146,8 @@ inline double calculateSimpleDistanceCost(const Point & robot_pos, const Point &
  * @brief SharedPtr版のコスト関数（WorldModelWrapper互換用）
  */
 inline double calculateAllocationCost(
-  const std::shared_ptr<RobotInfo> & robot, const Point & target,
-  const AssignmentContext & context, const AllocationCostConfig & config = AllocationCostConfig())
+  const std::shared_ptr<RobotInfo> & robot, const Point & target, const AssignmentContext & context,
+  const AllocationCostConfig & config = AllocationCostConfig())
 {
   return calculateAllocationCost(*robot, target, context, config);
 }

--- a/utility/crane_physics/include/crane_physics/hysteresis.hpp
+++ b/utility/crane_physics/include/crane_physics/hysteresis.hpp
@@ -4,8 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#ifndef CRANE_PHYSICS__ALLOCATION_HYSTERESIS_HPP_
-#define CRANE_PHYSICS__ALLOCATION_HYSTERESIS_HPP_
+#ifndef CRANE_PHYSICS__HYSTERESIS_HPP_
+#define CRANE_PHYSICS__HYSTERESIS_HPP_
 
 #include <cassert>
 #include <functional>
@@ -124,4 +124,4 @@ private:
 };
 
 }  // namespace crane
-#endif  // CRANE_PHYSICS__ALLOCATION_HYSTERESIS_HPP_
+#endif  // CRANE_PHYSICS__HYSTERESIS_HPP_

--- a/utility/crane_physics/include/crane_physics/hysteresis.hpp
+++ b/utility/crane_physics/include/crane_physics/hysteresis.hpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2024 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_PHYSICS__ALLOCATION_HYSTERESIS_HPP_
+#define CRANE_PHYSICS__ALLOCATION_HYSTERESIS_HPP_
+
+#include <cassert>
+#include <functional>
+
+namespace crane
+{
+/**
+ * @brief 2閾値によるヒステリシス制御クラス（ロボット割当用）
+ *
+ * Sumatraの実装を参考にした、チャタリング防止のためのヒステリシス機構。
+ * lower_threshold未満で下位状態、upper_threshold以上で上位状態に遷移。
+ * 閾値間では状態を維持してチャタリングを防止する。
+ *
+ * 注意: ball_info.hppの既存Hysteresisと競合しないよう、AllocationHysteresisに改名
+ *
+ * 使用例：
+ * @code
+ * AllocationHysteresis h(0.3, 0.7);  // 下限0.3、上限0.7
+ * h.update(0.8);  // 上位状態へ遷移
+ * h.update(0.5);  // 閾値間なので状態維持（上位のまま）
+ * h.update(0.2);  // 下位状態へ遷移
+ * @endcode
+ */
+class AllocationHysteresis
+{
+public:
+  /**
+   * @brief コンストラクタ
+   * @param lower_threshold 下位状態への遷移閾値
+   * @param upper_threshold 上位状態への遷移閾値
+   */
+  AllocationHysteresis(double lower_threshold, double upper_threshold)
+  : lower_threshold_(lower_threshold), upper_threshold_(upper_threshold), is_upper_state_(false)
+  {
+    assert(lower_threshold < upper_threshold);
+  }
+
+  /**
+   * @brief デフォルトコンストラクタ（閾値0.0, 1.0）
+   */
+  AllocationHysteresis() : AllocationHysteresis(0.0, 1.0) {}
+
+  /**
+   * @brief 値を更新してヒステリシス判定
+   * @param value 判定する値
+   * @return 自身の参照（メソッドチェーン用）
+   */
+  auto update(double value) -> AllocationHysteresis &
+  {
+    if (!is_upper_state_ && value >= upper_threshold_) {
+      is_upper_state_ = true;
+      if (on_upper_callback_) {
+        on_upper_callback_();
+      }
+    }
+    if (is_upper_state_ && value < lower_threshold_) {
+      is_upper_state_ = false;
+      if (on_lower_callback_) {
+        on_lower_callback_();
+      }
+    }
+    return *this;
+  }
+
+  /**
+   * @brief 上位状態かどうかを返す
+   * @return 上位状態の場合true
+   */
+  bool isUpper() const { return is_upper_state_; }
+
+  /**
+   * @brief 下位状態かどうかを返す
+   * @return 下位状態の場合true
+   */
+  bool isLower() const { return !is_upper_state_; }
+
+  /**
+   * @brief 上位状態への遷移時のコールバックを設定
+   * @param cb コールバック関数
+   */
+  void setOnUpperCallback(std::function<void()> cb) { on_upper_callback_ = std::move(cb); }
+
+  /**
+   * @brief 下位状態への遷移時のコールバックを設定
+   * @param cb コールバック関数
+   */
+  void setOnLowerCallback(std::function<void()> cb) { on_lower_callback_ = std::move(cb); }
+
+  /**
+   * @brief 状態を強制的にリセット（下位状態へ）
+   */
+  void reset() { is_upper_state_ = false; }
+
+  /**
+   * @brief 閾値を取得
+   */
+  double getLowerThreshold() const { return lower_threshold_; }
+  double getUpperThreshold() const { return upper_threshold_; }
+
+  /**
+   * @brief 閾値を設定
+   */
+  void setThresholds(double lower, double upper)
+  {
+    assert(lower < upper);
+    lower_threshold_ = lower;
+    upper_threshold_ = upper;
+  }
+
+private:
+  double lower_threshold_;
+  double upper_threshold_;
+  bool is_upper_state_;
+  std::function<void()> on_upper_callback_;
+  std::function<void()> on_lower_callback_;
+};
+
+}  // namespace crane
+#endif  // CRANE_PHYSICS__ALLOCATION_HYSTERESIS_HPP_

--- a/utility/crane_physics/include/crane_physics/position_assignments.hpp
+++ b/utility/crane_physics/include/crane_physics/position_assignments.hpp
@@ -239,5 +239,42 @@ inline auto getOptimalAssignments(
   return solution_index;
 }
 
+/**
+ * @brief カスタムコスト関数を用いた最適割当計算
+ *
+ * ユーザー定義のコスト関数を使用してロボットとターゲットの最適割当を計算する。
+ *
+ * @tparam CostFunc コスト関数の型 (int robot_index, int target_index) -> double
+ * @param num_robots ロボット数
+ * @param num_targets ターゲット数
+ * @param cost_func コスト計算関数
+ * @return 割当結果のインデックスベクター（solution_index[robot_index] = target_index）
+ */
+template <typename CostFunc>
+inline auto getOptimalAssignmentsWithCost(
+  size_t num_robots, size_t num_targets, CostFunc && cost_func) -> std::vector<int>
+{
+  assert(num_robots <= num_targets);
+  if (num_robots == 0) {
+    return {};
+  }
+  if (num_robots == 1) {
+    return {0};
+  }
+
+  // コスト行列を構築
+  std::vector<std::vector<double>> cost(num_robots, std::vector<double>(num_targets));
+  for (size_t i = 0; i < num_robots; ++i) {
+    for (size_t j = 0; j < num_targets; ++j) {
+      cost[i][j] = cost_func(i, j);
+    }
+  }
+
+  math::Hungarian<double> hungarian_solver(cost);
+  const auto [solution_cost, solution_index] = hungarian_solver.solve();
+
+  return solution_index;
+}
+
 }  // namespace crane
 #endif  // CRANE_PHYSICS__POSITION_ASSIGNMENTS_HPP_


### PR DESCRIPTION
## 概要
ロボット割当アルゴリズムを従来のTactic単位の貪欲法から、ハンガリアン法による全体最適化に移行しました。

## 主な変更

### 1. GlobalRobotAllocator の導入
- 全Tacticの要求を統一的に処理し、ハンガリアン法で最適割当を実行
- ハード制約（キーパー等）を先に処理し、ソフト制約を最適化
- コスト関数は距離、速度、ヒステリシス、優先度を総合的に評価

### 2. コスト計算の改善
- **AllocationCostConfig**: 距離、速度、ヒステリシス、優先度の重み設定
- **AllocationState**: 前フレームの割当状態を追跡してヒステリシス計算
- **Hysteresis**: チャタリング抑制のためのヒステリシスクラス

### 3. Tactic適性関数の実装
各Tacticに getRobotSuitabilityFunc() を実装：
- **AttackerSkillTactic**: ボールに近いロボットを優先
- **ForwardTactic**: IDが小さいロボットを優先
- **TotalDefenseTactic**: ゴールに近いロボットを優先
- **DefenderTactic**: 脅威に近いロボットを優先
- **EmplaceRobotTactic**: ゴールキーパーを最後まで残す（今回修正）

### 4. EmplaceRobotTactic の修正
- 本来の目的：出場ロボット数超過時の退場処理
- 修正前：ID=0のロボット（通常ゴールキーパー）が優先的に退場
- **修正後：ゴールキーパーを最後まで残すように適性関数を修正**

### 5. その他の修正
- Hungarian法のU≥V制約対応（行列転置）
- スキルの動的初期化対応
- メモリ管理の改善（shared_ptr使用）
- ログの調整

## テスト計画
- [x] ビルド成功
- [x] 実行時エラーなし
- [x] ロボットが動作
- [ ] シミュレーションでの動作確認
- [ ] チャタリング頻度の測定

## 期待される効果
1. **全体最適化**: Tactic間での最適なロボット配分
2. **チャタリング抑制**: ヒステリシスによる安定した割当
3. **優先度考慮**: 重要なTacticへの優先的な割当
4. **ゴールキーパー保護**: 退場時に最後まで残る

🤖 Generated with [Claude Code](https://claude.ai/claude-code)