### PR TITLE
fix: BangBangTrajectory2Dで合成速度がmax_velを超えないように制限

### DIFF
--- a/utility/crane_physics/include/crane_physics/bang_bang_trajectory.hpp
+++ b/utility/crane_physics/include/crane_physics/bang_bang_trajectory.hpp
@@ -304,6 +304,7 @@ class BangBangTrajectory2D
 public:
   BangBangTrajectory1D x;
   BangBangTrajectory1D y;
+  double max_vel = 0.0;
 
   /// 二分探索の初期刻み幅
   static constexpr double BINARY_SEARCH_INITIAL_INCREMENT = M_PI / 8.0;
@@ -323,7 +324,12 @@ public:
 
   [[nodiscard]] Eigen::Vector2d getVelocity(const double t) const noexcept
   {
-    return Eigen::Vector2d(x.getVelocity(t), y.getVelocity(t));
+    Eigen::Vector2d vel(x.getVelocity(t), y.getVelocity(t));
+    const double vel_norm_sq = vel.squaredNorm();
+    if (max_vel > 0.0 && vel_norm_sq > max_vel * max_vel) {
+      return vel * (max_vel / std::sqrt(vel_norm_sq));
+    }
+    return vel;
   }
 
   [[nodiscard]] Eigen::Vector2d getAcceleration(const double t) const noexcept
@@ -349,6 +355,7 @@ public:
     const Eigen::Vector2d & s0, const Eigen::Vector2d & s1, const Eigen::Vector2d & v0,
     const double vmax, const double acc, const double accuracy = DEFAULT_SYNC_ACCURACY)
   {
+    max_vel = vmax;
     const double s0x = s0.x();
     const double s0y = s0.y();
     const double s1x = s1.x();


### PR DESCRIPTION
## 概要

`BangBangTrajectory2D` の `getVelocity()` で合成速度が `max_vel` を超えないように制限を追加しました。

## 背景

初期速度を考慮するようになったことで（`rvo2_planner.cpp` での変更と連動）、軌道生成直後にX/Y合成速度が `max_vel` を超えるケースが発生するようになりました。

具体的には以下のケース：
1. **初期速度が大きい場合**: 軌道生成直後に合成速度が制限を超える
2. **急激な方向転換**: 初期速度ベクトルと目標方向が大きく異なる場合

## 変更内容

- `BangBangTrajectory2D` に `max_vel` メンバ変数を追加
- `generate()` で `max_vel` を保存
- `getVelocity()` で合成速度のノルムを確認し、`max_vel` を超える場合は正規化してスケーリング

## 実装

```cpp
[[nodiscard]] Eigen::Vector2d getVelocity(const double t) const noexcept
{
  Eigen::Vector2d vel(x.getVelocity(t), y.getVelocity(t));
  const double vel_norm_sq = vel.squaredNorm();
  if (max_vel > 0.0 && vel_norm_sq > max_vel * max_vel) {
    return vel * (max_vel / std::sqrt(vel_norm_sq));
  }
  return vel;
}
```

## テスト

- ビルド成功確認済み
- 初期速度を考慮する実装との組み合わせで動作確認

## 影響範囲

- `utility/crane_physics/include/crane_physics/bang_bang_trajectory.hpp` のみ
- 既存の動作に影響を与えず、速度制限の安全性を向上
