### PR TITLE
feat: ゲーム分析にメトリクスシステムを追加

### DIFF
--- a/crane_game_analyzer/CMakeLists.txt
+++ b/crane_game_analyzer/CMakeLists.txt
@@ -24,6 +24,11 @@ ament_auto_add_library(${PROJECT_NAME}_component SHARED
   src/evaluations.cpp
   src/threat_evaluator.cpp
   src/ronar_event_detector.cpp
+  src/metrics/metric_engine.cpp
+  src/metrics/threat_metrics.cpp
+  src/metrics/ball_horizon_metric.cpp
+  src/metrics/slack_metrics.cpp
+  src/metrics/attacker_metrics.cpp
 )
 
 target_precompile_headers(${PROJECT_NAME}_component

--- a/crane_game_analyzer/include/crane_game_analyzer/game_analyzer.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/game_analyzer.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "crane_game_analyzer/event_memory.hpp"
+#include "crane_game_analyzer/metrics/metric_engine.hpp"
 #include "crane_game_analyzer/ronar_event_detector.hpp"
 #include "crane_game_analyzer/threat_evaluator.hpp"
 #include "visibility_control.h"
@@ -243,9 +244,13 @@ private:
   // ロボット位置の履歴
   std::deque<RobotPositionStamped> robot_records_;
 
-  // 脅威評価システム
+  // 脅威評価システム（旧）
   ThreatEvaluator threat_evaluator_;
   rclcpp::Publisher<crane_msgs::msg::GameAnalysis>::SharedPtr game_analysis_pub_;
+
+  // メトリクス計算エンジン（新）
+  std::unique_ptr<metrics::MetricEngine> metric_engine_;
+  std::deque<crane_msgs::msg::BallInfo> ball_history_;
 
   // RONARイベント検出システム
   std::unique_ptr<RonarEventDetector> ronar_event_detector_;

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_GAME_ANALYZER__METRICS__ATTACKER_METRICS_HPP_
+#define CRANE_GAME_ANALYZER__METRICS__ATTACKER_METRICS_HPP_
+
+#include "metric_base.hpp"
+
+namespace crane::metrics
+{
+
+/**
+ * @brief 推奨アタッカーメトリクス
+ *
+ * ボール距離とSlack時間を考慮して推奨Attackerを決定
+ * OUR_SLACK, BALL_THREATに依存
+ */
+class AttackerCandidateMetric : public MetricBase
+{
+public:
+  AttackerCandidateMetric();
+
+  [[nodiscard]] auto getDependencies() const -> std::vector<MetricId> override
+  {
+    return {MetricId::OUR_SLACK, MetricId::BALL_THREAT};
+  }
+
+  auto compute(MetricContext & ctx) -> void override;
+
+private:
+  // ヒステリシス用の内部状態
+  int last_attacker_id_ = -1;
+  rclcpp::Time last_switch_time_{static_cast<int64_t>(0), RCL_ROS_TIME};
+  rclcpp::Clock ros_clock_{RCL_ROS_TIME};
+
+  static constexpr double MIN_HOLD_DURATION_SEC = 0.5;
+  static constexpr double MIN_IMPROVEMENT_MARGIN = 0.2;
+};
+
+
+}  // namespace crane::metrics
+
+#endif  // CRANE_GAME_ANALYZER__METRICS__ATTACKER_METRICS_HPP_

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
@@ -40,7 +40,6 @@ private:
   static constexpr double MIN_IMPROVEMENT_MARGIN = 0.2;
 };
 
-
 }  // namespace crane::metrics
 
 #endif  // CRANE_GAME_ANALYZER__METRICS__ATTACKER_METRICS_HPP_

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/ball_horizon_metric.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/ball_horizon_metric.hpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_GAME_ANALYZER__METRICS__BALL_HORIZON_METRIC_HPP_
+#define CRANE_GAME_ANALYZER__METRICS__BALL_HORIZON_METRIC_HPP_
+
+#include "metric_base.hpp"
+
+namespace crane::metrics
+{
+
+/**
+ * @brief ボールライン長メトリクス
+ *
+ * ボール軌道に対する敵ロボットの干渉距離を計算
+ * - ボールから3秒後までの軌道を計算
+ * - 敵ロボットとの最短距離を求める
+ * - 0.5m以内の敵がいる場合、その地点までの距離を返す
+ */
+class BallHorizonMetric : public MetricBase
+{
+public:
+  BallHorizonMetric();
+
+  [[nodiscard]] auto getDependencies() const -> std::vector<MetricId> override { return {}; }
+
+  auto compute(MetricContext & ctx) -> void override;
+};
+
+}  // namespace crane::metrics
+
+#endif  // CRANE_GAME_ANALYZER__METRICS__BALL_HORIZON_METRIC_HPP_

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/metric_base.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/metric_base.hpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_GAME_ANALYZER__METRICS__METRIC_BASE_HPP_
+#define CRANE_GAME_ANALYZER__METRICS__METRIC_BASE_HPP_
+
+#include <crane_msg_wrappers/crane_visualizer_wrapper.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "metric_context.hpp"
+
+namespace crane::metrics
+{
+
+/**
+ * @brief メトリクスの識別子
+ *
+ * 各メトリクスを一意に識別するための列挙型
+ */
+enum class MetricId
+{
+  // 基礎メトリクス
+  BALL_HORIZON,      ///< ボールライン長
+  OUR_SLACK,         ///< 味方ロボットのSlack時間
+  THEIR_SLACK,       ///< 敵ロボットのSlack時間
+
+  // 脅威評価
+  BALL_THREAT,             ///< ボール脅威
+  ROBOT_THREATS,           ///< ロボット脅威（優先度順）
+  RECOMMENDED_DEFENDERS,   ///< 推奨守備者数
+
+  // 役割決定（新規）
+  ATTACKER_CANDIDATE,         ///< 推奨アタッカー
+};
+
+/**
+ * @brief メトリクスの基底クラス
+ *
+ * 全てのメトリクスはこのクラスを継承し、依存関係と計算処理を実装する
+ */
+class MetricBase
+{
+public:
+  using Ptr = std::shared_ptr<MetricBase>;
+
+  /**
+   * @brief コンストラクタ
+   * @param id メトリクス識別子
+   * @param name メトリクス名（ログ出力用）
+   */
+  explicit MetricBase(MetricId id, const std::string & name) : id_(id), name_(name) {}
+
+  virtual ~MetricBase() = default;
+
+  // コピー・ムーブを禁止
+  MetricBase(const MetricBase &) = delete;
+  MetricBase(MetricBase &&) = delete;
+  auto operator=(const MetricBase &) -> MetricBase & = delete;
+  auto operator=(MetricBase &&) -> MetricBase & = delete;
+
+  /**
+   * @brief メトリクス識別子を取得
+   * @return メトリクスID
+   */
+  [[nodiscard]] auto getId() const -> MetricId { return id_; }
+
+  /**
+   * @brief メトリクス名を取得
+   * @return メトリクス名
+   */
+  [[nodiscard]] auto getName() const -> const std::string & { return name_; }
+
+  /**
+   * @brief このメトリクスが依存する他のメトリクスのIDリストを返す
+   *
+   * 依存関係を宣言することで、MetricEngineが自動的に計算順序を決定する
+   * @return 依存するメトリクスIDのリスト
+   */
+  [[nodiscard]] virtual auto getDependencies() const -> std::vector<MetricId> = 0;
+
+  /**
+   * @brief メトリクスを計算し、結果をctx.analysisに書き込む
+   *
+   * @param ctx 計算コンテキスト（ワールドモデル、出力先等）
+   */
+  virtual auto compute(MetricContext & ctx) -> void = 0;
+
+  /**
+   * @brief メトリクスの計算結果を可視化（オプション）
+   *
+   * デフォルト実装は何もしない。必要に応じて派生クラスでオーバーライド
+   * @param ctx 計算コンテキスト
+   * @param visualizer 可視化メッセージビルダー
+   */
+  virtual auto visualize(
+    MetricContext & ctx, const VisualizerMessageBuilder::SharedPtr & visualizer) -> void
+  {
+    (void)ctx;
+    (void)visualizer;
+  }
+
+protected:
+  MetricId id_;       ///< メトリクスID
+  std::string name_;  ///< メトリクス名
+};
+
+}  // namespace crane::metrics
+
+#endif  // CRANE_GAME_ANALYZER__METRICS__METRIC_BASE_HPP_

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/metric_base.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/metric_base.hpp
@@ -8,7 +8,6 @@
 #define CRANE_GAME_ANALYZER__METRICS__METRIC_BASE_HPP_
 
 #include <crane_msg_wrappers/crane_visualizer_wrapper.hpp>
