### PR TITLE
feat: Attackerをハード制約に

### DIFF
--- a/crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp
@@ -68,23 +68,39 @@ public:
       }
     }
     auto status = skill->run();
-    if (skill->getID() != robots.front().id) {
-      std::stringstream ss;
-      ss << "スキルのIDは" << static_cast<int>(skill->getID()) << "ですが、選択されたロボットのIDは"
-         << static_cast<int>(robots.front().id) << "です。";
-      ss << "スキルのStateは" << magic_enum::enum_name(skill->getCurrentState()) << "です。";
-      RCLCPP_WARN(rclcpp::get_logger("AttackerSkillTactic"), "%s", ss.str().c_str());
-    }
     return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};
   }
 
   auto getRobotSuitabilityFunc() const
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {
-    // ボールに近いロボットを優先（距離が小さいほど適している）
     auto wm = world_model;  // shared_ptrをコピー
-    return
-      [wm](const std::shared_ptr<RobotInfo> & robot) { return robot->getDistance(wm->ball().pos); };
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      // game_analysisで推奨ロボットが設定されている場合、そのロボットを最優先
+      try {
+        const auto & game_analysis = wm->getMsg().game_analysis;
+        if (
+          game_analysis.recommended_attacker_id >= 0 &&
+          robot->id == static_cast<uint8_t>(game_analysis.recommended_attacker_id)) {
+          return 0.0;  // 最高の適性（コスト最小）
+        }
+      } catch (...) {
+      }
+
+      // それ以外はボール距離ベース
+      return robot->getDistance(wm->ball().pos);
+    };
+  }
+
+  bool isHardConstraint() const override
+  {
+    // game_analysisでrecommended_attacker_idが設定されている場合はハード制約として扱う
+    try {
+      const auto & game_analysis = world_model->getMsg().game_analysis;
+      return game_analysis.recommended_attacker_id >= 0;
+    } catch (...) {
+      return false;
+    }
   }
 };
 


### PR DESCRIPTION
## 概要

game_analysisでrecommended_attacker_idが設定されている場合、AttackerSkillTacticをハード制約として扱うように変更しました。

## 変更内容

### `crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp`

1. **ロボット適性関数の改善**
   - `game_analysis.recommended_attacker_id`が設定されている場合、そのロボットに最高の適性（コスト0.0）を付与
   - それ以外のロボットはボール距離ベースで評価（従来通り）

2. **ハード制約の追加**
   - `isHardConstraint()` メソッドをオーバーライド
   - `recommended_attacker_id` が設定されている場合、タクティックをハード制約として扱う
   - これにより、game_analysisで推奨されたロボットが必ず割り当てられる

3. **不要なログ削除**
   - スキルIDとロボットIDの不一致警告を削除（ハード制約で適切なロボットが割り当てられるため）

## 変更の背景

Attacker タクティックにおいて、game_analysis で推奨されたロボットを確実に割り当てるため、ハード制約として実装しました。
