### PR TITLE
fix: Attackerロボット切り替え機能の修正とGameAnalysis連携の実装

### DIFF
--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
@@ -40,10 +40,10 @@ private:
   std::unordered_map<uint8_t, double> ema_scores_;
 
   // ヒステリシスパラメータ
-  static constexpr double MIN_HOLD_DURATION_SEC = 0.5;   // 0.5秒に短縮
-  static constexpr double MIN_IMPROVEMENT_RATIO = 0.2;   // 20%改善で切り替え（相対値）
-  static constexpr double EMERGENCY_SWITCH_RATIO = 1.5;  // 1.5倍良ければ即切り替え
-  static constexpr double EMA_ALPHA = 0.3;               // スムージング係数
+  static constexpr double MIN_HOLD_DURATION_SEC = 0.2;   // 0.2秒に短縮（より素早い応答）
+  static constexpr double MIN_IMPROVEMENT_RATIO = 0.01;  // 1%改善で切り替え（より敏感に）
+  static constexpr double EMERGENCY_SWITCH_RATIO = 1.03; // 3%良ければ即切り替え
+  static constexpr double EMA_ALPHA = 0.7;               // スムージング係数（新スコア70%、古いスコア30%）
 };
 
 }  // namespace crane::metrics

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
@@ -40,10 +40,10 @@ private:
   std::unordered_map<uint8_t, double> ema_scores_;
 
   // ヒステリシスパラメータ
-  static constexpr double MIN_HOLD_DURATION_SEC = 0.2;   // 0.2秒に短縮（より素早い応答）
-  static constexpr double MIN_IMPROVEMENT_RATIO = 0.01;  // 1%改善で切り替え（より敏感に）
-  static constexpr double EMERGENCY_SWITCH_RATIO = 1.03; // 3%良ければ即切り替え
-  static constexpr double EMA_ALPHA = 0.7;               // スムージング係数（新スコア70%、古いスコア30%）
+  static constexpr double MIN_HOLD_DURATION_SEC = 0.2;    // 0.2秒に短縮（より素早い応答）
+  static constexpr double MIN_IMPROVEMENT_RATIO = 0.01;   // 1%改善で切り替え（より敏感に）
+  static constexpr double EMERGENCY_SWITCH_RATIO = 1.03;  // 3%良ければ即切り替え
+  static constexpr double EMA_ALPHA = 0.7;  // スムージング係数（新スコア70%、古いスコア30%）
 };
 
 }  // namespace crane::metrics

--- a/crane_game_analyzer/src/metrics/attacker_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/attacker_metrics.cpp
@@ -89,8 +89,8 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
     // デバッグログ: 各ロボットのスコア
     RCLCPP_DEBUG(
       rclcpp::get_logger("AttackerMetric"),
-      "Robot %d: raw_score=%.2f, smoothed=%.2f, has_intercept=%d, distance=%.2f",
-      robot->id, score, smoothed_score, has_valid_intercept, metric_distance);
+      "Robot %d: raw_score=%.2f, smoothed=%.2f, has_intercept=%d, distance=%.2f", robot->id, score,
+      smoothed_score, has_valid_intercept, metric_distance);
   }
 
   // スコアでソート（降順）
@@ -129,8 +129,8 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
     double improvement_ratio = (best_score - current_score) / std::max(current_score, 0.1);
 
     // 絶対値判定の閾値とタイムアウト
