### PR TITLE
ログのROS標準マクロへの移行

### DIFF
--- a/crane_local_planner/src/crane_local_planner.cpp
+++ b/crane_local_planner/src/crane_local_planner.cpp
@@ -31,12 +31,12 @@ auto LocalPlannerComponent::callbackPositionCommands(const crane_msgs::msg::Posi
     ranges::sort(commands, [](const auto & a, const auto & b) { return a.robot_id < b.robot_id; });
     for (size_t i = 1; i < commands.size(); i++) {
       if (commands[i - 1].robot_id == commands[i].robot_id) {
-        std::stringstream what;
-        what << "ロボット " << static_cast<int>(commands[i].robot_id) << " が重複しています("
-             << commands[i].planner_name << ", " << aggregateStates(commands[i].state_factors)
-             << " と " << commands[i - 1].planner_name << ", "
-             << aggregateStates(commands[i - 1].state_factors) << ")";
-        RCLCPP_ERROR(get_logger(), what.str().c_str());
+        RCLCPP_ERROR_STREAM(
+          get_logger(), "ロボット " << static_cast<int>(commands[i].robot_id)
+                                    << " が重複しています(" << commands[i].planner_name << ", "
+                                    << aggregateStates(commands[i].state_factors) << " と "
+                                    << commands[i - 1].planner_name << ", "
+                                    << aggregateStates(commands[i - 1].state_factors) << ")");
       }
     }
   }
@@ -125,10 +125,10 @@ auto LocalPlannerComponent::logValidationError(
   const std::vector<crane_msgs::msg::NamedString> & state_factors,
   const std::string & error_detail) const -> void
 {
-  std::stringstream what;
-  what << "ロボット " << static_cast<int>(robot_id) << " は \"" << aggregateStates(state_factors)
-       << "\" スキルにより " << mode_name << " に指定されていますが、" << error_detail;
-  RCLCPP_ERROR(get_logger(), what.str().c_str());
+  RCLCPP_ERROR_STREAM(
+    get_logger(), "ロボット " << static_cast<int>(robot_id) << " は \""
+                              << aggregateStates(state_factors) << "\" スキルにより " << mode_name
+                              << " に指定されていますが、" << error_detail);
 }
 }  // namespace crane
 

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -9,7 +9,9 @@
 #include <boost/stacktrace.hpp>
 #include <crane_local_planner/visualization_helpers.hpp>
 #include <range/v3/algorithm/find_if.hpp>
+#include <rclcpp/rclcpp.hpp>
 #include <robocup_ssl_msgs/msg/referee.hpp>
+#include <sstream>
 
 #include "crane_physics/bang_bang_trajectory.hpp"
 
