### PR TITLE
fix: 障害物回避無効時の速度制限突き抜けバグを修正

### DIFF
--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -230,6 +230,9 @@ auto RVO2Planner::extractVelocityCommandsFromRVOSim(
     // 障害物回避を無効にする場合、目標速度をそのまま使う
     if (command.local_planner_config.disable_collision_avoidance) {
       vel = toPoint(rvo_sim->getAgentPrefVelocity(original_command.robot_id));
+      if (vel.norm() > rvo_sim->getAgentMaxSpeed(original_command.robot_id)) {
+        vel = vel.normalized() * rvo_sim->getAgentMaxSpeed(original_command.robot_id);
+      }
     }
 
     // 位置目標が許容誤差以下の場合、速度目標を0にする


### PR DESCRIPTION
## 概要

障害物回避を無効にした際に、ロボットの速度が最大速度制限を超えてしまうバグを修正しました。

## 変更内容

- `crane_local_planner/src/rvo2_planner.cpp`
  - `disable_collision_avoidance` が有効な場合、目標速度をそのまま使用していたが、最大速度チェックを追加
  - 速度のノルムが `getAgentMaxSpeed()` を超える場合、正規化して最大速度を乗算するように修正

## 修正の詳細

```cpp
if (command.local_planner_config.disable_collision_avoidance) {
  vel = toPoint(rvo_sim->getAgentPrefVelocity(original_command.robot_id));
  // 追加: 最大速度制限のチェック
  if (vel.norm() > rvo_sim->getAgentMaxSpeed(original_command.robot_id)) {
    vel = vel.normalized() * rvo_sim->getAgentMaxSpeed(original_command.robot_id);
  }
}
```
