### PR TITLE
fix: フィールド情報取得前のworld_model発行を抑制

### DIFF
--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -104,7 +104,10 @@ public:
 
   [[nodiscard]] auto available() const -> bool
   {
-    return has_vision_updated_ || has_tracked_frame_updated_;
+    bool has_data = has_vision_updated_ || has_tracked_frame_updated_;
+    bool has_field = geometry_initialized ||
+                     (game_data.field_w > 0.0 && game_data.field_h > 0.0);
+    return has_data && has_field;
   }
 
   auto setRobotIDsMask(const std::vector<uint8_t> & ids) -> void { robot_ids_mask = ids; }
@@ -117,6 +120,11 @@ public:
     -> void;
 
   auto updateGeometryIfNeeded() -> void;
+
+  // 状態確認用メソッド
+  [[nodiscard]] auto isGeometryInitialized() const -> bool { return geometry_initialized; }
+  [[nodiscard]] auto hasVisionUpdated() const -> bool { return has_vision_updated_; }
+  [[nodiscard]] auto hasTrackedFrameUpdated() const -> bool { return has_tracked_frame_updated_; }
 
   // Vision処理関連メソッド
   [[nodiscard]] auto getBallInfo() const -> const crane_msgs::msg::BallInfo & { return ball_info_; }

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -105,8 +105,7 @@ public:
   [[nodiscard]] auto available() const -> bool
   {
     bool has_data = has_vision_updated_ || has_tracked_frame_updated_;
-    bool has_field = geometry_initialized ||
-                     (game_data.field_w > 0.0 && game_data.field_h > 0.0);
+    bool has_field = geometry_initialized || (game_data.field_w > 0.0 && game_data.field_h > 0.0);
     return has_data && has_field;
   }
 

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -337,11 +337,20 @@ auto WorldModelDataProvider::updateGeometryIfNeeded() -> void
   game_data.penalty_area_h = geometry.penalty_area_height;
 
   if (geometry_changed) {
-    RCLCPP_INFO(
-      node.get_logger(),
-      "フィールド情報受信（%s）: field=%.3fx%.3f, goal=%.3fx%.3f, penalty_area=%.3fx%.3f",
-      geometry_initialized ? "更新" : "初期化", game_data.field_w, game_data.field_h,
-      game_data.goal_w, game_data.goal_h, game_data.penalty_area_w, game_data.penalty_area_h);
+    if (geometry_initialized) {
+      RCLCPP_INFO(
+        node.get_logger(),
+        "フィールド情報更新: field=%.3fx%.3f, goal=%.3fx%.3f, penalty_area=%.3fx%.3f",
+        game_data.field_w, game_data.field_h,
+        game_data.goal_w, game_data.goal_h, game_data.penalty_area_w, game_data.penalty_area_h);
+    } else {
+      RCLCPP_INFO(
+        node.get_logger(),
+        "フィールド情報初期化完了: field=%.3fx%.3f, goal=%.3fx%.3f, penalty_area=%.3fx%.3f "
+        "→ world_model発行が開始されます",
+        game_data.field_w, game_data.field_h,
+        game_data.goal_w, game_data.goal_h, game_data.penalty_area_w, game_data.penalty_area_h);
+    }
   }
 
   constexpr double OFFSET = 0.3;

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -341,15 +341,15 @@ auto WorldModelDataProvider::updateGeometryIfNeeded() -> void
       RCLCPP_INFO(
         node.get_logger(),
         "フィールド情報更新: field=%.3fx%.3f, goal=%.3fx%.3f, penalty_area=%.3fx%.3f",
-        game_data.field_w, game_data.field_h,
-        game_data.goal_w, game_data.goal_h, game_data.penalty_area_w, game_data.penalty_area_h);
+        game_data.field_w, game_data.field_h, game_data.goal_w, game_data.goal_h,
+        game_data.penalty_area_w, game_data.penalty_area_h);
     } else {
       RCLCPP_INFO(
         node.get_logger(),
         "フィールド情報初期化完了: field=%.3fx%.3f, goal=%.3fx%.3f, penalty_area=%.3fx%.3f "
         "→ world_model発行が開始されます",
-        game_data.field_w, game_data.field_h,
-        game_data.goal_w, game_data.goal_h, game_data.penalty_area_w, game_data.penalty_area_h);
+        game_data.field_w, game_data.field_h, game_data.goal_w, game_data.goal_h,
+        game_data.penalty_area_w, game_data.penalty_area_h);
     }
   }
 

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -148,9 +148,24 @@ WorldModelPublisherComponent::WorldModelPublisherComponent(const rclcpp::NodeOpt
       publishWorldModel();
       publishVisualization(wrapper_);
     } else {
-      RCLCPP_WARN_THROTTLE(
-        get_logger(), *get_clock(), 10000,
-        "No vision or tracker data available - world_model not published");
+      // より詳細な状態を表示
+      bool has_vision = data_provider_->hasVisionUpdated();
+      bool has_tracker = data_provider_->hasTrackedFrameUpdated();
+      bool has_geometry = data_provider_->isGeometryInitialized();
+
+      if (!has_vision && !has_tracker) {
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 10000,
+          "Vision/Trackerデータを待機中 - world_modelは未発行");
+      } else if (!has_geometry) {
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 10000,
+          "フィールド情報を待機中 - world_modelは未発行 (Vision/Trackerデータは受信済み)");
+      } else {
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 10000,
+          "データ準備中 - world_modelは未発行");
+      }
     }
 
     // 診断情報を更新

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -155,16 +155,14 @@ WorldModelPublisherComponent::WorldModelPublisherComponent(const rclcpp::NodeOpt
 
       if (!has_vision && !has_tracker) {
         RCLCPP_WARN_THROTTLE(
-          get_logger(), *get_clock(), 10000,
-          "Vision/Trackerデータを待機中 - world_modelは未発行");
+          get_logger(), *get_clock(), 10000, "Vision/Trackerデータを待機中 - world_modelは未発行");
       } else if (!has_geometry) {
         RCLCPP_WARN_THROTTLE(
           get_logger(), *get_clock(), 10000,
           "フィールド情報を待機中 - world_modelは未発行 (Vision/Trackerデータは受信済み)");
       } else {
         RCLCPP_WARN_THROTTLE(
-          get_logger(), *get_clock(), 10000,
-          "データ準備中 - world_modelは未発行");
+          get_logger(), *get_clock(), 10000, "データ準備中 - world_modelは未発行");
       }
     }
 