-
 #include <memory>
 #include <string>
 #include <vector>
@@ -23,20 +22,19 @@ namespace crane::metrics
  *
  * 各メトリクスを一意に識別するための列挙型
  */
-enum class MetricId
-{
+enum class MetricId {
   // 基礎メトリクス
-  BALL_HORIZON,      ///< ボールライン長
-  OUR_SLACK,         ///< 味方ロボットのSlack時間
-  THEIR_SLACK,       ///< 敵ロボットのSlack時間
+  BALL_HORIZON,  ///< ボールライン長
+  OUR_SLACK,     ///< 味方ロボットのSlack時間
+  THEIR_SLACK,   ///< 敵ロボットのSlack時間
 
   // 脅威評価
-  BALL_THREAT,             ///< ボール脅威
-  ROBOT_THREATS,           ///< ロボット脅威（優先度順）
-  RECOMMENDED_DEFENDERS,   ///< 推奨守備者数
+  BALL_THREAT,            ///< ボール脅威
+  ROBOT_THREATS,          ///< ロボット脅威（優先度順）
+  RECOMMENDED_DEFENDERS,  ///< 推奨守備者数
 
   // 役割決定（新規）
-  ATTACKER_CANDIDATE,         ///< 推奨アタッカー
+  ATTACKER_CANDIDATE,  ///< 推奨アタッカー
 };
 
 /**

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/metric_context.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/metric_context.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_GAME_ANALYZER__METRICS__METRIC_CONTEXT_HPP_
+#define CRANE_GAME_ANALYZER__METRICS__METRIC_CONTEXT_HPP_
+
+#include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_msgs/msg/ball_info.hpp>
+#include <crane_msgs/msg/game_analysis.hpp>
+#include <deque>
+#include <rclcpp/rclcpp.hpp>
+
+namespace crane::metrics
+{
+
+/**
+ * @brief メトリクス計算時に共有される計算コンテキスト
+ *
+ * 全メトリクスが共通してアクセスする入力データと出力先を保持
+ */
+struct MetricContext
+{
+  /// ワールドモデル（ロボット位置、ボール情報等）
+  /// ポインタで保持（参照と異なりnullableだが、実際には常に有効）
+  WorldModelWrapper * world_model;
+
+  /// ボール位置履歴（キック検出等に使用）
+  std::deque<crane_msgs::msg::BallInfo> * ball_history;
+
+  /// ROS2クロック（時刻取得用）
+  rclcpp::Clock::SharedPtr clock;
+
+  /// 計算済みメトリクス結果の出力先
+  /// 各メトリクスはこのメッセージの該当フィールドに結果を書き込む
+  crane_msgs::msg::GameAnalysis & analysis;
+};
+
+}  // namespace crane::metrics
+
+#endif  // CRANE_GAME_ANALYZER__METRICS__METRIC_CONTEXT_HPP_

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/metric_engine.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/metric_engine.hpp
@@ -8,9 +8,8 @@
 #define CRANE_GAME_ANALYZER__METRICS__METRIC_ENGINE_HPP_
 
 #include <crane_msg_wrappers/crane_visualizer_wrapper.hpp>
-#include <rclcpp/rclcpp.hpp>
-
 #include <memory>
+#include <rclcpp/rclcpp.hpp>
 #include <unordered_map>
 #include <vector>
 
@@ -65,8 +64,8 @@ public:
    * @param ctx 計算コンテキスト
    * @param visualizer 可視化メッセージビルダー
    */
