### PR TITLE
feat: grSim Binary Feedbackパケット対応とUDP受信クラスの統合

### DIFF
--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -198,11 +198,8 @@ limitations under the License.
 
   <node pkg="crane_game_analyzer" exec="crane_game_analyzer_node" output="screen"/>
 
-  <node pkg="crane_robot_receiver" exec="robot_receiver_node" output="screen" respawn="true"/>
-
-  <node pkg="crane_robot_receiver" exec="grsim_robot_status_node" if="$(var sim)">
-    <param name="blue_port" value="30011"/>
-    <param name="yellow_port" value="30012"/>
+  <node pkg="crane_robot_receiver" exec="robot_receiver_node" output="screen" respawn="true">
+    <param name="sim_mode" value="$(var sim)"/>
   </node>
 
   <!-- 可視化情報の集約 -->

--- a/crane_robot_receiver/src/robot_receiver_node.cpp
+++ b/crane_robot_receiver/src/robot_receiver_node.cpp
@@ -6,7 +6,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/thread.hpp>
-#include <crane_comm/multicast.hpp>
+#include <crane_comm/unicast.hpp>
 #include <crane_msg_wrappers/crane_visualizer_wrapper.hpp>
 #include <crane_msgs/msg/robot_feedback.hpp>
 #include <crane_msgs/msg/robot_feedback_array.hpp>
@@ -25,7 +25,7 @@ class RobotFeedbackReceiver
 public:
   RobotFeedbackReceiver(const std::string & host, const int port)
   : robot_id(port - 50100),
