### PR TITLE
fix: パッケージバージョンを1.0.118に統一

### DIFF
--- a/speak_ros_aivis_plugin/package.xml
+++ b/speak_ros_aivis_plugin/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>speak_ros_aivis_plugin</name>
-  <version>0.0.1</version>
+  <version>1.0.118</version>
   <description>Aivis Speech Engine plugin for speak_ros</description>
 
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>


### PR DESCRIPTION
## 概要
リポジトリ内の全パッケージのバージョンを1.0.118に統一しました。

## 問題
GitHub Actionsの `catkin_prepare_release` コマンドがバージョン不整合エラーを検出：
- `speak_ros_aivis_plugin`: `0.0.1`
- 他の全パッケージ: `1.0.118`

## 対応内容
- `speak_ros_aivis_plugin/package.xml` のバージョンを `1.0.118` に更新
- これにより全31パッケージのバージョンが統一され、リリースワークフローが正常に動作するようになります

## 関連
- GitHub Actions実行: https://github.com/ibis-ssl/crane/actions/runs/21477356510/job/61864610401

🤖 Generated with [Claude Code](https://claude.ai/code)