-    constexpr double absolute_threshold = 2.0;      // スコア差2.0以上（約0.2m距離差に相当）
-    constexpr double force_switch_timeout = 3.0;    // 3秒経過後は強制再評価
+    constexpr double absolute_threshold = 2.0;    // スコア差2.0以上（約0.2m距離差に相当）
+    constexpr double force_switch_timeout = 3.0;  // 3秒経過後は強制再評価
 
     // 切り替え判定（優先度順）
     if (time_since_switch >= force_switch_timeout) {
@@ -165,12 +165,12 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
       RCLCPP_INFO(
         rclcpp::get_logger("AttackerMetric"),
         "SWITCH: %d -> %d (old_score=%.2f, new_score=%.2f, improvement=%.1f%%, time=%.2fs)",
-        last_attacker_id_, best_id, current_score, best_score,
-        improvement_ratio * 100, time_since_switch);
+        last_attacker_id_, best_id, current_score, best_score, improvement_ratio * 100,
+        time_since_switch);
     } else {
       RCLCPP_INFO(
-        rclcpp::get_logger("AttackerMetric"),
-        "INITIAL: selected robot %d (score=%.2f)", best_id, best_score);
+        rclcpp::get_logger("AttackerMetric"), "INITIAL: selected robot %d (score=%.2f)", best_id,
+        best_score);
     }
     last_attacker_id_ = best_id;
     last_switch_time_ = current_time;
@@ -186,8 +186,8 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
     double time_since_switch = (current_time - last_switch_time_).seconds();
     RCLCPP_DEBUG(
       rclcpp::get_logger("AttackerMetric"),
-      "HOLD: robot %d (best=%d, best_score=%.2f, current=%.2f, time=%.2fs)",
-      last_attacker_id_, best_id, best_score, current_score, time_since_switch);
+      "HOLD: robot %d (best=%d, best_score=%.2f, current=%.2f, time=%.2fs)", last_attacker_id_,
+      best_id, best_score, current_score, time_since_switch);
   }
 
   ctx.analysis.recommended_attacker_id = last_attacker_id_;

--- a/crane_game_analyzer/src/metrics/attacker_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/attacker_metrics.cpp
@@ -64,9 +64,9 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
     // 到達距離が短いほど高スコア
     double score = 10.0 / std::max(metric_distance, 0.1);
 
-    // インターセプト計算ができなかった（ボールに追いつけない等）場合はスコアを下げる
+    // インターセプト計算ができなかった（ボールに追いつけない等）場合はスコアを大幅に下げる
     if (!has_valid_intercept) {
-      score *= 0.5;
+      score *= 0.3;  // 0.5 -> 0.3に強化（インターセプト不可能なロボットの優先度を下げる）
     }
 
     double total_score = score;
@@ -85,6 +85,12 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
     }
 
     robot_scores.push_back({robot->id, smoothed_score});
+
+    // デバッグログ: 各ロボットのスコア
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("AttackerMetric"),
+      "Robot %d: raw_score=%.2f, smoothed=%.2f, has_intercept=%d, distance=%.2f",
+      robot->id, score, smoothed_score, has_valid_intercept, metric_distance);
   }
 
   // スコアでソート（降順）
@@ -118,12 +124,26 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
       }
     }
 
