### PR TITLE
feat: Tacticの再利用機構とPositionCommandsへの速度情報設定

### DIFF
--- a/crane_tactic_coordinator/src/robot_allocator.cpp
+++ b/crane_tactic_coordinator/src/robot_allocator.cpp
@@ -46,6 +46,9 @@ auto RobotAllocator::allocate(
 
   // 前回のプランナーリストを保存し、新しいリストをクリア
   auto prev_available_planners = tactic_registry_->getAllPlanners();
+  RCLCPP_INFO(
+    logger_, "[RobotAllocator::allocate] Session「%s」: 前回のプランナー数=%zu",
+    session_name.c_str(), prev_available_planners.size());
   tactic_registry_->clear();
 
   // TacticRequirementリストを構築
@@ -118,10 +121,6 @@ auto RobotAllocator::allocate(
         allocation_state_.updateAssignment(id, tactic_name, robot->pose.pos);
         prev_robot_roles_.insert_or_assign(id, RobotRole{tactic_name, ""});
       }
-
-      RCLCPP_INFO_STREAM(
-        logger_,
-        "\tグローバルアロケータ: セッション「" << tactic_name << "」のロボット割当：" << robot_ids);
     }
   }
 

--- a/crane_tactic_coordinator/src/tactic_registry.cpp
+++ b/crane_tactic_coordinator/src/tactic_registry.cpp
@@ -30,8 +30,14 @@ auto TacticRegistry::getOrCreatePlanner(
   TacticBase::SharedPtr result_planner;
   if (matched_planner != prev_planners.end()) {
     result_planner = *matched_planner;
+    RCLCPP_INFO(
+      rclcpp::get_logger("TacticRegistry"), "Tactic「%s」を再利用 (robots: prev=%zu, new=%zu)",
+      tactic_name.c_str(), (*matched_planner)->getRobots().size(), new_planner->getRobots().size());
   } else {
     result_planner = new_planner;
+    RCLCPP_INFO(
+      rclcpp::get_logger("TacticRegistry"), "Tactic「%s」を新規作成 (robots: new=%zu)",
+      tactic_name.c_str(), new_planner->getRobots().size());
   }
 
   // パラメータを設定（新規・再利用どちらでも）

--- a/crane_tactics/include/crane_tactics/tactic_base.hpp
+++ b/crane_tactics/include/crane_tactics/tactic_base.hpp
@@ -94,7 +94,14 @@ public:
     crane_msgs::msg::PositionCommands msg;
     msg.is_yellow = world_model->isYellow();
     msg.on_positive_half = world_model->onPositiveHalf();
-    for (const auto & command : position_commands) {
+    for (auto command : position_commands) {
+      // WorldModelから現在の速度情報を取得して設定
+      auto robot = world_model->getOurRobot(command.robot_id);
+      if (robot) {
+        command.current_velocity.x = robot->vel.linear.x();
+        command.current_velocity.y = robot->vel.linear.y();
+        command.current_velocity.theta = robot->vel.omega;
+      }
       msg.robot_commands.emplace_back(command);
     }
     visualizer->flush();

--- a/crane_tactics/include/crane_tactics/tactic_base.hpp
+++ b/crane_tactics/include/crane_tactics/tactic_base.hpp
@@ -103,7 +103,18 @@ public:
 
   bool isSameConfiguration(TacticBase * other_tactic)
   {
-    return name == other_tactic->name && robots.size() == other_tactic->robots.size() && [&]() {
+    // 名前が異なる場合は別の設定
+    if (name != other_tactic->name) {
+      return false;
+    }
+
+    // どちらかのrobotsが空の場合は、名前のみで判定（ロボット割り当て前の比較用）
+    if (robots.empty() || other_tactic->robots.empty()) {
+      return true;
+    }
+
+    // 両方ともrobotsが設定されている場合は、ロボット構成も比較
+    return robots.size() == other_tactic->robots.size() && [&]() {
       std::vector<RobotIdentifier> ours = this->robots;
       std::vector<RobotIdentifier> others = other_tactic->robots;
       std::ranges::sort(ours, [](const auto & a, const auto & b) -> bool { return a.id < b.id; });


### PR DESCRIPTION
## 概要

Tacticの再利用機構を改善し、ロボットコマンドに現在の速度情報を付加する機能を実装しました。

## 主な変更

### 1. Tacticの再利用機構の改善

- **`TacticRegistry`**: Tacticの再利用/新規作成を明示的にログ出力
- **`TacticBase::isSameConfiguration`**: ロボット配列が空の場合は名前のみで判定するように改良
  - Tactic生成前の比較でも正しく動作するようになります
- **`RobotAllocator`**: ロギングを整理（前回のプランナー数を追加、冗長なログを削除）

### 2. PositionCommandsへの速度情報設定

- **`TacticBase::getPositionCommands`**: WorldModelから各ロボットの現在速度を取得し、`PositionCommand`に設定
  - 速度プロファイル生成やプランナーで現在速度を活用可能になります