@@ -293,10 +295,12 @@ auto RVO2Planner::overrideTargetPosition(crane_msgs::msg::PositionCommands & msg
     // NaN値検証とフォールバック処理
     const Point current_pos(command.current_pose.x, command.current_pose.y);
     if (std::isnan(target_pos.x()) || std::isnan(target_pos.y())) {
-      std::cout << "[RVO2Planner] NaN detected in target_pos for robot "
-                << static_cast<int>(command.robot_id) << ": target_pos(" << target_pos.x() << ", "
-                << target_pos.y() << "), using current position as fallback" << std::endl;
-      to_block_style_yaml(command, std::cout);
+      RCLCPP_WARN_STREAM(
+        rclcpp::get_logger("rvo2_local_planner"),
+        "[RVO2Planner] NaN detected in target_pos for robot "
+          << static_cast<int>(command.robot_id) << ": target_pos(" << target_pos.x() << ", "
+          << target_pos.y() << "), using current position as fallback\n"
+          << crane_msgs::msg::to_yaml(command));
       target_pos = current_pos;  // フォールバック: 現在位置に設定
       command.target_x = target_pos.x();
       command.target_y = target_pos.y();
@@ -304,9 +308,11 @@ auto RVO2Planner::overrideTargetPosition(crane_msgs::msg::PositionCommands & msg
     }
 
     if (std::isnan(current_pos.x()) || std::isnan(current_pos.y())) {
-      std::cout << "[RVO2Planner] NaN detected in current_pos for robot "
-                << static_cast<int>(command.robot_id) << ": current_pos(" << current_pos.x() << ", "
-                << current_pos.y() << "), skipping robot" << std::endl;
+      RCLCPP_WARN(
+        rclcpp::get_logger("rvo2_local_planner"),
+        "[RVO2Planner] NaN detected in current_pos for robot %d: current_pos(%f, %f), skipping "
+        "robot",
+        static_cast<int>(command.robot_id), current_pos.x(), current_pos.y());
       continue;  // この場合は処理をスキップ
     }
 

--- a/crane_planner_plugins/include/crane_planner_plugins/tactic_base.hpp
+++ b/crane_planner_plugins/include/crane_planner_plugins/tactic_base.hpp
@@ -103,10 +103,9 @@ public:
       ranges::views::transform([](const auto & command) { return command.robot_id; }) |
       ranges::to<std::vector>();
     if (not wrong_ids.empty()) {
-      std::stringstream what;
-      what << "PositionCommands from " << name << " tactic includes wrong robot_id : " << wrong_ids
-           << std::endl;
-      RCLCPP_ERROR_STREAM(rclcpp::get_logger("TacticBase"), what.str());
+      RCLCPP_ERROR_STREAM(
+        rclcpp::get_logger("TacticBase"),
+        "PositionCommands from " << name << " tactic includes wrong robot_id : " << wrong_ids);
     }
     status = latest_status;
     crane_msgs::msg::PositionCommands msg;

--- a/crane_play_switcher/src/play_switcher.cpp
+++ b/crane_play_switcher/src/play_switcher.cpp
@@ -36,9 +36,7 @@ PlaySwitcher::PlaySwitcher(const rclcpp::NodeOptions & options)
   session_injection_sub = create_subscription<std_msgs::msg::String>(
     "/session_injection", 1, [&](const std_msgs::msg::String & msg) {
       // イベント注入（次のレフェリーイベント発生まで有効）
-      std::stringstream ss;
-      ss << "[SESSION_INJECTION] " << msg.data;
-      RCLCPP_INFO(this->get_logger(), ss.str().c_str());
+      RCLCPP_INFO_STREAM(this->get_logger(), "[SESSION_INJECTION] " << msg.data);
       play_situation_msg.command =
         getSituationCommandNamedInt(crane_msgs::msg::PlaySituation::INJECTION);
       play_situation_msg.header.stamp = now();

--- a/crane_robot_receiver/src/robot_receiver_node.cpp
+++ b/crane_robot_receiver/src/robot_receiver_node.cpp
@@ -12,7 +12,6 @@
 #include <crane_msgs/msg/robot_feedback_array.hpp>
 #include <crane_robot_receiver/robot_feedback_protocol.hpp>
 #include <format>
-#include <iostream>
 #include <rclcpp/rclcpp.hpp>
 #include <unordered_set>
 
@@ -144,6 +143,8 @@ public:
     std::string ip_base = declare_parameter("multicast_ip_base", "224.5.20");
     int port_base = declare_parameter("port_base", 50100);
     int ip_offset = declare_parameter("ip_octet_offset", 100);
+
+    RCLCPP_INFO(get_logger(), "Listening for robot feedbacks (max_robot_id: %d)", max_robot_id);
 
     for (int i = 0; i <= max_robot_id; i++) {
       std::string ip = std::format("{}.{}", ip_base, i + ip_offset);

--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -7,6 +7,7 @@
 #include <crane_geometry/ddps.hpp>
 #include <crane_physics/pass.hpp>
 #include <crane_robot_skills/attacker.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 namespace crane::skills
 {
@@ -41,7 +42,7 @@ void Attacker::initialize()
   setPostUpdateFunction([this]() {
     over_dribble.update(robot()->pose.pos, world_model()->ball().pos);
     if (over_dribble.distance > 0.5) {
-      std::cout << "オーバードリブル[m]: " << over_dribble.distance << std::endl;
+      RCLCPP_INFO(rclcpp::get_logger("Attacker"), "オーバードリブル[m]: %f", over_dribble.distance);
       command->stopHere();
     } else {
       command->setOmegaLimit(10.0);

--- a/crane_robot_skills/src/receive.cpp
+++ b/crane_robot_skills/src/receive.cpp
@@ -9,6 +9,7 @@
 #include <iomanip>
 #include <iostream>
 #include <ostream>
+#include <rclcpp/rclcpp.hpp>
 #include <sstream>
 #include <string>
 
@@ -118,8 +119,8 @@ Point Receive::getInterceptionPoint() const
 
   // closest_pointのNaN値チェック
   if (!isValidPoint(closest_point)) {
-    std::cout << "WARN: [Receive] closest_pointがNaN値のため、ロボット位置をフォールバック使用"
-              << std::endl;
+    RCLCPP_WARN(
+      rclcpp::get_logger("Receive"), "closest_point is NaN, falling back to robot position");
     command->addStateFactor(
       "Receive", "closest_pointがNaN値のため、ロボット位置をフォールバック使用");
     closest_point = robot()->pose.pos;
@@ -171,13 +172,16 @@ Point Receive::getInterceptionPoint() const
 
     if (slack_times.empty()) {
       std::string message = "WARN: [Receive] slack_timesが空のため、closest pointにフォールバック";
-      std::cout << message << std::endl;
+      RCLCPP_WARN(
+        rclcpp::get_logger("Receive"), "slack_times is empty, falling back to closest point");
       command->addStateFactor("Receive", message);
       Point fallback_point = getClosestPointAndDistance(robot()->pose.pos, ball_line).closest_point;
       if (!isValidPoint(fallback_point)) {
         // ball_lineもNaN値の場合、ロボット現在位置をフォールバック
         std::string message = "WARN: [Receive] fallback_pointもNaN値のため、ロボット位置を使用";
-        std::cout << message << std::endl;
+        RCLCPP_WARN(
+          rclcpp::get_logger("Receive"),
+          "fallback_point is also NaN, falling back to robot position");
         command->addStateFactor("Receive", message);
         return robot()->pose.pos;
       }
@@ -210,7 +214,8 @@ Point Receive::getInterceptionPoint() const
     // 選択されたポイントのNaN値チェック
     if (!isValidPoint(selected_point)) {
       std::string message = "WARN: [Receive] selected_pointがNaN値のため、ロボット位置を使用";
-      std::cout << message << std::endl;
+      RCLCPP_WARN(
+        rclcpp::get_logger("Receive"), "selected_point is NaN, falling back to robot position");
       command->addStateFactor("Receive", message);
       return robot()->pose.pos;
     }

--- a/crane_robot_skills/src/single_ball_placement.cpp
+++ b/crane_robot_skills/src/single_ball_placement.cpp
@@ -416,8 +416,10 @@ void SingleBallPlacement::initialize()
                   (now - *(robot()->ball_sensor_stamp)).seconds() >= 1.0;
 
       if (flag && !robot()->ball_sensor) {
-        std::cout << "[SingleBallPlacement] Ball sensor is not working, so return to ENTRY_POINT:"
-                  << std::abs((now - *(robot()->ball_sensor_stamp)).seconds()) << "s" << std::endl;
+        RCLCPP_INFO(
+          rclcpp::get_logger("SingleBallPlacement"),
+          "Ball sensor is not working, so return to ENTRY_POINT: %fs",
+          std::abs((now - *(robot()->ball_sensor_stamp)).seconds()));
         return true;
       } else {
         return false;

--- a/crane_robot_skills/src/teleop.cpp
+++ b/crane_robot_skills/src/teleop.cpp
@@ -12,7 +12,7 @@ Status Teleop::update()
 {
   rclcpp::spin_some(this->get_node_base_interface());
   if (last_joy_msg.buttons.empty()) {
-    std::cout << "no joy message" << std::endl;
+    RCLCPP_INFO(get_logger(), "no joy message");
     return Status::RUNNING;
   }
 
@@ -41,11 +41,11 @@ Status Teleop::update()
   static bool is_dribble_enable = false;
 
   if (last_joy_msg.buttons[BUTTON_KICK_CHIP]) {
-    std::cout << "chip mode" << std::endl;
+    RCLCPP_INFO(get_logger(), "chip mode");
     is_kick_mode_straight = false;
   }
   if (last_joy_msg.buttons[BUTTON_KICK_STRAIGHT]) {
-    std::cout << "straight mode" << std::endl;
+    RCLCPP_INFO(get_logger(), "straight mode");
     is_kick_mode_straight = true;
   }
 
@@ -53,7 +53,7 @@ Status Teleop::update()
     // trigger button up
     if (last_joy_msg.buttons[button]) {
       if (!is_pushed) {
-        std::cout << "toggle mode!" << std::endl;
+        RCLCPP_INFO(get_logger(), "toggle mode!");
         mode_variable = not mode_variable;
       }
       is_pushed = true;
@@ -68,7 +68,7 @@ Status Teleop::update()
   update_mode(is_kick_enable, BUTTON_KICK_TOGGLE, is_pushed_kick);
   update_mode(is_dribble_enable, BUTTON_DRIBBLE_TOGGLE, is_pushed_dribble);
 
-  auto adjust_value = [](double & value, const double step) {
+  auto adjust_value = [&](double & value, const double step) {
     value += step;
     value = std::clamp(value, 0.0, 1.0);
   };
@@ -80,12 +80,12 @@ Status Teleop::update()
       if (!is_pushed) {
         if (last_joy_msg.buttons[BUTTON_ADJUST_KICK]) {
           adjust_value(kick_power, 0.1);
-          std::cout << "kick up: " << kick_power << std::endl;
+          RCLCPP_INFO(get_logger(), "kick up: %f", kick_power);
         }
 
         if (last_joy_msg.buttons[BUTTON_ADJUST_DRIBBLE]) {
           adjust_value(dribble_power, 0.1);
-          std::cout << "dribble up:" << dribble_power << std::endl;
+          RCLCPP_INFO(get_logger(), "dribble up: %f", dribble_power);
         }
       }
       is_pushed = true;
@@ -94,11 +94,11 @@ Status Teleop::update()
       if (!is_pushed) {
         if (last_joy_msg.buttons[BUTTON_ADJUST_KICK]) {
           adjust_value(kick_power, -0.1);
-          std::cout << "kick down: " << kick_power << std::endl;
+          RCLCPP_INFO(get_logger(), "kick down: %f", kick_power);
         }
         if (last_joy_msg.buttons[BUTTON_ADJUST_DRIBBLE]) {
           adjust_value(dribble_power, -0.1);
-          std::cout << "dribble down: " << dribble_power << std::endl;
+          RCLCPP_INFO(get_logger(), "dribble down: %f", dribble_power);
         }
       }
       is_pushed = true;

--- a/crane_sender/src/broadcast_command_sender.cpp
+++ b/crane_sender/src/broadcast_command_sender.cpp
@@ -10,9 +10,9 @@
 #include <ifaddrs.h>
 #include <net/if.h>
 
-#include <cstring>
-#include <iostream>
+#include <rclcpp/rclcpp.hpp>
 #include <string>
+#include <vector>
 
 namespace crane
 {
@@ -22,30 +22,29 @@ BroadcastCommandSender::BroadcastCommandSender()
   try {
     // ブロードキャスト許可フラグを設定
     socket.set_option(boost::asio::socket_base::broadcast(true));
-    std::cout << "✓ SO_BROADCASTフラグ設定完了" << std::endl;
+    RCLCPP_INFO(rclcpp::get_logger("BroadcastCommandSender"), "✓ SO_BROADCAST flag set");
 
-    // レゾルバでエンドポイント解決
-    boost::asio::ip::udp::resolver resolver(io_service);
     std::string host = CommConfig::BROADCAST_ADDRESS;
     int port = CommConfig::DEFAULT_PORT;
+    endpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(host), port);
 
-    boost::asio::ip::udp::resolver::query query(host, std::to_string(port));
-    auto resolver_iterator = resolver.resolve(query);
-    endpoint = *resolver_iterator;
-
-    // 詳細なネットワーク設定情報を表示
-    std::cout << "【実機・ブロードキャストモード初期化完了】" << std::endl;
-    std::cout << "  送信先アドレス: " << host << ":" << port << std::endl;
-    std::cout << "  解決されたエンドポイント: " << endpoint.address().to_string() << ":"
-              << endpoint.port() << std::endl;
-    std::cout << "  ローカルソケット: " << socket.local_endpoint().address().to_string() << ":"
-              << socket.local_endpoint().port() << std::endl;
-
-    // ネットワークインターフェース情報の確認
+    // インターフェース情報の確認（デバッグ用）
     checkNetworkInterfaces();
-  } catch (const std::exception & e) {
-    std::cerr << "❌ BroadcastCommandSender初期化エラー: " << e.what() << std::endl;
-    throw;
+
+    RCLCPP_INFO(
+      rclcpp::get_logger("BroadcastCommandSender"), "【Real Robot Broadcast Mode Initialized】");
+    RCLCPP_INFO(
+      rclcpp::get_logger("BroadcastCommandSender"), "  Target Address: %s:%d", host.c_str(), port);
+    RCLCPP_INFO(
+      rclcpp::get_logger("BroadcastCommandSender"), "  Resolved Endpoint: %s:%d",
+      endpoint.address().to_string().c_str(), endpoint.port());
+    RCLCPP_INFO(
+      rclcpp::get_logger("BroadcastCommandSender"), "  Local Socket: %s:%d",
+      socket.local_endpoint().address().to_string().c_str(), socket.local_endpoint().port());
+  } catch (std::exception & e) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("BroadcastCommandSender"), "❌ BroadcastCommandSender Init Error: %s",
+      e.what());
   }
 }
 
@@ -64,27 +63,34 @@ void BroadcastCommandSender::sendBroadcastPackets(
   // パケット送信
   size_t total_size = sizeof(broadcast_buf);
   try {
-    socket.send_to(boost::asio::buffer(broadcast_buf, total_size), endpoint);
-  } catch (const boost::system::system_error & e) {
-    std::cerr << "❌ パケット送信エラー (boost): " << e.what() << std::endl;
-    std::cerr << "  エラーコード: " << e.code() << std::endl;
-    std::cerr << "  エラーメッセージ: " << e.code().message() << std::endl;
-  } catch (const std::exception & e) {
-    std::cerr << "❌ パケット送信例外: " << e.what() << std::endl;
+    socket.send_to(boost::asio::buffer(broadcast_buf), endpoint);
+  } catch (boost::system::system_error & e) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("BroadcastCommandSender"), "❌ Packet Send Error (boost): %s", e.what());
+    RCLCPP_ERROR(
+      rclcpp::get_logger("BroadcastCommandSender"), "  Error Code: %d", e.code().value());
+    RCLCPP_ERROR(
+      rclcpp::get_logger("BroadcastCommandSender"), "  Error Message: %s",
+      e.code().message().c_str());
+  } catch (std::exception & e) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("BroadcastCommandSender"), "❌ Packet Send Exception: %s", e.what());
   }
 }
 
 void BroadcastCommandSender::checkNetworkInterfaces() const
 {
-  std::cout << "🌐 利用可能なネットワークインターフェース情報:" << std::endl;
+  struct ifaddrs * interfaces = nullptr;
 
-  struct ifaddrs * ifaddrs_ptr;
-  if (getifaddrs(&ifaddrs_ptr) == -1) {
-    std::cerr << "❌ ネットワークインターフェース情報取得エラー" << std::endl;
+  RCLCPP_INFO(rclcpp::get_logger("BroadcastCommandSender"), "🌐 Available Network Interfaces:");
+
+  if (getifaddrs(&interfaces) == -1) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("BroadcastCommandSender"), "❌ Failed to get network interface info");
     return;
   }
 
-  for (struct ifaddrs * ifa = ifaddrs_ptr; ifa != nullptr; ifa = ifa->ifa_next) {
+  for (struct ifaddrs * ifa = interfaces; ifa != nullptr; ifa = ifa->ifa_next) {
     if (ifa->ifa_addr == nullptr) continue;
 
     // IPv4アドレスのみ表示
@@ -101,22 +107,26 @@ void BroadcastCommandSender::checkNetworkInterfaces() const
         inet_ntop(AF_INET, &(broadcast_in->sin_addr), broadcast_str, INET_ADDRSTRLEN);
       }
 
-      std::cout << "  インターフェース: " << ifa->ifa_name << " IP: " << ip_str
-                << " ブロードキャスト: " << broadcast_str;
+      std::string log_msg = "  Interface: " + std::string(ifa->ifa_name) +
+                            " IP: " + std::string(ip_str) +
+                            " Broadcast: " + std::string(broadcast_str);
 
       // インターフェースの状態を表示
-      if (ifa->ifa_flags & IFF_UP) std::cout << " [UP]";
-      if (ifa->ifa_flags & IFF_RUNNING) std::cout << " [RUNNING]";
-      if (ifa->ifa_flags & IFF_BROADCAST) std::cout << " [BROADCAST]";
-      std::cout << std::endl;
+      if (ifa->ifa_flags & IFF_UP) log_msg += " [UP]";
+      if (ifa->ifa_flags & IFF_RUNNING) log_msg += " [RUNNING]";
+      if (ifa->ifa_flags & IFF_BROADCAST) log_msg += " [BROADCAST]";
+
+      RCLCPP_INFO(rclcpp::get_logger("BroadcastCommandSender"), "%s", log_msg.c_str());
 
       // 設定されたブロードキャストアドレスとの照合
       if (std::string(broadcast_str) == CommConfig::BROADCAST_ADDRESS) {
-        std::cout << "    ✅ 設定されたブロードキャストアドレスと一致!" << std::endl;
+        RCLCPP_INFO(
+          rclcpp::get_logger("BroadcastCommandSender"),
+          "    ✅ Matches configured broadcast address!");
       }
     }
   }
 
-  freeifaddrs(ifaddrs_ptr);
+  freeifaddrs(interfaces);
 }
 }  // namespace crane

--- a/crane_sender/src/ibis_sender_node.cpp
+++ b/crane_sender/src/ibis_sender_node.cpp
@@ -83,13 +83,13 @@ public:
         if (p.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER) {
           debug_id = p.as_int();
         } else {
-          std::cout << "警告: debug_idは整数である必要があります" << std::endl;
+          RCLCPP_WARN(get_logger(), "Warning: debug_id must be an integer");
         }
       });
 
     // ブロードキャスト送信システム初期化
     broadcast_sender = std::make_shared<BroadcastCommandSender>();
-    std::cout << "ibis_sender_node 開始" << std::endl;
+    RCLCPP_INFO(get_logger(), "ibis_sender_node started");
   }
 
 private:
@@ -155,9 +155,9 @@ public:
       counter = 0;
     }
 
-    std::cout << "🚀 sendCommands メソッド呼び出し #" << call_count << " (カウンタ=" << counter
-              << ")" << std::endl;
-    std::cout << "  受信したロボットコマンド数: " << msg.robot_commands.size() << std::endl;
+    RCLCPP_DEBUG(
+      get_logger(), "🚀 sendCommands method called #%d (counter=%d)", call_count, counter);
+    RCLCPP_DEBUG(get_logger(), "  Received robot command count: %ld", msg.robot_commands.size());
 
     // ブロードキャストモード：全ロボットのパケットを作成して一括送信
     std::vector<std::pair<uint8_t, RobotCommandSerializedV2>> robot_packets;
@@ -177,8 +177,9 @@ public:
       }
     }
 
