### PR TITLE
fix: SVG動画生成の性能改善とデッドロック問題の修正

### DIFF
--- a/crane_debug_tools/crane_debug_tools/svg_video/video_generator.py
+++ b/crane_debug_tools/crane_debug_tools/svg_video/video_generator.py
@@ -93,11 +93,12 @@ class VideoGenerator:
             logger.info(f"Running ffmpeg: {' '.join(cmd)}")
 
         # ffmpegプロセスを起動
+        # DEVNULL を使用してデッドロックを防ぐ
         process = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE if not verbose else None,
-            stderr=subprocess.PIPE if not verbose else None,
+            stdout=subprocess.DEVNULL if not verbose else None,
+            stderr=subprocess.DEVNULL if not verbose else None,
         )
 
         try:
@@ -115,11 +116,13 @@ class VideoGenerator:
                 process.stdin.close()
 
             # プロセスの完了を待機
-            stdout, stderr = process.communicate()
+            process.wait()
 
             if process.returncode != 0:
-                error_msg = stderr.decode("utf-8") if stderr else "Unknown error"
-                raise RuntimeError(f"ffmpeg failed: {error_msg}")
+                raise RuntimeError(
+                    f"ffmpeg failed with return code {process.returncode}. "
+                    "Run with --verbose for details."
+                )
 
             logger.info(
                 f"Video generation completed: {output_path} ({frame_count} frames)"
@@ -175,12 +178,14 @@ class VideoGenerator:
         try:
             subprocess.run(
                 cmd,
-                stdout=subprocess.PIPE if not verbose else None,
-                stderr=subprocess.PIPE if not verbose else None,
+                stdout=subprocess.DEVNULL if not verbose else None,
+                stderr=subprocess.DEVNULL if not verbose else None,
                 check=True,
             )
             logger.info(f"Video generation completed: {output_path}")
 
         except subprocess.CalledProcessError as e:
-            error_msg = e.stderr.decode("utf-8") if e.stderr else "Unknown error"
-            raise RuntimeError(f"ffmpeg failed: {error_msg}") from e
+            raise RuntimeError(
+                f"ffmpeg failed with return code {e.returncode}. "
+                "Run with --verbose for details."
+            ) from e

--- a/crane_debug_tools/scripts/svg_video_generator.py
+++ b/crane_debug_tools/scripts/svg_video_generator.py
@@ -165,28 +165,53 @@ Examples:
         logger.info("Extracting SVG frames from MCAP...")
 
         def generate_png_frames():
-            """PNGフレームを生成（ジェネレータ）."""
-            frame_count = 0
-            last_timestamp_ns = None
-            last_png = None
-            frame_duration_ns = int(1e9 / args.fps / args.speed)
+            """PNGフレームを生成（固定フレームレート）."""
+            # 全フレーム状態を収集
+            logger.info("Loading all SVG states from MCAP...")
+            all_frames = list(
+                extractor.extract_from_mcap(
+                    mcap_path,
+                    start_time_sec=args.start_time,
+                    end_time_sec=args.end_time,
+                )
+            )
 
-            for svg_frame in extractor.extract_from_mcap(
-                mcap_path, start_time_sec=args.start_time, end_time_sec=args.end_time
-            ):
-                # フレーム間引き/補間（speedに応じて）
-                if last_timestamp_ns is not None and last_png is not None:
-                    elapsed_ns = svg_frame.timestamp_ns - last_timestamp_ns
-                    frames_to_generate = max(1, int(elapsed_ns / frame_duration_ns))
+            if not all_frames:
+                logger.warning("No frames found in MCAP")
+                return
 
-                    # 同じフレームを複数回出力（フレームレートが高い場合）
-                    for _ in range(frames_to_generate - 1):
-                        yield last_png
-                        frame_count += 1
-                else:
-                    frames_to_generate = 1
+            # 時刻範囲を取得
+            start_time_ns = all_frames[0].timestamp_ns
+            end_time_ns = all_frames[-1].timestamp_ns
+            duration_sec = (end_time_ns - start_time_ns) / 1e9
 
-                last_timestamp_ns = svg_frame.timestamp_ns
+            # 目標フレーム数を計算（固定フレームレート）
+            target_frame_count = int(duration_sec * args.fps / args.speed)
+
+            if target_frame_count == 0:
+                logger.warning("Duration too short or invalid fps/speed")
+                return
+
+            frame_interval_ns = int((end_time_ns - start_time_ns) / target_frame_count)
+
+            logger.info(
+                f"Duration: {duration_sec:.2f}s, Target frames: {target_frame_count} "
+                f"(from {len(all_frames)} SVG states)"
+            )
+
+            # 固定フレームレートでサンプリング
+            frame_idx = 0
+            for i in range(target_frame_count):
+                target_time_ns = start_time_ns + i * frame_interval_ns
+
+                # target_time_ns以下で最も近いフレームを見つける
+                while (
+                    frame_idx < len(all_frames) - 1
+                    and all_frames[frame_idx + 1].timestamp_ns <= target_time_ns
+                ):
+                    frame_idx += 1
+
+                svg_frame = all_frames[frame_idx]
 
                 # レイヤーフィルタリング
                 layers_to_render = svg_frame.layers
@@ -204,25 +229,23 @@ Examples:
 
                 # PNG変換
                 current_png = renderer.render(svg_string)
-                last_png = current_png
 
                 # フレーム保存（デバッグ用）
                 if args.save_frames:
                     frames_dir = Path(args.save_frames)
                     frames_dir.mkdir(parents=True, exist_ok=True)
-                    frame_path = frames_dir / f"frame_{frame_count:06d}.png"
+                    frame_path = frames_dir / f"frame_{i:06d}.png"
                     frame_path.write_bytes(current_png)
 
                 yield current_png
-                frame_count += 1
 
-                if frame_count % 100 == 0:
+                if (i + 1) % 100 == 0:
+                    progress = (i + 1) / target_frame_count * 100
                     logger.info(
-                        f"Generated {frame_count} frames "
-                        f"(epoch={svg_frame.epoch}, seq={svg_frame.seq})"
+                        f"Generated {i + 1}/{target_frame_count} frames ({progress:.1f}%)"
                     )
 
-            logger.info(f"Total frames generated: {frame_count}")
+            logger.info(f"Total frames generated: {target_frame_count}")
 
         # 動画生成
         if args.save_frames:


### PR DESCRIPTION
## 概要

rosbagからSVG動画を生成する機能において、2つの重大な問題を修正しました。

## 問題1: 非効率な処理による性能劣化

### 症状
- 全メッセージ（12,785個）に対してSVG→PNG変換を実行
- 29.6秒のrosbagから3,200+フレーム生成（正しくは885フレーム）
- 処理時間が異常に長い（29分以上）

### 修正内容
- **固定フレームレート方式に変更**
  - 目標フレーム数を事前計算: `duration × fps / speed`
  - 各フレーム時刻に最も近いSVG状態をサンプリング
- **進捗表示の改善**
  - パーセンテージ表示を追加
  - 総フレーム数とSVG状態数を表示

### 効果
- フレーム数: 3,200+ → 885フレーム（約1/4削減）
- 処理時間: 29分+ → 約8分（約1/4に短縮）
- メッセージ数に依存しない固定処理時間

## 問題2: ffmpegとのパイプ通信でのデッドロック

### 症状
- 800/885フレーム処理後にプロセスがハング
- Python側がstdin書き込みでブロック
- ffmpeg側がstdout/stderr書き込みでブロック

### 原因
非verboseモードでstdout/stderrを`subprocess.PIPE`に設定していたため、ffmpegの出力バッファが満杯になると相互にブロックされるデッドロック状態に陥っていました。

### 修正内容
1. **stdout/stderrをDEVNULLに変更**
   - バッファ問題を根本的に解決
   - 出力が不要な場合はDEVNULLにリダイレクト
   
2. **process.communicate()をprocess.wait()に変更**
   - stdinをcloseした後はwaitのみで十分
   - PIPEを使用しないため通信不要

### 効果
- 885フレーム全て正常に処理完了
- 最終処理時間: 7分35秒
- 安定した動画生成（29.5秒、30fps、1920x1080、3.4MB）

## テスト

実際のrosbagファイル（29.6秒、12,785メッセージ）で検証済み：

```bash
ros2 run crane_debug_tools svg_video_generator.py \
  /path/to/rosbag.mcap \
  -o output.mp4 \
  --fps 30
```

**結果:**
- 処理時間: 7分35秒
- 出力動画: 29.5秒、30fps、1920x1080、3.4MB
- ffprobe検証: 正常なMP4ファイル、885フレーム

🤖 Generated with [Claude Code](https://claude.ai/code)