### PR TITLE
fix: SessionCoordinatorで誤ったパッケージ名を参照していた問題を修正

### DIFF
--- a/crane_session_coordinator/src/crane_session_coordinator.cpp
+++ b/crane_session_coordinator/src/crane_session_coordinator.cpp
@@ -43,7 +43,7 @@ SessionCoordinatorComponent::SessionCoordinatorComponent(const rclcpp::NodeOptio
   declare_parameter<std::string>("session_config_file_name", "unified_session_config.yaml");
   auto session_config_file_name = get_parameter("session_config_file_name").as_string();
   config_manager_ = std::make_shared<ConfigurationManager>(
-    ament_index_cpp::get_package_share_directory("crane_tactic_coordinator"),
+    ament_index_cpp::get_package_share_directory("crane_session_coordinator"),
     session_config_file_name, get_logger());
 
   // プランナー管理の初期化


### PR DESCRIPTION
## 問題

SessionCoordinatorComponentの初期化時に、設定ファイルの読み込みで誤ったパッケージ名を参照していました。

### 現状（誤り）
```cpp
ament_index_cpp::get_package_share_directory("crane_tactic_coordinator")
```

これは、プロジェクト全体の用語統一（tactic→session）が行われた際の修正漏れと思われます。

## 修正内容

正しいパッケージ名に修正:

```cpp
ament_index_cpp::get_package_share_directory("crane_session_coordinator")
```

### 変更箇所
- `crane_session_coordinator/src/crane_session_coordinator.cpp:46`

## 影響範囲

この修正により、SessionCoordinatorが正しい設定ファイルパス（`crane_session_coordinator`パッケージのshareディレクトリ）を参照できるようになります。

## テスト

ビルドが正常に完了することを確認済み。

🤖 Generated with [Claude Code](https://claude.ai/code)