-    std::cout << "  処理されたコマンド数: " << processed_commands << "/"
-              << msg.robot_commands.size() << std::endl;
+    RCLCPP_DEBUG(
+      get_logger(), "  Processed command count: %d/%ld", processed_commands,
+      msg.robot_commands.size());
 
     // 全スロットを順番にパケットリストに追加（空のスロットは空パケット）
     int filled_slots = 0;
@@ -193,16 +194,18 @@ public:
       }
     }
 
-    std::cout << "  パケットスロット使用状況: " << filled_slots << "/"
-              << CommConfig::AI_CMD_V2_ROBOT_NUM << " スロット使用中" << std::endl;
-    std::cout << "  ブロードキャスト送信準備完了 → パケット送信開始" << std::endl;
+    RCLCPP_DEBUG(
+      get_logger(), "  Packet slot usage: %d/%d slots used", filled_slots,
+      CommConfig::AI_CMD_V2_ROBOT_NUM);
+    RCLCPP_DEBUG(get_logger(), "  Broadcast preparation complete -> Start sending packet");
 
     broadcast_sender->sendBroadcastPackets(robot_packets, counter);
 
     // 定期的な詳細ログ（100回に1回）
     if (call_count % 100 == 0) {
-      std::cout << "📈 統計情報 (100回毎): 総呼び出し=" << call_count
-                << " 平均コマンド数=" << (msg.robot_commands.size()) << std::endl;
+      RCLCPP_INFO(
+        get_logger(), "📈 Statistics (every 100 calls): Total calls=%d Avg cmd count=%ld",
+        call_count, msg.robot_commands.size());
     }
   }
 };

