### PR TITLE
feat: 各TacticにgetRobotSuitabilityFunc関数を実装

### DIFF
--- a/crane_tactics/include/crane_tactics/ball_calibration_data_collector_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/ball_calibration_data_collector_tactic.hpp
@@ -34,6 +34,14 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    return [](const std::shared_ptr<RobotInfo> & robot) {
+      return static_cast<double>(robot->id);  // ID小優先
+    };
+  }
+
 private:
   // スキルインスタンス
   std::shared_ptr<skills::BallCalibrationDataCollector> skill_;

--- a/crane_tactics/include/crane_tactics/ball_near_by_positioner_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/ball_near_by_positioner_skill_tactic.hpp
@@ -34,6 +34,18 @@ public:
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    auto wm = world_model;
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      if (robot->id == wm->getOurGoalieId()) {
+        return 10000.0;  // ゴールキーパーは除外
+      }
+      return robot->getSquareDistance(wm->ball().pos);
+    };
+  }
+
 protected:
   void onRobotsChanged() override { skills.clear(); }
 };

--- a/crane_tactics/include/crane_tactics/ball_placement_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/ball_placement_skill_tactic.hpp
@@ -33,6 +33,18 @@ public:
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    auto wm = world_model;
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      if (robot->id == wm->getOurGoalieId()) {
+        return 10000.0;  // ゴールキーパーは除外
+      }
+      return robot->getSquareDistance(wm->ball().pos);
+    };
+  }
+
 protected:
   void onRobotsChanged() override { skill.reset(); }
 };

--- a/crane_tactics/include/crane_tactics/center_stop_kick_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/center_stop_kick_tactic.hpp
@@ -35,6 +35,14 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    return [](const std::shared_ptr<RobotInfo> & robot) {
+      return static_cast<double>(robot->id);  // ID小優先
+    };
+  }
+
 private:
   // スキルインスタンス
   std::shared_ptr<skills::CenterStopKick> skill_;

--- a/crane_tactics/include/crane_tactics/formation_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/formation_tactic.hpp
@@ -45,6 +45,14 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    return [](const std::shared_ptr<RobotInfo> & robot) {
+      return static_cast<double>(robot->id);  // ID小優先
+    };
+  }
+
   const FormationType formation_type;
 };
 

--- a/crane_tactics/include/crane_tactics/our_free_kick_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/our_free_kick_tactic.hpp
@@ -46,6 +46,18 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    auto wm = world_model;
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      if (robot->id == wm->getOurGoalieId()) {
+        return 10000.0;  // ゴールキーパーは除外
+      }
+      return robot->getDistance(wm->ball().pos);
+    };
+  }
+
 protected:
   void onRobotsChanged() override
   {

--- a/crane_tactics/include/crane_tactics/our_penalty_kick_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/our_penalty_kick_tactic.hpp
@@ -39,6 +39,18 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    auto wm = world_model;
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      if (robot->id == wm->getOurGoalieId()) {
+        return 10000.0;  // ゴールキーパーは除外
+      }
+      return robot->getDistance(wm->ball().pos);
+    };
+  }
+
 protected:
   void onRobotsChanged() override
   {

--- a/crane_tactics/include/crane_tactics/pass_receiver_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/pass_receiver_tactic.hpp
@@ -76,6 +76,14 @@ public:
     return {TacticBase::Status::RUNNING, {receive_skill->getRobotCommand()}};
   }
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    // PassReceiverはgame_analysisのpass_target_idで指定されるため
+    // 適性関数でのフィルタリングは不要（デフォルトコスト0.0を返す）
+    return [](const std::shared_ptr<RobotInfo> &) { return 0.0; };
+  }
+
 protected:
   void onRobotsChanged() override { receive_skill.reset(); }
 };

--- a/crane_tactics/include/crane_tactics/passable_ball_placement_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/passable_ball_placement_tactic.hpp
@@ -41,6 +41,18 @@ public:
     }
   }
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    auto wm = world_model;
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      if (robot->id == wm->getOurGoalieId()) {
+        return 10000.0;  // ゴールキーパーは除外
+      }
+      return robot->getSquareDistance(wm->ball().pos);
+    };
+  }
+
   std::shared_ptr<skills::SingleBallPlacement> ball_placement;
 };
 
@@ -63,6 +75,21 @@ public:
     } else {
       return {TacticBase::Status::RUNNING, {}};
     }
+  }
+
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    auto wm = world_model;
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      if (robot->id == wm->getOurGoalieId()) {
+        return 10000.0;  // ゴールキーパーは除外
+      }
+      if (auto target = wm->getBallPlacementTarget(); target) {
+        return robot->getDistance(target.value());
+      }
+      return robot->getDistance(wm->ball().pos);  // フォールバック
+    };
   }
 
   std::shared_ptr<PositionCommandWrapper> placer = nullptr;