-    // 緊急切り替え: 新しいロボットが2倍以上良い場合は保持時間を無視して即座に切り替え
-    if (best_score >= current_score * EMERGENCY_SWITCH_RATIO) {
+    // スコア差を計算
+    double score_diff = best_score - current_score;
+    double improvement_ratio = (best_score - current_score) / std::max(current_score, 0.1);
+
+    // 絶対値判定の閾値とタイムアウト
+    constexpr double absolute_threshold = 2.0;      // スコア差2.0以上（約0.2m距離差に相当）
+    constexpr double force_switch_timeout = 3.0;    // 3秒経過後は強制再評価
+
+    // 切り替え判定（優先度順）
+    if (time_since_switch >= force_switch_timeout) {
+      // 1. タイムアウト: わずかでも良ければ切り替え
+      should_switch = (score_diff > 0.1);
+    } else if (score_diff >= absolute_threshold) {
+      // 2. 絶対値判定: 大きな差がある場合は即座に切り替え
+      should_switch = true;
+    } else if (best_score >= current_score * EMERGENCY_SWITCH_RATIO) {
+      // 3. 緊急切り替え: 相対的に大幅に良い場合は即座に切り替え
       should_switch = true;
     } else if (time_since_switch >= MIN_HOLD_DURATION_SEC) {
-      // 通常切り替え: 保持時間経過後、相対的に50%以上改善がある場合のみ切り替え
-      double improvement_ratio = (best_score - current_score) / std::max(current_score, 0.1);
+      // 4. 通常切り替え: 保持時間経過後、相対的に改善がある場合のみ切り替え
       if (improvement_ratio >= MIN_IMPROVEMENT_RATIO) {
         should_switch = true;
       }
@@ -131,8 +151,43 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
   }
 
   if (should_switch) {
+    // スイッチ実行時のログ
+    if (last_attacker_id_ >= 0) {
+      double current_score = 0.0;
+      for (const auto & rs : robot_scores) {
+        if (static_cast<int>(rs.id) == last_attacker_id_) {
+          current_score = rs.score;
+          break;
+        }
+      }
+      double improvement_ratio = (best_score - current_score) / std::max(current_score, 0.1);
+      double time_since_switch = (current_time - last_switch_time_).seconds();
+      RCLCPP_INFO(
+        rclcpp::get_logger("AttackerMetric"),
+        "SWITCH: %d -> %d (old_score=%.2f, new_score=%.2f, improvement=%.1f%%, time=%.2fs)",
+        last_attacker_id_, best_id, current_score, best_score,
+        improvement_ratio * 100, time_since_switch);
+    } else {
+      RCLCPP_INFO(
+        rclcpp::get_logger("AttackerMetric"),
+        "INITIAL: selected robot %d (score=%.2f)", best_id, best_score);
+    }
     last_attacker_id_ = best_id;
     last_switch_time_ = current_time;
+  } else if (last_attacker_id_ >= 0 && best_id != last_attacker_id_) {
+    // ホールド時のログ（異なるロボットが最適だが切り替えない場合）
+    double current_score = 0.0;
+    for (const auto & rs : robot_scores) {
+      if (static_cast<int>(rs.id) == last_attacker_id_) {
+        current_score = rs.score;
+        break;
+      }
+    }
+    double time_since_switch = (current_time - last_switch_time_).seconds();
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("AttackerMetric"),
+      "HOLD: robot %d (best=%d, best_score=%.2f, current=%.2f, time=%.2fs)",
+      last_attacker_id_, best_id, best_score, current_score, time_since_switch);
   }
 
   ctx.analysis.recommended_attacker_id = last_attacker_id_;

--- a/crane_tactic_coordinator/include/crane_tactic_coordinator/command_aggregator.hpp
+++ b/crane_tactic_coordinator/include/crane_tactic_coordinator/command_aggregator.hpp
@@ -8,6 +8,7 @@
 #define CRANE_TACTIC_COORDINATOR__COMMAND_AGGREGATOR_HPP_
 
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_msgs/msg/game_analysis.hpp>
 #include <crane_msgs/msg/position_commands.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
@@ -29,11 +30,12 @@ public:
    * @brief 全プランナーからコマンドを収集してメッセージを構築
    * @param world_model WorldModelの参照
    * @param current_time 現在時刻
