### PR TITLE
Attacker割り当ての頻繁な切り替えを防止

### DIFF
--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
@@ -36,9 +36,14 @@ private:
   rclcpp::Time last_switch_time_{static_cast<int64_t>(0), RCL_ROS_TIME};
   rclcpp::Clock ros_clock_{RCL_ROS_TIME};
 
-  static constexpr double MIN_HOLD_DURATION_SEC = 0.5;
-  static constexpr double MIN_IMPROVEMENT_MARGIN = 0.2;
-};
+  // EMAスコア管理用マップ
+  std::unordered_map<uint8_t, double> ema_scores_;
+
+  // ヒステリシスパラメータ
+  static constexpr double MIN_HOLD_DURATION_SEC = 2.0;     // 2秒に延長
+  static constexpr double MIN_IMPROVEMENT_RATIO = 0.5;     // 50%改善で切り替え（相対値）
+  static constexpr double EMERGENCY_SWITCH_RATIO = 2.0;    // 2倍良ければ即切り替え
+  static constexpr double EMA_ALPHA = 0.3;                 // スムージング係数
 
 }  // namespace crane::metrics
 

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
@@ -40,10 +40,10 @@ private:
   std::unordered_map<uint8_t, double> ema_scores_;
 
   // ヒステリシスパラメータ
-  static constexpr double MIN_HOLD_DURATION_SEC = 2.0;     // 2秒に延長
-  static constexpr double MIN_IMPROVEMENT_RATIO = 0.5;     // 50%改善で切り替え（相対値）
-  static constexpr double EMERGENCY_SWITCH_RATIO = 2.0;    // 2倍良ければ即切り替え
-  static constexpr double EMA_ALPHA = 0.3;                 // スムージング係数
+  static constexpr double MIN_HOLD_DURATION_SEC = 2.0;   // 2秒に延長
+  static constexpr double MIN_IMPROVEMENT_RATIO = 0.5;   // 50%改善で切り替え（相対値）
+  static constexpr double EMERGENCY_SWITCH_RATIO = 2.0;  // 2倍良ければ即切り替え
+  static constexpr double EMA_ALPHA = 0.3;               // スムージング係数
 
 }  // namespace crane::metrics
 

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
@@ -44,6 +44,7 @@ private:
   static constexpr double MIN_IMPROVEMENT_RATIO = 0.5;   // 50%改善で切り替え（相対値）
   static constexpr double EMERGENCY_SWITCH_RATIO = 2.0;  // 2倍良ければ即切り替え
   static constexpr double EMA_ALPHA = 0.3;               // スムージング係数
+};
 
 }  // namespace crane::metrics
 

