### PR TITLE
タクティックにロボット割り当て変更時の内部状態リセット機能を追加

### DIFF
--- a/crane_tactics/include/crane_tactics/forward_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/forward_tactic.hpp
@@ -46,6 +46,10 @@ public:
     };
   }
 
+protected:
+  void onRobotsChanged() override { forward_skills.clear(); }
+
+private:
   std::vector<std::shared_ptr<skills::Forward>> forward_skills;
 };
 }  // namespace crane

--- a/crane_tactics/include/crane_tactics/our_free_kick_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/our_free_kick_tactic.hpp
@@ -45,6 +45,29 @@ public:
 
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
+
+protected:
+  void onRobotsChanged() override
+  {
+    // ロボット割り当てが変更されたら、kickerとother_robotsを再初期化
+    kicker.reset();
+    other_robots.clear();
+    fake_over = false;
+    fake_count = 0;
+
+    if (!robots.empty()) {
+      // 最初のロボットをキッカーとして選択
+      kicker =
+        std::make_shared<PositionCommandWrapper>("our_direct_free_kick", robots[0].id, world_model);
+
+      // 残りのロボットをother_robotsに割り当て
+      for (size_t i = 1; i < robots.size(); ++i) {
+        auto command = std::make_shared<PositionCommandWrapper>(
+          "our_direct_free_kick", robots[i].id, world_model);
+        other_robots.push_back(command);
+      }
+    }
+  }
 };
 }  // namespace crane
 #endif  // CRANE_TACTICS__OUR_FREE_KICK_TACTIC_HPP_

--- a/crane_tactics/include/crane_tactics/our_penalty_kick_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/our_penalty_kick_tactic.hpp
@@ -38,6 +38,26 @@ public:
 
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
+
+protected:
+  void onRobotsChanged() override
+  {
+    // ロボット割り当てが変更されたら、kickerとother_robotsを再初期化
+    kicker.reset();
+    other_robots.clear();
+
+    if (!robots.empty()) {
+      // 最初のロボットをキッカーとして選択
+      kicker = std::make_shared<skills::PenaltyKick>(robots[0].id, world_model);
+
+      // 残りのロボットをother_robotsに割り当て
+      for (size_t i = 1; i < robots.size(); ++i) {
+        auto command =
+          std::make_shared<PositionCommandWrapper>("our_penalty_kick", robots[i].id, world_model);
+        other_robots.push_back(command);
+      }
+    }
+  }
 };
 }  // namespace crane
 #endif  // CRANE_TACTICS__OUR_PENALTY_KICK_TACTIC_HPP_

--- a/crane_tactics/include/crane_tactics/placement_avoidance_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/placement_avoidance_tactic.hpp
@@ -24,16 +24,8 @@
 
 namespace crane
 {
-struct CommandWithOriginalPosition
-{
-  std::shared_ptr<PositionCommandWrapper> command;
-  Point original_position;
-};
 class BallPlacementAvoidanceTactic : public TacticBase
 {
-private:
-  std::vector<CommandWithOriginalPosition> commands;
-
 public:
   COMPOSITION_PUBLIC explicit BallPlacementAvoidanceTactic(
     WorldModelWrapper::SharedPtr & world_model, rclcpp::Node &)
@@ -55,22 +47,32 @@ public:
       }
     };
 
-    for (auto & command : commands) {
-      if (isInPlacementArea(command.original_position, 0.2)) {
+    for (const auto & robot_id : robots) {
+      auto robot = world_model->getOurRobot(robot_id.id);
+      if (!robot) {
+        continue;
+      }
+
+      Point current_position = robot->pose.pos;
+      auto command = std::make_shared<PositionCommandWrapper>(
+        "ball_placement_avoidance", robot_id.id, world_model);
+
+      Point target_position = current_position;
+
+      if (isInPlacementArea(current_position, 0.2)) {
         auto [distance, closest_point] = getClosestPointAndDistance(
-          world_model->getBallPlacementArea().value().segment, command.original_position);
-        // 0.6m離れる
-        Point target_position =
-          closest_point + (command.original_position - closest_point).normalized() * 0.8;
+          world_model->getBallPlacementArea().value().segment, current_position);
+        // 0.8m離れる
+        target_position = closest_point + (current_position - closest_point).normalized() * 0.8;
+
         if (not world_model->point_checker.isFieldInside(target_position, 0.2)) {
-          // 一番近いフィールド外のポイントがだめなので逆方向に0.6m離れる
-          target_position =
-            closest_point + (closest_point - command.original_position).normalized() * 0.8;
+          // 一番近いフィールド外のポイントがだめなので逆方向に0.8m離れる
+          target_position = closest_point + (closest_point - current_position).normalized() * 0.8;
 
           if (auto segment = world_model->getBallPlacementArea().value().segment;
               (closest_point == segment.first || closest_point == segment.second)) {
             // 一番近い点が端点の場合は単純に反対側の点を選択するだけではだめなので、
-            // 垂直方向に0.6m離れた点を複数選択して、フィールド外かつ配置エリア外の点を選択する
+            // 垂直方向に0.8m離れた点を複数選択して、フィールド内かつ配置エリア外の点を選択する
             std::vector<Point> target_candidates;
             Vector2 vertical_vec =
               getVerticalVec((segment.second - segment.first).normalized()) * 0.8;
@@ -81,33 +83,29 @@ public:
                   target_candidates,
                   [&](const auto & target_candidate) {
                     return (
-                      not world_model->point_checker.isFieldInside(target_candidate, 0.2) &&
+                      world_model->point_checker.isFieldInside(target_candidate, 0.2) &&
                       not isInPlacementArea(target_candidate, 0.1));
                   });
                 target != target_candidates.end()) {
               target_position = *target;
             } else {
               // どの候補もだめな場合は移動しない
-              target_position = command.original_position;
+              target_position = current_position;
             }
           }
         }
-        // ボールプレイスメントエリアを横切ってしまうことがあるため、上書きしてしまう
-        command.original_position = target_position;
-        command.command->setTargetPosition(target_position);
+
         visualizer->line()
-          .start(command.original_position)
+          .start(current_position)
           .end(target_position)
           .stroke("yellow")
           .strokeWidth(20)
           .build();
-      } else {
-        command.command->setTargetPosition(command.original_position);
       }
 
