### PR TITLE
防御戦術の改善: SecondThreatDefender復活とロボットID変更対応

### DIFF
--- a/crane_tactic_coordinator/config/unified_session_config.yaml
+++ b/crane_tactic_coordinator/config/unified_session_config.yaml
@@ -7,17 +7,18 @@ situations:
     sessions:
       - name: emplace_robot
         capacity: 1
-      - name: total_defense
-        capacity: 6
-        params:
-          max_defense_line_robots: 2
-          enable_second_threat_defender: true
       - name: attacker_skill
         capacity: 1
       - name: pass_receive
         capacity: 1
+      - name: defender
+        capacity: 2
+      - name: second_threat_defender
+        capacity: 1
       - name: sub_attacker_skill
         capacity: 1
+      - name: marker
+        capacity: 3
       - name: forward
         capacity: 20
   OUR_BALL_PLACEMENT:
@@ -30,15 +31,16 @@ situations:
   OUR_FREE_KICK:
     description: OUR_FREE_KICK
     sessions:
-      - name: total_defense
-        capacity: 3
-        params:
-          max_defense_line_robots: 2
-          enable_second_threat_defender: false
+      - name: goalie_skill
+        capacity: 1
       - name: attacker_skill
         capacity: 1
       - name: pass_receive
         capacity: 1
+      - name: defender
+        capacity: 2
+      - name: marker
+        capacity: 2
       - name: forward
         capacity: 20
   OUR_KICKOFF_START:
@@ -65,13 +67,16 @@ situations:
     sessions:
       - name: emplace_robot
         capacity: 1
-      - name: total_defense
-        capacity: 4
-        params:
-          max_defense_line_robots: 2
-          enable_second_threat_defender: true
+      - name: goalie_skill
+        capacity: 1
+      - name: defender
+        capacity: 2
+      - name: second_threat_defender
+        capacity: 1
       - name: ball_nearby_positioner_skill
         capacity: 1
+      - name: marker
+        capacity: 2
       - name: forward
         capacity: 20
   TEST:
@@ -89,11 +94,12 @@ situations:
   THEIR_FREE_KICK:
     description: THEIR_FREE_KICK
     sessions:
-      - name: total_defense
-        capacity: 4
-        params:
-          max_defense_line_robots: 2
-          enable_second_threat_defender: true
+      - name: goalie_skill
+        capacity: 1
+      - name: defender
+        capacity: 2
+      - name: second_threat_defender
+        capacity: 1
       - name: ball_nearby_positioner_skill
         capacity: 1
       - name: marker

--- a/crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp
@@ -102,6 +102,9 @@ public:
       return false;
     }
   }
+
+protected:
+  void onRobotsChanged() override { skill.reset(); }
 };
 
 }  // namespace crane

--- a/crane_tactics/include/crane_tactics/pass_receiver_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/pass_receiver_tactic.hpp
@@ -75,6 +75,9 @@ public:
     receive_skill->commander()->stopHere().lookAtBall();
     return {TacticBase::Status::RUNNING, {receive_skill->getRobotCommand()}};
   }
+
+protected:
+  void onRobotsChanged() override { receive_skill.reset(); }
 };
 
 }  // namespace crane

--- a/crane_tactics/include/crane_tactics/second_threat_defender_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/second_threat_defender_tactic.hpp
@@ -47,6 +47,9 @@ public:
     };
   }
 
+protected:
+  void onRobotsChanged() override { skill.reset(); }
+
 private:
   std::shared_ptr<skills::SecondThreatDefender> skill;
 };

--- a/crane_tactics/include/crane_tactics/skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/skill_tactic.hpp
@@ -68,6 +68,9 @@ public:
 
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override;
+
+  bool isHardConstraint() const override { return true; }
+
 protected:
   void onRobotsChanged() override { skill.reset(); }
 };

--- a/crane_tactics/include/crane_tactics/skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/skill_tactic.hpp
@@ -50,6 +50,9 @@ namespace crane
       auto status = skill->run();                                                              \
       return {static_cast<TacticBase::Status>(status), {skill->getRobotCommand()}};            \
     }                                                                                          \
+                                                                                               \
+  protected:                                                                                   \
+    void onRobotsChanged() override { skill.reset(); }                                         \
   }
 
 class GoalieSkillTactic : public TacticBase
@@ -65,6 +68,8 @@ public:
 
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override;
+protected:
+  void onRobotsChanged() override { skill.reset(); }
 };
 
 class BallPlacementSkillTactic : public TacticBase