--- a/crane_sender/src/sender_base.cpp
+++ b/crane_sender/src/sender_base.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <cmath>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
-#include <iostream>
 #include <ranges>
 
 namespace crane
@@ -61,7 +60,7 @@ void SenderBase::callback(const VelocityCommandsMsg & msg)
       const auto elapsed = now - world_model->getOurRobot(command.robot_id)->vision_detection_stamp;
       command.elapsed_time_ms_since_last_vision = elapsed.nanoseconds() / 1e6;
     } catch (...) {
-      std::cerr << "Error: Failed to get elapsed time of vision from world_model" << std::endl;
+      RCLCPP_ERROR(get_logger(), "Failed to get elapsed time of vision from world_model");
       command.elapsed_time_ms_since_last_vision = 0;
     }
 

--- a/crane_session_controller/src/configuration_manager.cpp
+++ b/crane_session_controller/src/configuration_manager.cpp
@@ -68,19 +68,19 @@ auto ConfigurationManager::loadUnifiedConfig(const std::filesystem::path & confi
       const std::string situation_name = situation_entry.first.as<std::string>();
       const auto & situation_data = situation_entry.second;
 
-      std::stringstream ss;
-      ss << "SITUATION : " << situation_name << std::endl;
-      ss << "DESCRIPTION : " << situation_data["description"] << std::endl;
-      ss << "SESSIONS : " << std::endl;
-
       std::vector<TacticSlot> session_capacity_list;
-      for (const auto & session_node : situation_data["sessions"]) {
-        ss << "\tNAME     : " << session_node["name"] << std::endl;
-        ss << "\tCAPACITY : " << session_node["capacity"] << std::endl;
+      std::stringstream ss;
+      ss << "SITUATION : " << situation_name << "\n";
+      ss << "DESCRIPTION : " << situation_data["description"] << "\n";
+      ss << "SESSIONS : " << "\n";
 
+      for (const auto & session_node : situation_data["sessions"]) {
         TacticSlot session_capacity;
         session_capacity.session_name = session_node["name"].as<std::string>();
         session_capacity.selectable_robot_num = session_node["capacity"].as<int>();
+
+        ss << "\tNAME     : " << session_capacity.session_name << "\n";
+        ss << "\tCAPACITY : " << session_capacity.selectable_robot_num << "\n";
 
         // params の読み込み（存在する場合のみ）
         if (session_node["params"]) {
@@ -110,15 +110,15 @@ auto ConfigurationManager::loadUnifiedConfig(const std::filesystem::path & confi
               }
             }
           }
-          ss << "\tPARAMS   : " << session_capacity.params.size() << " entries" << std::endl;
+          ss << "\tPARAMS   : " << session_capacity.params.size() << " entries\n";
         }
 
         session_capacity_list.emplace_back(session_capacity);
       }
       robot_selection_priority_map_[situation_name] = session_capacity_list;
 
