### PR TITLE
ベクトル加速度制限とVision遅延補償、疑似I項による目標到達改善

### DIFF
--- a/crane_local_planner/src/crane_local_planner.cpp
+++ b/crane_local_planner/src/crane_local_planner.cpp
@@ -42,6 +42,10 @@ auto LocalPlannerComponent::callbackPositionCommands(const crane_msgs::msg::Posi
   }
 
   // 位置指令を検証して処理
+  // 【座標系の設計】
+  // - 位置・速度のベクトル成分(x,y)：フィールド座標系のまま（theta_offset未適用）
+  // - 角度(theta)：theta_offsetを適用（half_court_practice_mode対応）
+  // - この設計により、位置・速度は元の座標系を保持しつつ、角度だけ変換できる
   crane_msgs::msg::PositionCommands commands;
   for (const auto & raw_command : msg.robot_commands) {
     // 位置目標の可視化
@@ -51,13 +55,13 @@ auto LocalPlannerComponent::callbackPositionCommands(const crane_msgs::msg::Posi
 
     crane_msgs::msg::PositionCommand command = raw_command;
     auto robot = world_model->getOurRobot(command.robot_id);
-    command.current_pose.x = robot->pose.pos.x();
-    command.current_pose.y = robot->pose.pos.y();
-    command.current_pose.theta = robot->pose.theta + theta_offset;
-    command.current_velocity.x = robot->vel.linear.x();
-    command.current_velocity.y = robot->vel.linear.y();
+    command.current_pose.x = robot->pose.pos.x();  // フィールド座標系
+    command.current_pose.y = robot->pose.pos.y();  // フィールド座標系
+    command.current_pose.theta = robot->pose.theta + theta_offset;  // theta_offset適用
+    command.current_velocity.x = robot->vel.linear.x();  // フィールド座標系
+    command.current_velocity.y = robot->vel.linear.y();  // フィールド座標系
     command.current_velocity.theta = robot->vel.omega;
-    command.target_theta += theta_offset;
+    command.target_theta += theta_offset;  // theta_offset適用
     commands.robot_commands.push_back(command);
   }
 

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -157,9 +157,8 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::PositionCommands & msg) 
       Eigen::Vector2d(command.current_velocity.x, command.current_velocity.y), max_vel, max_acc);
 
     // BangBangTrajectoryから速度を取得
-    // sim_sender側のベクトル加速度制限で方向変化時の加速度も制限される
-    // lookahead時間を短くすることでVision遅延の影響を軽減
-    const double lookahead_time = 0.05;
+    // Vision遅延（~100ms）を考慮してlookahead時間を設定
+    const double lookahead_time = 0.1;
     Eigen::Vector2d next_vel = trajectory.getVelocity(lookahead_time);
     target_vel << next_vel.x(), next_vel.y();
 

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -155,21 +155,16 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::PositionCommands & msg) 
       Eigen::Vector2d(current_position.x(), current_position.y()),
       Eigen::Vector2d(command.target_x, command.target_y),
       Eigen::Vector2d(command.current_velocity.x, command.current_velocity.y), max_vel, max_acc);
-    // ルックアヘッド時間を動的に調整：軌道時間の20%または最大0.2秒
-    // 加速初期段階でも十分な速度を目標とするため、固定0.05秒から変更
-    const double lookahead_time = std::min(0.2, std::max(0.05, trajectory.getTotalTime() * 0.2));
+
+    // BangBangTrajectoryから速度を取得
+    // sim_sender側のベクトル加速度制限で方向変化時の加速度も制限される
+    // lookahead時間を短くすることでVision遅延の影響を軽減
+    const double lookahead_time = 0.05;
     Eigen::Vector2d next_vel = trajectory.getVelocity(lookahead_time);
     target_vel << next_vel.x(), next_vel.y();
 