### PR DESCRIPTION
## Summary
Vision/Trackerからロボット・ボール情報を受信した際に、フィールド情報(geometry)が初期化される前にworld_modelを発行してしまい、skillなどがエラーで落ちる問題を修正しました。

### 変更内容
- `available()`メソッドにフィールド情報の有効性チェックを追加
- 状態確認用のgetterメソッドを追加（`isGeometryInitialized()`など）
- フィールド情報待ち状態のログ出力を改善

### 効果
- フィールド情報が完全に初期化されるまでworld_modelは発行されない
- skillがフィールド情報なし（`field_size = (0, 0)`）のworld_modelを受信してエラーで落ちる問題が解決
- Vision geometry待機状態がログで明確に確認できる

## Test plan
- [x] ビルド成功を確認（`colcon build --packages-up-to crane_world_model_publisher`）
- [x] シミュレーションで動作確認（`ros2 launch crane_bringup sim.launch.xml`）
- [x] `field_geometry_config_path="vision"`に設定して実機テスト
  - [x] 起動時に「フィールド情報を待機中」のログが表示されること
  - [x] Vision geometry受信後に「フィールド情報初期化完了 → world_model発行が開始されます」のログが表示されること
  - [x] skillが正常に動作すること（エラーで落ちないこと）

## Related Files
- `crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp`
- `crane_world_model_publisher/src/world_model_data_provider.cpp`
- `crane_world_model_publisher/src/world_model_publisher.cpp`
