### PR TITLE
feat: Receiveスキルに敵割り込み回避機能を実装

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/receive.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/receive.hpp
@@ -34,11 +34,16 @@ public:
     setParameter("viz_candidates", true);
     setParameter("viz_offset_arrow", true);
     setParameter("viz_redirect_preview", true);
+    setParameter("viz_enemy_block", true);
   }
 
   Status update() override;
 
   Point getInterceptionPoint() const;
+
+  // 敵割り込み検出・回避関数
+  bool isEnemyBlockingPassLine(const Point & interception_point) const;
+  Point getInterceptionPointWithEnemyAvoidance() const;
 };
 
 }  // namespace crane::skills

--- a/crane_robot_skills/src/receive.cpp
+++ b/crane_robot_skills/src/receive.cpp
@@ -44,7 +44,7 @@ Status Receive::update()
   }();
 
   // Base interception point before offset (also draws candidate visuals inside)
-  Point base_interception_point = getInterceptionPoint();
+  Point base_interception_point = getInterceptionPointWithEnemyAvoidance();
   Point interception_point = base_interception_point + offset;
 
   // Minimal HUD near robot: policy only
@@ -238,5 +238,65 @@ Point Receive::getInterceptionPoint() const
   } else {
     throw std::runtime_error("Invalid policy for Receive::getInterceptionPoint: " + policy);
   }
+}
+
+bool Receive::isEnemyBlockingPassLine(const Point & interception_point) const
+{
+  Segment pass_line{world_model()->ball().pos, interception_point};
+  auto enemy_robots = world_model()->theirs().robotsWhere().available().get();
+
+  if (auto nearest_enemy =
+        world_model()->getNearestRobotWithDistanceFromSegment(pass_line, enemy_robots);
+      nearest_enemy.has_value()) {
+    constexpr double BLOCKING_THRESHOLD = 0.3;  // 敵がパスラインから0.3m以内
+    return nearest_enemy->distance < BLOCKING_THRESHOLD;
+  }
+  return false;
+}
+
+Point Receive::getInterceptionPointWithEnemyAvoidance() const
+{
+  Point base_point = getInterceptionPoint();
+
+  if (!isEnemyBlockingPassLine(base_point)) {
+    return base_point;  // 敵がいなければそのまま
+  }
+
+  // 敵が割り込んでいる場合、Slack Timeベースで代替位置を探す
+  auto slack_times = world_model()->getSlackInterceptPointAndSlackTimeArray({robot()});
+
+  // 有効なNaN値チェックと敵ブロックチェック
+  auto isValidPoint = [](const Point & p) -> bool {
+    return std::isfinite(p.x()) && std::isfinite(p.y());
+  };
+
+  std::vector<WorldModelWrapper::SlackTimeResult> valid_points;
+  for (const auto & slack : slack_times) {
+    if (
+      slack.slack_time > 0 && isValidPoint(slack.intercept_point) &&
+      !isEnemyBlockingPassLine(slack.intercept_point)) {
+      valid_points.push_back(slack);
+    }
+  }
+
+  if (valid_points.empty()) {
+    command->addPlanningFactor("Receive", "敵割り込み: 有効な代替位置なし");
+    return base_point;  // 代替がなければ元の位置を維持
+  }
+
+  // 最もSlack Timeが大きい位置を選択
+  auto best = std::max_element(
+    valid_points.begin(), valid_points.end(),
+    [](const auto & a, const auto & b) { return a.slack_time < b.slack_time; });
+
+  command->addPlanningFactor("Receive", "敵割り込み: 代替位置に移動");
+
+  // 可視化: 敵割り込み警告マーカー
+  if (getParameter<bool>("viz_enemy_block")) {
+    visualizer->drawCircle(base_point, 0.08, "red", 0.7, 8);
+    visualizer->drawCircle(best->intercept_point, 0.08, "lime", 0.7, 8);
+  }
+
+  return best->intercept_point;
 }
 }  // namespace crane::skills


### PR DESCRIPTION
## Summary
- パス受け中に敵がパスラインに割り込んだ際、動的に位置を調整する機能を実装
- Slack Timeベースで最適な代替位置を選択
- 可視化機能により敵ブロック状況を確認可能

## 実装内容
- `isEnemyBlockingPassLine()`: 敵がパスラインを遮っているか判定（閾値0.3m）
- `getInterceptionPointWithEnemyAvoidance()`: 敵回避付きインターセプトポイント取得
- 有効な代替位置の中から最もSlack Timeが大きい位置を選択
- 可視化: 赤=ブロックされた位置、緑=代替位置

## 変更ファイル
- `crane_robot_skills/include/crane_robot_skills/receive.hpp`: 関数宣言追加
- `crane_robot_skills/src/receive.cpp`: 敵割り込み検出・回避ロジック実装

## Test plan
- [x] ビルド確認
- [ ] シミュレーションでパス受け実行
- [ ] 敵ロボットがパスライン上に移動した際、レシーバーが位置変更することを確認
- [ ] 可視化マーカー（赤・緑）が正しく表示されることを確認
- [ ] PlanningFactorに適切なメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)