### PR TITLE
fix: GoalieSkillTacticがReferee指定のゴールキーパーIDに従うように修正

### DIFF
--- a/crane_tactics/include/crane_tactics/goalie_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/goalie_skill_tactic.hpp
@@ -35,6 +35,21 @@ public:
 
   bool isHardConstraint() const override { return true; }
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    // Refereeが指定したゴールキーパーIDを優先的に割り当てる
+    return [referee_goalie_id =
+              world_model->getOurGoalieId()](const std::shared_ptr<RobotInfo> & robot) {
+      // レフェリーが指定したゴールキーパーIDの場合、コスト0（最高の適性）
+      if (robot->id == referee_goalie_id) {
+        return 0.0;
+      }
+      // その他のロボットは非常に高いコストを返して避ける
+      return 1000.0;
+    };
+  }
+
 protected:
   void onRobotsChanged() override { skill.reset(); }
 };


### PR DESCRIPTION
## 概要
GoalieSkillTacticがRefereeから送られてくるゴールキーパーIDに必ず従うように修正しました。

[Screencast from 2026-01-13 00-42-19.webm](https://github.com/user-attachments/assets/9b43e781-0459-44b2-82a7-5151d186d8e5)


## 変更内容
- `getRobotSuitabilityFunc()`をオーバーライドして、ロボット割り当て時の適性評価を実装
- Refereeが指定したゴールキーパーID（`world_model->getOurGoalieId()`）のロボットに最高適性（コスト0.0）を付与
- その他のロボットには非常に低い適性（コスト1000.0）を付与

## 動作の仕組み
1. `GlobalRobotAllocator`がロボット割り当て時に各タクティックの`getRobotSuitabilityFunc()`を呼び出し
2. Referee指定のGK IDと一致するロボットが最もコストが低いため、必ず選択される
3. `calculatePositionCommand`では割り当て済みのロボットIDをそのまま使用

## 修正前の問題
- ロボット適性評価が未実装のため、`GlobalRobotAllocator`がデフォルトのロジック（位置ベース等）でロボットを選択
- Refereeが指定したゴールキーパーIDが考慮されていなかった

## 修正後
- ロボット割り当て時にRefereeのゴールキーパーIDが確実に選ばれる
- `calculatePositionCommand`内でIDを変更せず、正しいアーキテクチャで実装
