### PR TITLE
robot_commandsの型をVelocityCommandsに変更

### DIFF
--- a/crane_debug_tools/src/simple_web_server.cpp
+++ b/crane_debug_tools/src/simple_web_server.cpp
@@ -8,7 +8,7 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cctype>
 #include <crane_msgs/action/skill_execution.hpp>
-#include <crane_msgs/msg/robot_commands.hpp>
+#include <crane_msgs/msg/velocity_commands.hpp>
 #include <crane_msgs/msg/world_model.hpp>
 #include <filesystem>
 #include <fstream>
@@ -48,8 +48,8 @@ public:
         latest_world_model_ = msg;
       });
 
-    robot_commands_sub_ = this->create_subscription<crane_msgs::msg::RobotCommands>(
-      "/robot_commands", 10, [this](const crane_msgs::msg::RobotCommands::SharedPtr msg) {
+    robot_commands_sub_ = this->create_subscription<crane_msgs::msg::VelocityCommands>(
+      "/robot_commands", 10, [this](const crane_msgs::msg::VelocityCommands::SharedPtr msg) {
         // Store latest robot commands
         latest_robot_commands_ = msg;
       });
@@ -80,7 +80,7 @@ private:
   // ROS components
   SkillExecutionClient::SharedPtr skill_client_;
   rclcpp::Subscription<crane_msgs::msg::WorldModel>::SharedPtr world_model_sub_;
-  rclcpp::Subscription<crane_msgs::msg::RobotCommands>::SharedPtr robot_commands_sub_;
+  rclcpp::Subscription<crane_msgs::msg::VelocityCommands>::SharedPtr robot_commands_sub_;
 
   // HTTP server components
   std::thread server_thread_;
@@ -90,7 +90,7 @@ private:
 
   // Latest data storage
   crane_msgs::msg::WorldModel::SharedPtr latest_world_model_;
-  crane_msgs::msg::RobotCommands::SharedPtr latest_robot_commands_;
+  crane_msgs::msg::VelocityCommands::SharedPtr latest_robot_commands_;
 };
 
 int main(int argc, char ** argv)

--- a/crane_debug_tools/src/state_history_logger.cpp
+++ b/crane_debug_tools/src/state_history_logger.cpp
@@ -105,7 +105,7 @@ public:
     }
 
     // サブスクライバー作成
-    robot_commands_sub_ = this->create_subscription<crane_msgs::msg::RobotCommands>(
+    robot_commands_sub_ = this->create_subscription<crane_msgs::msg::VelocityCommands>(
       "/robot_commands", 10,
       std::bind(&StateHistoryLogger::robotCommandsCallback, this, std::placeholders::_1));
 

--- a/crane_debug_tools/src/web_bridge_server.cpp
+++ b/crane_debug_tools/src/web_bridge_server.cpp
@@ -55,9 +55,10 @@ public:
       "/world_model", 10,
       [this](const crane_msgs::msg::WorldModel::SharedPtr msg) { broadcastWorldModel(msg); });
 
-    robot_commands_sub_ = this->create_subscription<crane_msgs::msg::RobotCommands>(
-      "/robot_commands", 10,
-      [this](const crane_msgs::msg::RobotCommands::SharedPtr msg) { broadcastRobotCommands(msg); });
+    robot_commands_sub_ = this->create_subscription<crane_msgs::msg::VelocityCommands>(
+      "/robot_commands", 10, [this](const crane_msgs::msg::VelocityCommands::SharedPtr msg) {
+        broadcastRobotCommands(msg);
+      });
 
     // Initialize WebSocket server
     initializeWebSocketServer();
@@ -412,7 +413,7 @@ private:
     broadcastToAll(world_model);
   }
 