-      command.command->disableGoalAreaAvoidance().setTargetTheta(
-        command.command->getMsg().current_pose.theta);
-      robot_commands.push_back(command.command->getMsg());
+      command->setTargetPosition(target_position);
+      command->disableGoalAreaAvoidance().setTargetTheta(robot->pose.theta);
+      robot_commands.push_back(command->getMsg());
     }
     return {Status::RUNNING, robot_commands};
   }

--- a/crane_tactics/include/crane_tactics/skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/skill_tactic.hpp
@@ -142,6 +142,9 @@ public:
 
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override;
+
+protected:
+  void onRobotsChanged() override { skills.clear(); }
 };
 
 class PlacementTargetNearByPositionerSkillTactic : public TacticBase
@@ -157,6 +160,9 @@ public:
 
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override;
+
+protected:
+  void onRobotsChanged() override { skills.clear(); }
 };
 }  // namespace crane
 #endif  // CRANE_TACTICS__SKILL_TACTIC_HPP_

--- a/crane_tactics/include/crane_tactics/their_penalty_kick_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/their_penalty_kick_tactic.hpp
@@ -39,6 +39,26 @@ public:
 
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
+
+protected:
+  void onRobotsChanged() override
+  {
+    // ロボット割り当てが変更されたら、goalieとother_robotsを再初期化
+    goalie.reset();
+    other_robots.clear();
+
+    if (!robots.empty()) {
+      // 最初のロボットをゴーリーとして選択
+      goalie = std::make_shared<skills::Goalie>(robots[0].id, world_model);
+
+      // 残りのロボットをother_robotsに割り当て
+      for (size_t i = 1; i < robots.size(); ++i) {
+        auto command =
+          std::make_shared<PositionCommandWrapper>("their_penalty_kick", robots[i].id, world_model);
+        other_robots.push_back(command);
+      }
+    }
+  }
 };
 }  // namespace crane
 #endif  // CRANE_TACTICS__THEIR_PENALTY_KICK_TACTIC_HPP_

--- a/crane_tactics/src/marker_tactic.cpp
+++ b/crane_tactics/src/marker_tactic.cpp
@@ -96,6 +96,16 @@ auto MarkerTactic::assignMarkingTarget(
         "black", 20);
     }
   }
+
+  // マークする敵がいない場合、残りのロボットには待機スキルを割り当てる
+  for (const auto & robot : remaining_selectable_robots) {
+    markers.emplace_back(
+      std::make_shared<skills::Marker>(
+        "marker_planner", static_cast<uint8_t>(robot->id), world_model));
+    // デフォルトのパラメータで待機させる（マーク対象なし）
+    selected_robots.push_back(robot->id);
+  }
+
   return selected_robots;
 }
 }  // namespace crane

--- a/crane_tactics/src/our_free_kick_tactic.cpp
+++ b/crane_tactics/src/our_free_kick_tactic.cpp
@@ -13,8 +13,7 @@
 namespace crane
 {
 std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
-OurDirectFreeKickTactic::calculatePositionCommand(
-  [[maybe_unused]] const std::vector<RobotIdentifier> & robots)
+OurDirectFreeKickTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
 {
   std::vector<crane_msgs::msg::PositionCommand> robot_commands;
 

--- a/crane_tactics/src/our_penalty_kick_tactic.cpp
+++ b/crane_tactics/src/our_penalty_kick_tactic.cpp
@@ -9,8 +9,7 @@
 namespace crane
 {
 std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
-OurPenaltyKickTactic::calculatePositionCommand(
-  [[maybe_unused]] const std::vector<RobotIdentifier> &)
+OurPenaltyKickTactic::calculatePositionCommand(const std::vector<RobotIdentifier> &)
 {
   std::vector<crane_msgs::msg::PositionCommand> robot_commands;
 

--- a/crane_tactics/src/their_penalty_kick_tactic.cpp
+++ b/crane_tactics/src/their_penalty_kick_tactic.cpp
@@ -9,8 +9,7 @@
 namespace crane
 {
 std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
-TheirPenaltyKickTactic::calculatePositionCommand(
-  [[maybe_unused]] const std::vector<RobotIdentifier> & robots)
+TheirPenaltyKickTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
 {
   std::vector<crane_msgs::msg::PositionCommand> robot_commands;
 


### PR DESCRIPTION
## 概要

複数のタクティッククラスに `onRobotsChanged()` メソッドを実装し、ロボット割り当てが変更された際に内部状態を適切にリセットする機能を追加しました。

## 主な変更内容

- **ForwardTactic, SkillTactic類**: スキルリストをクリアする `onRobotsChanged()` を追加
- **OurDirectFreeKickTactic**: kicker、other_robots、フェイク関連状態のリセット処理を追加
- **OurPenaltyKickTactic**: kicker、other_robotsのリセット処理を追加
- **TheirPenaltyKickTactic**: goalie、other_robotsのリセット処理を追加
- **BallPlacementAvoidanceTactic**: 内部状態管理を簡素化し、リアルタイム処理に変更
- **MarkerTactic**: マーク対象がいない場合の待機スキル割り当てを追加
