### PR TITLE
feat: フィールドジオメトリの設定ファイル対応を追加

### DIFF
--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -94,6 +94,12 @@ limitations under the License.
   <arg name="commentary" default="false" description="実況システムの起動フラグ"/>
   <arg name="record" default="true" description="rosbag記録フラグ"/>
   <arg name="ball_physics_config_path" default="grsim_ball_physics.yaml" description="ボール物理パラメータ設定ファイル名（configフォルダ内）"/>
+  <arg name="field_geometry" default="B" description="フィールドジオメトリ設定: A (Division A), B (Division B), vision (Visionから取得)"/>
+
+  <!-- フィールドジオメトリ設定の解決 -->
+  <let name="field_geometry_config_path" value="field_geometry_div_a.yaml" if="$(eval '\'$(var field_geometry)\' == \'A\'')"/>
+  <let name="field_geometry_config_path" value="field_geometry_div_b.yaml" if="$(eval '\'$(var field_geometry)\' == \'B\'')"/>
+  <let name="field_geometry_config_path" value="" if="$(eval '\'$(var field_geometry)\' == \'vision\'')"/>
 
   <!-- ============================================================ -->
   <!-- コアシステム -->

--- a/crane_world_model_publisher/config/field_geometry_div_a.yaml
+++ b/crane_world_model_publisher/config/field_geometry_div_a.yaml
@@ -1,0 +1,21 @@
+# SSL RoboCup Field Geometry Configuration - Division A
+# フィールドジオメトリ設定 - Division A
+#
+# このファイルは、Visionシステムがgeometryパケットを送信しない場合に使用されます。
+# SSL Division A標準サイズを設定しています。
+
+field_geometry:
+  # フィールドサイズ (SSL Division A標準)
+  field_length: 12.0      # フィールド長さ [m]
+  field_width: 9.0        # フィールド幅 [m]
+
+  # ゴールサイズ
+  goal_width: 1.2         # ゴール幅 [m]
+  goal_depth: 0.18        # ゴール深さ [m]
+
+  # ペナルティエリアサイズ
+  penalty_area_depth: 1.8  # ペナルティエリア深さ [m]
+  penalty_area_width: 3.6  # ペナルティエリア幅 [m]
+
+  # その他
+  center_circle_radius: 0.5  # センターサークル半径 [m]

--- a/crane_world_model_publisher/config/field_geometry_div_b.yaml
+++ b/crane_world_model_publisher/config/field_geometry_div_b.yaml
@@ -1,0 +1,21 @@
+# SSL RoboCup Field Geometry Configuration - Division B
+# フィールドジオメトリ設定 - Division B
+#
+# このファイルは、Visionシステムがgeometryパケットを送信しない場合に使用されます。
+# SSL Division B標準サイズを設定しています。
+
+field_geometry:
+  # フィールドサイズ (SSL Division B標準)
+  field_length: 9.0       # フィールド長さ [m]
+  field_width: 6.0        # フィールド幅 [m]
+
+  # ゴールサイズ
+  goal_width: 1.0         # ゴール幅 [m]
+  goal_depth: 0.18        # ゴール深さ [m]
+
+  # ペナルティエリアサイズ
+  penalty_area_depth: 1.0  # ペナルティエリア深さ [m]
+  penalty_area_width: 2.0  # ペナルティエリア幅 [m]
+
+  # その他
+  center_circle_radius: 0.5  # センターサークル半径 [m]

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -256,6 +256,7 @@ private:
   auto processGeometryData(const robocup_ssl::SSL_GeometryData & geometry) -> bool;
   auto convertBallDetection(const robocup_ssl::SSL_DetectionBall & ssl_ball) -> void;
   auto convertFieldGeometry(const robocup_ssl::SSL_GeometryData & ssl_geometry) -> void;