-  auto visualizeAll(
-    MetricContext & ctx, const VisualizerMessageBuilder::SharedPtr & visualizer) -> void;
+  auto visualizeAll(MetricContext & ctx, const VisualizerMessageBuilder::SharedPtr & visualizer)
+    -> void;
 
 private:
   /**

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/metric_engine.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/metric_engine.hpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_GAME_ANALYZER__METRICS__METRIC_ENGINE_HPP_
+#define CRANE_GAME_ANALYZER__METRICS__METRIC_ENGINE_HPP_
+
+#include <crane_msg_wrappers/crane_visualizer_wrapper.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "metric_base.hpp"
+
+namespace crane::metrics
+{
+
+/**
+ * @brief メトリクス計算エンジン
+ *
+ * 登録されたメトリクスの依存関係を解決し、適切な順序で計算を実行する
+ * - トポロジカルソート（Kahnのアルゴリズム）による計算順序決定
+ * - 循環依存の検出
+ * - 全メトリクスの一括計算・可視化
+ */
+class MetricEngine
+{
+public:
+  /**
+   * @brief コンストラクタ
+   * @param logger ROS2ロガー（エラー・情報出力用）
+   */
+  explicit MetricEngine(rclcpp::Logger logger) : logger_(logger) {}
+
+  /**
+   * @brief メトリクスを登録
+   *
+   * 登録順序は不問（エンジンが依存関係を解決）
+   * @param metric 登録するメトリクス
+   */
+  auto registerMetric(MetricBase::Ptr metric) -> void;
+
+  /**
+   * @brief 初期化（トポロジカルソート・循環依存検出）
+   *
+   * 全メトリクス登録後、一度だけ呼び出す
+   * @return 成功: true, 失敗（循環依存等）: false
+   */
+  auto initialize() -> bool;
+
+  /**
+   * @brief 全メトリクスを計算順序に従って実行
+   *
+   * @param ctx 計算コンテキスト
+   */
+  auto computeAll(MetricContext & ctx) -> void;
+
+  /**
+   * @brief 全メトリクスの可視化を実行
+   *
+   * @param ctx 計算コンテキスト
+   * @param visualizer 可視化メッセージビルダー
+   */
+  auto visualizeAll(
+    MetricContext & ctx, const VisualizerMessageBuilder::SharedPtr & visualizer) -> void;
+
+private:
+  /**
+   * @brief トポロジカルソートを実行し、実行順序を構築
+   *
+   * Kahnのアルゴリズムを使用:
+   * 1. 入次数0のノード（依存なし）をキューに追加
+   * 2. キューから取り出してexecution_order_に追加
+   * 3. そのノードから出ている辺を削除し、入次数を更新
+   * 4. 全ノードを処理できれば成功、残りがあれば循環依存
+   *
+   * @return 成功: true, 失敗（循環依存）: false
+   */
+  auto buildExecutionOrder() -> bool;
+
+  rclcpp::Logger logger_;  ///< ROS2ロガー
+
+  /// メトリクスID -> メトリクスのマップ
+  std::unordered_map<MetricId, MetricBase::Ptr> metrics_;
+
+  /// 実行順序（トポロジカルソート済み）
+  std::vector<MetricId> execution_order_;
+};
+
+}  // namespace crane::metrics
+
+#endif  // CRANE_GAME_ANALYZER__METRICS__METRIC_ENGINE_HPP_

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/slack_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/slack_metrics.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_GAME_ANALYZER__METRICS__SLACK_METRICS_HPP_
+#define CRANE_GAME_ANALYZER__METRICS__SLACK_METRICS_HPP_
+
+#include "metric_base.hpp"
+
+namespace crane::metrics
+{
+
+/**
+ * @brief 味方ロボットのSlack時間メトリクス
+ *
+ * 各味方ロボットのボールインターセプト余裕時間を計算
+ * - min_slack: 最も早くボールに到達できる地点
+ * - max_slack: 最も余裕がある地点
+ */
+class OurSlackMetric : public MetricBase
+{
+public:
+  OurSlackMetric();
+
+  [[nodiscard]] auto getDependencies() const -> std::vector<MetricId> override { return {}; }
+
+  auto compute(MetricContext & ctx) -> void override;
+};
+
+/**
+ * @brief 敵ロボットのSlack時間メトリクス
+ *
+ * 各敵ロボットのボールインターセプト余裕時間を計算
+ */
+class TheirSlackMetric : public MetricBase
+{
+public:
+  TheirSlackMetric();
+
+  [[nodiscard]] auto getDependencies() const -> std::vector<MetricId> override { return {}; }
+
+  auto compute(MetricContext & ctx) -> void override;
+};
+
+}  // namespace crane::metrics
+
+#endif  // CRANE_GAME_ANALYZER__METRICS__SLACK_METRICS_HPP_

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/threat_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/threat_metrics.hpp
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_GAME_ANALYZER__METRICS__THREAT_METRICS_HPP_
+#define CRANE_GAME_ANALYZER__METRICS__THREAT_METRICS_HPP_
+
+#include "crane_game_analyzer/threat_evaluator.hpp"
+#include "metric_base.hpp"
+
+namespace crane::metrics
+{
+
+/**
+ * @brief ボール脅威メトリクス
+ *
+ * ボール位置からゴールへの脅威を評価
+ */
+class BallThreatMetric : public MetricBase
+{
+public:
+  BallThreatMetric();
+
+  [[nodiscard]] auto getDependencies() const -> std::vector<MetricId> override { return {}; }
+
+  auto compute(MetricContext & ctx) -> void override;
+
+  auto visualize(MetricContext & ctx, const VisualizerMessageBuilder::SharedPtr & visualizer)
+    -> void override;
+
+  /// 他のメトリクスが参照できるよう、最後の計算結果を公開
+  [[nodiscard]] auto getLastBallThreat() const -> const BallThreat & { return last_ball_threat_; }
+
+private:
+  ThreatEvaluator evaluator_;
+  BallThreat last_ball_threat_;
+};
+
+/**
+ * @brief ロボット脅威メトリクス
+ *
+ * 敵ロボットの脅威度を評価（優先度順）
+ * BALL_THREATに依存
+ */
+class RobotThreatsMetric : public MetricBase
+{
+public:
+  explicit RobotThreatsMetric(std::shared_ptr<BallThreatMetric> ball_threat_metric);
+
+  [[nodiscard]] auto getDependencies() const -> std::vector<MetricId> override
+  {
+    return {MetricId::BALL_THREAT};
+  }
+
+  auto compute(MetricContext & ctx) -> void override;
+
+  auto visualize(MetricContext & ctx, const VisualizerMessageBuilder::SharedPtr & visualizer)
+    -> void override;
+
+  /// 他のメトリクスが参照できるよう、最後の計算結果を公開
+  [[nodiscard]] auto getLastRobotThreats() const -> const std::vector<RobotThreat> &
+  {
+    return last_robot_threats_;
+  }
+
+private:
+  std::shared_ptr<BallThreatMetric> ball_threat_metric_;
+  ThreatEvaluator evaluator_;
+  std::vector<RobotThreat> last_robot_threats_;
+
+  /// 脅威度に応じた色を返すヘルパー
+  static auto threatToColor(double threat_rating) -> std::string;
+};
+
+/**
+ * @brief 推奨守備者数メトリクス
+ *
+ * ボールとロボット脅威から推奨守備者数を計算
+ * BALL_THREAT, ROBOT_THREATSに依存
+ */
+class RecommendedDefendersMetric : public MetricBase
+{
+public:
+  RecommendedDefendersMetric(
+    std::shared_ptr<BallThreatMetric> ball_threat_metric,
+    std::shared_ptr<RobotThreatsMetric> robot_threats_metric);
+
+  [[nodiscard]] auto getDependencies() const -> std::vector<MetricId> override
+  {
+    return {MetricId::BALL_THREAT, MetricId::ROBOT_THREATS};
+  }
+
+  auto compute(MetricContext & ctx) -> void override;
+
+  auto visualize(MetricContext & ctx, const VisualizerMessageBuilder::SharedPtr & visualizer)
+    -> void override;
+
+private:
+  std::shared_ptr<BallThreatMetric> ball_threat_metric_;
+  std::shared_ptr<RobotThreatsMetric> robot_threats_metric_;
+  ThreatEvaluator evaluator_;
+};
+
+}  // namespace crane::metrics
+
+#endif  // CRANE_GAME_ANALYZER__METRICS__THREAT_METRICS_HPP_

