### PR TITLE
速度制御の改善: PC側は方向のみ計算、加速度制限はロボット側/シミュレーション側に委譲

### DIFF
--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -155,17 +155,17 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::PositionCommands & msg) 
       Eigen::Vector2d(current_position.x(), current_position.y()),
       Eigen::Vector2d(command.target_x, command.target_y),
       Eigen::Vector2d(command.current_velocity.x, command.current_velocity.y), max_vel, max_acc);
-    // ルックアヘッド時間を動的に調整：軌道時間の20%または最大0.2秒
-    // 加速初期段階でも十分な速度を目標とするため、固定0.05秒から変更
-    const double lookahead_time = std::min(0.2, std::max(0.05, trajectory.getTotalTime() * 0.2));
-    Eigen::Vector2d next_vel = trajectory.getVelocity(lookahead_time);
-    target_vel << next_vel.x(), next_vel.y();
+    // 軌道の方向のみを使用し、大きさは最大速度を指定
+    // 加速度制限はロボット側で行う（IMU/オドメトリによる高精度制御）
+    Eigen::Vector2d traj_vel = trajectory.getVelocity(0.01);  // 方向取得用（10ms後）
+    if (traj_vel.norm() > 1e-6) {
+      target_vel = traj_vel.normalized() * max_vel;
+    } else {
+      target_vel.setZero();
+    }
 