-    // すでに目標に到達している場合のNaN回避
-    if (target_vel.norm() > 1e-6) {
-      // target_velはすでにBangBangTrajectoryによってスケーリングされています（方向と大きさを含む）
-      // BangBangの同期プロファイルを尊重するため、再度正規化してmax_velを掛ける必要はありません
-      // ただし、終端速度（terminal_velocity）はチェックします
-      if (target_vel.norm() < command.local_planner_config.terminal_velocity) {
-        target_vel = target_vel.normalized() * command.local_planner_config.terminal_velocity;
-      }
-    } else {
+    // 目標到達済みの場合
+    if (target_vel.norm() < 1e-6) {
       target_vel.setZero();
     }
     rvo_sim->setAgentPrefVelocity(command.robot_id, toRVO(target_vel));
@@ -234,6 +229,11 @@ auto RVO2Planner::extractVelocityCommandsFromRVOSim(
     }
 
     command.target_velocity_r = vel.norm();
+    // 座標系の設計について：
+    // - target_velocity_thetaはtheta_offsetを含む（half_court_practice_mode対応）
+    // - vel.x/y（RVOの出力）はフィールド座標系のまま（theta_offset未適用）
+    // - sim_senderで velocity_theta = target_velocity_theta - current_theta により
+    //   ロボットローカル座標系に変換される
     command.target_velocity_theta = std::atan2(vel.y(), vel.x()) + theta_offset;
 
     // 解決済みの速度・加速度制限を設定

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -160,11 +160,29 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::PositionCommands & msg) 
     // Vision遅延（~100ms）を考慮してlookahead時間を設定
     const double lookahead_time = 0.1;
     Eigen::Vector2d next_vel = trajectory.getVelocity(lookahead_time);
-    target_vel << next_vel.x(), next_vel.y();
 
