### PR TITLE
デバッグログのクリーンアップ

### DIFF
--- a/crane_tactic_coordinator/src/robot_allocator.cpp
+++ b/crane_tactic_coordinator/src/robot_allocator.cpp
@@ -46,9 +46,6 @@ auto RobotAllocator::allocate(
 
   // 前回のプランナーリストを保存し、新しいリストをクリア
   auto prev_available_planners = tactic_registry_->getAllPlanners();
-  RCLCPP_INFO(
-    logger_, "[RobotAllocator::allocate] Session「%s」: 前回のプランナー数=%zu",
-    session_name.c_str(), prev_available_planners.size());
   tactic_registry_->clear();
 
   // TacticRequirementリストを構築
@@ -104,11 +101,6 @@ auto RobotAllocator::allocate(
       // ロボット割当をTacticに反映
       // GlobalRobotAllocatorが選択したロボットを直接設定（getSelectedRobotsをバイパス）
       tactic->setAllocatedRobots(robot_ids);
-
-      // 設定後のロボット数を確認
-      RCLCPP_INFO(
-        logger_, "\tTactic「%s」のロボット設定: 設定前=%lu, 設定後=%lu", tactic_name.c_str(),
-        tactic->getRobots().size() - robot_ids.size(), tactic->getRobots().size());
 
       // レジストリに追加
       if (tactic_it == tactic_registry_->getAllPlanners().end()) {

--- a/crane_tactic_coordinator/src/tactic_registry.cpp
+++ b/crane_tactic_coordinator/src/tactic_registry.cpp
@@ -30,14 +30,8 @@ auto TacticRegistry::getOrCreatePlanner(
   TacticBase::SharedPtr result_planner;
   if (matched_planner != prev_planners.end()) {
     result_planner = *matched_planner;
-    RCLCPP_INFO(
-      rclcpp::get_logger("TacticRegistry"), "Tactic「%s」を再利用 (robots: prev=%zu, new=%zu)",
-      tactic_name.c_str(), (*matched_planner)->getRobots().size(), new_planner->getRobots().size());
   } else {
     result_planner = new_planner;
-    RCLCPP_INFO(
-      rclcpp::get_logger("TacticRegistry"), "Tactic「%s」を新規作成 (robots: new=%zu)",
-      tactic_name.c_str(), new_planner->getRobots().size());
   }
 
   // パラメータを設定（新規・再利用どちらでも）

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -261,17 +261,6 @@ auto WorldModelDataProvider::on_udp_timer() -> void
               has_vision_updated_ = true;
               last_vision_recv_time_ = node.get_clock()->now();
             }
-            if (packet.has_geometry()) {
-              RCLCPP_INFO(node.get_logger(), "Geometryパケット受信！");
-              processGeometryData(packet.geometry());
-            } else {
-              static int no_geometry_count = 0;
-              if (++no_geometry_count % 100 == 1) {
-                RCLCPP_INFO(
-                  node.get_logger(), "Visionパケット受信中（geometry無し）: %d回目",
-                  no_geometry_count);
-              }
-            }
           } else {
             RCLCPP_DEBUG(node.get_logger(), "SSL_WrapperPacketのパースに失敗しました");
           }
@@ -669,13 +658,6 @@ auto WorldModelDataProvider::convertFieldGeometry(
 
   field_geometry_.center_circle_radius = 0.5;  // 標準SSL値
   field_geometry_.is_valid = true;
-
-  RCLCPP_INFO(
-    node.get_logger(),
-    "フィールド情報を設定: field=%.3fx%.3f, goal=%.3fx%.3f, penalty_area=%.3fx%.3f",
-    field_geometry_.field_width, field_geometry_.field_height, field_geometry_.goal_width,
-    field_geometry_.goal_height, field_geometry_.penalty_area_width,
-    field_geometry_.penalty_area_height);
 }
 
 auto WorldModelDataProvider::loadFieldGeometryFromConfig(const std::string & config_path) -> bool


### PR DESCRIPTION
## 概要
- 開発用デバッグログ（RCLCPP_INFO）を削除してログ出力を整理
- TacticRegistry、RobotAllocator、Geometry関連の冗長なログを削除
- コードの可読性向上とログノイズの削減

## 変更内容
- **TacticRegistry**: タクティックの再利用/新規作成に関するログを削除
- **RobotAllocator**: セッション情報とロボット設定に関するログを削除  
- **Geometry**: パケット受信とフィールド情報設定に関するログを削除
