### PR TITLE
feat: SubAttacker推奨位置をgame_analyzerのmetricsで計算

### DIFF
--- a/crane_game_analyzer/CMakeLists.txt
+++ b/crane_game_analyzer/CMakeLists.txt
@@ -29,6 +29,7 @@ ament_auto_add_library(${PROJECT_NAME}_component SHARED
   src/metrics/ball_horizon_metric.cpp
   src/metrics/slack_metrics.cpp
   src/metrics/attacker_metrics.cpp
+  src/metrics/sub_attacker_metrics.cpp
 )
 
 target_precompile_headers(${PROJECT_NAME}_component

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/metric_base.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/metric_base.hpp
@@ -34,7 +34,8 @@ enum class MetricId {
   RECOMMENDED_DEFENDERS,  ///< 推奨守備者数
 
   // 役割決定（新規）
-  ATTACKER_CANDIDATE,  ///< 推奨アタッカー
+  ATTACKER_CANDIDATE,     ///< 推奨アタッカー
+  SUB_ATTACKER_POSITION,  ///< SubAttacker推奨位置
 };
 
 /**

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/sub_attacker_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/sub_attacker_metrics.hpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_GAME_ANALYZER__METRICS__SUB_ATTACKER_METRICS_HPP_
+#define CRANE_GAME_ANALYZER__METRICS__SUB_ATTACKER_METRICS_HPP_
+
+#include <crane_geometry/boost_geometry.hpp>
+
+#include "metric_base.hpp"
+#include "metric_context.hpp"
+
+namespace crane::metrics
+{
+
+/**
+ * @brief SubAttacker推奨位置を計算するメトリクス
+ *
+ * ボール周辺のDPPS候補点から最適なSubAttacker配置位置を計算し、
+ * GameAnalysisに推奨位置を設定する
+ */
+class SubAttackerPositionMetric : public MetricBase
+{
+public:
+  SubAttackerPositionMetric();
+
+  /**
+   * @brief このメトリクスは他のメトリクスに依存しない
+   */
+  [[nodiscard]] auto getDependencies() const -> std::vector<MetricId> override { return {}; }
+
+  /**
+   * @brief SubAttacker推奨位置を計算
+   *
+   * 1. ボールが自陣にある場合は無効化
+   * 2. getDPPSPoints() でボール周りの候補点を生成
+   * 3. フィールド内・ペナルティエリア外でフィルタ
+   * 4. SubAttacker::getPointScore() で各点のスコア計算
+   * 5. 最高スコアの点を推奨位置として設定
+   *
+   * @param ctx 計算コンテキスト
+   */
+  auto compute(MetricContext & ctx) -> void override;
+
+private:
+  // ヒステリシス用状態（位置の急変を防ぐ）
+  Point last_position_{0.0, 0.0};
+  bool has_last_position_ = false;
+};
+
+}  // namespace crane::metrics
+
+#endif  // CRANE_GAME_ANALYZER__METRICS__SUB_ATTACKER_METRICS_HPP_

--- a/crane_game_analyzer/src/crane_game_analyzer.cpp
+++ b/crane_game_analyzer/src/crane_game_analyzer.cpp
@@ -15,6 +15,7 @@
 #include "crane_game_analyzer/metrics/attacker_metrics.hpp"
 #include "crane_game_analyzer/metrics/ball_horizon_metric.hpp"
 #include "crane_game_analyzer/metrics/slack_metrics.hpp"
+#include "crane_game_analyzer/metrics/sub_attacker_metrics.hpp"
 #include "crane_game_analyzer/metrics/threat_metrics.hpp"
 
 namespace crane
