### PR TITLE
feat: Tacticの動的ロボット数割当機能を実装

### DIFF
--- a/crane_tactic_coordinator/config/unified_session_config.yaml
+++ b/crane_tactic_coordinator/config/unified_session_config.yaml
@@ -1,170 +1,174 @@
 situations:
   HALT:
     description: HALT
-    sessions: []
+    sessions:
+      - name: waiter
+        max_robots: 20
   INPLAY:
     description: INPLAY
     sessions:
       - name: goalie_skill
-        capacity: 1
+        max_robots: 1
       - name: emplace_robot
-        capacity: 1
+        max_robots: 1
       - name: attacker_skill
-        capacity: 1
+        max_robots: 1
       - name: pass_receive
-        capacity: 1
+        max_robots: 1
       - name: defender
-        capacity: 2
+        max_robots: 2
       - name: second_threat_defender
-        capacity: 1
+        max_robots: 1
       - name: sub_attacker_skill
-        capacity: 1
+        max_robots: 1
       - name: marker
-        capacity: 3
+        max_robots: 3
       - name: forward
-        capacity: 20
+        max_robots: 20
 
   OUR_BALL_PLACEMENT:
     description: OUR_BALL_PLACEMENT
     sessions:
       - name: ball_placement_skill
-        capacity: 1
+        max_robots: 1
       - name: ball_placement_avoidance
-        capacity: 20
+        max_robots: 20
   OUR_FREE_KICK:
     description: OUR_FREE_KICK
     sessions:
       - name: goalie_skill
-        capacity: 1
+        max_robots: 1
       - name: attacker_skill
-        capacity: 1
+        max_robots: 1
       - name: pass_receive
-        capacity: 1
+        max_robots: 1
       - name: defender
-        capacity: 2
+        max_robots: 2
       - name: marker
-        capacity: 2
+        max_robots: 2
       - name: forward
-        capacity: 20
+        max_robots: 20
   OUR_KICKOFF_START:
     description: OUR_KICKOFF_START
     sessions:
       - name: goalie_skill
-        capacity: 1
+        max_robots: 1
       - name: simple_kickoff
-        capacity: 1
+        max_robots: 1
   OUR_PENALTY_KICK:
     description: OUR_PENALTY_KICK
     sessions:
       - name: our_penalty_kick
-        capacity: 20
+        max_robots: 20
   PRE_KICK_OFF:
     description: PRE_KICK_OFF
     sessions:
       - name: goalie_skill
-        capacity: 1
+        max_robots: 1
       - name: wing_formation
-        capacity: 20
+        max_robots: 20
   STOP:
     description: STOP
     sessions:
       - name: emplace_robot
-        capacity: 1
+        max_robots: 1
       - name: goalie_skill
-        capacity: 1
+        max_robots: 1
       - name: defender
-        capacity: 2
+        max_robots: 3
       - name: second_threat_defender
-        capacity: 1
+        max_robots: 1
       - name: ball_nearby_positioner_skill
-        capacity: 1
+        max_robots: 1
       - name: marker
-        capacity: 2
+        max_robots: 2
       - name: forward
-        capacity: 20
+        max_robots: 20
   TEST:
     description: TEST
     sessions:
       - name: test
-        capacity: 1
+        max_robots: 1
+      - name: waiter
+        max_robots: 20
   THEIR_BALL_PLACEMENT:
     description: THEIR_BALL_PLACEMENT
     sessions:
       - name: defender
-        capacity: 2
+        max_robots: 2
       - name: ball_placement_avoidance
-        capacity: 20
+        max_robots: 20
   THEIR_FREE_KICK:
     description: THEIR_FREE_KICK
     sessions:
       - name: goalie_skill
-        capacity: 1
+        max_robots: 1
       - name: defender
-        capacity: 2
+        max_robots: 2
       - name: second_threat_defender
-        capacity: 1
+        max_robots: 1
       - name: ball_nearby_positioner_skill
-        capacity: 1
+        max_robots: 1
       - name: marker
-        capacity: 5
+        max_robots: 5
       - name: forward
-        capacity: 20
+        max_robots: 20
   THEIR_PENALTY_KICK:
     description: THEIR_PENALTY_KICK
     sessions:
       - name: their_penalty_kick
