### PR TITLE
chore: package.xmlにpython3-cairosvg依存を追加

### DIFF
--- a/crane_debug_tools/package.xml
+++ b/crane_debug_tools/package.xml
@@ -25,6 +25,7 @@
   <depend>std_msgs</depend>
 
   <!-- Python dependencies -->
+  <exec_depend>python3-cairosvg</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rosbag2_py</exec_depend>


### PR DESCRIPTION
## 概要

SVG動画生成機能（#1122）で使用するcairosvgをrosdepで管理できるよう、`package.xml`に`python3-cairosvg`依存を追加しました。

## 変更内容

- `crane_debug_tools/package.xml`に`<exec_depend>python3-cairosvg</exec_depend>`を追加

## 効果

rosdepコマンドで依存関係を自動インストール可能になります：

```bash
rosdep install --from-paths src --ignore-src -r -y
```

## 確認

```bash
$ rosdep resolve python3-cairosvg
#apt
python3-cairosvg
```

## 関連PR

- #1122 - SVG動画生成機能の実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)