@@ -117,6 +118,9 @@ GameAnalyzerComponent::GameAnalyzerComponent(const rclcpp::NodeOptions & options
   // 役割決定メトリクス（新規）
   auto attacker_metric = std::make_shared<metrics::AttackerCandidateMetric>();
   metric_engine_->registerMetric(attacker_metric);
+
+  auto sub_attacker_position_metric = std::make_shared<metrics::SubAttackerPositionMetric>();
+  metric_engine_->registerMetric(sub_attacker_position_metric);
 
   // メトリクスエンジン初期化（トポロジカルソート・循環依存検出）
   if (!metric_engine_->initialize()) {

--- a/crane_game_analyzer/src/metrics/sub_attacker_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/sub_attacker_metrics.cpp
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "crane_game_analyzer/metrics/sub_attacker_metrics.hpp"
+
+#include <crane_geometry/ddps.hpp>
+#include <crane_geometry/geometry_operations.hpp>
+
+namespace crane::metrics
+{
+
+SubAttackerPositionMetric::SubAttackerPositionMetric()
+: MetricBase(MetricId::SUB_ATTACKER_POSITION, "SubAttackerPosition")
+{
+}
+
+namespace
+{
+// SubAttacker::getPointScoreのロジックを再実装
+// TODO: 将来的にはcrane_geometryなど共通パッケージに移動すべき
+double evaluateSubAttackerPosition(
+  const Point & p, const WorldModelWrapper * world_model)
+{
+  Segment line{world_model->ball().pos, p};
+
+  // 敵ロボットとの最短距離を計算
+  double min_enemy_dist = std::numeric_limits<double>::max();
+  Point closest_enemy_point = world_model->ball().pos;
+
+  for (const auto & robot : world_model->theirs().getAvailableRobots()) {
+    auto result = getClosestPointAndDistance(robot->pose.pos, line);
+    if (result.distance < min_enemy_dist) {
+      min_enemy_dist = result.distance;
+      closest_enemy_point = result.closest_point;
+    }
+  }
+
+  auto [angle, width] = world_model->getLargestGoalAngleRangeFromPoint(p);
+  // ゴールが見える角度が大きいほどよい
+  double score = width;
+
+  // 敵が動いてボールをブロック出来るかどうか
+  double enemy_closest_to_ball_dist = (closest_enemy_point - world_model->ball().pos).norm();
+  double ratio = min_enemy_dist / enemy_closest_to_ball_dist;
+  // ratioが大きいほどよい / 0.1以下は厳しい
+  if (ratio < 0.1) {
+    score = 0.;
+  } else {
+    score *= std::clamp(ratio * 5, 0.0, 1.0);
+  }
+
+  if (
+    std::abs(world_model->ball().pos.x() - world_model->goal().x()) >
+    std::abs(world_model->goal().x())) {
+    // 反射角　小さいほどよい（敵ゴールに近い場合のみ）
+    auto reflect_angle = std::abs(getAngleDiff(angle, getAngle(world_model->ball().pos - p)));
+    score *= (1.0 - std::min(reflect_angle * 0.5, 1.0));
+  }
+
+  // 距離評価: 最小距離制約と適度な距離を評価
+  const double dist = (world_model->ball().pos - p).norm();
+  // 最小距離制約: 1.5m未満は大幅減点
+  constexpr double MIN_PASS_DISTANCE = 1.5;
+  if (dist < MIN_PASS_DISTANCE) {
+    score *= dist / MIN_PASS_DISTANCE;  // 1.0mなら0.67倍、0.5mなら0.33倍
+  }
+  // 距離が遠すぎても減点（10m以上はスコア0）
+  score = score * std::max(1.0 - dist / 10.0, 0.0);
+
+  // シュートラインに近すぎる場所は避ける
+  Segment shoot_line{world_model->getOurGoalCenter(), world_model->ball().pos};
+  const auto dist_to_shoot_line = bg::distance(p, shoot_line);
+  if (dist_to_shoot_line < 0.5) {
+    score = 0.0;
+  }
+
+  // 自分とボールの延長線上にゴールがある場合は避ける
+  Segment robot_to_ball_and_more{
+    p, world_model->ball().pos + (world_model->ball().pos - p).normalized() * 10.0};
+  Segment goal_line{
+    world_model->getTheirGoalPosts().first, world_model->getTheirGoalPosts().second};
+  if (double distance = bg::distance(robot_to_ball_and_more, goal_line); distance < 1.0) {
+    score *= distance;
+  }
+
+  // ボールの後側にには行かない
+  double dot = (world_model->getTheirGoalCenter() - world_model->ball().pos)
+                 .normalized()
+                 .dot((p - world_model->ball().pos).normalized());
+  score *= std::max((dot + 0.5), 0.0);
+
+  return score;
+}
+}  // namespace
+
+auto SubAttackerPositionMetric::compute(MetricContext & ctx) -> void
+{
+  auto & wm = ctx.world_model;
+  auto & analysis = ctx.analysis;
+
+  // デフォルトでは無効
+  analysis.has_sub_attacker_position = false;
+  analysis.sub_attacker_position_score = 0.0f;
+
+  // ボールが自陣にある場合はSubAttacker不要
+  if (wm->point_checker.isInOurHalf(wm->ball().pos)) {
+    return;
+  }
+
+  // DPPS候補点を生成（旧SubAttackerSkillPlannerと同じパラメータ）
+  // 半径0.25m刻み、最大10m、64方向
+  auto candidates = getDPPSPoints(wm->ball().pos, 0.25, 10.0, 64);
+
+  // フィルタリング：フィールド内かつペナルティエリア外
+  std::vector<Point> valid_candidates;
+  for (const auto & candidate : candidates) {
+    if (wm->point_checker.isFieldInside(candidate) &&
+        !wm->point_checker.isPenaltyArea(candidate)) {
+      valid_candidates.push_back(candidate);
+    }
+  }
+
+  if (valid_candidates.empty()) {
+    return;
+  }
+
+  // 各候補点のスコアを計算
+  double best_score = -std::numeric_limits<double>::infinity();
+  Point best_position{0.0, 0.0};
+
+  for (const auto & candidate : valid_candidates) {
+    double score = evaluateSubAttackerPosition(candidate, wm);
+
+    if (score > best_score) {
+      best_score = score;
+      best_position = candidate;
+    }
+  }
+
+  // ヒステリシス：前回位置から大きく変わる場合のみ更新
+  constexpr double HYSTERESIS_THRESHOLD = 0.5;  // 0.5m以上動いたら更新
+  if (has_last_position_) {
+    double distance = std::hypot(
+      best_position.x() - last_position_.x(), best_position.y() - last_position_.y());
+    if (distance < HYSTERESIS_THRESHOLD) {
+      // 前回位置を維持
+      best_position = last_position_;
+    }
+  }
+
+  // 結果を設定
+  analysis.has_sub_attacker_position = true;
+  analysis.recommended_sub_attacker_position.x = best_position.x();
+  analysis.recommended_sub_attacker_position.y = best_position.y();
+  analysis.sub_attacker_position_score = static_cast<float>(best_score);
+
+  // 状態を更新
+  last_position_ = best_position;
+  has_last_position_ = true;
+}
+
+}  // namespace crane::metrics

--- a/crane_game_analyzer/src/metrics/sub_attacker_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/sub_attacker_metrics.cpp
@@ -21,8 +21,7 @@ namespace
 {
 // SubAttacker::getPointScoreのロジックを再実装
 // TODO: 将来的にはcrane_geometryなど共通パッケージに移動すべき
-double evaluateSubAttackerPosition(
-  const Point & p, const WorldModelWrapper * world_model)
+double evaluateSubAttackerPosition(const Point & p, const WorldModelWrapper * world_model)
 {
   Segment line{world_model->ball().pos, p};
 
@@ -117,8 +116,7 @@ auto SubAttackerPositionMetric::compute(MetricContext & ctx) -> void
   // フィルタリング：フィールド内かつペナルティエリア外
   std::vector<Point> valid_candidates;
   for (const auto & candidate : candidates) {
-    if (wm->point_checker.isFieldInside(candidate) &&
-        !wm->point_checker.isPenaltyArea(candidate)) {
+    if (wm->point_checker.isFieldInside(candidate) && !wm->point_checker.isPenaltyArea(candidate)) {
       valid_candidates.push_back(candidate);
     }
   }
@@ -143,8 +141,8 @@ auto SubAttackerPositionMetric::compute(MetricContext & ctx) -> void
   // ヒステリシス：前回位置から大きく変わる場合のみ更新
   constexpr double HYSTERESIS_THRESHOLD = 0.5;  // 0.5m以上動いたら更新
   if (has_last_position_) {
-    double distance = std::hypot(
-      best_position.x() - last_position_.x(), best_position.y() - last_position_.y());
+    double distance =
+      std::hypot(best_position.x() - last_position_.x(), best_position.y() - last_position_.y());
     if (distance < HYSTERESIS_THRESHOLD) {
       // 前回位置を維持
       best_position = last_position_;

--- a/crane_msgs/msg/analysis/GameAnalysis.msg
+++ b/crane_msgs/msg/analysis/GameAnalysis.msg
@@ -34,3 +34,8 @@ uint8 recommended_num_defenders
 int32 recommended_attacker_id        # 推奨アタッカーID（-1は未選択）
 float32 attacker_suitability_score   # アタッカー適性スコア
 int32 recommended_pass_receiver_id   # 推奨パスレシーバーID（-1は未選択）
+
+# SubAttacker推奨位置
+geometry_msgs/Point recommended_sub_attacker_position
+float32 sub_attacker_position_score
+bool has_sub_attacker_position  # 有効な位置が存在するか

--- a/crane_tactics/include/crane_tactics/sub_attacker_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/sub_attacker_skill_tactic.hpp
@@ -36,18 +36,19 @@ public:
   auto getRobotSuitabilityFunc() const
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {
-    // 注意: SubAttacker用のDPPS最適位置は将来game_analyzerのmetricsで計算予定
-    // 現時点では簡略版を使用し、metrics追加後に更新する
-    // TODO: game_analyzerにSubAttacker用metricsが追加されたら、
-    //       recommended_sub_attacker_position等を使用するように更新
     auto wm = world_model;
     return [wm](const std::shared_ptr<RobotInfo> & robot) {
-      // ボールが自陣にある場合は高コスト（SubAttacker不要）
-      if (wm->point_checker.isInOurHalf(wm->ball().pos)) {
+      const auto & ga = wm->getMsg().game_analysis;
+
+      // 有効な推奨位置がない場合は高コスト
+      if (!ga.has_sub_attacker_position) {
         return 10000.0;
       }
-      // 敵ゴール方向でボール付近のロボットを優先
-      return robot->getSquareDistance(wm->ball().pos);
+
+      // 推奨位置への距離をコストとして返す
+      Point recommended_pos{
+        ga.recommended_sub_attacker_position.x, ga.recommended_sub_attacker_position.y};
+      return robot->getSquareDistance(recommended_pos);
     };
   }
 


### PR DESCRIPTION
## 概要
SubAttackerSkillTacticの最適化を実施し、ロボット適性評価をgame_analyzerのmetricsで計算されるDPPS（Dynamic Potential Positioning System）ベースの推奨位置を使用するように変更しました。

## 主な変更点

### 1. GameAnalysis.msgに新しいフィールドを追加
- `recommended_sub_attacker_position`: SubAttacker推奨位置
- `sub_attacker_position_score`: 推奨位置のスコア  
- `has_sub_attacker_position`: 有効な位置が存在するかのフラグ

### 2. SubAttackerPositionMetricの実装
- MetricIdに`SUB_ATTACKER_POSITION`を追加
- ボール周辺のDPPS候補点を生成（半径0.25m刻み、最大10m、64方向）
- フィールド内かつペナルティエリア外の候補点をフィルタリング
- 各候補点のスコアを評価し最適位置を算出
- ヒステリシス機能により位置の急変を防止（閾値0.5m）

### 3. スコア評価ロジック
循環依存を避けるため、SubAttacker::getPointScoreのロジックをcrane_game_analyzer内で再実装しました：
- ゴールが見える角度の幅
- 敵ロボットによるブロック可能性
- 反射角の評価
- 距離制約（最小1.5m、最大10m）
- シュートラインからの距離
- ボールの後側にいかない制約

### 4. SubAttackerSkillTacticの更新
適性関数をgame_analyzerで計算された推奨位置への距離ベースに変更。有効な推奨位置がない場合は高コストを返します。

## 技術的課題と解決策
- **循環依存**: crane_robot_skillsがcrane_game_analyzerに依存しているため、逆方向の依存を追加できず。スコア評価ロジックをcrane_game_analyzer内で再実装することで解決。
- **API互換性**: PointCheckerのAPI名称を修正（`isInOurPenaltyArea`→`isPenaltyArea`）