-        capacity: 20
+        max_robots: 20
   BALL_CALIBRATION_DATA_COLLECTION:
     description: Ball calibration data collection using single kicker robot
     sessions:
       - name: ball_calibration_data_collector
-        capacity: 1
+        max_robots: 1
       - name: emplace_robot
-        capacity: 19
+        max_robots: 19
   CENTER_STOP_KICK:
     description: Center stop kick testing using CenterStopKickTactic for stop distance
       kick verification
     sessions:
       - name: center_stop_kick
-        capacity: 1
+        max_robots: 1
       - name: emplace_robot
-        capacity: 19
+        max_robots: 19
   emplace_robot:
     description: emplace_robot
     sessions:
       - name: emplace_robot
-        capacity: 100
+        max_robots: 100
   formation:
     description: formation
     sessions:
       - name: goalie_skill
-        capacity: 1
+        max_robots: 1
       - name: wing_formation
-        capacity: 20
+        max_robots: 20
   goalie:
     description: for goalie
     sessions:
       - name: goalie_skill
-        capacity: 1
+        max_robots: 1
   ibis_formation:
     description: ibisのi/キーパーなし
     sessions:
       - name: ibis_formation
-        capacity: 20
+        max_robots: 20
   pass_placement:
     description: pass_placement
     sessions:
       - name: passable_ball_placement
-        capacity: 1
+        max_robots: 1
       - name: placement_target_placer
-        capacity: 1
+        max_robots: 1
       - name: ball_placement_avoidance
-        capacity: 20
+        max_robots: 20
   wing_formation:
     description: wing/キーパーなし
     sessions:
       - name: wing_formation
-        capacity: 20
+        max_robots: 20
 events:
   - name: HALT
     situation: HALT

--- a/crane_tactic_coordinator/include/crane_tactic_coordinator/configuration_manager.hpp
+++ b/crane_tactic_coordinator/include/crane_tactic_coordinator/configuration_manager.hpp
@@ -22,7 +22,8 @@ using SessionParameterType = std::variant<double, bool, int, std::string>;
 struct TacticSlot
 {
   std::string session_name;
-  int selectable_robot_num;
+  int min_robots = 1;
+  int max_robots;
   std::unordered_map<std::string, SessionParameterType> params;
 };
 