-    // 目標到達済みの場合
-    if (target_vel.norm() < 1e-6) {
+    // 目標との距離を計算
+    double distance_to_target = std::hypot(
+      command.target_x - current_position.x(), command.target_y - current_position.y());
+
+    // 疑似I項：低速かつ目標から離れている場合に補正
+    // terminal_velocity（0の場合はフォールバック値0.3 m/sを使用）
+    const double terminal_vel = command.local_planner_config.terminal_velocity > 0
+                                  ? command.local_planner_config.terminal_velocity
+                                  : 0.3;
+    const double min_distance =
+      std::max(static_cast<double>(command.position_tolerance) * 2, 0.03);  // 最低3cm
+
+    if (next_vel.norm() < terminal_vel && distance_to_target > min_distance) {
+      // 低速かつ目標から離れている場合、目標方向への terminal_velocity を設定
+      Eigen::Vector2d direction =
+        (Eigen::Vector2d(command.target_x, command.target_y) - current_position).normalized();
+      target_vel = direction * terminal_vel;
+    } else if (next_vel.norm() < 1e-6) {
+      // 目標到達済み
       target_vel.setZero();
+    } else {
+      target_vel << next_vel.x(), next_vel.y();
     }
     rvo_sim->setAgentPrefVelocity(command.robot_id, toRVO(target_vel));
     rvo_sim->setAgentMaxSpeed(command.robot_id, max_vel);

--- a/crane_sender/src/sim_sender.cpp
+++ b/crane_sender/src/sim_sender.cpp
@@ -30,31 +30,55 @@ void SimSenderComponent::sendCommands(const crane_msgs::msg::VelocityCommands & 
     omega = std::clamp(omega, -command.omega_limit, command.omega_limit);
     move_local_velocity->set_angular(omega);
 
-    // VelocityCommand は常に極座標速度モード
-    double v_r = command.target_velocity_r;
+    // VelocityCommand は極座標速度モード
+    //
+    // 【座標系の設計について】
+    // RVO2Plannerから受け取る座標系：
+    // - target_velocity_theta: theta_offsetを含むGLOBAL角度
+    // - current_pose.theta: theta_offsetを含むGLOBAL角度
+    // - current_velocity.x/y: フィールド座標系（theta_offset未適用）※参考用のみ
+    //
+    // 本実装では：
+    // - velocity_theta = target_velocity_theta - current_theta でロボットローカル角度に変換
+    // - ローカル座標系で速度ベクトルを構築してベクトル加速度制限を適用
+    // - previous_velocity（前回の出力、ローカル座標）を現在速度として使用
     double current_theta = command.current_pose.theta + omega * delay_s;
+    const double dt = 1.0 / 30.0;
+
+    // Step 1: ロボットローカル座標系での目標速度ベクトルを構築
     double velocity_theta = command.target_velocity_theta - current_theta;
+    Eigen::Vector2d target_vel_local(
+      command.target_velocity_r * std::cos(velocity_theta),
+      command.target_velocity_r * std::sin(velocity_theta));
 
-    double current_velocity = std::hypot(command.current_velocity.x, command.current_velocity.y);
-    double target_velocity = v_r;
+    // Step 2: ローカル座標系での現在速度（前回の出力速度を使用）
+    Eigen::Vector2d current_vel_local = robot_states_[command.robot_id].previous_velocity;
 
+    // Step 3: 加速度制限を選択（速度の大きさで加速/減速を判定）
+    double current_speed = current_vel_local.norm();
+    double target_speed = target_vel_local.norm();
     double acceleration_limit = calculateAccelerationLimit(
-      current_velocity, target_velocity, robot_acceleration_acceleration_,
+      current_speed, target_speed, robot_acceleration_acceleration_,
       robot_acceleration_deceleration_high_, robot_acceleration_deceleration_low_,
       robot_acceleration_velocity_threshold_);
 
-    const double dt = 1.0 / 30.0;
+    // Step 4: ローカル座標系で速度変化ベクトルの大きさを制限（方向は維持）
+    Eigen::Vector2d delta_vel = target_vel_local - current_vel_local;
+    double max_delta_vel = acceleration_limit * dt;
+    Eigen::Vector2d limited_vel_local;
+    if (delta_vel.norm() > max_delta_vel) {
+      limited_vel_local = current_vel_local + delta_vel.normalized() * max_delta_vel;
+    } else {
+      limited_vel_local = target_vel_local;
+    }
 
-    double max_velocity_by_acceleration = current_velocity + acceleration_limit * dt;
-
-    double limited_velocity = std::min(target_velocity, max_velocity_by_acceleration);
-
-    double vx = limited_velocity * cos(velocity_theta);
-    double vy = limited_velocity * sin(velocity_theta);
+    double vx = limited_vel_local.x();  // forward
+    double vy = limited_vel_local.y();  // left
 
     move_local_velocity->set_forward(vx);
     move_local_velocity->set_left(vy);
 
+    // 次回の計算用に保存
     robot_states_[command.robot_id].previous_velocity = Velocity(vx, vy);
 
     // ストップ


### PR DESCRIPTION
## 概要

ロボット制御の応答性と精度を向上させるため、以下の3つの改善を実装しました：
1. ベクトル加速度制限の導入
2. Vision遅延を考慮したlookahead時間の最適化
3. 疑似I項による目標到達補正

## 変更内容

### 1. ベクトル加速度制限とlookahead時間の最適化 (#223ab282)

**変更ファイル**:
- `crane_local_planner/src/rvo2_planner.cpp`
- `crane_local_planner/src/crane_local_planner.cpp`
- `crane_sender/src/sim_sender.cpp`

**主な変更**:
- スカラー加速度制限からベクトル加速度制限に変更
  - 方向変化時の加速度も正しく制限
  - ローカル座標系で統一して計算
- lookahead時間を0.05秒に固定（従来の動的調整0.05-0.2秒から変更）
- 座標系の設計に関する詳細なコメントを追加
  - `target_velocity_theta`にはtheta_offsetが含まれる（設計通り）
  - 位置・速度はフィールド座標系、角度のみtheta_offset適用

**効果**:
- Vision遅延（~100ms）の影響を軽減
- 方向変化時の急激な加速度を制限
- X/Y軸同期を維持しながら滑らかな加減速を実現
- オーバーシュートの削減

### 2. lookahead時間をVision遅延に合わせて0.1秒に変更 (#86ca4478)

**変更ファイル**:
- `crane_local_planner/src/rvo2_planner.cpp`
- `crane_local_planner/src/crane_local_planner.cpp`

**主な変更**:
- lookahead時間を0.05秒から0.1秒に変更
- Vision遅延（~100ms）を考慮した値に設定
- 座標系の設計に関するコメントを追加

**効果**:
- Vision遅延分を先読みすることで、より適切なタイミングで速度指令を送信
- ロボットが実際に実行する頃には適切な速度になる

### 3. 疑似I項による目標到達補正を追加 (#1eead8e0)

**変更ファイル**:
- `crane_local_planner/src/rvo2_planner.cpp`

**問題**:
lookahead時間を0.1秒に設定したことで、減速フェーズで目標到達の0.1秒前に速度0を指令してしまい、目標地点に到達する前に停止する問題が発生。

**解決策**:
PIDのI項的な補正を追加：
- 低速かつ目標から離れている場合に、目標方向への速度を設定
- BangBangプロファイル（D項的）+ 疑似I項（補正）の組み合わせ

**発動条件**:
1. BangBangの出力速度が terminal_velocity 以下
2. 目標との距離が min_distance（position_tolerance × 2 または 最低3cm）以上

**補正内容**:
- 目標方向への terminal_velocity で移動
- terminal_velocity が 0 の場合は 0.3 m/s をフォールバック値として使用

**効果**:
- 目標地点に正しく到達できるようになる
- lookahead時間0.1秒の利点（Vision遅延補償）を維持
- オーバーシュートを防止

## テスト

grSimで以下を確認：
- ✅ 加速がスムーズ
- ✅ 減速して目標地点で正しく停止
- ✅ オーバーシュートしない
- ✅ 方向変化時に急激な動きがない

## 関連issue

なし

🤖 Generated with [Claude Code](https://claude.ai/code)