--- a/crane_game_analyzer/package.xml
+++ b/crane_game_analyzer/package.xml
@@ -14,6 +14,7 @@
   <depend>crane_msgs</depend>
   <depend>crane_physics</depend>
   <depend>crane_visualization_interfaces</depend>
+  <depend>crane_world_model_publisher</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>robocup_ssl_msgs</depend>

--- a/crane_game_analyzer/src/crane_game_analyzer.cpp
+++ b/crane_game_analyzer/src/crane_game_analyzer.cpp
@@ -12,6 +12,10 @@
 #include <vector>
 
 #include "crane_game_analyzer/game_analyzer.hpp"
+#include "crane_game_analyzer/metrics/attacker_metrics.hpp"
+#include "crane_game_analyzer/metrics/ball_horizon_metric.hpp"
+#include "crane_game_analyzer/metrics/slack_metrics.hpp"
+#include "crane_game_analyzer/metrics/threat_metrics.hpp"
 
 namespace crane
 {
@@ -91,6 +95,35 @@ GameAnalyzerComponent::GameAnalyzerComponent(const rclcpp::NodeOptions & options
   game_event_sub_ = create_subscription<robocup_ssl_msgs::msg::GameEvent>(
     "/game_event", 10, [this](const robocup_ssl_msgs::msg::GameEvent & msg) { onGameEvent(msg); });
 
+  // メトリクス計算エンジンの初期化
+  metric_engine_ = std::make_unique<metrics::MetricEngine>(get_logger());
+
+  // 基礎メトリクス
+  metric_engine_->registerMetric(std::make_shared<metrics::BallHorizonMetric>());
+  metric_engine_->registerMetric(std::make_shared<metrics::OurSlackMetric>());
+  metric_engine_->registerMetric(std::make_shared<metrics::TheirSlackMetric>());
+
+  // 脅威評価メトリクス
+  auto ball_threat_metric = std::make_shared<metrics::BallThreatMetric>();
+  metric_engine_->registerMetric(ball_threat_metric);
+
+  auto robot_threats_metric = std::make_shared<metrics::RobotThreatsMetric>(ball_threat_metric);
+  metric_engine_->registerMetric(robot_threats_metric);
+
+  metric_engine_->registerMetric(
+    std::make_shared<metrics::RecommendedDefendersMetric>(
+      ball_threat_metric, robot_threats_metric));
+
+  // 役割決定メトリクス（新規）
+  auto attacker_metric = std::make_shared<metrics::AttackerCandidateMetric>();
+  metric_engine_->registerMetric(attacker_metric);
+
+  // メトリクスエンジン初期化（トポロジカルソート・循環依存検出）
+  if (!metric_engine_->initialize()) {
+    RCLCPP_FATAL(get_logger(), "Failed to initialize metric engine!");
+    throw std::runtime_error("Metric engine initialization failed");
+  }
+
   world_model->addCallback([&]() {
     auto robot_collision_info = getRobotCollisionInfo();
 
@@ -102,8 +135,25 @@ GameAnalyzerComponent::GameAnalyzerComponent(const rclcpp::NodeOptions & options
         robot_collision_info->relative_velocity);
     }
 
-    // 脅威評価を実行
-    auto analysis = evaluateThreats();
+    // ボール履歴を更新
+    crane_msgs::msg::BallInfo ball_info_msg;
+    world_model->ball().toMsg(ball_info_msg);
+    ball_history_.push_front(ball_info_msg);
+    if (ball_history_.size() > 100) {
+      ball_history_.pop_back();
+    }
+
+    // メトリクス計算エンジンで脅威評価を実行
+    crane_msgs::msg::GameAnalysis analysis;
+    metrics::MetricContext ctx{
+      .world_model = world_model.get(),
+      .ball_history = &ball_history_,
+      .clock = get_clock(),
+      .analysis = analysis};
+
+    metric_engine_->computeAll(ctx);
+    metric_engine_->visualizeAll(ctx, visualizer);
+
     game_analysis_pub_->publish(analysis);
 
     // RONARイベント検出を実行

--- a/crane_game_analyzer/src/metrics/attacker_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/attacker_metrics.cpp
@@ -114,5 +114,4 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
   ctx.analysis.recommended_pass_receiver_id = -1;
 }
 
-
 }  // namespace crane::metrics

--- a/crane_game_analyzer/src/metrics/attacker_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/attacker_metrics.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "crane_game_analyzer/metrics/attacker_metrics.hpp"
+
+#include <algorithm>
+
+namespace crane::metrics
+{
+
+// AttackerCandidateMetric実装
+
+AttackerCandidateMetric::AttackerCandidateMetric()
+: MetricBase(MetricId::ATTACKER_CANDIDATE, "AttackerCandidate")
+{
+}
+
+auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
+{
+  const auto & ball_pos = ctx.world_model->ball().pos;
+  const auto available_robots = ctx.world_model->ours().getAvailableRobots();
+
+  if (available_robots.empty()) {
+    ctx.analysis.recommended_attacker_id = -1;
+    ctx.analysis.attacker_suitability_score = 0.0;
+    ctx.analysis.recommended_pass_receiver_id = -1;
+    return;
+  }
+
+  // 各ロボットの適性スコアを計算
+  // スコア = ボール距離の逆数 × Slack時間の逆数
+  struct RobotScore
+  {
+    uint8_t id;
+    double score;
+  };
+
+  std::vector<RobotScore> robot_scores;
+
+  for (const auto & robot : available_robots) {
+    double distance = (robot->pose.pos - ball_pos).norm();
+
+    // Slack時間を取得
+    double min_slack_time = 10.0;  // デフォルト値
+    for (const auto & slack : ctx.analysis.our_slack) {
+      if (slack.id == robot->id) {
+        min_slack_time = slack.min.slack_time;
+        break;
+      }
+    }
+
+    // スコア計算（距離が近く、Slack時間が短いほど高スコア）
+    // 距離0m→スコア無限大を避けるため、最小距離0.1mとする
+    double distance_score = 1.0 / std::max(distance, 0.1);
+    double slack_score = 1.0 / std::max(min_slack_time, 0.1);
+
+    double total_score = distance_score * 0.6 + slack_score * 0.4;
+
+    robot_scores.push_back({robot->id, total_score});
+  }
+
+  // スコアでソート（降順）
+  std::sort(robot_scores.begin(), robot_scores.end(), [](const auto & a, const auto & b) {
+    return a.score > b.score;
+  });
+
+  int best_id = robot_scores[0].id;
+  double best_score = robot_scores[0].score;
+
+  // ヒステリシス処理
+  auto current_time = ros_clock_.now();
+  bool should_switch = false;
+
+  if (last_attacker_id_ < 0) {
+    // 初回は即座にスイッチ
+    should_switch = true;
+  } else if (best_id == last_attacker_id_) {
+    // 同じロボットなら継続
+    should_switch = false;
+  } else {
+    // 異なるロボットの場合
+    double time_since_switch = (current_time - last_switch_time_).seconds();
+
+    if (time_since_switch >= MIN_HOLD_DURATION_SEC) {
+      // 最低保持時間が経過している
+      // 現在のロボットのスコアを取得
+      double current_score = 0.0;
+      for (const auto & rs : robot_scores) {
+        if (static_cast<int>(rs.id) == last_attacker_id_) {
+          current_score = rs.score;
+          break;
+        }
+      }
+
+      // 十分な改善がある場合のみスイッチ
+      if (best_score > current_score + MIN_IMPROVEMENT_MARGIN) {
+        should_switch = true;
+      }
+    }
+  }
+
+  if (should_switch) {
+    last_attacker_id_ = best_id;
+    last_switch_time_ = current_time;
+  }
+
+  ctx.analysis.recommended_attacker_id = last_attacker_id_;
+  ctx.analysis.attacker_suitability_score = best_score;
+
+  // recommended_pass_receiver_idは未使用（-1固定）
+  ctx.analysis.recommended_pass_receiver_id = -1;
+}
+
+
+}  // namespace crane::metrics

--- a/crane_game_analyzer/src/metrics/ball_horizon_metric.cpp
+++ b/crane_game_analyzer/src/metrics/ball_horizon_metric.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "crane_game_analyzer/metrics/ball_horizon_metric.hpp"
+
+#include <crane_geometry/geometry_operations.hpp>
+#include <range/v3/algorithm/min.hpp>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/transform.hpp>
+
+namespace crane::metrics
+{
+
+BallHorizonMetric::BallHorizonMetric() : MetricBase(MetricId::BALL_HORIZON, "BallHorizon") {}
+
+auto BallHorizonMetric::compute(MetricContext & ctx) -> void
+{
+  const auto & ball = ctx.world_model->ball();
+
+  // ボールラインの長さを計算
+  ctx.analysis.ball_horizon = [&]() {
+    Segment ball_line = ball.getTrajectorySegmentByTime(3.0);
+    auto robots = ctx.world_model->theirs().getAvailableRobots();
+    auto ball_line_lengths =
+      robots |
+      ranges::views::transform(
+        [&](const auto & robot) { return getClosestPointAndDistance(ball_line, robot->pose.pos); })
+      // 距離が0.5m以下のものを抽出
+      | ranges::views::filter([](const ClosestPoint & pair) { return pair.distance < 0.5; })
+      // ball.posとの距離を計算
+      | ranges::views::transform(
+          [&](const ClosestPoint & pair) -> double { return (pair.closest_point - ball.pos).norm(); });
+    return ranges::empty(ball_line_lengths) ? 10.0 : ranges::min(ball_line_lengths);
+  }();
+}
+
+}  // namespace crane::metrics

--- a/crane_game_analyzer/src/metrics/ball_horizon_metric.cpp
+++ b/crane_game_analyzer/src/metrics/ball_horizon_metric.cpp
@@ -32,8 +32,9 @@ auto BallHorizonMetric::compute(MetricContext & ctx) -> void
       // 距離が0.5m以下のものを抽出
       | ranges::views::filter([](const ClosestPoint & pair) { return pair.distance < 0.5; })
       // ball.posとの距離を計算
-      | ranges::views::transform(
-          [&](const ClosestPoint & pair) -> double { return (pair.closest_point - ball.pos).norm(); });
+      | ranges::views::transform([&](const ClosestPoint & pair) -> double {
+          return (pair.closest_point - ball.pos).norm();
+        });
     return ranges::empty(ball_line_lengths) ? 10.0 : ranges::min(ball_line_lengths);
   }();
 }

