### PR TITLE
feat: モーター温度が高いロボットを優先して退出させる機能を追加

### DIFF
--- a/crane_msgs/msg/world_model/RobotInfo.msg
+++ b/crane_msgs/msg/world_model/RobotInfo.msg
@@ -35,3 +35,7 @@ uint16 error_info
 float32 error_value
 builtin_interfaces/Time last_error_stamp
 float32 error_duration_sec
+
+# モーター温度情報（/robot_feedback 由来）
+# motor_temperatures[0-3]: モーター1-4の温度（℃）
+uint8[] motor_temperatures

--- a/crane_tactics/include/crane_tactics/emplace_robot_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/emplace_robot_tactic.hpp
@@ -38,17 +38,10 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
 
-  bool isHardConstraint() const override { return true; }
+  bool isHardConstraint() const override;
 
   auto getRobotSuitabilityFunc() const
-    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
-  {
-    // ゴールキーパーだけ退場させにくくする
-    auto wm = world_model;  // shared_ptrをコピー
-    return [wm](const std::shared_ptr<RobotInfo> & robot) {
-      return (robot->id == wm->getOurGoalieId()) ? 100.0 : 0.0;
-    };
-  }
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override;
 
 private:
   std::unordered_map<uint8_t, std::shared_ptr<skills::EmplaceRobot>> m_skill_map;

--- a/crane_tactics/src/emplace_robot_tactic.cpp
+++ b/crane_tactics/src/emplace_robot_tactic.cpp
@@ -12,6 +12,7 @@ std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
 EmplaceRobotTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
 {
   // GlobalRobotAllocator対応: robotsが変更されたらスキルマップを再生成
+  // ロボットの優先順位はgetRobotSuitabilityFunc()で決定される（モーター温度が高いほど優先）
   if (m_skill_map.size() != robots.size()) {
     m_skill_map.clear();
 
@@ -38,6 +39,41 @@ EmplaceRobotTactic::calculatePositionCommand(const std::vector<RobotIdentifier> 
     robot_commands.emplace_back(skill->getRobotCommand());
   }
   return {TacticBase::Status::RUNNING, robot_commands};
+}
+
+bool EmplaceRobotTactic::isHardConstraint() const
+{
+  // 現在出ているロボット台数が出場可能台数を超えている場合はハード制約
+  auto available_robots = world_model->ours().getAvailableRobots();
+  auto max_allowed = world_model->getOurMaxAllowedBots();
+  return available_robots.size() > max_allowed;
+}
+
+auto EmplaceRobotTactic::getRobotSuitabilityFunc() const
+  -> std::function<double(const std::shared_ptr<RobotInfo> &)>
+{
+  auto wm = world_model;
+  return [wm](const std::shared_ptr<RobotInfo> & robot) {
+    // ゴールキーパーは退場させにくくする
+    if (robot->id == wm->getOurGoalieId()) {
+      return 100.0;
+    }
+
+    // モーター温度の最大値を計算
+    float max_temp = 0.0f;
+    if (robot->motor_temperatures.size() >= 4) {
+      for (size_t i = 0; i < 4; ++i) {
+        max_temp = std::max(max_temp, static_cast<float>(robot->motor_temperatures[i]));
+      }
+    }
+
+    // 温度が高いほど小さい値を返す（逆数）
+    // 温度が0の場合は大きな値を返して退場優先度を下げる
+    if (max_temp > 0.0f) {
+      return 1.0 / max_temp;
+    }
+    return 99.0;  // 温度情報がない場合は退場させにくい
+  };
 }
 
 }  // namespace crane

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -431,6 +431,9 @@ crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
             feedback_robot.error_duration_sec = 0.0f;
           }
 
+          // モーター温度情報を転送
+          feedback_robot.motor_temperatures = feedback.temperatures;
+
           // visionデータとfeedbackデータを統合
           robot = mergeRobotInfo(robot, feedback_robot);
           break;

--- a/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
@@ -133,6 +133,8 @@ auto WorldModelWrapper::update(const crane_msgs::msg::WorldModel & world_model) 
       info->ball_contact.update((info->kicker_center() - ball_.pos).norm() < 0.1);
       // ボールセンサは味方だけ
       info->ball_sensor = robot.ball_sensor;
+      // モーター温度情報を転送
+      info->motor_temperatures = robot.motor_temperatures;
       if (robot.last_ball_sensor_stamp.sec == 0 && robot.last_ball_sensor_stamp.nanosec == 0) {
         info->ball_sensor_stamp = std::nullopt;
       } else {

--- a/utility/crane_physics/include/crane_physics/robot_info.hpp
+++ b/utility/crane_physics/include/crane_physics/robot_info.hpp
@@ -108,6 +108,9 @@ struct RobotInfo
 
   auto geometry() const { return Circle{.center = pose.pos, .radius = 0.060}; }
 
+  // モーター温度情報（/robot_feedback 由来）
+  std::vector<uint8_t> motor_temperatures;
+
   auto getDistance(const Point & pos) const -> double { return (pos - pose.pos).norm(); }
 
   auto getDistance(const Pose2D & pose2d) const -> double


### PR DESCRIPTION
- RobotInfo.msgにmotor_temperaturesフィールドを追加
- WorldModelDataProviderでRobotFeedbackから温度情報を取得
- WorldModelWrapperで温度情報をRobotInfo構造体に転送
- EmplaceRobotTacticのgetRobotSuitabilityFuncで温度の逆数を評価値として返す
- isHardConstraintを動的に判定（ロボット台数 > 出場可能台数のときのみハード制約）