### PR TITLE
fix: robot_select_resultsトピックのデグレードを修正

### DIFF
--- a/crane_msgs/msg/control/RobotSelectResult.msg
+++ b/crane_msgs/msg/control/RobotSelectResult.msg
@@ -1,5 +1,7 @@
 string name
 
+uint8 min_robots_num
+uint8 max_robots_num
 uint8 selectable_robots_num
 uint8[] selectable_robots
 uint8[] selected_robots

--- a/crane_tactic_coordinator/src/robot_allocator.cpp
+++ b/crane_tactic_coordinator/src/robot_allocator.cpp
@@ -120,6 +120,24 @@ auto RobotAllocator::allocate(
         allocation_state_.updateAssignment(id, tactic_name, robot->pose.pos);
         prev_robot_roles_.insert_or_assign(id, RobotRole{tactic_name, ""});
       }
+
+      // RobotSelectResult を構築
+      crane_msgs::msg::RobotSelectResult result;
+      result.name = tactic_name;
+
+      // session_capacities から min/max を取得
+      auto session_it = std::find_if(
+        session_capacities.begin(), session_capacities.end(),
+        [&tactic_name](const auto & s) { return s.session_name == tactic_name; });
+      if (session_it != session_capacities.end()) {
+        result.min_robots_num = static_cast<uint8_t>(session_it->min_robots);
+        result.max_robots_num = static_cast<uint8_t>(session_it->max_robots);
+      }
+
+      result.selectable_robots_num = static_cast<uint8_t>(selectable_robot_ids.size());
+      result.selectable_robots = selectable_robot_ids;
+      result.selected_robots = robot_ids;
+      results.results.push_back(result);
     }
   }
 


### PR DESCRIPTION
## 概要

PR #1080で発生した`robot_select_results`トピックのデグレードを修正しました。

## 問題

PR #1080で動的ロボット数割当機能が追加された際、`RobotSelectResults`を構築するコードが削除されたため、トピックが空のデータをパブリッシュしていました。これにより`crane_commentary`の`IntentTracker`が正しく動作しない問題が発生していました。

## 変更内容

- **crane_msgs/msg/control/RobotSelectResult.msg**
  - `min_robots_num`フィールドを追加（動的ロボット数割当情報）
  - `max_robots_num`フィールドを追加（動的ロボット数割当情報）

- **crane_tactic_coordinator/src/robot_allocator.cpp**
  - `RobotSelectResults`を構築するコードを追加
  - 各Tacticの選択可能/選択済みロボット情報を正しくパブリッシュ
  - `session_capacities`から`min_robots`/`max_robots`を取得してメッセージに設定