-    // すでに目標に到達している場合のNaN回避
+    // 終端速度のチェック
     if (target_vel.norm() > 1e-6) {
-      // target_velはすでにBangBangTrajectoryによってスケーリングされています（方向と大きさを含む）
-      // BangBangの同期プロファイルを尊重するため、再度正規化してmax_velを掛ける必要はありません
-      // ただし、終端速度（terminal_velocity）はチェックします
       if (target_vel.norm() < command.local_planner_config.terminal_velocity) {
         target_vel = target_vel.normalized() * command.local_planner_config.terminal_velocity;
       }

--- a/crane_sender/src/sim_sender.cpp
+++ b/crane_sender/src/sim_sender.cpp
@@ -6,6 +6,7 @@
 
 #include "crane_sender/sim_sender.hpp"
 
+#include <Eigen/Core>
 #include <crane_geometry/boost_geometry.hpp>
 #include <crane_geometry/geometry_operations.hpp>
 #include <iostream>
@@ -30,32 +31,49 @@ void SimSenderComponent::sendCommands(const crane_msgs::msg::VelocityCommands & 
     omega = std::clamp(omega, -command.omega_limit, command.omega_limit);
     move_local_velocity->set_angular(omega);
 
-    // VelocityCommand は常に極座標速度モード
-    double v_r = command.target_velocity_r;
-    double current_theta = command.current_pose.theta + omega * delay_s;
-    double velocity_theta = command.target_velocity_theta - current_theta;
+    // グローバル座標での速度ベクトルを使用
+    Eigen::Vector2d current_vel(command.current_velocity.x, command.current_velocity.y);
 
-    double current_velocity = std::hypot(command.current_velocity.x, command.current_velocity.y);
-    double target_velocity = v_r;
+    // 目標速度（極座標からグローバル座標に変換）
+    Eigen::Vector2d target_vel(
+      command.target_velocity_r * std::cos(command.target_velocity_theta),
+      command.target_velocity_r * std::sin(command.target_velocity_theta));
 
+    // 速度変化量を計算し、加速度制限を適用
+    Eigen::Vector2d delta_vel = target_vel - current_vel;
+    double delta_vel_norm = delta_vel.norm();
+
+    double current_speed = current_vel.norm();
+    double target_speed = target_vel.norm();
     double acceleration_limit = calculateAccelerationLimit(
-      current_velocity, target_velocity, robot_acceleration_acceleration_,
+      current_speed, target_speed, robot_acceleration_acceleration_,
       robot_acceleration_deceleration_high_, robot_acceleration_deceleration_low_,
       robot_acceleration_velocity_threshold_);
 
     const double dt = 1.0 / 30.0;
+    double max_delta_vel = acceleration_limit * dt;
 
-    double max_velocity_by_acceleration = current_velocity + acceleration_limit * dt;
+    Eigen::Vector2d limited_vel;
+    if (delta_vel_norm > max_delta_vel && delta_vel_norm > 1e-6) {
+      limited_vel = current_vel + delta_vel.normalized() * max_delta_vel;
+    } else {
+      limited_vel = target_vel;
+    }
 
-    double limited_velocity = std::min(target_velocity, max_velocity_by_acceleration);
-
-    double vx = limited_velocity * cos(velocity_theta);
-    double vy = limited_velocity * sin(velocity_theta);
+    // グローバル座標からローカル座標（ロボット座標系）に変換
+    // forward = x * cos(θ) + y * sin(θ)
+    // left = -x * sin(θ) + y * cos(θ)
+    double current_theta = command.current_pose.theta + omega * delay_s;
+    double cos_theta = std::cos(current_theta);
+    double sin_theta = std::sin(current_theta);
+    double vx = limited_vel.x() * cos_theta + limited_vel.y() * sin_theta;   // forward
+    double vy = -limited_vel.x() * sin_theta + limited_vel.y() * cos_theta;  // left
 
     move_local_velocity->set_forward(vx);
     move_local_velocity->set_left(vy);
 
-    robot_states_[command.robot_id].previous_velocity = Velocity(vx, vy);
+    // グローバル座標で速度を保存
+    robot_states_[command.robot_id].previous_velocity = Velocity(limited_vel.x(), limited_vel.y());
 
     // ストップ
     if (command.stop_flag) {


### PR DESCRIPTION
## 概要

PC側の速度計算とシミュレーション/実機での加速度制限の役割分担を明確化し、制御性を改善しました。

## 変更内容

### 1. RVO2Planner: 軌道方向のみを使用 (#1コミット)

**問題点**:
- lookahead時間で速度の方向と大きさ両方を計算していた
- PC側の遅延した情報では最適な速度の大きさを計算できない
- オーバーシュートや加速の遅さが発生

**解決策**:
- BangBangTrajectoryから速度の**方向のみ**を取得（10ms後の速度）
- 速度の**大きさは最大速度**を指定
- 加速度制限はロボット側に委譲（IMU/オドメトリ使用）

**役割分担**:
| 役割 | 担当 | 理由 |
|------|------|------|
| 速度の方向 | PC側（BangBangTrajectory） | X/Y軸同期が必要 |
| 速度の大きさ | ロボット側 | IMU/オドメトリで高精度制御 |

### 2. sim_sender: ベクトル加速度制限を実装 (#2コミット)

**問題点**:
- grSimは速度指令のみ受け付け、加速度制約を送信できない
- 実機ではロボット側で加速度制限が行われるが、シミュレーションでは未実装
- シミュレーションと実機で挙動が大きく異なる

**解決策**:
- sim_senderでベクトル加速度制限を実装
- スカラー制限（速度の大きさのみ）→ベクトル制限（X/Y軸同期）に変更
- 速度変化ベクトルの大きさを `max_acc × dt` で制限

**実装詳細**:
```cpp
// 1. グローバル座標で速度ベクトルの差分を計算
Eigen::Vector2d delta_vel = target_vel - current_vel;

// 2. 差分の大きさを制限（方向は維持）
if (delta_vel.norm() > max_delta_vel) {
  limited_vel = current_vel + delta_vel.normalized() * max_delta_vel;
}

// 3. ローカル座標に変換してgrSimに送信
```

## 期待される効果

### RVO2Planner
- ✅ オーバーシュートの解消
- ✅ 十分な加速性能
- ✅ 直線的な軌道（BangBangTrajectoryのX/Y軸同期を維持）
- ✅ パラメータ調整不要

### sim_sender
- ✅ 加速・減速が滑らかに（実機と同様）
- ✅ X/Y軸が同期的に制限される（方向維持）
- ✅ シミュレーションでの動作検証精度が向上
