### PR TITLE
fix: ゴール可視化の向き修正

### DIFF
--- a/utility/crane_msg_wrappers/src/crane_visualizer_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/crane_visualizer_wrapper.cpp
@@ -234,10 +234,10 @@ auto VisualizerMessageBuilder::drawGoal(
 {
   // U字型のゴールを描画（奥の壁と左右の壁）
   double half_width = width / 2.0;
-  Point top_left = back_center + Vector2(-half_width, depth);
-  Point top_right = back_center + Vector2(half_width, depth);
-  Point bottom_left = back_center + Vector2(-half_width, 0.0);
-  Point bottom_right = back_center + Vector2(half_width, 0.0);
+  Point top_left = back_center + Vector2(depth, -half_width);
+  Point top_right = back_center + Vector2(depth, half_width);
+  Point bottom_left = back_center + Vector2(0.0, -half_width);
+  Point bottom_right = back_center + Vector2(0.0, half_width);
 
   // 3本の線で描画（奥、左、右）
   line().start(top_left).end(top_right).stroke(color).strokeWidth(stroke_width).build();


### PR DESCRIPTION
## Summary
- ゴール可視化が90度回転して表示されていた問題を修正

## 変更内容
`drawGoal`関数で、ゴールの幅(width)と奥行き(depth)の軸割り当てが誤っていた。
- **修正前**: widthがX軸、depthがY軸に適用され、ゴールが90度回転
- **修正後**: depthがX軸（フィールドエンド方向）、widthがY軸（サイドライン方向）に正しく配置

## 影響範囲
- `utility/crane_msg_wrappers/src/crane_visualizer_wrapper.cpp`の`drawGoal`関数のみ

## Test plan
- [ ] ビルド確認（成功）
- [ ] 可視化でゴールが正しい向きで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)