### PR TITLE
feat: SessionBaseのロボット適性評価関数を純粋仮想関数化

### DIFF
--- a/crane_sessions/include/crane_sessions/placement_avoidance_session.hpp
+++ b/crane_sessions/include/crane_sessions/placement_avoidance_session.hpp
@@ -33,6 +33,23 @@ public:
   {
   }
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    auto wm = world_model;
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      // ゴールキーパーは除外
+      if (robot->id == wm->getOurGoalieId()) {
+        return 10000.0;
+      }
+      // ボール配置エリアへの距離（近いほど優先）
+      if (auto placement_area = wm->getBallPlacementArea(); placement_area) {
+        return bg::distance(robot->pose.pos, placement_area.value());
+      }
+      return 0.0;
+    };
+  }
+
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> override
   {

--- a/crane_sessions/include/crane_sessions/session_base.hpp
+++ b/crane_sessions/include/crane_sessions/session_base.hpp
@@ -174,11 +174,7 @@ public:
    * @return ロボット適性評価関数
    */
   virtual auto getRobotSuitabilityFunc() const
-    -> std::function<double(const std::shared_ptr<RobotInfo> &)>
-  {
-    // デフォルト実装: すべてのロボットを等価とみなす（コスト0）
-    return [](const std::shared_ptr<RobotInfo> &) { return 0.0; };
-  }
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> = 0;
 
   /**
    * @brief ハード制約Tacticかどうかを返す

--- a/crane_sessions/include/crane_sessions/test_session.hpp
+++ b/crane_sessions/include/crane_sessions/test_session.hpp
@@ -30,6 +30,18 @@ public:
   COMPOSITION_PUBLIC explicit TestSession(
     WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node);
 
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    uint8_t target_id = target_robot_id;
+    return [target_id](const std::shared_ptr<RobotInfo> & robot) {
+      if (robot->id == target_id) {
+        return 0.0;
+      }
+      return 1000.0;
+    };
+  }
+
   std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
 


### PR DESCRIPTION
## 概要

`SessionBase::getRobotSuitabilityFunc()` を純粋仮想関数化し、すべてのセッションクラスがロボット適性評価関数を明示的に実装することを強制します。

## 変更内容

### 1. SessionBase (session_base.hpp)
- `getRobotSuitabilityFunc()` のデフォルト実装を削除
- 純粋仮想関数化（`= 0`）により、すべての派生クラスで実装を強制

### 2. BallPlacementAvoidanceSession (placement_avoidance_session.hpp)
- ボール配置エリアへの距離をコストとする関数を実装
- ゴールキーパーは高コスト（10000.0）で除外
- エリア内・近くのロボットが優先的に選ばれる設計

### 3. TestSession (test_session.hpp)
- YAML設定の `target_robot_id` で指定されたロボットを最優先
- 指定IDのロボットはコスト0.0、それ以外は1000.0

## 効果

GlobalRobotAllocatorがロボット割り当て時に各セッションの要求を適切に考慮できるようになります。

## テスト

- ✅ `colcon build --packages-select crane_sessions` でビルド成功
- ✅ コンパイルエラーなし
- ✅ pre-commitフック全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)