+   * @param game_analysis GameAnalysisメッセージ
    * @return 構築されたPositionCommandsメッセージ
    */
   auto collectCommands(
-    const WorldModelWrapper::SharedPtr & world_model, const rclcpp::Time & current_time)
-    -> crane_msgs::msg::PositionCommands;
+    const WorldModelWrapper::SharedPtr & world_model, const rclcpp::Time & current_time,
+    const crane_msgs::msg::GameAnalysis & game_analysis) -> crane_msgs::msg::PositionCommands;
 
 private:
   /**

--- a/crane_tactic_coordinator/include/crane_tactic_coordinator/tactic_coordinator.hpp
+++ b/crane_tactic_coordinator/include/crane_tactic_coordinator/tactic_coordinator.hpp
@@ -12,6 +12,7 @@
 #include <crane_msg_wrappers/crane_visualizer_wrapper.hpp>
 #include <crane_msg_wrappers/play_situation_wrapper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_msgs/msg/game_analysis.hpp>
 #include <crane_msgs/msg/play_situation.hpp>
 #include <crane_msgs/msg/position_commands.hpp>
 #include <crane_msgs/msg/robot_select_results.hpp>
@@ -68,6 +69,8 @@ private:
 
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr session_injection_sub;
 
+  rclcpp::Subscription<crane_msgs::msg::GameAnalysis>::SharedPtr game_analysis_sub;
+
   DiagnosedPublisher<crane_msgs::msg::PositionCommands> position_commands_pub;
 
   rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr timer_process_time_pub;
@@ -77,6 +80,8 @@ private:
   rclcpp::Publisher<crane_msgs::msg::RobotSelectResults>::SharedPtr robot_select_results_pub;
 
   crane_msgs::msg::PlaySituation play_situation;
+
+  crane_msgs::msg::GameAnalysis latest_game_analysis_;
 
   rclcpp::TimerBase::SharedPtr timer;
 

--- a/crane_tactic_coordinator/src/command_aggregator.cpp
+++ b/crane_tactic_coordinator/src/command_aggregator.cpp
@@ -18,8 +18,8 @@ CommandAggregator::CommandAggregator(std::shared_ptr<TacticRegistry> tactic_regi
 }
 
 auto CommandAggregator::collectCommands(
-  const WorldModelWrapper::SharedPtr & world_model, const rclcpp::Time & current_time)
-  -> crane_msgs::msg::PositionCommands
+  const WorldModelWrapper::SharedPtr & world_model, const rclcpp::Time & current_time,
+  const crane_msgs::msg::GameAnalysis & game_analysis) -> crane_msgs::msg::PositionCommands
 {
   crane_msgs::msg::PositionCommands msg;
 
@@ -28,6 +28,9 @@ auto CommandAggregator::collectCommands(
 
   // 全プランナーからコマンドを収集
   for (const auto & tactic : tactic_registry_->getAllPlanners()) {
+    // 各Tacticにgame_analysisを設定
+    tactic->setGameAnalysis(game_analysis);
+
     auto robot_count = tactic->getRobots().size();
     auto commands_msg = tactic->getPositionCommands();
     auto command_count = commands_msg.robot_commands.size();

--- a/crane_tactic_coordinator/src/crane_tactic_coordinator.cpp
+++ b/crane_tactic_coordinator/src/crane_tactic_coordinator.cpp
@@ -94,6 +94,14 @@ TacticCoordinatorComponent::TacticCoordinatorComponent(const rclcpp::NodeOptions
       config_manager_->updateEventMapping("INJECTION", msg.data);
     });
 
+  game_analysis_sub = create_subscription<crane_msgs::msg::GameAnalysis>(
+    "/game_analysis", 10, [this](const crane_msgs::msg::GameAnalysis::SharedPtr msg) {
+      latest_game_analysis_ = *msg;
+      RCLCPP_DEBUG(
+        get_logger(), "Received game_analysis: recommended_attacker_id=%d",
+        latest_game_analysis_.recommended_attacker_id);
+    });
+
   // 診断Updater設定
   diagnostic_updater_.setHardwareID("session_controller");
   diagnostic_updater_.add(
@@ -162,7 +170,7 @@ auto TacticCoordinatorComponent::onWorldModelUpdate() -> void
   }
 
   // コマンド収集と構築
-  auto msg = command_aggregator_->collectCommands(world_model, now());
+  auto msg = command_aggregator_->collectCommands(world_model, now(), latest_game_analysis_);
 
   position_commands_pub.publish(msg);
   visualizer->flush();

--- a/crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp
@@ -74,7 +74,7 @@ public:
   auto getRobotSuitabilityFunc() const
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {
-    auto wm = world_model;  // shared_ptrをコピー
+    auto wm = world_model;                   // shared_ptrをコピー
     auto game_analysis = getGameAnalysis();  // GameAnalysisをコピー
 
     // デバッグ用：推奨ロボットIDをログ出力
@@ -101,8 +101,8 @@ public:
       // それ以外はボール距離ベース
       double distance = robot->getDistance(wm->ball().pos);
       RCLCPP_DEBUG(
-        rclcpp::get_logger("AttackerSkillTactic"),
-        "Robot %d cost: %.2f (ball distance)", robot->id, distance);
+        rclcpp::get_logger("AttackerSkillTactic"), "Robot %d cost: %.2f (ball distance)", robot->id,
+        distance);
       return distance;
     };
   }

--- a/crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp
+++ b/crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp
@@ -75,32 +75,43 @@ public:
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {
     auto wm = world_model;  // shared_ptrをコピー
-    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+    auto game_analysis = getGameAnalysis();  // GameAnalysisをコピー
+
+    // デバッグ用：推奨ロボットIDをログ出力
+    static int last_logged_id = -999;
+    if (game_analysis.recommended_attacker_id != last_logged_id) {
+      RCLCPP_INFO(
+        rclcpp::get_logger("AttackerSkillTactic"),
+        "Recommended attacker ID from game_analysis: %d (score: %.2f)",
+        game_analysis.recommended_attacker_id, game_analysis.attacker_suitability_score);
+      last_logged_id = game_analysis.recommended_attacker_id;
+    }
+
+    return [wm, game_analysis](const std::shared_ptr<RobotInfo> & robot) {
       // game_analysisで推奨ロボットが設定されている場合、そのロボットを最優先
-      try {
-        const auto & game_analysis = wm->getMsg().game_analysis;
-        if (
-          game_analysis.recommended_attacker_id >= 0 &&
-          robot->id == static_cast<uint8_t>(game_analysis.recommended_attacker_id)) {
-          return 0.0;  // 最高の適性（コスト最小）
-        }
-      } catch (...) {
+      if (
+        game_analysis.recommended_attacker_id >= 0 &&
+        robot->id == static_cast<uint8_t>(game_analysis.recommended_attacker_id)) {
+        RCLCPP_DEBUG(
+          rclcpp::get_logger("AttackerSkillTactic"),
+          "Robot %d matches recommended attacker, returning cost 0.0", robot->id);
+        return 0.0;  // 最高の適性（コスト最小）
       }
 
       // それ以外はボール距離ベース
-      return robot->getDistance(wm->ball().pos);
+      double distance = robot->getDistance(wm->ball().pos);
+      RCLCPP_DEBUG(
+        rclcpp::get_logger("AttackerSkillTactic"),
+        "Robot %d cost: %.2f (ball distance)", robot->id, distance);
+      return distance;
     };
   }
 
   bool isHardConstraint() const override
   {
     // game_analysisでrecommended_attacker_idが設定されている場合はハード制約として扱う
-    try {
-      const auto & game_analysis = world_model->getMsg().game_analysis;
-      return game_analysis.recommended_attacker_id >= 0;
-    } catch (...) {
-      return false;
-    }
+    const auto & game_analysis = getGameAnalysis();
+    return game_analysis.recommended_attacker_id >= 0;
   }
 
 protected:

--- a/crane_tactics/include/crane_tactics/tactic_base.hpp
+++ b/crane_tactics/include/crane_tactics/tactic_base.hpp
@@ -13,6 +13,7 @@
 #include <crane_msg_wrappers/position_command_wrapper.hpp>
 #include <crane_msg_wrappers/robot_command_wrapper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_msgs/msg/game_analysis.hpp>
 #include <crane_msgs/msg/position_commands.hpp>
 #include <crane_physics/position_assignments.hpp>
 #include <crane_utils/stream.hpp>
@@ -200,6 +201,25 @@ public:
    */
   virtual int getDesiredRobotNumber(int min_robots, int max_robots) const { return max_robots; }
 
