### PR TITLE
ロボット制御の安定性とフィードバック診断の改善

### DIFF
--- a/crane_robot_receiver/src/diagnostic_publisher.cpp
+++ b/crane_robot_receiver/src/diagnostic_publisher.cpp
@@ -232,7 +232,6 @@ auto RobotData::batteryDiagnosticCallback(
       stat.summary(level, message);
       removeError("battery");
     } else {
-
       // 実機環境ではWARN（フィードバックなしでもVision/Trackerで制御可能）
       std::string message = "No robot feedback received";
       int level = diagnostic_msgs::msg::DiagnosticStatus::WARN;

--- a/crane_robot_receiver/src/diagnostic_publisher.cpp
+++ b/crane_robot_receiver/src/diagnostic_publisher.cpp
@@ -232,11 +232,12 @@ auto RobotData::batteryDiagnosticCallback(
       stat.summary(level, message);
       removeError("battery");
     } else {
-      // 実機環境ではERROR
+
+      // 実機環境ではWARN（フィードバックなしでもVision/Trackerで制御可能）
       std::string message = "No robot feedback received";
-      int level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      int level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
       stat.summary(level, message);
-      updateErrorMap("battery", message, level, now_time);
+      removeError("battery");
     }
   }
 }
@@ -276,11 +277,10 @@ auto RobotData::robotErrorDiagnosticCallback(
       stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, message);
       removeError("robot_error");
     } else {
-      // 実機環境ではERROR
+      // 実機環境ではWARN（フィードバックなしでもVision/Trackerで制御可能）
       std::string message = "No robot feedback received";
-      stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, message);
-      updateErrorMap(
-        "robot_error", message, diagnostic_msgs::msg::DiagnosticStatus::ERROR, now_time);
+      stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, message);
+      removeError("robot_error");
     }
   }
 }

--- a/crane_tactics/src/formation_tactic.cpp
+++ b/crane_tactics/src/formation_tactic.cpp
@@ -93,9 +93,10 @@ FormationTactic::calculatePositionCommand(const std::vector<RobotIdentifier> & r
 
   auto robot_commands = assignRobotsToPoints(
     robots, formation_points, "formation_planner", world_model->getOurGoalCenter(),
-    [target_theta](std::shared_ptr<PositionCommandWrapper> & command) {
+    [this, target_theta](std::shared_ptr<PositionCommandWrapper> & command) {
       // フォーメーション特有の固定角度を設定
       command->setTargetTheta(target_theta);
+      command->setMaxVelocity("フォーメーションはゆっくり", 1.0);
     });
   return {TacticBase::Status::RUNNING, robot_commands};
 }

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -828,16 +828,19 @@ auto WorldModelDataProvider::convertTrackedRobot(
     robot_info.velocity_norm = 0.0;
   }
 
-  // Vision情報
+  // Vision情報（Trackerは内部でVisionを統合しているため、Vision情報としても扱う）
   robot_info.vision.stamp = now;
   robot_info.vision.pose.x = tracked_robot.pos.x;
   robot_info.vision.pose.y = tracked_robot.pos.y;
   robot_info.vision.pose.theta = tracked_robot.orientation;
 
-  // 検出フラグ
-  robot_info.available_vision = false;
+  // 検出フラグ（TrackerはVisionを統合しているため、両方trueに設定）
+  robot_info.available_vision = true;
   robot_info.available_feedback = false;
   robot_info.available_tracker = true;
+
+  // タイムスタンプ設定
+  robot_info.last_tracker_detection_stamp = now;
 
   return robot_info;
 }


### PR DESCRIPTION
## 概要

実機環境でのロボット制御の安定性を向上させるための3つの改善：
- フォーメーション時の速度制限
- Tracker情報をVisionフラグとしても扱う
- フィードバック欠損時の診断レベル調整

## 変更内容

### フォーメーション速度制限
- `crane_tactics/src/formation_tactic.cpp:99`
- フォーメーション時のロボット最高速度を1.0に制限
- 安全で安定したフォーメーション移動を実現

### Vision情報の統合
- `crane_world_model_publisher/src/world_model_data_provider.cpp:831-843`
- TrackerデータをVision情報としても扱うように変更
- `available_vision` フラグを true に設定
- Trackerは内部でVisionを統合しているため、両方のフラグを有効化

### 診断レベルの調整
- `crane_robot_receiver/src/diagnostic_publisher.cpp:235-240, 280-283`
- ロボットフィードバックが無い場合のエラーレベルを ERROR → WARN に変更
- フィードバックなしでもVision/Trackerで制御可能なため、システムを停止させない
