### PR TITLE
feat: RVO2プランナーにフィールド境界制限機能を追加

### DIFF
--- a/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
@@ -51,6 +51,10 @@ private:
     Point & target_pos, const Point & current_pos,
     const crane_msgs::msg::PositionCommand & command) const -> void;
 
+  auto adjustForFieldBoundary(
+    Point & target_pos, const Point & current_pos,
+    const crane_msgs::msg::PositionCommand & command) const -> void;
+
   std::unique_ptr<RVO::RVOSimulator> rvo_sim;
 
   crane_msgs::msg::PositionCommands pre_commands;
@@ -70,6 +74,7 @@ private:
   double MAX_VEL = 5.0;
   double ACCELERATION = 4.0;
   double STOP_STATE_MAX_VELOCITY = 1.0;
+  double FIELD_BOUNDARY_OFFSET = 0.2;
   // 加速度は減速度の何倍にするかという係数
   ParameterWithEvent<double> acceleration_factor;
 

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -44,6 +44,9 @@ RVO2Planner::RVO2Planner(rclcpp::Node & node)
   node.declare_parameter("stop_state_max_velocity", STOP_STATE_MAX_VELOCITY);
   STOP_STATE_MAX_VELOCITY = node.get_parameter("stop_state_max_velocity").as_double();
 
+  node.declare_parameter("field_boundary_offset", FIELD_BOUNDARY_OFFSET);
+  FIELD_BOUNDARY_OFFSET = node.get_parameter("field_boundary_offset").as_double();
+
   rvo_sim = std::make_unique<RVO::RVOSimulator>(
     RVO_TIME_STEP, RVO_NEIGHBOR_DIST, RVO_MAX_NEIGHBORS, RVO_TIME_HORIZON, RVO_TIME_HORIZON_OBST,
     RVO_RADIUS, RVO_MAX_SPEED);
@@ -337,13 +340,62 @@ auto RVO2Planner::overrideTargetPosition(crane_msgs::msg::PositionCommands & msg
       continue;  // この場合は処理をスキップ
     }
 
-    // 3つの独立した回避ロジックを適用
+    // 4つの独立した回避ロジックを適用
+    adjustForFieldBoundary(target_pos, current_pos, command);
     adjustForPenaltyAreaAvoidance(target_pos, current_pos, command);
     adjustForBallAvoidance(target_pos, current_pos, command);
     adjustForPlacementAvoidance(target_pos, current_pos, command);
 
     command.target_x = target_pos.x();
     command.target_y = target_pos.y();
+  }
+}
+
+auto RVO2Planner::adjustForFieldBoundary(
+  Point & target_pos, const Point & current_pos,
+  const crane_msgs::msg::PositionCommand & command) const -> void
+{
+  const double max_x = world_model->fieldSize().x() / 2.0 + FIELD_BOUNDARY_OFFSET;
+  const double max_y = world_model->fieldSize().y() / 2.0 + FIELD_BOUNDARY_OFFSET;
+
+  // フィールド境界のBox
+  Box field_box;
+  field_box.min_corner() << -max_x, -max_y;
+  field_box.max_corner() << max_x, max_y;
+
+  // 目標位置がフィールド内ならそのまま
+  if (isInBox(field_box, target_pos)) {
+    return;
+  }
+
+  // 現在位置から目標位置への線分
+  Segment move_line(current_pos, target_pos);
+
+  // フィールド境界の4辺
+  Segment top_edge(Point(-max_x, max_y), Point(max_x, max_y));
+  Segment bottom_edge(Point(-max_x, -max_y), Point(max_x, -max_y));
+  Segment right_edge(Point(max_x, -max_y), Point(max_x, max_y));
+  Segment left_edge(Point(-max_x, -max_y), Point(-max_x, max_y));
+
+  // 各辺との交点を計算
+  std::vector<Point> all_intersections;
+  for (const auto & edge : {top_edge, bottom_edge, right_edge, left_edge}) {
+    auto intersections = getIntersections(move_line, edge);
+    all_intersections.insert(all_intersections.end(), intersections.begin(), intersections.end());
+  }
+
+  // 現在位置に最も近い交点を選択（最初に交差する点）
+  if (!all_intersections.empty()) {
+    auto closest = std::min_element(
+      all_intersections.begin(), all_intersections.end(),
+      [&current_pos](const Point & a, const Point & b) {
+        return bg::distance(a, current_pos) < bg::distance(b, current_pos);
+      });
+    target_pos = *closest;
+  } else {
+    // 交点がない場合（現在位置がフィールド外など）、単純なクランプにフォールバック
+    target_pos.x() = std::clamp(target_pos.x(), -max_x, max_x);
+    target_pos.y() = std::clamp(target_pos.y(), -max_y, max_y);
   }
 }
 


### PR DESCRIPTION
## 概要

RVO2プランナーに、目標座標がフィールド外に指定された場合にフィールド境界内に自動的に制限する機能を追加しました。

## 変更内容

- `adjustForFieldBoundary` メソッドを新規追加
  - 目標位置がフィールド外の場合、現在位置から目標位置への移動線とフィールド境界の交点を計算
  - 最も近い交点に目標位置を調整することで、フィールド境界を超えないようにする
- `FIELD_BOUNDARY_OFFSET` パラメータを追加（デフォルト: 0.2m）
  - フィールド境界からのオフセットを設定可能
- `overrideTargetPosition` メソッド内で、他の回避ロジック（ペナルティエリア、ボール回避、プレースメント回避）と並んで適用

## 動機

目標座標がフィールド外に設定された場合、ロボットがフィールド外に出てしまう問題を防ぐため。特に、タクティクスやスキルの計算誤差によりフィールド外の座標が指定された場合の安全機構として機能します。