+  /**
+   * @brief GameAnalysisメッセージを設定する
+   *
+   * TacticCoordinatorから呼ばれ、game_analyzerが計算した分析結果を受け取る。
+   *
+   * @param game_analysis GameAnalysisメッセージ
+   */
+  void setGameAnalysis(const crane_msgs::msg::GameAnalysis & game_analysis)
+  {
+    game_analysis_ = game_analysis;
+  }
+
+  /**
+   * @brief GameAnalysisメッセージを取得する
+   *
+   * @return GameAnalysisメッセージの参照
+   */
+  const crane_msgs::msg::GameAnalysis & getGameAnalysis() const { return game_analysis_; }
+
 protected:
   /**
    * @brief ロボット割り当てが変更された時に呼ばれるコールバック
@@ -262,6 +282,9 @@ protected:
   Status status = Status::RUNNING;
 
   VisualizerMessageBuilder::SharedPtr visualizer;
+
+private:
+  crane_msgs::msg::GameAnalysis game_analysis_;
 };
 
 }  // namespace crane


### PR DESCRIPTION
## 問題

AttackerCandidateMetricで推奨ロボットを計算しているにも関わらず、実際のAttackerは常に0番ロボットに固定されていた。

## 根本原因

1. **ヒステリシスパラメータが過度に保守的**
   - EMA_ALPHA=0.3（古いスコアの重みが70%）
   - MIN_IMPROVEMENT_RATIO=0.2（20%改善が必要）
   - 一度選択されたロボットが固定化される

2. **GameAnalysisメッセージの伝播不備**
   - AttackerCandidateMetricが計算した`recommended_attacker_id`がworld_modelに反映されていなかった
   - AttackerSkillTacticが推奨ロボットIDを取得できていなかった

## 実装内容

### 1. AttackerCandidateMetricの改善

#### ヒステリシスパラメータの最適化
- `MIN_HOLD_DURATION_SEC`: 0.5→0.2秒（より素早い応答）
- `MIN_IMPROVEMENT_RATIO`: 0.2→0.01（1%改善で切り替え）
- `EMERGENCY_SWITCH_RATIO`: 1.5→1.03（3%改善で即切り替え）
- `EMA_ALPHA`: 0.3→0.7（新スコアを70%重視）

#### 切り替えロジックの改善
- 絶対値判定の追加（スコア差2.0以上で即切り替え）
- タイムアウト強制切り替え（3秒経過後は再評価）
- インターセプト不可能なロボットへのペナルティ強化（0.5→0.3倍）

#### デバッグログの追加
- 各ロボットのスコア表示（RCLCPP_DEBUG）
- 切り替え実行時の詳細ログ（RCLCPP_INFO）
- ホールド時の判定理由（RCLCPP_DEBUG）

### 2. GameAnalysis連携アーキテクチャの実装

#### TacticBase（`crane_tactics/include/crane_tactics/tactic_base.hpp`）
- GameAnalysisを保持するメンバー変数を追加
- `setGameAnalysis()`メソッドでGameAnalysisを受け取る
- `getGameAnalysis()`メソッドで取得

#### TacticCoordinator（`crane_tactic_coordinator`）
- `game_analysis_sub`でgame_analysisトピックを購読
- `latest_game_analysis_`にメッセージを保存
- デバッグログで受信を確認

#### CommandAggregator（`crane_tactic_coordinator/src/command_aggregator.cpp`）
- `collectCommands()`にGameAnalysisパラメータを追加
- 各TacticにGameAnalysisを配信（`tactic->setGameAnalysis()`）

#### AttackerSkillTactic（`crane_tactics/include/crane_tactics/attacker_skill_tactic.hpp`）
- `getRobotSuitabilityFunc()`でGameAnalysisから推奨ロボットIDを取得
- 推奨ロボットに最高適性（コスト0.0）を付与
- `isHardConstraint()`でハード制約として扱う

## 効果

✅ 最適なロボットが適切に選択され、状況に応じて切り替わるようになった  
✅ デバッグログにより切り替え判定の可視化が可能になった  
✅ アーキテクチャ的にGameAnalysisとWorldModelの責務が明確に分離された