--- a/crane_game_analyzer/src/metrics/metric_engine.cpp
+++ b/crane_game_analyzer/src/metrics/metric_engine.cpp
@@ -102,8 +102,8 @@ auto MetricEngine::buildExecutionOrder() -> bool
     std::stringstream ss;
     ss << "Unresolved metrics: ";
     for (const auto & [id, metric] : metrics_) {
-      if (std::find(execution_order_.begin(), execution_order_.end(), id) ==
-          execution_order_.end()) {
+      if (
+        std::find(execution_order_.begin(), execution_order_.end(), id) == execution_order_.end()) {
         ss << metric->getName() << " ";
       }
     }

--- a/crane_game_analyzer/src/metrics/metric_engine.cpp
+++ b/crane_game_analyzer/src/metrics/metric_engine.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "crane_game_analyzer/metrics/metric_engine.hpp"
+
+#include <queue>
+#include <sstream>
+#include <unordered_map>
+
+namespace crane::metrics
+{
+
+auto MetricEngine::registerMetric(MetricBase::Ptr metric) -> void
+{
+  metrics_[metric->getId()] = metric;
+}
+
+auto MetricEngine::initialize() -> bool { return buildExecutionOrder(); }
+
+auto MetricEngine::computeAll(MetricContext & ctx) -> void
+{
+  for (const auto & id : execution_order_) {
+    auto it = metrics_.find(id);
+    if (it != metrics_.end()) {
+      it->second->compute(ctx);
+    }
+  }
+}
+
+auto MetricEngine::visualizeAll(
+  MetricContext & ctx, const VisualizerMessageBuilder::SharedPtr & visualizer) -> void
+{
+  for (const auto & id : execution_order_) {
+    auto it = metrics_.find(id);
+    if (it != metrics_.end()) {
+      it->second->visualize(ctx, visualizer);
+    }
+  }
+}
+
+auto MetricEngine::buildExecutionOrder() -> bool
+{
+  // 入次数と隣接リストを構築
+  std::unordered_map<MetricId, int> in_degree;
+  std::unordered_map<MetricId, std::vector<MetricId>> adj;
+
+  // 全メトリクスの入次数を0で初期化
+  for (const auto & [id, metric] : metrics_) {
+    in_degree[id] = 0;
+  }
+
+  // グラフ構築: 依存関係を辺として表現
+  // A depends on B => edge B -> A
+  for (const auto & [id, metric] : metrics_) {
+    for (const auto & dep : metric->getDependencies()) {
+      // 依存先が登録されているか確認
+      if (metrics_.find(dep) == metrics_.end()) {
+        RCLCPP_ERROR(
+          logger_, "Metric '%s' depends on unregistered metric (ID: %d)", metric->getName().c_str(),
+          static_cast<int>(dep));
+        return false;
+      }
+      // 依存関係を追加: dep -> id
+      adj[dep].push_back(id);
+      in_degree[id]++;
+    }
+  }
+
+  // Kahnのアルゴリズム: トポロジカルソート
+  std::queue<MetricId> queue;
+
+  // 入次数0のノードをキューに追加
+  for (const auto & [id, degree] : in_degree) {
+    if (degree == 0) {
+      queue.push(id);
+    }
+  }
+
+  execution_order_.clear();
+
+  while (!queue.empty()) {
+    auto current = queue.front();
+    queue.pop();
+    execution_order_.push_back(current);
+
+    // currentから出ている辺を削除
+    for (const auto & next : adj[current]) {
+      if (--in_degree[next] == 0) {
+        queue.push(next);
+      }
+    }
+  }
+
+  // 循環依存検出: 全ノードを処理できなかった場合
+  if (execution_order_.size() != metrics_.size()) {
+    RCLCPP_ERROR(logger_, "Circular dependency detected in metrics!");
+
+    // 処理できなかったメトリクスをログ出力
+    std::stringstream ss;
+    ss << "Unresolved metrics: ";
+    for (const auto & [id, metric] : metrics_) {
+      if (std::find(execution_order_.begin(), execution_order_.end(), id) ==
+          execution_order_.end()) {
+        ss << metric->getName() << " ";
+      }
+    }
+    RCLCPP_ERROR(logger_, "%s", ss.str().c_str());
+
+    return false;
+  }
+
+  // 実行順序をログ出力
+  std::stringstream ss;
+  ss << "Metric execution order: ";
+  for (size_t i = 0; i < execution_order_.size(); ++i) {
+    if (i > 0) ss << " -> ";
+    ss << metrics_[execution_order_[i]]->getName();
+  }
+  RCLCPP_INFO(logger_, "%s", ss.str().c_str());
+
+  return true;
+}
+
+}  // namespace crane::metrics

--- a/crane_game_analyzer/src/metrics/slack_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/slack_metrics.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "crane_game_analyzer/metrics/slack_metrics.hpp"
+
+namespace crane::metrics
+{
+
+// OurSlackMetric実装
+
+OurSlackMetric::OurSlackMetric() : MetricBase(MetricId::OUR_SLACK, "OurSlack") {}
+
+auto OurSlackMetric::compute(MetricContext & ctx) -> void
+{
+  for (const auto & robot : ctx.world_model->ours().getAvailableRobots()) {
+    RobotList single_robot{robot};
+    auto [min_slack, max_slack] =
+      ctx.world_model->getMinMaxSlackInterceptPointAndSlackTime(single_robot);
+
+    crane_msgs::msg::Slack slack_msg;
+    slack_msg.id = robot->id;
+
+    if (min_slack) {
+      slack_msg.min.slack_time = min_slack->slack_time;
+      slack_msg.min.x = min_slack->intercept_point.x();
+      slack_msg.min.y = min_slack->intercept_point.y();
+    }
+
+    if (max_slack) {
+      slack_msg.max.slack_time = max_slack->slack_time;
+      slack_msg.max.x = max_slack->intercept_point.x();
+      slack_msg.max.y = max_slack->intercept_point.y();
+    }
+
+    ctx.analysis.our_slack.push_back(slack_msg);
+  }
+}
+
+// TheirSlackMetric実装
+
+TheirSlackMetric::TheirSlackMetric() : MetricBase(MetricId::THEIR_SLACK, "TheirSlack") {}
+
+auto TheirSlackMetric::compute(MetricContext & ctx) -> void
+{
+  for (const auto & robot : ctx.world_model->theirs().getAvailableRobots()) {
+    RobotList single_robot{robot};
+    auto [min_slack, max_slack] =
+      ctx.world_model->getMinMaxSlackInterceptPointAndSlackTime(single_robot);
+
+    crane_msgs::msg::Slack slack_msg;
+    slack_msg.id = robot->id;
+
+    if (min_slack) {
+      slack_msg.min.slack_time = min_slack->slack_time;
+      slack_msg.min.x = min_slack->intercept_point.x();
+      slack_msg.min.y = min_slack->intercept_point.y();
+    }
+
+    if (max_slack) {
+      slack_msg.max.slack_time = max_slack->slack_time;
+      slack_msg.max.x = max_slack->intercept_point.x();
+      slack_msg.max.y = max_slack->intercept_point.y();
+    }
+
+    ctx.analysis.their_slack.push_back(slack_msg);
+  }
+}
+
+}  // namespace crane::metrics

--- a/crane_game_analyzer/src/metrics/threat_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/threat_metrics.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "crane_game_analyzer/metrics/threat_metrics.hpp"
+
+#include <algorithm>
+
+namespace crane::metrics
+{
+
+// BallThreatMetric実装
+
+BallThreatMetric::BallThreatMetric()
+: MetricBase(MetricId::BALL_THREAT, "BallThreat"), evaluator_(ThreatEvaluatorConfig{})
+{
+}
+
+auto BallThreatMetric::compute(MetricContext & ctx) -> void
+{
+  last_ball_threat_ = evaluator_.calculateBallThreat(*ctx.world_model);
+  ctx.analysis.ball_threat = evaluator_.toThreatInfoMsg(last_ball_threat_);
+}
+
+auto BallThreatMetric::visualize(
+  MetricContext & ctx, const VisualizerMessageBuilder::SharedPtr & visualizer) -> void
+{
+  (void)ctx;
+
+  // ボール脅威ライン（オレンジ）
+  visualizer->line()
+    .fromSegment(last_ball_threat_.threat_line)
+    .stroke("orange", 0.9)
+    .strokeWidth(3)
+    .build();
+
+  // ボール脅威の防御ライン（シアン）
+  if (last_ball_threat_.protection_line) {
+    visualizer->line()
+      .fromSegment(*last_ball_threat_.protection_line)
+      .stroke("cyan", 0.8)
+      .strokeWidth(2)
+      .build();
+
+    // 防御ライン端点のマーカー
+    visualizer->drawStyledCircle(
+      last_ball_threat_.protection_line->first, 0.03, "cyan", 0.5, "cyan", 1.0, 2);
+    visualizer->drawStyledCircle(
+      last_ball_threat_.protection_line->second, 0.03, "cyan", 0.5, "cyan", 1.0, 2);
+  }
+}
+
+// RobotThreatsMetric実装
+
+RobotThreatsMetric::RobotThreatsMetric(std::shared_ptr<BallThreatMetric> ball_threat_metric)
+: MetricBase(MetricId::ROBOT_THREATS, "RobotThreats"),
+  ball_threat_metric_(ball_threat_metric),
+  evaluator_(ThreatEvaluatorConfig{})
+{
+}
+
+auto RobotThreatsMetric::compute(MetricContext & ctx) -> void
+{
+  const auto & ball_threat = ball_threat_metric_->getLastBallThreat();
+  last_robot_threats_ = evaluator_.calculateRobotThreats(*ctx.world_model, ball_threat);
+
+  ctx.analysis.robot_threats.clear();
+  for (const auto & threat : last_robot_threats_) {
+    ctx.analysis.robot_threats.push_back(evaluator_.toThreatInfoMsg(threat));
+  }
+}
+
+auto RobotThreatsMetric::visualize(
+  MetricContext & ctx, const VisualizerMessageBuilder::SharedPtr & visualizer) -> void
+{
+  // ロボット脅威（上位5つを可視化）
+  int vis_count = 0;
+  for (const auto & threat : last_robot_threats_) {
+    if (vis_count >= 5) break;
+
+    // 脅威度に応じたグラデーション色
+    std::string color = threatToColor(threat.threat_rating);
+
+    // 線の太さも脅威度に応じて変化 (1.0 - 4.0)
+    double line_width = 1.0 + threat.threat_rating * 3.0;
+
+    // 不透明度も脅威度に応じて変化 (0.4 - 1.0)
+    double opacity = 0.4 + threat.threat_rating * 0.6;
+
+    // 脅威ライン
+    visualizer->line()
+      .fromSegment(threat.threat_line)
+      .stroke(color, opacity)
+      .strokeWidth(line_width)
+      .build();
+
+    // 脅威スコア表示
+    std::string score_text = std::to_string(threat.threat_rating).substr(0, 4);
+    visualizer->drawCenteredLabel(threat.robot->pose.pos + Vector2(0, 0.15), score_text, color, 30);
+
+    // 順位表示
+    std::string rank_text = "#" + std::to_string(vis_count + 1);
+    visualizer->drawCenteredLabel(
+      threat.robot->pose.pos + Vector2(-0.12, 0.15), rank_text, color, 20);
+
+    // 防御ライン（存在する場合）
+    if (threat.protection_line) {
+      visualizer->line()
+        .fromSegment(*threat.protection_line)
+        .stroke("cyan", 0.6)
+        .strokeWidth(1.5)
+        .build();
+    }
+
+    vis_count++;
+  }
+
+  // 上位脅威のリダイレクト角度を可視化（上位2つのみ）
+  if (!last_robot_threats_.empty()) {
+    for (size_t i = 0; i < std::min(size_t(2), last_robot_threats_.size()); ++i) {
+      const auto & threat = last_robot_threats_[i];
+      Point ball_pos = ctx.world_model->ball().pos;
+      Point goal_center = ctx.world_model->getOurGoalCenter();
+      Point threat_pos = threat.robot->pose.pos;
+
+      // ボール→脅威→ゴール のリダイレクト角度を弧で表示
+      Vector2 from_ball = (threat_pos - ball_pos).normalized();
+      Vector2 to_goal = (goal_center - threat_pos).normalized();
+
+      double angle1 = std::atan2(-from_ball.y(), -from_ball.x());
+      double angle2 = std::atan2(to_goal.y(), to_goal.x());
+
+      // 角度が大きすぎる場合はスキップ
+      double angle_diff = std::abs(angle2 - angle1);
+      if (angle_diff > M_PI) angle_diff = 2 * M_PI - angle_diff;
+      if (angle_diff < M_PI) {
+        std::string arc_color = threatToColor(threat.threat_rating);
+        visualizer->arc(
+          threat_pos, 0.15, std::min(angle1, angle2), std::max(angle1, angle2), arc_color, 1.5, 8);
+      }
+    }
+  }
+}
+
+auto RobotThreatsMetric::threatToColor(double threat_rating) -> std::string
+{
+  // 脅威度に応じた色（緑→黄→赤）
+  if (threat_rating < 0.3) {
+    return "green";
+  } else if (threat_rating < 0.6) {
+    return "yellow";
+  } else {
+    return "red";
+  }
+}
+
+// RecommendedDefendersMetric実装
+
+RecommendedDefendersMetric::RecommendedDefendersMetric(
+  std::shared_ptr<BallThreatMetric> ball_threat_metric,
+  std::shared_ptr<RobotThreatsMetric> robot_threats_metric)
+: MetricBase(MetricId::RECOMMENDED_DEFENDERS, "RecommendedDefenders"),
+  ball_threat_metric_(ball_threat_metric),
+  robot_threats_metric_(robot_threats_metric),
+  evaluator_(ThreatEvaluatorConfig{})
+{
+}
+
+auto RecommendedDefendersMetric::compute(MetricContext & ctx) -> void
+{
+  const auto & ball_threat = ball_threat_metric_->getLastBallThreat();
+  const auto & robot_threats = robot_threats_metric_->getLastRobotThreats();
+
+  int available_robots = static_cast<int>(ctx.world_model->ours().getAvailableRobots().size());
+  ctx.analysis.recommended_num_defenders = static_cast<uint8_t>(
+    evaluator_.calculateRecommendedDefenders(ball_threat, robot_threats, available_robots));
+}
+
+auto RecommendedDefendersMetric::visualize(
+  MetricContext & ctx, const VisualizerMessageBuilder::SharedPtr & visualizer) -> void
+{
+  // 推奨守備者数を画面左上に表示
+  std::string def_text = "DEF:" + std::to_string(ctx.analysis.recommended_num_defenders);
+  visualizer->text().viewBoxPosition(3, -97).text(def_text).fill("cyan").fontSize(100).build();
+}
+
+}  // namespace crane::metrics

--- a/crane_msgs/msg/analysis/GameAnalysis.msg
+++ b/crane_msgs/msg/analysis/GameAnalysis.msg
@@ -29,3 +29,8 @@ uint8 pass_disruption_defender_id
 
 # 推奨守備者数
 uint8 recommended_num_defenders
+
+# 推奨役割（新規フィールド）
+int32 recommended_attacker_id        # 推奨アタッカーID（-1は未選択）
+float32 attacker_suitability_score   # アタッカー適性スコア
+int32 recommended_pass_receiver_id   # 推奨パスレシーバーID（-1は未選択）


### PR DESCRIPTION
## 概要

ゲーム分析システム（`crane_game_analyzer`）に、新しいメトリクス計算エンジンを追加しました。従来の脅威評価システムと並行して動作し、より詳細な試合状況の定量評価を提供します。

## 主な変更点

### 新規追加されたコンポーネント

- **MetricEngine**: メトリクス計算の中核エンジン
  - 依存関係グラフに基づく自動計算順序決定
  - メトリクスの登録・取得・計算実行を管理

- **MetricBase**: すべてのメトリクスの基底クラス
  - 統一されたインターフェース定義
  - 依存関係の明示的な宣言

- **MetricContext**: メトリクス計算時のコンテキスト
  - ワールドモデル、ロボット情報、ボール情報などへのアクセス
  - 計算結果の一時保存

### 実装されたメトリクス

1. **ThreatMetrics** (脅威評価)
   - `BALL_THREAT`: ボール到達脅威度の評価
   - `SHOOT_THREAT`: シュート脅威度の評価
   - `PASS_THREAT`: パス脅威度の評価

2. **SlackMetrics** (余裕時間)
   - `OUR_SLACK`: 味方ロボットの行動余裕時間
   - `THEIR_SLACK`: 敵ロボットの行動余裕時間

3. **BallHorizonMetric** (ボール到達時間)
   - `BALL_HORIZON`: ボール到達予測時間の計算

4. **AttackerCandidateMetric** (アタッカー推奨)
   - `ATTACKER_CANDIDATE`: 推奨アタッカーの決定
   - ヒステリシスによる安定した切り替え

### アーキテクチャの特徴

- **依存関係の明示化**: 各メトリクスが依存する他のメトリクスを明示的に宣言
- **自動計算順序**: 依存グラフから最適な計算順序を自動決定
- **拡張性**: 新しいメトリクスの追加が容易
- **並行動作**: 旧脅威評価システムと並行して動作し、段階的な移行が可能

### メッセージの更新

`crane_msgs/msg/analysis/GameAnalysis.msg` に新しいメトリクス情報のフィールドを追加しました。
