### PR TITLE
feat: Aivis Speech Engine対応プラグインを実装

### DIFF
--- a/docker/match_vs_tigers/scripts/match_controller.py
+++ b/docker/match_vs_tigers/scripts/match_controller.py
@@ -11,12 +11,12 @@ import sys
 import socket
 import struct
 from typing import List, Tuple, Optional
+from importlib.util import find_spec
 
-try:
-    import requests
-except ImportError:
+if find_spec("requests") is None:
     print("requestsモジュールが必要です: pip install requests", file=sys.stderr)
     sys.exit(1)
+
 
 # Add proto directory to path
 sys.path.insert(0, "/app/proto")
@@ -66,7 +66,7 @@ class MatchController:
         """
         try:
             event_type = referee_pb2.GameEvent.Type.Name(event.type)
-        except:
+        except Exception:
             event_type = "UNKNOWN"
 
         # Team name helper
@@ -96,7 +96,7 @@ class MatchController:
                                 )
                                 break
                     break
-        except:
+        except Exception:
             pass
 
         return f"{event_type}{team_info}"

--- a/docker/real/docker-compose.yaml
+++ b/docker/real/docker-compose.yaml
@@ -44,3 +44,8 @@ services:
 #    image: voicevox/voicevox_engine:nvidia-latest
     ports:
       - 127.0.0.1:50021:50021
+
+  aivis-speech:
+    image: ghcr.io/aivis-project/aivisspeech-engine:cpu-latest
+    ports:
+      - 127.0.0.1:10101:10101

--- a/docker/sim/docker-compose.yaml
+++ b/docker/sim/docker-compose.yaml
@@ -72,3 +72,8 @@ services:
     # image: voicevox/voicevox_engine:nvidia-latest
     ports:
       - 127.0.0.1:50021:50021
+
+  aivis-speech:
+    image: ghcr.io/aivis-project/aivisspeech-engine:cpu-latest
+    ports:
+      - 127.0.0.1:10101:10101

--- a/speak_ros_aivis_plugin/CMakeLists.txt
+++ b/speak_ros_aivis_plugin/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.5)
+project(speak_ros_aivis_plugin)
+
+find_package(ament_cmake_auto REQUIRED)
+find_package(cpprestsdk REQUIRED)
+ament_auto_find_build_dependencies()
+
+add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+
+ament_target_dependencies(${PROJECT_NAME}
+  rclcpp
+  speak_ros
+  pluginlib
+)
+
+target_link_libraries(${PROJECT_NAME} cpprestsdk::cpprest)
+
+pluginlib_export_plugin_description_file(speak_ros plugins.xml)
+
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_libraries(
+  ${PROJECT_NAME}
+)
+ament_export_targets(
+  export_${PROJECT_NAME}
+)
+
+if($ENV{ROS_DISTRO} STREQUAL "humble" OR $ENV{ROS_DISTRO} STREQUAL "jazzy")
+  ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)
+else()
+  ament_auto_package()
+endif()

--- a/speak_ros_aivis_plugin/README.md
+++ b/speak_ros_aivis_plugin/README.md
@@ -1,0 +1,141 @@
+# speak_ros_aivis_plugin
+
+[Aivis Speech Engine](https://github.com/Aivis-Project/AivisSpeech-Engine)用のspeak_rosプラグイン
+
+## 概要
+
+Aivis Speech EngineはVOICEVOX互換のAPIを持つオープンソース音声合成エンジンです。このプラグインにより、speak_ros経由でAivis Speech Engineを使用できます。
+
+## 特徴
+
+- VOICEVOX API互換（`/audio_query` → `/synthesis`）
+- デフォルトポート: **10101**
+- Aivis固有パラメータのサポート:
+  - `intonationScale`: 感情の強さ（0.0-2.0）
+  - `tempoDynamicsScale`: 話速変動（0.0-2.0）
+
+## 依存関係
+
+- speak_ros
+- rclcpp
+- pluginlib
+- libcpprest-dev
+
+## ビルド
+
+```bash
+colcon build --packages-select speak_ros_aivis_plugin
+```
+
+## 使用方法
+
+### 1. Aivis Speech Engineの起動
+
+```bash
+# Dockerで起動（推奨）
+docker compose -f docker/sim/docker-compose.yaml up aivis-speech -d
+
+# または手動で起動
+# https://github.com/Aivis-Project/AivisSpeech-Engine
+```
+
+### 2. speak_rosノードの起動
+
+```bash
+ros2 run speak_ros speak_ros_node --ros-args \
+  -p plugin_name:=aivis_plugin::AivisPlugin
+```
+
+### 3. パラメータのカスタマイズ
+
+```bash
+ros2 run speak_ros speak_ros_node --ros-args \
+  -p plugin_name:=aivis_plugin::AivisPlugin \
+  -p aivis_plugin/speaker:=888753760 \
+  -p aivis_plugin/intonationScale:=1.5 \
+  -p aivis_plugin/tempoDynamicsScale:=1.2
+```
+
+### 4. 音声合成の実行
+
+```bash
+ros2 action send_goal /speak speak_ros_interfaces/action/Speak \
+  "{text: 'こんにちは、Aivisです。', speed_rate: 1.0}"
+```
+
+## パラメータ一覧
+
+| パラメータ名 | 型 | デフォルト値 | 説明 |
+|------------|-----|------------|------|
+| speaker | int | 888753760 | AivisスピーカーID |
+| host_name | string | localhost | Aivisエンジンのホスト |
+| port | int | 10101 | Aivisエンジンのポート |
+| speedScale | double | 1.0 | 話速（1.0が標準） |
+| pitchScale | double | 0.0 | ピッチ調整 |
+| intonationScale | double | 1.0 | 感情の強さ（0.0-2.0） |
+| volumeScale | double | 1.0 | 音量スケール |
+| tempoDynamicsScale | double | 1.0 | 話速変動（0.0-2.0） |
+| prePhonemeLength | double | 0.1 | 前音素長 [秒] |
+| postPhonemeLength | double | 0.1 | 後音素長 [秒] |
+| outputSamplingRate | int | 44100 | 出力サンプリングレート [Hz] |
+| outputStereo | string | false | ステレオ出力 |
+
+## スピーカーID一覧
+
+デフォルトモデル（まお v1.2.0）:
+
+| ID | スタイル |
+|----|---------|
+| 888753760 | ノーマル |
+| 888753761 | ふつー |
+| 888753762 | あまあま |
+| 888753763 | おちつき |
+| 888753764 | からかい |
+| 888753765 | せつなめ |
+
+スピーカーIDの確認:
+
+```bash
+curl http://localhost:10101/speakers
+```
+
+## VOICEVOXとの違い
+
+| 項目 | VOICEVOX | Aivis |
+|------|----------|-------|
+| ポート | 50021（固定） | 10101（設定可能） |
+| `speedScale` デフォルト | 2.0 | 1.0 |
+| `intonationScale` | なし | あり（感情の強さ） |
+| `tempoDynamicsScale` | なし | あり（話速変動） |
+| `outputSamplingRate` | 24000 | 44100 |
+| `outputStereo` | true | false |
+
+## トラブルシューティング
+
+### エンジンに接続できない
+
+```bash
+# エンジンの起動を確認
+curl http://localhost:10101/speakers
+
+# Dockerコンテナの状態を確認
+docker compose -f docker/sim/docker-compose.yaml ps aivis-speech
+```
+
+### スピーカーIDが見つからない
+
+利用可能なスピーカーIDを確認:
+
+```bash
+curl http://localhost:10101/speakers | python3 -m json.tool
+```
+
+## ライセンス
+
+MIT License
+
+## 参考リンク
+
+- [Aivis Speech Engine](https://github.com/Aivis-Project/AivisSpeech-Engine)
+- [speak_ros](https://github.com/HansRobo/speak_ros)
+- [speak_ros_voicevox_plugin](https://github.com/HansRobo/speak_ros_voicevox_plugin)

--- a/speak_ros_aivis_plugin/include/speak_ros_aivis_plugin/aivis_plugin.hpp
+++ b/speak_ros_aivis_plugin/include/speak_ros_aivis_plugin/aivis_plugin.hpp
@@ -1,0 +1,47 @@
+// Copyright 2025 ibis-ssl All rights reserved.
+//
+// Licensed under the MIT License.
+
+#ifndef SPEAK_ROS_AIVIS_PLUGIN__AIVIS_PLUGIN_HPP
+#define SPEAK_ROS_AIVIS_PLUGIN__AIVIS_PLUGIN_HPP
+
+#include <speak_ros/speak_ros_plugin_base.hpp>
+
+namespace aivis_plugin
+{
+class AivisPlugin : public speak_ros::SpeakROSPluginBase
+{
+public:
+  AivisPlugin() : speak_ros::SpeakROSPluginBase() {}
+
+  std::string getPluginName() const override { return "aivis_plugin"; }
+
+  std::filesystem::path generateSoundFile(
+    const std::string input_text, const std::filesystem::path output_directory,
+    const std::string file_name) override;
+
+  std::vector<speak_ros::Parameter> getParametersDefault() const override;
+
+  void importParameters(
+    const std::unordered_map<std::string, std::variant<int, double, std::string>> & parameters)
+    override;
+
+  int speaker;
+  std::string host_name;
+  int port;
+  double speed_scale;
+  double pitch_scale;
+  double intonation_scale;
+  double volume_scale;
+  double tempo_dynamics_scale;
+  double pre_phoneme_length;
+  double post_phoneme_length;
+  int output_sampling_rate;
+  std::string output_stereo;
+};
+}  // namespace aivis_plugin
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(aivis_plugin::AivisPlugin, speak_ros::SpeakROSPluginBase)
+
+#endif  // SPEAK_ROS_AIVIS_PLUGIN__AIVIS_PLUGIN_HPP

--- a/speak_ros_aivis_plugin/include/speak_ros_aivis_plugin/aivis_plugin.hpp
+++ b/speak_ros_aivis_plugin/include/speak_ros_aivis_plugin/aivis_plugin.hpp
@@ -2,8 +2,8 @@
 //
 // Licensed under the MIT License.
 
-#ifndef SPEAK_ROS_AIVIS_PLUGIN__AIVIS_PLUGIN_HPP
-#define SPEAK_ROS_AIVIS_PLUGIN__AIVIS_PLUGIN_HPP
+#ifndef SPEAK_ROS_AIVIS_PLUGIN__AIVIS_PLUGIN_HPP_
+#define SPEAK_ROS_AIVIS_PLUGIN__AIVIS_PLUGIN_HPP_
 
 #include <speak_ros/speak_ros_plugin_base.hpp>
 
@@ -44,4 +44,4 @@ public:
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(aivis_plugin::AivisPlugin, speak_ros::SpeakROSPluginBase)
 
-#endif  // SPEAK_ROS_AIVIS_PLUGIN__AIVIS_PLUGIN_HPP
+#endif  // SPEAK_ROS_AIVIS_PLUGIN__AIVIS_PLUGIN_HPP_

--- a/speak_ros_aivis_plugin/package.xml
+++ b/speak_ros_aivis_plugin/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="3">
+    <name>speak_ros_aivis_plugin</name>
+    <version>0.0.1</version>
+    <description>Aivis Speech Engine plugin for speak_ros</description>
+
+    <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
+
+    <license>MIT</license>
+
+    <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+    <depend>speak_ros</depend>
+    <depend>rclcpp</depend>
+    <depend>pluginlib</depend>
+    <depend>libcpprest-dev</depend>
+
+    <test_depend>ament_lint_auto</test_depend>
+    <test_depend>ament_cmake_clang_format</test_depend>
+    <test_depend>ament_cmake_lint_cmake</test_depend>
+    <test_depend>ament_cmake_xmllint</test_depend>
+
+    <export>
+        <build_type>ament_cmake</build_type>
+        <speak_ros plugin="${prefix}/plugins.xml" />
+    </export>
+</package>

--- a/speak_ros_aivis_plugin/package.xml
+++ b/speak_ros_aivis_plugin/package.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0"?>
 <package format="3">
-    <name>speak_ros_aivis_plugin</name>
-    <version>0.0.1</version>
-    <description>Aivis Speech Engine plugin for speak_ros</description>
+  <name>speak_ros_aivis_plugin</name>
+  <version>0.0.1</version>
+  <description>Aivis Speech Engine plugin for speak_ros</description>
 
-    <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
+  <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
 
-    <license>MIT</license>
+  <license>MIT</license>
 
-    <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-    <depend>speak_ros</depend>
-    <depend>rclcpp</depend>
-    <depend>pluginlib</depend>
-    <depend>libcpprest-dev</depend>
+  <depend>libcpprest-dev</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>speak_ros</depend>
 
-    <test_depend>ament_lint_auto</test_depend>
-    <test_depend>ament_cmake_clang_format</test_depend>
-    <test_depend>ament_cmake_lint_cmake</test_depend>
-    <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
 
-    <export>
-        <build_type>ament_cmake</build_type>
-        <speak_ros plugin="${prefix}/plugins.xml" />
-    </export>
+  <export>
+    <build_type>ament_cmake</build_type>
+    <speak_ros plugin="${prefix}/plugins.xml"/>
+  </export>
 </package>

--- a/speak_ros_aivis_plugin/plugins.xml
+++ b/speak_ros_aivis_plugin/plugins.xml
@@ -1,0 +1,5 @@
+<library path="speak_ros_aivis_plugin">
+	<class type="aivis_plugin::AivisPlugin" base_class_type="speak_ros::SpeakROSPluginBase">
+		<description>Aivis Speech Engine plugin for speak_ros</description>
+	</class>
+</library>

--- a/speak_ros_aivis_plugin/src/speak_ros_aivis_plugin.cpp
+++ b/speak_ros_aivis_plugin/src/speak_ros_aivis_plugin.cpp
@@ -111,8 +111,7 @@ std::vector<speak_ros::Parameter> aivis_plugin::AivisPlugin::getParametersDefaul
       {"prePhonemeLength", "[number] pre phoneme length [sec]", 0.1},
       {"postPhonemeLength", "[number] post phoneme length [sec]", 0.1},
       {"outputSamplingRate", "[number] output sampling rate [Hz]", 44100},
-      {"outputStereo", "[bool] output stereo", "false"}
-    // clang-format on
+      {"outputStereo", "[bool] output stereo", "false"}  // clang-format on
   };
 }
 

--- a/speak_ros_aivis_plugin/src/speak_ros_aivis_plugin.cpp
+++ b/speak_ros_aivis_plugin/src/speak_ros_aivis_plugin.cpp
@@ -1,0 +1,134 @@
+// Copyright 2025 ibis-ssl All rights reserved.
+//
+// Licensed under the MIT License.
+
+#include <cpprest/filestream.h>
+#include <cpprest/http_client.h>
+
+#include "speak_ros_aivis_plugin/aivis_plugin.hpp"
+
+std::filesystem::path aivis_plugin::AivisPlugin::generateSoundFile(
+  const std::string input_text, const std::filesystem::path output_directory,
+  const std::string file_name)
+{
+  updateParameters();
+
+  std::string generated_file_path = output_directory / (file_name + ".wav");
+
+  std::string base_url = "http://" + host_name + ":" + std::to_string(port);
+
+  auto audio_query_task =
+    pplx::create_task([=] {
+      web::http::client::http_client_config config;
+      web::http::client::http_client client(base_url, config);
+      web::json::value body;
+
+      body[U("accent_phrases")] = web::json::value::array();
+      body[U("speedScale")] = web::json::value::number(speed_scale);
+      body[U("pitchScale")] = web::json::value::number(pitch_scale);
+      body[U("intonationScale")] = web::json::value::number(intonation_scale);
+      body[U("volumeScale")] = web::json::value::number(volume_scale);
+      body[U("tempoDynamicsScale")] = web::json::value::number(tempo_dynamics_scale);
+      body[U("prePhonemeLength")] = web::json::value::number(pre_phoneme_length);
+      body[U("postPhonemeLength")] = web::json::value::number(post_phoneme_length);
+      body[U("outputSamplingRate")] = web::json::value::number(output_sampling_rate);
+      body[U("outputStereo")] = web::json::value::string(output_stereo);
+
+      return client.request(
+        web::http::methods::POST,
+        web::http::uri_builder(U("/audio_query"))
+          .append_query(U("text"), input_text)
+          .append_query(U("speaker"), speaker)
+          .to_string(),
+        web::json::value().serialize(), U("application/json"));
+    }).then([](web::http::http_response response) {
+      if (response.status_code() == web::http::status_codes::OK) {
+        std::cout << "audio_query succeeded" << std::endl;
+        std::cout << response.to_string() << std::endl;
+        return response;
+      }
+      throw std::runtime_error("network error");
+    });
+
+  audio_query_task.wait();
+  auto audio_query_response = audio_query_task.get();
+
+  using concurrency::streams::ostream;
+  auto file_stream = std::make_shared<ostream>();
+
+  pplx::task<void> synthesis_task =
+    concurrency::streams::fstream::open_ostream(generated_file_path)
+      .then([&](ostream out_file) {
+        *file_stream = out_file;
+
+        web::json::value body = audio_query_response.extract_json().get();
+        body[U("speedScale")] = web::json::value::number(speed_scale);
+        body[U("pitchScale")] = web::json::value::number(pitch_scale);
+        body[U("intonationScale")] = web::json::value::number(intonation_scale);
+        body[U("volumeScale")] = web::json::value::number(volume_scale);
+        body[U("tempoDynamicsScale")] = web::json::value::number(tempo_dynamics_scale);
+        body[U("prePhonemeLength")] = web::json::value::number(pre_phoneme_length);
+        body[U("postPhonemeLength")] = web::json::value::number(post_phoneme_length);
+        body[U("outputSamplingRate")] = web::json::value::number(output_sampling_rate);
+        body[U("outputStereo")] = web::json::value::string(output_stereo);
+
+        web::http::client::http_client_config config;
+        web::http::client::http_client client(base_url, config);
+        return client.request(
+          web::http::methods::POST,
+          web::http::uri_builder(U("/synthesis")).append_query(U("speaker"), speaker).to_string(),
+          body.serialize(), "application/json");
+      })
+      .then([&](web::http::http_response response) {
+        if (response.status_code() == web::http::status_codes::OK) {
+          // write out the audio
+          return response.body().read_to_end(file_stream->streambuf());
+        }
+        throw std::runtime_error("network error");
+      })
+      .then([=](size_t) {
+        // close the file stream
+        return file_stream->close();
+      });
+
+  synthesis_task.wait();
+
+  return std::filesystem::path(generated_file_path);
+}
+
+std::vector<speak_ros::Parameter> aivis_plugin::AivisPlugin::getParametersDefault() const
+{
+  return {
+    // clang-format off
+      {"speaker", "[number/integer] aivis speaker id", 888753760},
+      {"host_name", "[string] host of aivis engine", "localhost"},
+      {"port", "[number/integer] port of aivis engine", 10101},
+      {"speedScale", "[number] voice speed", 1.0},
+      {"pitchScale", "[number] voice pitch", 0.0},
+      {"intonationScale", "[number] emotional expression (0.0-2.0)", 1.0},
+      {"volumeScale", "[number] volume scale", 1.0},
+      {"tempoDynamicsScale", "[number] speech speed fluctuation (0.0-2.0)", 1.0},
+      {"prePhonemeLength", "[number] pre phoneme length [sec]", 0.1},
+      {"postPhonemeLength", "[number] post phoneme length [sec]", 0.1},
+      {"outputSamplingRate", "[number] output sampling rate [Hz]", 44100},
+      {"outputStereo", "[bool] output stereo", "false"}
+    // clang-format on
+  };
+}
+
+void aivis_plugin::AivisPlugin::importParameters(
+  const std::unordered_map<std::string, std::variant<int, double, std::string>> & parameters)
+{
+  speaker = std::get<int>(parameters.at("speaker"));
+  host_name = std::get<std::string>(parameters.at("host_name"));
+  port = std::get<int>(parameters.at("port"));
+  speed_scale = std::get<double>(parameters.at("speedScale"));
+  pitch_scale = std::get<double>(parameters.at("pitchScale"));
+  intonation_scale = std::get<double>(parameters.at("intonationScale"));
+  volume_scale = std::get<double>(parameters.at("volumeScale"));
+  tempo_dynamics_scale = std::get<double>(parameters.at("tempoDynamicsScale"));
+  pre_phoneme_length = std::get<double>(parameters.at("prePhonemeLength"));
+  post_phoneme_length = std::get<double>(parameters.at("postPhonemeLength"));
+  output_sampling_rate = std::get<int>(parameters.at("outputSamplingRate"));
+  output_stereo = std::get<std::string>(parameters.at("outputStereo"));
+}

--- a/speak_ros_aivis_plugin/test_aivis.bash
+++ b/speak_ros_aivis_plugin/test_aivis.bash
@@ -46,5 +46,5 @@ echo "次のコマンドでspeak_rosノードを起動できます:"
 echo "  ros2 run speak_ros speak_ros_node --ros-args -p plugin_name:=aivis_plugin::AivisPlugin"
 echo ""
 echo "音声合成のテスト:"
-echo '  ros2 action send_goal /speak speak_ros_interfaces/action/Speak \'
+printf '  ros2 action send_goal /speak speak_ros_interfaces/action/Speak \\\n'
 echo "    \"{text: 'こんにちは、Aivisです。', speed_rate: 1.0}\""

--- a/speak_ros_aivis_plugin/test_aivis.bash
+++ b/speak_ros_aivis_plugin/test_aivis.bash
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Aivis Speech Engine プラグインの動作確認スクリプト
+
+set -e
+
+echo "=== Aivis Speech Engine プラグイン テスト ==="
+echo ""
+
+# 1. Aivisエンジンの起動確認
+echo "1. Aivisエンジンの起動を確認中..."
+if curl -s http://localhost:10101/speakers > /dev/null 2>&1; then
+    echo "   ✓ Aivisエンジンは起動しています"
+else
+    echo "   ✗ Aivisエンジンが起動していません"
+    echo "   docker compose -f docker/sim/docker-compose.yaml up aivis-speech -d を実行してください"
+    exit 1
+fi
+
+# 2. スピーカー一覧の表示
+echo ""
+echo "2. 利用可能なスピーカー:"
+curl -s http://localhost:10101/speakers | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for speaker in data:
+    print(f\"   - {speaker['name']}:\")
+    for style in speaker['styles']:
+        print(f\"     ID {style['id']}: {style['name']}\")
+" 2>/dev/null || echo "   (スピーカー情報の取得に失敗)"
+
+# 3. プラグインのビルド確認
+echo ""
+echo "3. プラグインのビルド確認..."
+if [ -f "$COLCON_PREFIX_PATH/speak_ros_aivis_plugin/lib/libspeak_ros_aivis_plugin.so" ]; then
+    echo "   ✓ プラグインライブラリが存在します"
+else
+    echo "   ✗ プラグインがビルドされていません"
+    echo "   colcon build --packages-select speak_ros_aivis_plugin を実行してください"
+    exit 1
+fi
+
+echo ""
+echo "=== テスト完了 ==="
+echo ""
+echo "次のコマンドでspeak_rosノードを起動できます:"
+echo "  ros2 run speak_ros speak_ros_node --ros-args -p plugin_name:=aivis_plugin::AivisPlugin"
+echo ""
+echo "音声合成のテスト:"
+echo "  ros2 action send_goal /speak speak_ros_interfaces/action/Speak \\"
+echo "    \"{text: 'こんにちは、Aivisです。', speed_rate: 1.0}\""

--- a/speak_ros_aivis_plugin/test_aivis.bash
+++ b/speak_ros_aivis_plugin/test_aivis.bash
@@ -8,7 +8,7 @@ echo ""
 
 # 1. Aivisエンジンの起動確認
 echo "1. Aivisエンジンの起動を確認中..."
-if curl -s http://localhost:10101/speakers > /dev/null 2>&1; then
+if curl -s http://localhost:10101/speakers >/dev/null 2>&1; then
     echo "   ✓ Aivisエンジンは起動しています"
 else
     echo "   ✗ Aivisエンジンが起動していません"
@@ -46,5 +46,5 @@ echo "次のコマンドでspeak_rosノードを起動できます:"
 echo "  ros2 run speak_ros speak_ros_node --ros-args -p plugin_name:=aivis_plugin::AivisPlugin"
 echo ""
 echo "音声合成のテスト:"
-echo "  ros2 action send_goal /speak speak_ros_interfaces/action/Speak \\"
+echo '  ros2 action send_goal /speak speak_ros_interfaces/action/Speak \'
 echo "    \"{text: 'こんにちは、Aivisです。', speed_rate: 1.0}\""


### PR DESCRIPTION
## 概要

speak_rosにAivis Speech Engineのサポートを追加しました。VOICEVOXと同様のプラグイン方式により、エンジンを切り替えて使用可能です。

## 主な変更内容

### 新規パッケージ: `speak_ros_aivis_plugin`

- **プラグイン実装**: VOICEVOX互換API（`/audio_query` → `/synthesis`）の実装
- **Aivis固有パラメータのサポート**:
  - `intonationScale`: 感情の強さ（0.0-2.0）
  - `tempoDynamicsScale`: 話速変動（0.0-2.0）
- **設定可能なポート**: デフォルト10101（VOICEVOXは50021固定）
- **高音質出力**: 44.1kHz（VOICEVOXは24kHz）

### Docker環境の更新

- `docker/sim/docker-compose.yaml`: Aivisサービス追加
- `docker/real/docker-compose.yaml`: Aivisサービス追加

## 使用方法

```bash
# 1. Aivisエンジン起動
docker compose -f docker/sim/docker-compose.yaml up aivis-speech -d

# 2. speak_rosノード起動（Aivisプラグイン使用）
ros2 run speak_ros speak_ros_node --ros-args \
  -p plugin_name:=aivis_plugin::AivisPlugin

# 3. 音声合成テスト
ros2 action send_goal /speak speak_ros_interfaces/action/Speak \
  "{text: 'こんにちは、Aivisです。', speed_rate: 1.0}"
```

## VOICEVOXとの切り替え

プラグインは起動時のパラメータで切り替え可能：

```bash
# VOICEVOXを使用
ros2 run speak_ros speak_ros_node --ros-args \
  -p plugin_name:=voicevox_plugin::VoiceVoxPlugin

# Aivisを使用
ros2 run speak_ros speak_ros_node --ros-args \
  -p plugin_name:=aivis_plugin::AivisPlugin
```

## 参考リンク

- [Aivis Speech Engine](https://github.com/Aivis-Project/AivisSpeech-Engine)
- [speak_ros](https://github.com/HansRobo/speak_ros)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)