--- a/crane_tactics/include/crane_tactics/placement_target_near_by_positioner_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/placement_target_near_by_positioner_skill_tactic.hpp
@@ -33,6 +33,15 @@ public:
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    auto wm = world_model;
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      return robot->getSquareDistance(wm->ball().pos);
+    };
+  }
+
 protected:
   void onRobotsChanged() override { skills.clear(); }
 };

--- a/crane_tactics/include/crane_tactics/simple_kick_off_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/simple_kick_off_skill_tactic.hpp
@@ -33,6 +33,15 @@ public:
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    auto wm = world_model;
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      return robot->getSquareDistance(wm->ball().pos);
+    };
+  }
+
 protected:
   void onRobotsChanged() override { skill.reset(); }
 };

--- a/crane_tactics/include/crane_tactics/sub_attacker_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/sub_attacker_skill_tactic.hpp
@@ -33,6 +33,24 @@ public:
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    // 注意: SubAttacker用のDPPS最適位置は将来game_analyzerのmetricsで計算予定
+    // 現時点では簡略版を使用し、metrics追加後に更新する
+    // TODO: game_analyzerにSubAttacker用metricsが追加されたら、
+    //       recommended_sub_attacker_position等を使用するように更新
+    auto wm = world_model;
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      // ボールが自陣にある場合は高コスト（SubAttacker不要）
+      if (wm->point_checker.isInOurHalf(wm->ball().pos)) {
+        return 10000.0;
+      }
+      // 敵ゴール方向でボール付近のロボットを優先
+      return robot->getSquareDistance(wm->ball().pos);
+    };
+  }
+
 protected:
   void onRobotsChanged() override { skill.reset(); }
 };

--- a/crane_tactics/include/crane_tactics/their_penalty_kick_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/their_penalty_kick_tactic.hpp
@@ -40,6 +40,14 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    auto wm = world_model;
+    return
+      [wm](const std::shared_ptr<RobotInfo> & robot) { return robot->getDistance(wm->ball().pos); };
+  }
+
 protected:
   void onRobotsChanged() override
   {


### PR DESCRIPTION
## 概要
crane_planner_pluginsから移行する際に失われていたロボット適性評価機能を17個のTacticクラスに実装し、RobotAllocatorが適切にロボットを割り当てられるようにしました。

## 背景
多くのTacticがgetRobotSuitabilityFunc関数を実装していなかったため、今までとは異なる挙動を示していました。旧crane_planner_pluginsの実装を参考に、各Tacticに適性関数を実装しました。

## 実装内容

### カテゴリ1: ボール距離ベース (5件)
- **OurDirectFreeKickTactic**: ボールに近いロボット優先（キーパー除外）
- **OurPenaltyKickTactic**: ボールに近いロボット優先（キーパー除外）
- **TheirPenaltyKickTactic**: ボールに近いロボット優先
- **SimpleKickOffSkillTactic**: ボールに近いロボット優先（二乗距離）
- **PlacementTargetNearByPositionerSkillTactic**: ボールに近いロボット優先

### カテゴリ2: ボール距離 + キーパー除外 (3件)
- **BallPlacementSkillTactic**
- **BallNearByPositionerSkillTactic**
- **PassableBallPlacementTactic**

### カテゴリ3: 配置ターゲット距離 (1件)
- **PlacementTargetPlacerTactic**: 配置目標位置に近いロボット優先

### カテゴリ4: ID番号ベース (4件)
- **FormationTactic**: ID番号小さい順（IbisFormationTactic, WingFormationTacticも継承）
- **CenterStopKickTactic**: ID番号小さい順
- **BallCalibrationDataCollectorTactic**: ID番号小さい順

### カテゴリ5: 特殊ケース (2件)
- **SubAttackerSkillTactic**: 簡略版実装（将来game_analyzerのmetricsで最適位置計算予定）
- **PassReceiverTactic**: デフォルトコスト0.0（game_analysisのpass_target_idで外部指定）

## 技術的詳細

### PlannerとTacticの違い
| 項目 | Planner | Tactic |
|------|---------|--------|
| 評価基準 | 高スコア = 優先 | 低コスト = 優先 |
| 典型例 | `100. / distance` | `distance` |
| 除外方法 | `-100.` を返す | `10000.0` を返す |

### 実装パターン
- 戻り値型: `std::function<double(const std::shared_ptr<RobotInfo>&)>`
- キーパー除外: コスト`10000.0`を返すことで実現
- world_modelのキャプチャ: ラムダ内で使用するためローカル変数`wm`にコピー