--- a/crane_game_analyzer/src/metrics/attacker_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/attacker_metrics.cpp
@@ -109,9 +109,8 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
     // 緊急切り替え: 新しいロボットが2倍以上良い場合は保持時間を無視して即座に切り替え
     if (best_score >= current_score * EMERGENCY_SWITCH_RATIO) {
       should_switch = true;
-    }
-    // 通常切り替え: 保持時間経過後、相対的に50%以上改善がある場合のみ切り替え
-    else if (time_since_switch >= MIN_HOLD_DURATION_SEC) {
+    } else if (time_since_switch >= MIN_HOLD_DURATION_SEC) {
+      // 通常切り替え: 保持時間経過後、相対的に50%以上改善がある場合のみ切り替え
       double improvement_ratio = (best_score - current_score) / std::max(current_score, 0.1);
       if (improvement_ratio >= MIN_IMPROVEMENT_RATIO) {
         should_switch = true;

--- a/crane_game_analyzer/src/metrics/attacker_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/attacker_metrics.cpp
@@ -59,7 +59,20 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
 
     double total_score = distance_score * 0.6 + slack_score * 0.4;
 
-    robot_scores.push_back({robot->id, total_score});
+    // EMAでスムージング
+    auto it = ema_scores_.find(robot->id);
+    double smoothed_score;
+    if (it == ema_scores_.end()) {
+      // 初回は生スコアをそのまま使用
+      ema_scores_[robot->id] = total_score;
+      smoothed_score = total_score;
+    } else {
+      // EMA更新: smoothed = α * new + (1-α) * old
+      smoothed_score = EMA_ALPHA * total_score + (1.0 - EMA_ALPHA) * it->second;
+      ema_scores_[robot->id] = smoothed_score;
+    }
+
+    robot_scores.push_back({robot->id, smoothed_score});
   }
 
   // スコアでソート（降順）
@@ -84,19 +97,23 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
     // 異なるロボットの場合
     double time_since_switch = (current_time - last_switch_time_).seconds();
 
-    if (time_since_switch >= MIN_HOLD_DURATION_SEC) {
-      // 最低保持時間が経過している
-      // 現在のロボットのスコアを取得
-      double current_score = 0.0;
-      for (const auto & rs : robot_scores) {
-        if (static_cast<int>(rs.id) == last_attacker_id_) {
-          current_score = rs.score;
-          break;
-        }
+    // 現在のロボットのスコアを取得
+    double current_score = 0.0;
+    for (const auto & rs : robot_scores) {
+      if (static_cast<int>(rs.id) == last_attacker_id_) {
+        current_score = rs.score;
+        break;
       }
+    }
 
-      // 十分な改善がある場合のみスイッチ
-      if (best_score > current_score + MIN_IMPROVEMENT_MARGIN) {
+    // 緊急切り替え: 新しいロボットが2倍以上良い場合は保持時間を無視して即座に切り替え
+    if (best_score >= current_score * EMERGENCY_SWITCH_RATIO) {
+      should_switch = true;
+    }
+    // 通常切り替え: 保持時間経過後、相対的に50%以上改善がある場合のみ切り替え
+    else if (time_since_switch >= MIN_HOLD_DURATION_SEC) {
+      double improvement_ratio = (best_score - current_score) / std::max(current_score, 0.1);
+      if (improvement_ratio >= MIN_IMPROVEMENT_RATIO) {
         should_switch = true;
       }
     }

--- a/crane_local_planner/src/crane_local_planner.cpp
+++ b/crane_local_planner/src/crane_local_planner.cpp
@@ -55,11 +55,11 @@ auto LocalPlannerComponent::callbackPositionCommands(const crane_msgs::msg::Posi
 
     crane_msgs::msg::PositionCommand command = raw_command;
     auto robot = world_model->getOurRobot(command.robot_id);
-    command.current_pose.x = robot->pose.pos.x();  // フィールド座標系
-    command.current_pose.y = robot->pose.pos.y();  // フィールド座標系
+    command.current_pose.x = robot->pose.pos.x();                   // フィールド座標系
+    command.current_pose.y = robot->pose.pos.y();                   // フィールド座標系
     command.current_pose.theta = robot->pose.theta + theta_offset;  // theta_offset適用
-    command.current_velocity.x = robot->vel.linear.x();  // フィールド座標系
-    command.current_velocity.y = robot->vel.linear.y();  // フィールド座標系
+    command.current_velocity.x = robot->vel.linear.x();             // フィールド座標系
+    command.current_velocity.y = robot->vel.linear.y();             // フィールド座標系
     command.current_velocity.theta = robot->vel.omega;
     command.target_theta += theta_offset;  // theta_offset適用
     commands.robot_commands.push_back(command);

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -162,8 +162,8 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::PositionCommands & msg) 
     Eigen::Vector2d next_vel = trajectory.getVelocity(lookahead_time);
 
     // 目標との距離を計算
-    double distance_to_target = std::hypot(
-      command.target_x - current_position.x(), command.target_y - current_position.y());
+    double distance_to_target =
+      std::hypot(command.target_x - current_position.x(), command.target_y - current_position.y());
 
     // 疑似I項：低速かつ目標から離れている場合に補正
     // terminal_velocity（0の場合はフォールバック値0.3 m/sを使用）


### PR DESCRIPTION
## 概要
Attackerロボットの割り当てが頻繁に切り替わる問題を修正しました。

## 問題
- Attackerの役割が0.5秒ごとに異なるロボットに切り替わることがあった
- 最適ではないロボットに割り当てられることがあった
- game_analyzerの`recommended_attacker_id`が安定しなかった

## 解決策
`AttackerCandidateMetric`のヒステリシス機構を強化：

### 1. パラメータ調整
| パラメータ | 変更前 | 変更後 |
|-----------|--------|--------|
| 最低保持時間 | 0.5秒 | 2.0秒 |
| 改善マージン | 絶対値0.2 | 相対値50% |
| EMAスムージング | なし | α=0.3 |
| 緊急切り替え | なし | 2倍以上良い場合 |

### 2. 実装内容
- **EMAスムージング**: 各ロボットのスコアを指数移動平均で平滑化（ノイズ対策）
- **相対改善マージン**: 50%以上の改善がないと切り替えない
- **緊急切り替え**: 2倍以上良いロボットは即座に切り替え
- **保持時間延長**: 2秒間は同じロボットを維持

## 効果
- Attackerの切り替え頻度が大幅に削減
- 最適なロボットが安定して割り当てられる
- game_analyzerの推奨IDがそのまま反映される