@@ -80,6 +85,9 @@ public:
 
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override;
+
+protected:
+  void onRobotsChanged() override { skill.reset(); }
 };
 
 class SubAttackerSkillTactic : public TacticBase
@@ -95,6 +103,9 @@ public:
 
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override;
+
+protected:
+  void onRobotsChanged() override { skill.reset(); }
 };
 
 class SimpleKickOffSkillTactic : public TacticBase
@@ -110,6 +121,9 @@ public:
 
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override;
+
+protected:
+  void onRobotsChanged() override { skill.reset(); }
 };
 
 class BallNearByPositionerSkillTactic : public TacticBase

--- a/crane_tactics/include/crane_tactics/tactic_base.hpp
+++ b/crane_tactics/include/crane_tactics/tactic_base.hpp
@@ -65,10 +65,20 @@ public:
    */
   void setAllocatedRobots(const std::vector<uint8_t> & robot_ids)
   {
+    // ロボットIDが変更されたかチェック
+    bool robots_changed =
+      robots.size() != robot_ids.size() ||
+      !std::ranges::equal(robots, robot_ids, [](const auto & r, uint8_t id) { return r.id == id; });
+
     robots.clear();
     for (auto id : robot_ids) {
       RobotIdentifier robot_id{true, id};
       robots.emplace_back(robot_id);
+    }
+
+    // 変更があれば通知
+    if (robots_changed) {
+      onRobotsChanged();
     }
   }
 
@@ -179,6 +189,13 @@ public:
   virtual bool isHardConstraint() const { return false; }
 
 protected:
+  /**
+   * @brief ロボット割り当てが変更された時に呼ばれるコールバック
+   *
+   * サブクラスでオーバーライドして、ロボットID変更時の処理を実装する。
+   * 例: スキルオブジェクトの再作成など
+   */
+  virtual void onRobotsChanged() {}
   // ロボットを最適な位置に割り当て、位置コマンドを生成する共通メソッド
   auto assignRobotsToPoints(
     const std::vector<RobotIdentifier> & robots, const std::vector<Point> & target_points,

--- a/crane_tactics/src/second_threat_defender_tactic.cpp
+++ b/crane_tactics/src/second_threat_defender_tactic.cpp
@@ -17,8 +17,7 @@ auto SecondThreatDefenderTactic::calculatePositionCommand(
     return {TacticBase::Status::RUNNING, {}};
   }
   if (not skill) {
-    skill = std::make_shared<skills::SecondThreatDefender>(
-      robots.front().id, world_model);
+    skill = std::make_shared<skills::SecondThreatDefender>(robots.front().id, world_model);
   }
   skill->run();
   return {TacticBase::Status::RUNNING, {skill->getRobotCommand()}};

--- a/crane_tactics/src/second_threat_defender_tactic.cpp
+++ b/crane_tactics/src/second_threat_defender_tactic.cpp
@@ -10,14 +10,17 @@
 namespace crane
 {
 auto SecondThreatDefenderTactic::calculatePositionCommand(
-  [[maybe_unused]] const std::vector<RobotIdentifier> & robots)
+  const std::vector<RobotIdentifier> & robots)
   -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>>
 {
-  if (skill) {
-    skill->run();
-    return {TacticBase::Status::RUNNING, {skill->getRobotCommand()}};
-  } else {
+  if (robots.empty()) {
     return {TacticBase::Status::RUNNING, {}};
   }
+  if (not skill) {
+    skill = std::make_shared<skills::SecondThreatDefender>(
+      robots.front().id, world_model);
+  }
+  skill->run();
+  return {TacticBase::Status::RUNNING, {skill->getRobotCommand()}};
 }
 }  // namespace crane


### PR DESCRIPTION
## 概要
- SecondThreatDefenderTacticを復活
- ロボットID変更時のスキルリセット機能を追加
- GoalieSkillTacticにハード制約フラグを追加

## 変更詳細

### 1. SecondThreatDefenderTacticの復活
セカンドボール脅威（ボールの次に危険な相手ロボット）への防御対応を復活させました。

### 2. ロボットID変更通知への対応
各tacticsに`onRobotsChanged()`メソッドを実装し、担当ロボットIDが変更された際にスキルインスタンスをリセットすることで、状態の一貫性を保証します。

対応したtactics:
- AttackerSkillTactic
- PassReceiverTactic
- SecondThreatDefenderTactic
- GoalieSkillTactic
- BallPlacementSkillTactic
- SubAttackerSkillTactic
- SimpleKickOffSkillTactic

### 3. GoalieSkillTacticのハード制約化
`isHardConstraint()`をオーバーライドし、ゴールキーパーの配置を優先するようにしました。