-    receiver_(std::make_unique<crane::MulticastReceiver>(host, port)),
+    receiver_(std::make_unique<crane::UdpReceiver>(host, port)),
     buffer_(protocol::BUFFER_SIZE),
     clock(RCL_ROS_TIME)
   {
@@ -137,7 +137,7 @@ public:
   const int robot_id;
 
 private:
-  std::unique_ptr<crane::MulticastReceiver> receiver_;
+  std::unique_ptr<crane::UdpReceiver> receiver_;
 
   std::vector<char> buffer_;
 
@@ -160,14 +160,24 @@ public:
 
     // パラメータの宣言と取得
     int max_robot_id = declare_parameter("max_robot_id", 15);
+    bool sim_mode = declare_parameter("sim_mode", false);
     std::string ip_base = declare_parameter("multicast_ip_base", "224.5.20");
     int port_base = declare_parameter("port_base", 50100);
     int ip_offset = declare_parameter("ip_octet_offset", 100);
 
-    RCLCPP_INFO(get_logger(), "Listening for robot feedbacks (max_robot_id: %d)", max_robot_id);
+    RCLCPP_INFO(
+      get_logger(), "Listening for robot feedbacks (max_robot_id: %d, sim_mode: %s)", max_robot_id,
+      sim_mode ? "true" : "false");
 
     for (int i = 0; i <= max_robot_id; i++) {
-      std::string ip = std::format("{}.{}", ip_base, i + ip_offset);
+      std::string ip;
+      if (sim_mode) {
+        // シミュレータモード: 127.0.0.1 (固定)
+        ip = "127.0.0.1";
+      } else {
+        // 実機モード: 224.5.20.{100+robot_id}
+        ip = std::format("{}.{}", ip_base, i + ip_offset);
+      }
       int port = port_base + i;
       receivers.push_back(std::make_shared<RobotFeedbackReceiver>(ip, port));
     }

--- a/utility/crane_comm/include/crane_comm/unicast.hpp
+++ b/utility/crane_comm/include/crane_comm/unicast.hpp
@@ -1,0 +1,153 @@
+// Copyright 2021 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CRANE_COMM__UNICAST_HPP_
+#define CRANE_COMM__UNICAST_HPP_
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <sys/socket.h>
+
+#include <boost/asio.hpp>
+#include <exception>
+#include <rclcpp/logging.hpp>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace crane
+{
+namespace asio = boost::asio;
+
+// SO_REUSEPORTソケットオプションの定義
+typedef asio::detail::socket_option::boolean<SOL_SOCKET, SO_REUSEPORT> reuse_port;
+
+class UdpReceiver
+{
+public:
+  UdpReceiver(const std::string & host, const int port) : socket(io_context, asio::ip::udp::v4())
+  {
+    asio::ip::address addr = asio::ip::address::from_string(host);
+
+    // ソケットオプションを設定
+    boost::system::error_code ec;
+
+    socket.set_option(asio::socket_base::reuse_address(true), ec);
+
+    socket.set_option(reuse_port(true), ec);
+
+    // マルチキャストかユニキャストかで処理を分岐
+    if (addr.is_multicast()) {
+      // マルチキャストの場合: ANY_ADDRでバインド後にグループに参加
+      socket.bind(asio::ip::udp::endpoint(asio::ip::udp::v4(), port), ec);
+      if (ec) {
+        RCLCPP_ERROR(
+          rclcpp::get_logger("crane_comm"), "[ERROR] bind失敗: %s", ec.message().c_str());
+        throw std::runtime_error("bind failed: " + ec.message());
+      }
+
+      socket.non_blocking(true);
+
+      // マルチキャストグループに参加
+      try {
+        struct ifaddrs * interfaces = nullptr;
+        struct ifaddrs * ifa = nullptr;
+
+        // ネットワークインターフェース情報の取得
+        if (getifaddrs(&interfaces) == -1) {
+          throw std::runtime_error("Error: getifaddrs failed.");
+        }
+
+        int interface_count = 0;
+        int success_count = 0;
+        int skip_count = 0;
+        std::unordered_set<std::string> joined_interfaces;  // 参加済みインターフェース名を記録
+
+        // ネットワークインターフェースのリストを巡回
+        for (ifa = interfaces; ifa != nullptr; ifa = ifa->ifa_next) {
+          if (ifa->ifa_addr == nullptr) {
+            continue;
+          }
+
+          if (ifa->ifa_addr->sa_family == AF_INET) {  // IPv4アドレスのみ
+            char ip[INET_ADDRSTRLEN];
+            struct sockaddr_in * addr_in =
+              (struct sockaddr_in *)ifa->ifa_addr;  // キャスト後に変数に格納
+            inet_ntop(AF_INET, &(addr_in->sin_addr), ip, INET_ADDRSTRLEN);
+
+            interface_count++;
+            // 同じインターフェースで既に参加済みの場合はスキップ
+            std::string if_name(ifa->ifa_name);
+            RCLCPP_DEBUG(rclcpp::get_logger("crane_comm"), "Multicast: %s: %s", ifa->ifa_name, ip);
+            if (joined_interfaces.count(if_name) > 0) {
+              skip_count++;
+              continue;
+            }
+
+            boost::asio::ip::detail::socket_option::multicast_request<
+              IPPROTO_IP, IP_ADD_MEMBERSHIP, IPPROTO_IPV6, IPV6_JOIN_GROUP>
+              join_device(addr.to_v4(), asio::ip::address::from_string(ip).to_v4());
+
+            boost::system::error_code join_ec;
+            socket.set_option(join_device, join_ec);
+
+            if (join_ec) {
+              skip_count++;
+            } else {
+              joined_interfaces.insert(if_name);  // 参加成功したインターフェースを記録
+              success_count++;
+            }
+          }
+        }
+
+        freeifaddrs(interfaces);  // メモリの解放
+      } catch (std::exception & e) {
+        RCLCPP_ERROR(rclcpp::get_logger("crane_comm"), "%s", e.what());
+      }
+    } else {
+      // ユニキャストの場合: 指定されたアドレスとポートでバインド
+      socket.bind(asio::ip::udp::endpoint(addr, port), ec);
+      if (ec) {
+        RCLCPP_ERROR(
+          rclcpp::get_logger("crane_comm"), "[ERROR] bind失敗: %s", ec.message().c_str());
+        throw std::runtime_error("bind failed: " + ec.message());
+      }
+
+      socket.non_blocking(true);
+    }
+  }
+
+  auto receive(std::vector<char> & msg) -> size_t
+  {
+    boost::system::error_code error;
+    const size_t received = socket.receive(asio::buffer(msg), 0, error);
+    if (error && error != asio::error::message_size) {
+      throw boost::system::system_error(error);
+      return 0;
+    }
+    return received;
+  }
+
+  auto available() const -> size_t { return socket.available(); }
+
+private:
+  asio::io_context io_context;
+
+  asio::ip::udp::socket socket;
+};
+
+}  // namespace crane
+
+#endif  // CRANE_COMM__UNICAST_HPP_


### PR DESCRIPTION
## 概要

grSimのBinary Feedbackパケット送信機能（`127.0.0.1:50100+robot_id`）に対応し、実機とシミュレータで同じ`robot_receiver_node`を使用できるようにしました。

## 背景

従来は以下の2つのノードでフィードバックを受信していました：
- **実機**: `robot_receiver_node`（マルチキャスト、バイナリ形式）
- **シミュレータ**: `grsim_robot_status_node`（マルチキャスト、protobuf形式）

grSimにBinary Feedbackパケット送信機能が実装されたことで、シミュレータでも実機と同じバイナリ形式のパケットを受信できるようになりました。ただし、送信先がユニキャスト（`127.0.0.1`）のため、従来の`MulticastReceiver`では対応できませんでした。

## 主な変更

### 1. `UdpReceiver`クラスの追加（`crane_comm/unicast.hpp`）
- マルチキャストとユニキャストの両方に対応する統合クラスを実装
- アドレス文字列から自動的にマルチキャスト/ユニキャストを判定
- **マルチキャスト**: 従来の`MulticastReceiver`と同じ動作（全インターフェースに参加）
- **ユニキャスト**: 指定されたアドレスとポートでバインド

### 2. `robot_receiver_node`の拡張
- `sim_mode`パラメータを追加（デフォルト: `false`）
- **シミュレータモード時**: `127.0.0.1:50100+robot_id` でユニキャスト受信
- **実機モード時**: `224.5.20.{100+robot_id}:50100+robot_id` でマルチキャスト受信
- `MulticastReceiver`から`UdpReceiver`に変更（受信方式を意識しない実装）

### 3. `crane.launch.xml`の修正
- `robot_receiver_node`に`sim_mode`パラメータを追加
- `grsim_robot_status_node`の起動を削除（不要になったため）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `crane_comm/include/crane_comm/unicast.hpp` | 新規作成（マルチキャスト/ユニキャスト統合UDP受信クラス） |
| `crane_robot_receiver/src/robot_receiver_node.cpp` | `sim_mode`パラメータ追加、`UdpReceiver`使用 |
| `crane_bringup/launch/crane.launch.xml` | `sim_mode`パラメータ追加、`grsim_robot_status_node`削除 |

## テスト方法

1. grSimを起動し、Binary Feedbackを有効化
2. `ros2 launch crane_bringup crane.launch.xml sim:=true` で起動
3. `ros2 topic echo /robot_feedback` でフィードバックが受信できることを確認
4. ボール検出、キック状態、オドメトリなどの値がgrSimの状態と一致することを確認

## チェックリスト

- [x] ビルドが正常に完了することを確認
- [x] コードが規約に準拠していることを確認（pre-commit hookパス）
- [x] シミュレータモードでフィードバックが受信できることを確認
- [ ] 実機モードで従来通り動作することを確認（後日検証予定）

🤖 Generated with [Claude Code](https://claude.ai/code)