+  auto loadFieldGeometryFromConfig(const std::string & config_path) -> bool;
   auto reportError(const std::string & error_message) -> void;
 
   auto mergeRobotInfo(

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -10,9 +10,11 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <crane_msg_wrappers/crane_visualizer_wrapper.hpp>
 #include <crane_msg_wrappers/delay_monitor_wrapper.hpp>
 #include <crane_msgs/msg/robot_info.hpp>
+#include <filesystem>
 #include <robocup_ssl_msgs/msg/robot_id.hpp>
 #include <string>
 #include <vector>
@@ -100,6 +102,32 @@ WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
 
   area_mask.min_corner() << -20., -10.;
   area_mask.max_corner() << 20., 10.;
+
+  // フィールドジオメトリ設定ファイルの読み込み
+  node.declare_parameter("field_geometry_config_path", "");
+  std::string field_geometry_config_path =
+    node.get_parameter("field_geometry_config_path").as_string();
+  if (!field_geometry_config_path.empty()) {
+    // ファイル名だけの場合はconfigディレクトリと結合
+    std::string full_config_path = field_geometry_config_path;
+    if (!std::filesystem::path(field_geometry_config_path).is_absolute()) {
+      try {
+        std::string package_share_dir =
+          ament_index_cpp::get_package_share_directory("crane_world_model_publisher");
+        full_config_path =
+          std::filesystem::path(package_share_dir) / "config" / field_geometry_config_path;
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(
+          node.get_logger(),
+          "パッケージディレクトリの取得に失敗しました: %s 相対パスとして扱います", e.what());
+      }
+    }
+
+    if (loadFieldGeometryFromConfig(full_config_path)) {
+      geometry_initialized = true;
+      updateGeometryIfNeeded();
+    }
+  }
 
   udp_timer = node.create_wall_timer(10ms, std::bind(&WorldModelDataProvider::on_udp_timer, this));
 
@@ -234,7 +262,15 @@ auto WorldModelDataProvider::on_udp_timer() -> void
               last_vision_recv_time_ = node.get_clock()->now();
             }
             if (packet.has_geometry()) {
+              RCLCPP_INFO(node.get_logger(), "Geometryパケット受信！");
               processGeometryData(packet.geometry());
+            } else {
+              static int no_geometry_count = 0;
+              if (++no_geometry_count % 100 == 1) {
+                RCLCPP_INFO(
+                  node.get_logger(), "Visionパケット受信中（geometry無し）: %d回目",
+                  no_geometry_count);
+              }
             }
           } else {
             RCLCPP_DEBUG(node.get_logger(), "SSL_WrapperPacketのパースに失敗しました");
@@ -603,6 +639,8 @@ auto WorldModelDataProvider::convertFieldGeometry(
   const robocup_ssl::SSL_GeometryData & ssl_geometry) -> void
 {
   if (!ssl_geometry.has_field()) {
+    RCLCPP_WARN(
+      node.get_logger(), "GeometryデータにFieldが含まれていません（has_field() = false）");
     return;
   }
 
@@ -628,6 +666,60 @@ auto WorldModelDataProvider::convertFieldGeometry(
 
   field_geometry_.center_circle_radius = 0.5;  // 標準SSL値
   field_geometry_.is_valid = true;
+
+  RCLCPP_INFO(
+    node.get_logger(),
+    "フィールド情報を設定: field=%.3fx%.3f, goal=%.3fx%.3f, penalty_area=%.3fx%.3f",
+    field_geometry_.field_width, field_geometry_.field_height, field_geometry_.goal_width,
+    field_geometry_.goal_height, field_geometry_.penalty_area_width,
+    field_geometry_.penalty_area_height);
+}
+
+auto WorldModelDataProvider::loadFieldGeometryFromConfig(const std::string & config_path) -> bool
+{
+  if (config_path.empty()) {
+    return false;
+  }
+
+  try {
+    YAML::Node config = YAML::LoadFile(config_path);
+    if (!config["field_geometry"]) {
+      RCLCPP_WARN(
+        node.get_logger(), "設定ファイルに'field_geometry'セクションが見つかりません: %s",
+        config_path.c_str());
+      return false;
+    }
+
+    auto geometry = config["field_geometry"];
+
+    field_geometry_.field_width = geometry["field_length"].as<double>();
+    field_geometry_.field_height = geometry["field_width"].as<double>();
+    field_geometry_.goal_width = geometry["goal_width"].as<double>();
+    field_geometry_.goal_height = geometry["goal_depth"].as<double>();
+    field_geometry_.penalty_area_height = geometry["penalty_area_depth"].as<double>();
+    field_geometry_.penalty_area_width = geometry["penalty_area_width"].as<double>();
+    field_geometry_.center_circle_radius = geometry["center_circle_radius"].as<double>(0.5);
+    field_geometry_.is_valid = true;
+
+    RCLCPP_INFO(
+      node.get_logger(),
+      "設定ファイルからフィールド情報を読み込みました: field=%.3fx%.3f, goal=%.3fx%.3f, "
+      "penalty_area=%.3fx%.3f",
+      field_geometry_.field_width, field_geometry_.field_height, field_geometry_.goal_width,
+      field_geometry_.goal_height, field_geometry_.penalty_area_width,
+      field_geometry_.penalty_area_height);
+    return true;
+  } catch (const YAML::Exception & e) {
+    RCLCPP_WARN(
+      node.get_logger(), "フィールド設定ファイルのYAMLパースエラー: %s (file: %s)", e.what(),
+      config_path.c_str());
+    return false;
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(
+      node.get_logger(), "フィールド設定ファイルの読み込みに失敗: %s (file: %s)", e.what(),
+      config_path.c_str());
+    return false;
+  }
 }
 
 auto WorldModelDataProvider::reportError(const std::string & error_message) -> void


### PR DESCRIPTION
## 概要
Visionシステムからのgeometryパケットに加えて、設定ファイルからフィールドジオメトリを読み込めるように機能拡張しました。

## 変更内容
- Division A/B標準サイズの設定ファイルを追加（`field_geometry_div_a.yaml`, `field_geometry_div_b.yaml`）
- launchファイルに`field_geometry`パラメータを追加（A/B/visionから選択可能）
- `world_model_data_provider`に設定ファイル読み込み機能を実装

## 主な実装
- YAMLパーサーを使用してフィールドサイズ、ゴールサイズ、ペナルティエリアサイズを読み込み
- 設定ファイル指定時は起動時に自動的にジオメトリを初期化
- Visionパケット受信状況のログ出力を強化（デバッグ用）
