### PR TITLE
Tactics関連の改善とリファクタリング

### DIFF
--- a/crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp
@@ -62,7 +62,7 @@ public:
       {
         auto polyline_builder = visualizer->polyline();
         for (auto [point, distance] : world_model->getBallSequence(2.0, 0.1)) {
-          polyline_builder.addPoint(point);
+          (void)polyline_builder.addPoint(point);
         }
         polyline_builder.stroke("orange", 0.3).strokeWidth(100).build();
       }

--- a/crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp
@@ -33,7 +33,7 @@ public:
   std::shared_ptr<skills::Attacker> skill = nullptr;
 
   COMPOSITION_PUBLIC explicit AttackerSkillTactic(
-    WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node)
+    WorldModelWrapper::SharedPtr & world_model, [[maybe_unused]] rclcpp::Node & node)
   : TacticBase("attacker_skill", world_model)
   {
   }

--- a/crane_tactics/include/crane_tactics/emplace_robot_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/emplace_robot_tactic.hpp
@@ -43,6 +43,9 @@ public:
   auto getRobotSuitabilityFunc() const
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override;
 
+protected:
+  void onRobotsChanged() override;
+
 private:
   std::unordered_map<uint8_t, std::shared_ptr<skills::EmplaceRobot>> m_skill_map;
 };

--- a/crane_tactics/include/crane_tactics/passable_ball_placement_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/passable_ball_placement_tactic.hpp
@@ -30,7 +30,7 @@ public:
   {
   }
 
-  auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
+  auto calculatePositionCommand([[maybe_unused]] const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override
   {
     if (ball_placement) {
@@ -53,7 +53,7 @@ public:
   {
   }
 
-  auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
+  auto calculatePositionCommand([[maybe_unused]] const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override
   {
     if (placer) {

--- a/crane_tactics/include/crane_tactics/simple_placer_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/simple_placer_tactic.hpp
@@ -259,7 +259,6 @@ public:
         .build();
 
       // 目標到達状態を可視化
-      uint8_t robot_id = cmd.robot_id;
       double distance =
         (Point(cmd.current_pose.x, cmd.current_pose.y) - Point(cmd.target_x, cmd.target_y)).norm();
 

--- a/crane_tactics/include/crane_tactics/skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/skill_tactic.hpp
@@ -136,7 +136,8 @@ public:
 
   COMPOSITION_PUBLIC explicit BallNearByPositionerSkillTactic(
     WorldModelWrapper::SharedPtr & world_model, rclcpp::Node &)
-  : TacticBase("BallNearByPositionerSkill", world_model)
+
+  : TacticBase("ball_nearby_positioner_skill", world_model)
   {
   }
 
@@ -154,7 +155,7 @@ public:
 
   COMPOSITION_PUBLIC explicit PlacementTargetNearByPositionerSkillTactic(
     WorldModelWrapper::SharedPtr & world_model, rclcpp::Node &)
-  : TacticBase("PlacementTargetNearByPositionerSkill", world_model)
+  : TacticBase("placement_target_nearby_positioner_skill", world_model)
   {
   }
 

--- a/crane_tactics/src/emplace_robot_tactic.cpp
+++ b/crane_tactics/src/emplace_robot_tactic.cpp
@@ -8,6 +8,8 @@
 
 namespace crane
 {
+void EmplaceRobotTactic::onRobotsChanged() { m_skill_map.clear(); }
+
 std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
 EmplaceRobotTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
 {

--- a/crane_tactics/src/our_free_kick_tactic.cpp
+++ b/crane_tactics/src/our_free_kick_tactic.cpp
@@ -13,7 +13,8 @@
 namespace crane
 {
 std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
-OurDirectFreeKickTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
+OurDirectFreeKickTactic::calculatePositionCommand(
+  [[maybe_unused]] const std::vector<RobotIdentifier> & robots)
 {
   std::vector<crane_msgs::msg::PositionCommand> robot_commands;
 

--- a/crane_tactics/src/their_penalty_kick_tactic.cpp
+++ b/crane_tactics/src/their_penalty_kick_tactic.cpp
@@ -9,7 +9,8 @@
 namespace crane
 {
 std::pair<TacticBase::Status, std::vector<crane_msgs::msg::PositionCommand>>
-TheirPenaltyKickTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
+TheirPenaltyKickTactic::calculatePositionCommand(
+  [[maybe_unused]] const std::vector<RobotIdentifier> & robots)
 {
   std::vector<crane_msgs::msg::PositionCommand> robot_commands;
 

--- a/crane_tactics/src/total_defense_tactic.cpp
+++ b/crane_tactics/src/total_defense_tactic.cpp
@@ -157,6 +157,9 @@ TotalDefenseTactic::calculatePositionCommand(const std::vector<RobotIdentifier> 
   // 残りのロボットをMarkerに割り当て
   if (not marker_robot_ids.empty()) {
     assignMarkingTargets(marker_robot_ids);
+  } else {
+    std::lock_guard lock(markers_mutex);
+    markers.clear();
   }
 
   // Markerの実行


### PR DESCRIPTION
## 概要

Tacticsモジュールに関する複数の改善とリファクタリングを実施しました。

### 主な変更内容

- **TotalDefenseTacticでMarkerの排他制御を追加** (de5e5099)
  - 複数のTacticが同じMarkerを使用しないように排他制御を実装
  
- **EmplaceRobotTactic::onRobotsChanged を実装** (a7d6b671)
  - ロボット構成変更時の適切なハンドリングを追加

- **警告抑制とコードクリーンアップ** (70beee68, 7f32384a)
  - 未使用変数に `maybe_unused` 属性を追加
  - コンパイル警告を抑制

- **Tacticの名前変更** (a3acc2ec)
  - より明確な命名に改善

### 変更されたファイル

- `crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp`
- `crane_tactics/include/crane_tactics/emplace_robot_tactic.hpp`
- `crane_tactics/include/crane_tactics/passable_ball_placement_tactic.hpp`
- `crane_tactics/include/crane_tactics/simple_placer_tactic.hpp`
- `crane_tactics/include/crane_tactics/skill_tactic.hpp`
- `crane_tactics/src/emplace_robot_tactic.cpp`
- `crane_tactics/src/our_free_kick_tactic.cpp`
- `crane_tactics/src/their_penalty_kick_tactic.cpp`
- `crane_tactics/src/total_defense_tactic.cpp`