-  void broadcastRobotCommands(const crane_msgs::msg::RobotCommands::SharedPtr msg)
+  void broadcastRobotCommands(const crane_msgs::msg::VelocityCommands::SharedPtr msg)
   {
     json commands = {{"type", "robot_commands"}, {"commands", json::array()}};
 
@@ -448,7 +449,7 @@ private:
   // ROS components
   SkillExecutionClient::SharedPtr skill_client_;
   rclcpp::Subscription<crane_msgs::msg::WorldModel>::SharedPtr world_model_sub_;
-  rclcpp::Subscription<crane_msgs::msg::RobotCommands>::SharedPtr robot_commands_sub_;
+  rclcpp::Subscription<crane_msgs::msg::VelocityCommands>::SharedPtr robot_commands_sub_;
 
   // WebSocket components
   WebSocketServer server_;

--- a/crane_debug_tools/src/websocket_server.cpp
+++ b/crane_debug_tools/src/websocket_server.cpp
@@ -15,7 +15,7 @@
 #include <cctype>
 #include <chrono>
 #include <crane_msgs/action/skill_execution.hpp>
-#include <crane_msgs/msg/robot_commands.hpp>
+#include <crane_msgs/msg/velocity_commands.hpp>
 #include <crane_msgs/msg/world_model.hpp>
 #include <crane_visualization_interfaces/msg/svg_snapshot.hpp>
 #include <crane_visualization_interfaces/msg/svg_updates.hpp>
@@ -262,9 +262,10 @@ public:
       "/world_model", 10,
       [this](const crane_msgs::msg::WorldModel::SharedPtr msg) { broadcastWorldModel(msg); });
 
-    robot_commands_sub_ = this->create_subscription<crane_msgs::msg::RobotCommands>(
-      "/robot_commands", 10,
-      [this](const crane_msgs::msg::RobotCommands::SharedPtr msg) { broadcastRobotCommands(msg); });
+    robot_commands_sub_ = this->create_subscription<crane_msgs::msg::VelocityCommands>(
+      "/robot_commands", 10, [this](const crane_msgs::msg::VelocityCommands::SharedPtr msg) {
+        broadcastRobotCommands(msg);
+      });
 
     aggregated_svgs_sub_ =
       this->create_subscription<crane_visualization_interfaces::msg::SvgSnapshot>(
@@ -598,7 +599,7 @@ private:
     broadcastToAll(world_model.dump());
   }
 
-  void broadcastRobotCommands(const crane_msgs::msg::RobotCommands::SharedPtr msg)
+  void broadcastRobotCommands(const crane_msgs::msg::VelocityCommands::SharedPtr msg)
   {
     json commands = {{"type", "robot_commands"}, {"commands", json::array()}};
 
@@ -777,7 +778,7 @@ private:
   // ROS components
   SkillExecutionClient::SharedPtr skill_client_;
   rclcpp::Subscription<crane_msgs::msg::WorldModel>::SharedPtr world_model_sub_;
-  rclcpp::Subscription<crane_msgs::msg::RobotCommands>::SharedPtr robot_commands_sub_;
+  rclcpp::Subscription<crane_msgs::msg::VelocityCommands>::SharedPtr robot_commands_sub_;
   rclcpp::Subscription<crane_visualization_interfaces::msg::SvgSnapshot>::SharedPtr
     aggregated_svgs_sub_;
   rclcpp::Subscription<crane_visualization_interfaces::msg::SvgUpdates>::SharedPtr

--- a/scripts/measure_laytency.py
+++ b/scripts/measure_laytency.py
@@ -5,7 +5,7 @@ import rclpy
 from rclpy.node import Node
 from robocup_ssl_msgs.msg import RobotId, TrackedFrame
 
-from crane_msgs.msg import RobotCommands
+from crane_msgs.msg import VelocityCommands
 
 
 class MeasureLatency(Node):
@@ -15,7 +15,7 @@ class MeasureLatency(Node):
             TrackedFrame, "/detection_tracked", self.detection_callback, 10
         )
         self.command_sub = self.create_subscription(
-            RobotCommands, "/robot_commands", self.command_callback, 10
+            VelocityCommands, "/robot_commands", self.command_callback, 10
         )
         self.robot_id = 0
         self.move_start_time = None


### PR DESCRIPTION
## Summary
- `/robot_commands` トピックのメッセージ型を `RobotCommands` から `VelocityCommands` に変更
- crane_debug_tools の各サーバーおよびスクリプトを更新