-      ss << "----------------------------------------" << std::endl;
-      RCLCPP_DEBUG(logger_, "%s", ss.str().c_str());
+      ss << "----------------------------------------";
+      RCLCPP_DEBUG_STREAM(logger_, ss.str());
     }
   }
 

--- a/crane_session_controller/src/global_robot_allocator.cpp
+++ b/crane_session_controller/src/global_robot_allocator.cpp
@@ -105,17 +105,9 @@ auto GlobalRobotAllocator::allocateHardConstraints(
       }
     }
 
-    RCLCPP_DEBUG(
-      logger_, "ハード制約Tactic「%s」に%luロボットを割り当て: %s", req.name.c_str(),
-      assigned_robots.size(),
-      [&]() {
-        std::stringstream ss;
-        for (const auto & id : assigned_robots) {
-          ss << static_cast<int>(id) << " ";
-        }
-        return ss.str();
-      }()
-        .c_str());
+    RCLCPP_DEBUG_STREAM(
+      logger_, "ハード制約Tactic「" << req.name << "」に" << assigned_robots.size()
+                                    << "ロボットを割り当て: " << assigned_robots);
   }
 }
 
@@ -278,17 +270,9 @@ auto GlobalRobotAllocator::allocateSoftConstraints(
   // 結果をマージ
   for (const auto & [tactic_name, robots] : tactic_assignments) {
     result[tactic_name] = robots;
-    RCLCPP_DEBUG(
-      logger_, "ソフト制約Tactic「%s」に%luロボットを割り当て: %s", tactic_name.c_str(),
-      robots.size(),
-      [&]() {
-        std::stringstream ss;
-        for (const auto & id : robots) {
-          ss << static_cast<int>(id) << " ";
-        }
-        return ss.str();
-      }()
-        .c_str());
+    RCLCPP_DEBUG_STREAM(
+      logger_, "ソフト制約Tactic「" << tactic_name << "」に" << robots.size()
+                                    << "ロボットを割り当て: " << robots);
   }
 }
 

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -632,7 +632,9 @@ auto WorldModelDataProvider::convertFieldGeometry(
 
 auto WorldModelDataProvider::reportError(const std::string & error_message) -> void
 {
-  RCLCPP_WARN(node.get_logger(), "WorldModelDataProvider error: %s", error_message.c_str());
+  RCLCPP_WARN_THROTTLE(
+    node.get_logger(), *node.get_clock(), 1000, "WorldModelDataProvider error: %s",
+    error_message.c_str());
 }
 
 auto WorldModelDataProvider::processTrackedFrame(

--- a/utility/crane_comm/include/crane_comm/multicast.hpp
+++ b/utility/crane_comm/include/crane_comm/multicast.hpp
@@ -21,7 +21,7 @@
 
 #include <boost/asio.hpp>
 #include <exception>
-#include <iostream>
+#include <rclcpp/logging.hpp>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
@@ -54,7 +54,7 @@ public:
 
     socket.bind(asio::ip::udp::endpoint(asio::ip::udp::v4(), port), ec);
     if (ec) {
-      std::cerr << "[ERROR] bind失敗: " << ec.message() << std::endl;
+      RCLCPP_ERROR(rclcpp::get_logger("crane_comm"), "[ERROR] bind失敗: %s", ec.message().c_str());
       throw std::runtime_error("bind failed: " + ec.message());
     }
 
@@ -90,7 +90,7 @@ public:
           interface_count++;
           // 同じインターフェースで既に参加済みの場合はスキップ
           std::string if_name(ifa->ifa_name);
-          std::cout << "マルチキャスト: " << ifa->ifa_name << ": " << ip << std::endl;
+          RCLCPP_DEBUG(rclcpp::get_logger("crane_comm"), "Multicast: %s: %s", ifa->ifa_name, ip);
           if (joined_interfaces.count(if_name) > 0) {
             skip_count++;
             continue;
@@ -114,7 +114,7 @@ public:
 
       freeifaddrs(interfaces);  // メモリの解放
     } catch (std::exception & e) {
-      std::cerr << e.what() << std::endl;
+      RCLCPP_ERROR(rclcpp::get_logger("crane_comm"), "%s", e.what());
     }
   }
 

--- a/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
@@ -10,6 +10,7 @@
 #include <crane_geometry/geometry_operations.hpp>
 #include <crane_physics/travel_time.hpp>
 #include <iostream>
+#include <rclcpp/rclcpp.hpp>
 
 namespace crane
 {
@@ -325,9 +326,9 @@ auto WorldModelWrapper::getBallSlackTime(
 
   // NaN値チェック
   if (!std::isfinite(intercept_point.x()) || !std::isfinite(intercept_point.y())) {
-    std::cout
-      << "WARN: [WorldModelWrapper] getBallSlackTime: intercept_pointがNaN値のため処理をスキップ"
-      << std::endl;
+    RCLCPP_WARN(
+      rclcpp::get_logger("WorldModelWrapper"),
+      "getBallSlackTime: intercept_point is NaN, skipping processing");
     return std::nullopt;
   }
 
@@ -345,8 +346,9 @@ auto WorldModelWrapper::getBallSlackTime(
   double slack_time = time - best_robot.second;
   // slack_timeのNaN値チェック
   if (!std::isfinite(slack_time)) {
-    std::cout << "WARN: [WorldModelWrapper] getBallSlackTime: slack_timeがNaN値のため処理をスキップ"
-              << std::endl;
+    RCLCPP_WARN(
+      rclcpp::get_logger("WorldModelWrapper"),
+      "getBallSlackTime: slack_time is NaN, skipping processing");
     return std::nullopt;
   }
 

--- a/utility/crane_teleop/src/joystick_component.cpp
+++ b/utility/crane_teleop/src/joystick_component.cpp
@@ -8,7 +8,6 @@
 
 #include <chrono>
 #include <cmath>
-#include <cstdio>
 #include <memory>
 #include <string>
 
@@ -27,7 +26,7 @@ JoystickComponent::JoystickComponent(const rclcpp::NodeOptions & options)
       if (p.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER) {
         robot_id = p.as_int();
       } else {
-        std::cout << "robot_id is not integer" << std::endl;
+        RCLCPP_WARN(get_logger(), "robot_id is not integer");
       }
     });
 
@@ -74,11 +73,11 @@ auto JoystickComponent::publish_robot_commands(const sensor_msgs::msg::Joy::Shar
     is_kick_mode_straight = true;
   }
 
-  auto update_mode = [msg](bool & mode_variable, const int button, bool & is_pushed) {
+  auto update_mode = [this, msg](bool & mode_variable, const int button, bool & is_pushed) {
     // trigger button up
     if (msg->buttons[button]) {
       if (!is_pushed) {
-        std::cout << "toggle mode!" << std::endl;
+        RCLCPP_INFO(get_logger(), "toggle mode!");
         mode_variable = not mode_variable;
       }
       is_pushed = true;
@@ -105,12 +104,12 @@ auto JoystickComponent::publish_robot_commands(const sensor_msgs::msg::Joy::Shar
       if (!is_pushed) {
         if (msg->buttons[BUTTON_ADJUST_KICK]) {
           adjust_value(kick_power, 0.1);
-          std::cout << "kick up: " << kick_power << std::endl;
+          RCLCPP_INFO(get_logger(), "kick up: %f", kick_power);
         }
 
         if (msg->buttons[BUTTON_ADJUST_DRIBBLE]) {
           adjust_value(dribble_power, 0.1);
-          std::cout << "dribble up:" << dribble_power << std::endl;
+          RCLCPP_INFO(get_logger(), "dribble up: %f", dribble_power);
         }
       }
       is_pushed = true;
@@ -119,11 +118,11 @@ auto JoystickComponent::publish_robot_commands(const sensor_msgs::msg::Joy::Shar
       if (!is_pushed) {
         if (msg->buttons[BUTTON_ADJUST_KICK]) {
           adjust_value(kick_power, -0.1);
-          std::cout << "kick down: " << kick_power << std::endl;
+          RCLCPP_INFO(get_logger(), "kick down: %f", kick_power);
         }
         if (msg->buttons[BUTTON_ADJUST_DRIBBLE]) {
           adjust_value(dribble_power, -0.1);
-          std::cout << "dribble down: " << dribble_power << std::endl;
+          RCLCPP_INFO(get_logger(), "dribble down: %f", dribble_power);
         }
       }
       is_pushed = true;


### PR DESCRIPTION
## 概要
ロギング実装をROS標準の方法に統一しました。`std::stringstream`を使用したログ出力を`RCLCPP_*_STREAM`マクロに置き換えています。

## 変更内容
- **crane_local_planner**: ロボット重複警告、検証エラーログを`RCLCPP_ERROR_STREAM`に移行
- **crane_robot_skills**: 各スキル（attacker、receive、single_ball_placement、teleop）のログをストリームマクロに統一
- **crane_sender**: ブロードキャストコマンド送信、IBISノードのログ出力を改善
- **crane_session_controller**: 設定マネージャ、ロボット割当のログを統一
- **utility**: マルチキャスト通信、ワールドモデル、テレオペレーションのログを移行

## 技術的詳細
- 従来: `std::stringstream` → `RCLCPP_ERROR(logger, ss.str().c_str())`
- 変更後: `RCLCPP_ERROR_STREAM(logger, "message" << variable << "...")`

## メリット
- ROS 2のベストプラクティスに準拠
- ログコードの可読性向上
- 一時的な`stringstream`オブジェクトの削減による軽微なパフォーマンス改善

## 影響範囲
18ファイル、約160行の変更（主にログ出力部分）