--- a/crane_tactic_coordinator/src/configuration_manager.cpp
+++ b/crane_tactic_coordinator/src/configuration_manager.cpp
@@ -77,10 +77,48 @@ auto ConfigurationManager::loadUnifiedConfig(const std::filesystem::path & confi
       for (const auto & session_node : situation_data["sessions"]) {
         TacticSlot session_capacity;
         session_capacity.session_name = session_node["name"].as<std::string>();
-        session_capacity.selectable_robot_num = session_node["capacity"].as<int>();
 
-        ss << "\tNAME     : " << session_capacity.session_name << "\n";
-        ss << "\tCAPACITY : " << session_capacity.selectable_robot_num << "\n";
+        // min_robotsの読み込みとデフォルト値設定
+        if (session_node["min_robots"]) {
+          session_capacity.min_robots = session_node["min_robots"].as<int>();
+        } else {
+          session_capacity.min_robots = 1;  // デフォルト: 1
+        }
+
+        // max_robotsの読み込みとデフォルト値設定
+        if (session_node["max_robots"]) {
+          session_capacity.max_robots = session_node["max_robots"].as<int>();
+        } else {
+          session_capacity.max_robots = session_capacity.min_robots;  // デフォルト: min_robotsと同じ
+        }
+
+        // バリデーション
+        if (session_capacity.min_robots < 0) {
+          RCLCPP_ERROR(
+            logger_, "Invalid min_robots (%d) for session '%s': must be >= 0. Using 0.",
+            session_capacity.min_robots, session_capacity.session_name.c_str());
+          session_capacity.min_robots = 0;
+        }
+
+        if (session_capacity.max_robots <= 0) {
+          RCLCPP_WARN(
+            logger_, "Invalid max_robots (%d) for session '%s': must be > 0. Using 1.",
+            session_capacity.max_robots, session_capacity.session_name.c_str());
+          session_capacity.max_robots = 1;
+        }
+
+        if (session_capacity.min_robots > session_capacity.max_robots) {
+          RCLCPP_WARN(
+            logger_,
+            "Invalid range for session '%s': min_robots (%d) > max_robots (%d). Adjusting min_robots to match max_robots.",
+            session_capacity.session_name.c_str(), session_capacity.min_robots,
+            session_capacity.max_robots);
+          session_capacity.min_robots = session_capacity.max_robots;
+        }
+
+        ss << "\tNAME       : " << session_capacity.session_name << "\n";
+        ss << "\tMIN_ROBOTS : " << session_capacity.min_robots << "\n";
+        ss << "\tMAX_ROBOTS : " << session_capacity.max_robots << "\n";
 
         // params の読み込み（存在する場合のみ）
         if (session_node["params"]) {

--- a/crane_tactic_coordinator/src/configuration_manager.cpp
+++ b/crane_tactic_coordinator/src/configuration_manager.cpp
@@ -89,7 +89,8 @@ auto ConfigurationManager::loadUnifiedConfig(const std::filesystem::path & confi
         if (session_node["max_robots"]) {
           session_capacity.max_robots = session_node["max_robots"].as<int>();
         } else {
-          session_capacity.max_robots = session_capacity.min_robots;  // デフォルト: min_robotsと同じ
+          session_capacity.max_robots =
+            session_capacity.min_robots;  // デフォルト: min_robotsと同じ
         }
 
         // バリデーション
@@ -110,7 +111,8 @@ auto ConfigurationManager::loadUnifiedConfig(const std::filesystem::path & confi
         if (session_capacity.min_robots > session_capacity.max_robots) {
           RCLCPP_WARN(
             logger_,
-            "Invalid range for session '%s': min_robots (%d) > max_robots (%d). Adjusting min_robots to match max_robots.",
+            "Invalid range for session '%s': min_robots (%d) > max_robots (%d). Adjusting "
+            "min_robots to match max_robots.",
             session_capacity.session_name.c_str(), session_capacity.min_robots,
             session_capacity.max_robots);
           session_capacity.min_robots = session_capacity.max_robots;

--- a/crane_tactic_coordinator/src/robot_allocator.cpp
+++ b/crane_tactic_coordinator/src/robot_allocator.cpp
@@ -66,14 +66,15 @@ auto RobotAllocator::allocate(
     bool is_hard = tactic->isHardConstraint();
 
     // 動的ロボット数を取得してクランプ
-    int desired = tactic->getDesiredRobotNumber(
-      session_capacity.min_robots, session_capacity.max_robots);
-    int effective_max = std::clamp(desired, session_capacity.min_robots, session_capacity.max_robots);
+    int desired =
+      tactic->getDesiredRobotNumber(session_capacity.min_robots, session_capacity.max_robots);
+    int effective_max =
+      std::clamp(desired, session_capacity.min_robots, session_capacity.max_robots);
 
     requirements.emplace_back(
       session_capacity.session_name, priority++,
       session_capacity.min_robots,  // min_robots
-      effective_max,                 // max_robots（動的に調整）
+      effective_max,                // max_robots（動的に調整）
       suitability_func, is_hard);
   }
 

--- a/crane_tactic_coordinator/src/robot_allocator.cpp
+++ b/crane_tactic_coordinator/src/robot_allocator.cpp
@@ -52,7 +52,7 @@ auto RobotAllocator::allocate(
   std::vector<TacticRequirement> requirements;
   int priority = 0;
   for (const auto & session_capacity : session_capacities) {
-    if (session_capacity.selectable_robot_num <= 0) {
+    if (session_capacity.max_robots <= 0) {
       continue;
     }
 
@@ -65,9 +65,15 @@ auto RobotAllocator::allocate(
     auto suitability_func = tactic->getRobotSuitabilityFunc();
     bool is_hard = tactic->isHardConstraint();
 
+    // 動的ロボット数を取得してクランプ
+    int desired = tactic->getDesiredRobotNumber(
+      session_capacity.min_robots, session_capacity.max_robots);
+    int effective_max = std::clamp(desired, session_capacity.min_robots, session_capacity.max_robots);
+
     requirements.emplace_back(
-      session_capacity.session_name, priority++, 1,  // min_robots
-      session_capacity.selectable_robot_num,         // max_robots
+      session_capacity.session_name, priority++,
+      session_capacity.min_robots,  // min_robots
+      effective_max,                 // max_robots（動的に調整）
       suitability_func, is_hard);
   }
 

--- a/crane_tactics/include/crane_tactics/marker_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/marker_tactic.hpp
@@ -58,6 +58,13 @@ public:
     };
   }
 
+  int getDesiredRobotNumber(int /* min_robots */, int /* max_robots */) const override
+  {
+    // 危険な敵の数に基づいてロボット数を決定
+    auto danger_enemies = getDangerEnemies(world_model);
+    return static_cast<int>(danger_enemies.size());
+  }
+
 private:
   auto assignMarkingTarget(
     uint8_t selectable_robots_num, const std::vector<uint8_t> selectable_robots)

--- a/crane_tactics/include/crane_tactics/tactic_base.hpp
+++ b/crane_tactics/include/crane_tactics/tactic_base.hpp
@@ -188,6 +188,18 @@ public:
    */
   virtual bool isHardConstraint() const { return false; }
 
+  /**
+   * @brief 現在の状況に基づく推奨ロボット数を返す（動的ロボット割当用）
+   *
+   * Tacticが状況に応じて必要なロボット数を動的に決定するためのメソッド。
+   * 返される値は呼び出し側でmin_robots〜max_robotsの範囲にクランプされる。
+   *
+   * @param min_robots YAML設定の最小ロボット数
+   * @param max_robots YAML設定の最大ロボット数
+   * @return 推奨ロボット数。デフォルトはmax_robots
+   */
+  virtual int getDesiredRobotNumber(int min_robots, int max_robots) const { return max_robots; }
+
 protected:
   /**
    * @brief ロボット割り当てが変更された時に呼ばれるコールバック


### PR DESCRIPTION
## 概要

状況に応じてTacticが必要なロボット数を動的に決定できる機能を実装しました。例えばMarkerTacticは、敵が自陣に攻め入っているときは多くのロボットを、そうでないときは少ないロボット数を要求できるようになります。

## 主な変更内容

### 1. 命名の統一（min_robots / max_robots）

従来の`capacity`を`max_robots`に変更し、`TacticRequirement`の命名と統一しました。

**TacticSlot構造体**:
```cpp
struct TacticSlot {
  std::string session_name;
  int min_robots = 1;  // 最小ロボット数
  int max_robots;      // 最大ロボット数
  std::unordered_map<std::string, SessionParameterType> params;
};
```

### 2. 拡張性の高いAPI設計

**TacticBase::getDesiredRobotNumber()**:
```cpp
virtual int getDesiredRobotNumber(int min_robots, int max_robots) const {
  return max_robots;  // デフォルト実装
}
```

**メリット**:
- マジックナンバーなし
- ステートレス（メンバ変数不要）
- Tactic側がmin/maxの制約を知ることができる
- 必要に応じて範囲内で調整可能

### 3. YAMLバリデーション

**configuration_manager.cpp**:
- `max_robots`未指定時は`min_robots`と同じ値を使用
- `min_robots < 0`のチェック
- `max_robots <= 0`のチェック
- `min_robots > max_robots`のチェック
- すべてログ出力して自動修正

### 4. MarkerTacticでの実装例

```cpp
int getDesiredRobotNumber(int /* min_robots */, int /* max_robots */) const override {
  auto danger_enemies = getDangerEnemies(world_model);
  return static_cast<int>(danger_enemies.size());
}
```

危険な敵の数に応じて動的にロボット数を調整します。

### 5. YAML設定の移行

すべての`capacity:`を`max_robots:`に変更（全43箇所）:

```yaml
# 変更前
- name: marker
  capacity: 3

# 変更後
- name: marker
  max_robots: 3

# 範囲指定（新機能）
- name: marker
  min_robots: 1
  max_robots: 5
```

## 影響範囲

### 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `configuration_manager.hpp` | TacticSlot構造体の更新 |
| `configuration_manager.cpp` | YAMLパースとバリデーション追加 |
| `robot_allocator.cpp` | 動的ロボット数反映ロジック |
| `tactic_base.hpp` | `getDesiredRobotNumber()`追加 |
| `marker_tactic.hpp` | 実装例追加 |
| `unified_session_config.yaml` | capacity→max_robots移行 |

### 既存Tacticへの影響

既存のすべてのTacticは変更不要です。デフォルト実装で`max_robots`を返すため、既存動作を維持します。

## 将来の拡張

この設計により、以下のTacticでも動的ロボット数が実装可能です：
- DefenderTactic: 守備状況に応じて調整
- ReceiverTactic: パス受け手の数を調整
