### PR TITLE
refactor: ドキュメント・コード整合性修正「Tactic」→「Session」移行

### DIFF
--- a/crane_commentary/crane_commentary/self_commentary/commentary_generator.py
+++ b/crane_commentary/crane_commentary/self_commentary/commentary_generator.py
@@ -75,8 +75,8 @@ class CommentaryGenerator:
         """
         robot_id = change.robot_id
 
-        if change.change_type == ChangeType.TACTIC_CHANGED:
-            return f"ロボット{robot_id}のタクティクスを{change.old_value}から{change.new_value}に切り替えました"
+        if change.change_type == ChangeType.SESSION_CHANGED:
+            return f"ロボット{robot_id}のセッションを{change.old_value}から{change.new_value}に切り替えました"
 
         elif change.change_type == ChangeType.SKILL_CHANGED:
             return f"ロボット{robot_id}のスキルを{change.old_value}から{change.new_value}に移行しました"
@@ -104,27 +104,27 @@ class CommentaryGenerator:
         """
         intents = self._tracker.get_current_intents()
 
-        # Group robots by tactic
-        tactics_map: Dict[str, List[int]] = {}
+        # Group robots by session
+        sessions_map: Dict[str, List[int]] = {}
         for robot_id, intent in intents.items():
-            tactic = intent.tactic_name
-            if tactic and tactic != "Unknown":
-                if tactic not in tactics_map:
-                    tactics_map[tactic] = []
-                tactics_map[tactic].append(robot_id)
+            session = intent.session_name
+            if session and session != "Unknown":
+                if session not in sessions_map:
+                    sessions_map[session] = []
+                sessions_map[session].append(robot_id)
 
         # Build robot details
         robots_detail = {}
         for robot_id, intent in intents.items():
             robots_detail[str(robot_id)] = {
-                "tactic": intent.tactic_name,
+                "session": intent.session_name,
                 "skill": intent.skill_name,
                 "state": intent.skill_state,
             }
 
         return {
-            "active_tactics": list(tactics_map.keys()),
+            "active_sessions": list(sessions_map.keys()),
             "robot_count": len(intents),
-            "tactics_assignment": tactics_map,
+            "sessions_assignment": sessions_map,
             "robots": robots_detail,
         }

--- a/crane_commentary/crane_commentary/self_commentary/intent_tracker.py
+++ b/crane_commentary/crane_commentary/self_commentary/intent_tracker.py
@@ -14,7 +14,7 @@ from enum import Enum
 class ChangeType(Enum):
     """Type of intent change."""
 
-    TACTIC_CHANGED = "tactic_changed"
+    SESSION_CHANGED = "session_changed"
     SKILL_CHANGED = "skill_changed"
     STATE_CHANGED = "state_changed"
     ROBOT_ASSIGNED = "robot_assigned"
@@ -27,7 +27,7 @@ class RobotIntent:
     """Represents a robot's current intent."""
 
     robot_id: int
-    tactic_name: str = ""
+    session_name: str = ""
     skill_name: str = ""  # planning_factors[0].name
     skill_state: str = ""  # planning_factors[0].value
     nested_skills: List[Dict[str, str]] = field(
@@ -41,7 +41,7 @@ class RobotIntent:
             return NotImplemented
         return (
             self.robot_id == other.robot_id
-            and self.tactic_name == other.tactic_name
+            and self.session_name == other.session_name
             and self.skill_name == other.skill_name
             and self.skill_state == other.skill_state
         )
@@ -62,7 +62,7 @@ class IntentChange:
         priority_map = {
             ChangeType.SKILL_COMPLETED: 3,
             ChangeType.SKILL_FAILED: 3,
-            ChangeType.TACTIC_CHANGED: 2,
+            ChangeType.SESSION_CHANGED: 2,
             ChangeType.SKILL_CHANGED: 2,
             ChangeType.ROBOT_ASSIGNED: 2,
             ChangeType.STATE_CHANGED: 1,
@@ -90,23 +90,23 @@ class IntentTracker:
         self._current_intents: Dict[int, RobotIntent] = {}
         # Previous intent state
         self._previous_intents: Dict[int, RobotIntent] = {}
-        # Tactic mapping (robot_id -> tactic_name)
-        self._robot_to_tactic: Dict[int, str] = {}
+        # Session mapping (robot_id -> session_name)
+        self._robot_to_session: Dict[int, str] = {}
 
     def update_from_robot_select_results(self, msg: any) -> None:
-        """Update tactic information from RobotSelectResults message.
+        """Update session information from RobotSelectResults message.
 
         Args:
             msg: RobotSelectResults message
         """
         # Clear old mapping
-        self._robot_to_tactic.clear()
+        self._robot_to_session.clear()
 
         # Build new mapping
         for result in msg.results:
-            tactic_name = result.name
+            session_name = result.name
             for robot_id in result.selected_robots:
-                self._robot_to_tactic[robot_id] = tactic_name
+                self._robot_to_session[robot_id] = session_name
 
     def update_from_control_targets(self, msg: any) -> None:
         """Update intent information from PositionCommands message.
@@ -121,7 +121,7 @@ class IntentTracker:
         new_intents = {}
         for cmd in msg.robot_commands:
             robot_id = cmd.robot_id
-            tactic_name = self._robot_to_tactic.get(robot_id, "Unknown")
+            session_name = self._robot_to_session.get(robot_id, "Unknown")
 
             # Extract skill and state from planning_factors
             skill_name = ""
@@ -147,7 +147,7 @@ class IntentTracker:
 
             new_intents[robot_id] = RobotIntent(
                 robot_id=robot_id,
-                tactic_name=tactic_name,
+                session_name=session_name,
                 skill_name=skill_name,
                 skill_state=skill_state,
                 nested_skills=nested_skills,
@@ -167,13 +167,13 @@ class IntentTracker:
         # No previous state -> initial assignment
         if not self._previous_intents:
             for robot_id, intent in self._current_intents.items():
-                if intent.tactic_name and intent.tactic_name != "Unknown":
+                if intent.session_name and intent.session_name != "Unknown":
                     changes.append(
                         IntentChange(
                             change_type=ChangeType.ROBOT_ASSIGNED,
                             robot_id=robot_id,
                             old_value="",
-                            new_value=intent.tactic_name,
+                            new_value=intent.session_name,
                             context={
                                 "skill": intent.skill_name,
                                 "state": intent.skill_state,
@@ -188,13 +188,13 @@ class IntentTracker:
 
             # New robot assignment
             if not previous:
-                if current.tactic_name and current.tactic_name != "Unknown":
+                if current.session_name and current.session_name != "Unknown":
                     changes.append(
                         IntentChange(
                             change_type=ChangeType.ROBOT_ASSIGNED,
                             robot_id=robot_id,
                             old_value="",
-                            new_value=current.tactic_name,
+                            new_value=current.session_name,
                             context={
                                 "skill": current.skill_name,
                                 "state": current.skill_state,
@@ -203,14 +203,14 @@ class IntentTracker:
                     )
                 continue
 
-            # Tactic change
-            if previous.tactic_name != current.tactic_name:
+            # Session change
+            if previous.session_name != current.session_name:
                 changes.append(
                     IntentChange(
-                        change_type=ChangeType.TACTIC_CHANGED,
+                        change_type=ChangeType.SESSION_CHANGED,
                         robot_id=robot_id,
-                        old_value=previous.tactic_name,
-                        new_value=current.tactic_name,
+                        old_value=previous.session_name,
+                        new_value=current.session_name,
                         context={
                             "skill": current.skill_name,
                             "state": current.skill_state,

--- a/crane_session_coordinator/include/crane_session_coordinator/allocation_state.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/allocation_state.hpp
@@ -25,15 +25,15 @@ public:
   AllocationState() = default;
 
   /**
-   * @brief 前フレームで指定のロボットが指定のTacticに割り当てられていたかを確認
+   * @brief 前フレームで指定のロボットが指定のSessionに割り当てられていたかを確認
    * @param robot_id ロボットID
-   * @param tactic_name Tactic名
+   * @param session_name Session名
    * @return 割り当てられていた場合true
    */
-  [[nodiscard]] auto wasAssignedTo(uint8_t robot_id, const std::string & tactic_name) const -> bool
+  [[nodiscard]] auto wasAssignedTo(uint8_t robot_id, const std::string & session_name) const -> bool
   {
-    auto it = robot_to_tactic_.find(robot_id);
-    return it != robot_to_tactic_.end() && it->second == tactic_name;
+    auto it = robot_to_session_.find(robot_id);
+    return it != robot_to_session_.end() && it->second == session_name;
   }
 
   /**
@@ -64,15 +64,15 @@ public:
   /**
    * @brief 割当状態を更新
    * @param robot_id ロボットID
-   * @param tactic_name 割り当てられたTactic名
+   * @param session_name 割り当てられたSession名
    * @param target_position ターゲット位置
    */
   void updateAssignment(
-    uint8_t robot_id, const std::string & tactic_name, const Point & target_position)
+    uint8_t robot_id, const std::string & session_name, const Point & target_position)
   {
-    // Tactic割当を更新
-    bool same_tactic = wasAssignedTo(robot_id, tactic_name);
-    robot_to_tactic_[robot_id] = tactic_name;
+    // Session割当を更新
+    bool same_tactic = wasAssignedTo(robot_id, session_name);
+    robot_to_session_[robot_id] = session_name;
     robot_to_position_[robot_id] = target_position;
 
     // 継続フレーム数を更新
@@ -89,7 +89,7 @@ public:
    */
   void clearAssignment(uint8_t robot_id)
   {
-    robot_to_tactic_.erase(robot_id);
+    robot_to_session_.erase(robot_id);
     robot_to_position_.erase(robot_id);
     assignment_duration_.erase(robot_id);
   }
@@ -99,7 +99,7 @@ public:
    */
   void clearAll()
   {
-    robot_to_tactic_.clear();
+    robot_to_session_.clear();
     robot_to_position_.clear();
     assignment_duration_.clear();
   }
@@ -111,24 +111,24 @@ public:
   [[nodiscard]] auto getAllAssignedRobots() const -> std::vector<uint8_t>
   {
     std::vector<uint8_t> robots;
-    robots.reserve(robot_to_tactic_.size());
-    for (const auto & [robot_id, _] : robot_to_tactic_) {
+    robots.reserve(robot_to_session_.size());
+    for (const auto & [robot_id, _] : robot_to_session_) {
       robots.push_back(robot_id);
     }
     return robots;
   }
 
   /**
-   * @brief 指定のTacticに割り当てられているロボットIDの一覧を取得
-   * @param tactic_name Tactic名
+   * @brief 指定のSessionに割り当てられているロボットIDの一覧を取得
+   * @param session_name Session名
    * @return ロボットIDのベクター
    */
-  [[nodiscard]] auto getRobotsAssignedTo(const std::string & tactic_name) const
+  [[nodiscard]] auto getRobotsAssignedTo(const std::string & session_name) const
     -> std::vector<uint8_t>
   {
     std::vector<uint8_t> robots;
-    for (const auto & [robot_id, assigned_tactic] : robot_to_tactic_) {
-      if (assigned_tactic == tactic_name) {
+    for (const auto & [robot_id, assigned_tactic] : robot_to_session_) {
+      if (assigned_tactic == session_name) {
         robots.push_back(robot_id);
       }
     }
@@ -143,8 +143,8 @@ public:
   {
     std::stringstream ss;
     ss << "AllocationState: ";
-    for (const auto & [robot_id, tactic_name] : robot_to_tactic_) {
-      ss << "[" << static_cast<int>(robot_id) << "->" << tactic_name << "("
+    for (const auto & [robot_id, session_name] : robot_to_session_) {
+      ss << "[" << static_cast<int>(robot_id) << "->" << session_name << "("
          << getAssignmentDuration(robot_id) << ")] ";
     }
     return ss.str();
@@ -152,8 +152,8 @@ public:
 
 private:
   // 前フレームの割当情報
-  std::unordered_map<uint8_t, std::string> robot_to_tactic_;  // robot_id -> tactic_name
-  std::unordered_map<uint8_t, Point> robot_to_position_;      // robot_id -> target_position
+  std::unordered_map<uint8_t, std::string> robot_to_session_;  // robot_id -> session_name
+  std::unordered_map<uint8_t, Point> robot_to_position_;       // robot_id -> target_position
 
   // 割当継続フレーム数
   std::unordered_map<uint8_t, int> assignment_duration_;  // robot_id -> frames

--- a/crane_session_coordinator/include/crane_session_coordinator/command_aggregator.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/command_aggregator.hpp
@@ -24,7 +24,7 @@ namespace crane
 class CommandAggregator
 {
 public:
-  explicit CommandAggregator(std::shared_ptr<SessionRegistry> tactic_registry);
+  explicit CommandAggregator(std::shared_ptr<SessionRegistry> session_registry);
 
   /**
    * @brief 全プランナーからコマンドを収集してメッセージを構築
@@ -50,7 +50,7 @@ private:
    */
   auto assignPriorities(crane_msgs::msg::PositionCommands & msg) -> void;
 
-  std::shared_ptr<SessionRegistry> tactic_registry_;
+  std::shared_ptr<SessionRegistry> session_registry_;
 };
 
 }  // namespace crane

--- a/crane_session_coordinator/include/crane_session_coordinator/configuration_manager.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/configuration_manager.hpp
@@ -19,7 +19,7 @@ namespace crane
 {
 using SessionParameterType = std::variant<double, bool, int, std::string>;
 
-struct TacticSlot
+struct SessionSlot
 {
   std::string session_name;
   int min_robots = 1;
@@ -57,12 +57,12 @@ public:
   auto getSessionNameForEvent(const std::string & event_name) const -> std::optional<std::string>;
 
   /**
-   * @brief セッション名に対応するTacticSlotリストを取得
+   * @brief セッション名に対応するSessionSlotリストを取得
    * @param situation_name セッション名
-   * @return TacticSlotリスト（存在しない場合はstd::nullopt）
+   * @return SessionSlotリスト（存在しない場合はstd::nullopt）
    */
   auto getSessionCapacitiesForSituation(const std::string & situation_name) const
-    -> std::optional<std::vector<TacticSlot>>;
+    -> std::optional<std::vector<SessionSlot>>;
 
   /**
    * @brief イベントマップを取得（読み取り専用）
@@ -82,8 +82,8 @@ private:
   // イベント名 → セッション名のマッピング
   std::unordered_map<std::string, std::string> event_map_;
 
-  // セッション名 → TacticSlotリストのマッピング
-  std::unordered_map<std::string, std::vector<TacticSlot>> robot_selection_priority_map_;
+  // セッション名 → SessionSlotリストのマッピング
+  std::unordered_map<std::string, std::vector<SessionSlot>> robot_selection_priority_map_;
 
   rclcpp::Logger logger_;
 

--- a/crane_session_coordinator/include/crane_session_coordinator/diagnostics_reporter.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/diagnostics_reporter.hpp
@@ -24,7 +24,7 @@ class DiagnosticsReporter
 {
 public:
   explicit DiagnosticsReporter(
-    rclcpp::Clock::SharedPtr clock, std::shared_ptr<SessionRegistry> tactic_registry,
+    rclcpp::Clock::SharedPtr clock, std::shared_ptr<SessionRegistry> session_registry,
     rclcpp::Logger logger);
 
   /**
@@ -41,7 +41,7 @@ public:
 
 private:
   rclcpp::Clock::SharedPtr clock_;
-  std::shared_ptr<SessionRegistry> tactic_registry_;
+  std::shared_ptr<SessionRegistry> session_registry_;
   rclcpp::Logger logger_;
 
   rclcpp::Time last_planning_time_;

--- a/crane_session_coordinator/include/crane_session_coordinator/global_robot_allocator.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/global_robot_allocator.hpp
@@ -23,11 +23,11 @@ namespace crane
 {
 
 /**
- * @brief Tacticのロボット要求情報
+ * @brief Sessionのロボット要求情報
  */
-struct TacticRequirement
+struct SessionRequirement
 {
-  // Tactic名
+  // Session名
   std::string name;
 
   // 優先度（数値が小さいほど優先度が高い、0が最高優先度）
@@ -45,7 +45,7 @@ struct TacticRequirement
   // ハード制約フラグ（trueの場合、優先的に確保される）
   bool is_hard_constraint = false;
 
-  TacticRequirement(
+  SessionRequirement(
     std::string n, int p, int min_r, int max_r,
     std::function<double(const std::shared_ptr<RobotInfo> &)> func, bool hard = false)
   : name(std::move(n)),
@@ -61,7 +61,7 @@ struct TacticRequirement
 /**
  * @brief 全体最適化ロボット割当クラス
  *
- * 複数のTacticからの要求を統一的に処理し、ハンガリアン法で全体最適な割当を行う。
+ * 複数のSessionからの要求を統一的に処理し、ハンガリアン法で全体最適な割当を行う。
  */
 class GlobalRobotAllocator
 {
@@ -71,15 +71,15 @@ public:
   /**
    * @brief 全体最適化によるロボット割当
    *
-   * @param requirements Tacticごとの要求リスト
+   * @param requirements Sessionごとの要求リスト
    * @param available_robots 利用可能なロボットIDリスト
    * @param world_model ワールドモデル
    * @param prev_state 前フレームの割当状態
    * @param config コスト計算設定
-   * @return Tactic名→割り当てられたロボットIDリストのマップ
+   * @return Session名→割り当てられたロボットIDリストのマップ
    */
   auto allocate(
-    const std::vector<TacticRequirement> & requirements,
+    const std::vector<SessionRequirement> & requirements,
     const std::vector<uint8_t> & available_robots, WorldModelWrapper::SharedPtr & world_model,
     const AllocationState & prev_state, const AllocationCostConfig & config)
     -> std::unordered_map<std::string, std::vector<uint8_t>>;
@@ -88,30 +88,30 @@ private:
   rclcpp::Logger logger_;
 
   /**
-   * @brief ハード制約Tacticを先に処理
+   * @brief ハード制約Sessionを先に処理
    */
   auto allocateHardConstraints(
-    const std::vector<TacticRequirement> & hard_requirements,
+    const std::vector<SessionRequirement> & hard_requirements,
     std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
     const AllocationState & prev_state, const AllocationCostConfig & config,
     std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void;
 
   /**
-   * @brief ソフト制約Tacticをハンガリアン法で処理
+   * @brief ソフト制約Sessionをハンガリアン法で処理
    */
   auto allocateSoftConstraints(
-    const std::vector<TacticRequirement> & soft_requirements,
+    const std::vector<SessionRequirement> & soft_requirements,
     const std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
     const AllocationState & prev_state, const AllocationCostConfig & config,
     std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void;
 
   /**
-   * @brief 仮想ターゲット（Tactic-Robot ペア）を生成
+   * @brief 仮想ターゲット（Session-Robot ペア）を生成
    */
   struct VirtualTarget
   {
-    std::string tactic_name;
-    int tactic_priority;
+    std::string session_name;
+    int session_priority;
     size_t robot_index;
     std::shared_ptr<std::function<double(const std::shared_ptr<RobotInfo> &)>> suitability_func;
   };

--- a/crane_session_coordinator/include/crane_session_coordinator/robot_allocator.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/robot_allocator.hpp
@@ -31,7 +31,7 @@ class RobotAllocator
 public:
   explicit RobotAllocator(
     std::shared_ptr<ConfigurationManager> config_manager,
-    std::shared_ptr<SessionRegistry> tactic_registry, rclcpp::Logger logger);
+    std::shared_ptr<SessionRegistry> session_registry, rclcpp::Logger logger);
 
   /**
    * @brief セッション名と利用可能ロボットから割当を実行
@@ -79,7 +79,7 @@ public:
 
 private:
   std::shared_ptr<ConfigurationManager> config_manager_;
-  std::shared_ptr<SessionRegistry> tactic_registry_;
+  std::shared_ptr<SessionRegistry> session_registry_;
   rclcpp::Logger logger_;
 
   std::unordered_map<uint8_t, RobotRole> prev_robot_roles_;

--- a/crane_session_coordinator/include/crane_session_coordinator/session_coordinator.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/session_coordinator.hpp
@@ -57,7 +57,7 @@ private:
 
   std::shared_ptr<ConfigurationManager> config_manager_;
 
-  std::shared_ptr<SessionRegistry> tactic_registry_;
+  std::shared_ptr<SessionRegistry> session_registry_;
 
   std::unique_ptr<DiagnosticsReporter> diagnostics_reporter_;
 

--- a/crane_session_coordinator/include/crane_session_coordinator/session_registry.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/session_registry.hpp
@@ -55,9 +55,9 @@ public:
 
   /**
    * @brief プランナーを追加
-   * @param tactic 追加するプランナー
+   * @param session 追加するプランナー
    */
-  auto addPlanner(const SessionBase::SharedPtr & tactic) -> void;
+  auto addPlanner(const SessionBase::SharedPtr & session) -> void;
 
   /**
    * @brief 全プランナーをクリア
@@ -72,7 +72,7 @@ public:
 
 private:
   // 現在アクティブなプランナーのリスト
-  std::vector<SessionBase::SharedPtr> active_tactics_;
+  std::vector<SessionBase::SharedPtr> active_sessions_;
 };
 
 }  // namespace crane

--- a/crane_session_coordinator/src/command_aggregator.cpp
+++ b/crane_session_coordinator/src/command_aggregator.cpp
@@ -12,8 +12,8 @@
 namespace crane
 {
 
-CommandAggregator::CommandAggregator(std::shared_ptr<SessionRegistry> tactic_registry)
-: tactic_registry_(tactic_registry)
+CommandAggregator::CommandAggregator(std::shared_ptr<SessionRegistry> session_registry)
+: session_registry_(session_registry)
 {
 }
 
@@ -27,31 +27,31 @@ auto CommandAggregator::collectCommands(
   setMessageMetadata(msg, world_model, current_time);
 
   // 全プランナーからコマンドを収集
-  for (const auto & tactic : tactic_registry_->getAllPlanners()) {
-    // 各Tacticにgame_analysisを設定
-    tactic->setGameAnalysis(game_analysis);
+  for (const auto & session : session_registry_->getAllPlanners()) {
+    // 各Sessionにgame_analysisを設定
+    session->setGameAnalysis(game_analysis);
 
-    auto robot_count = tactic->getRobots().size();
-    auto commands_msg = tactic->getPositionCommands();
+    auto robot_count = session->getRobots().size();
+    auto commands_msg = session->getPositionCommands();
     auto command_count = commands_msg.robot_commands.size();
 
     if (robot_count > 0 && command_count == 0) {
       // ロボットは割り当てられているがコマンドが生成されていない
-      std::cerr << "[CommandAggregator] 警告: Tactic「" << tactic->name << "」にロボット "
+      std::cerr << "[CommandAggregator] 警告: Session「" << session->name << "」にロボット "
                 << robot_count << " 台が割り当てられていますが、"
                 << "コマンドが0件生成されました" << std::endl;
     }
 
-    // Note: tactic_name フィールドはメッセージ定義にないためコメントアウト
+    // Note: session_name フィールドはメッセージ定義にないためコメントアウト
     // ranges::for_each(
     //   commands_msg.robot_commands, [&](crane_msgs::msg::PositionCommand & position_command) {
-    //     position_command.tactic_name = tactic->name;
+    //     position_command.session_name = session->name;
     //   });
     msg.robot_commands.insert(
       msg.robot_commands.end(), commands_msg.robot_commands.begin(),
       commands_msg.robot_commands.end());
 
-    if (tactic->getStatus() != SessionBase::Status::RUNNING) {
+    if (session->getStatus() != SessionBase::Status::RUNNING) {
       // TODO(HansRobo): プランナが成功・失敗した場合の処理
     }
   }
@@ -75,7 +75,7 @@ auto CommandAggregator::setMessageMetadata(
 
   msg.header.stamp = current_time;
 
-  // 遅延監視: TacticCoordinator処理完了、PositionCommands送信
+  // 遅延監視: SessionCoordinator処理完了、PositionCommands送信
   DelayMonitorWrapper::addDelayCheckpoint(
     msg.delay_checkpoints, "session_controller_end", "strategy_computed");
 }

--- a/crane_session_coordinator/src/configuration_manager.cpp
+++ b/crane_session_coordinator/src/configuration_manager.cpp
@@ -37,7 +37,7 @@ auto ConfigurationManager::getSessionNameForEvent(const std::string & event_name
 }
 
 auto ConfigurationManager::getSessionCapacitiesForSituation(
-  const std::string & situation_name) const -> std::optional<std::vector<TacticSlot>>
+  const std::string & situation_name) const -> std::optional<std::vector<SessionSlot>>
 {
   auto it = robot_selection_priority_map_.find(situation_name);
   if (it != robot_selection_priority_map_.end()) {
@@ -68,14 +68,14 @@ auto ConfigurationManager::loadUnifiedConfig(const std::filesystem::path & confi
       const std::string situation_name = situation_entry.first.as<std::string>();
       const auto & situation_data = situation_entry.second;
 
-      std::vector<TacticSlot> session_capacity_list;
+      std::vector<SessionSlot> session_capacity_list;
       std::stringstream ss;
       ss << "SITUATION : " << situation_name << "\n";
       ss << "DESCRIPTION : " << situation_data["description"] << "\n";
       ss << "SESSIONS : " << "\n";
 
       for (const auto & session_node : situation_data["sessions"]) {
-        TacticSlot session_capacity;
+        SessionSlot session_capacity;
         session_capacity.session_name = session_node["name"].as<std::string>();
 
         // min_robotsの読み込みとデフォルト値設定

--- a/crane_session_coordinator/src/crane_session_coordinator.cpp
+++ b/crane_session_coordinator/src/crane_session_coordinator.cpp
@@ -47,18 +47,18 @@ SessionCoordinatorComponent::SessionCoordinatorComponent(const rclcpp::NodeOptio
     session_config_file_name, get_logger());
 
   // プランナー管理の初期化
-  tactic_registry_ = std::make_shared<SessionRegistry>();
+  session_registry_ = std::make_shared<SessionRegistry>();
 
   // 診断レポーターの初期化
   diagnostics_reporter_ =
-    std::make_unique<DiagnosticsReporter>(get_clock(), tactic_registry_, get_logger());
+    std::make_unique<DiagnosticsReporter>(get_clock(), session_registry_, get_logger());
 
   // コマンドアグリゲーターの初期化
-  command_aggregator_ = std::make_unique<CommandAggregator>(tactic_registry_);
+  command_aggregator_ = std::make_unique<CommandAggregator>(session_registry_);
 
   // ロボット割当マネージャーの初期化
   robot_allocator_ =
-    std::make_unique<RobotAllocator>(config_manager_, tactic_registry_, get_logger());
+    std::make_unique<RobotAllocator>(config_manager_, session_registry_, get_logger());
 
   play_situation_sub = create_subscription<crane_msgs::msg::PlaySituation>(
     "/play_situation", 1, [this](const crane_msgs::msg::PlaySituation & msg) {

--- a/crane_session_coordinator/src/diagnostics_reporter.cpp
+++ b/crane_session_coordinator/src/diagnostics_reporter.cpp
@@ -10,10 +10,10 @@ namespace crane
 {
 
 DiagnosticsReporter::DiagnosticsReporter(
-  rclcpp::Clock::SharedPtr clock, std::shared_ptr<SessionRegistry> tactic_registry,
+  rclcpp::Clock::SharedPtr clock, std::shared_ptr<SessionRegistry> session_registry,
   rclcpp::Logger logger)
 : clock_(clock),
-  tactic_registry_(tactic_registry),
+  session_registry_(session_registry),
   logger_(logger),
   last_planning_time_(clock_->now())
 {
@@ -52,7 +52,7 @@ auto DiagnosticsReporter::updateDiagnostics(
 
   stat.add("time_since_last_planning", time_since_last_planning);
   stat.add("planning_count", planning_count_);
-  stat.add("active_planners", static_cast<int>(tactic_registry_->getAllPlanners().size()));
+  stat.add("active_planners", static_cast<int>(session_registry_->getAllPlanners().size()));
   stat.add(
     "available_robots",
     static_cast<int>(world_model->ours().robotsWhere().available().getIds().size()));

--- a/crane_session_coordinator/src/global_robot_allocator.cpp
+++ b/crane_session_coordinator/src/global_robot_allocator.cpp
@@ -16,7 +16,7 @@ namespace crane
 {
 
 auto GlobalRobotAllocator::allocate(
-  const std::vector<TacticRequirement> & requirements,
+  const std::vector<SessionRequirement> & requirements,
   const std::vector<uint8_t> & available_robots, WorldModelWrapper::SharedPtr & world_model,
   const AllocationState & prev_state, const AllocationCostConfig & config)
   -> std::unordered_map<std::string, std::vector<uint8_t>>
@@ -29,8 +29,8 @@ auto GlobalRobotAllocator::allocate(
   }
 
   // ハード制約とソフト制約に分類
-  std::vector<TacticRequirement> hard_requirements;
-  std::vector<TacticRequirement> soft_requirements;
+  std::vector<SessionRequirement> hard_requirements;
+  std::vector<SessionRequirement> soft_requirements;
 
   for (const auto & req : requirements) {
     if (req.is_hard_constraint) {
@@ -50,11 +50,11 @@ auto GlobalRobotAllocator::allocate(
 
   auto remaining_robots = available_robots;
 
-  // Phase 1: ハード制約Tacticを先に処理
+  // Phase 1: ハード制約Sessionを先に処理
   allocateHardConstraints(
     hard_requirements, remaining_robots, world_model, prev_state, config, result);
 
-  // Phase 2: 残りのロボットでソフト制約Tacticをハンガリアン法で処理
+  // Phase 2: 残りのロボットでソフト制約Sessionをハンガリアン法で処理
   allocateSoftConstraints(
     soft_requirements, remaining_robots, world_model, prev_state, config, result);
 
@@ -62,15 +62,15 @@ auto GlobalRobotAllocator::allocate(
 }
 
 auto GlobalRobotAllocator::allocateHardConstraints(
-  const std::vector<TacticRequirement> & hard_requirements, std::vector<uint8_t> & remaining_robots,
-  WorldModelWrapper::SharedPtr & world_model, const AllocationState & prev_state,
-  const AllocationCostConfig & config,
+  const std::vector<SessionRequirement> & hard_requirements,
+  std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
+  const AllocationState & prev_state, const AllocationCostConfig & config,
   std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void
 {
   for (const auto & req : hard_requirements) {
     if (remaining_robots.empty()) {
       RCLCPP_WARN(
-        logger_, "ハード制約Tactic「%s」に割り当てるロボットが不足しています", req.name.c_str());
+        logger_, "ハード制約Session「%s」に割り当てるロボットが不足しています", req.name.c_str());
       break;
     }
 
@@ -106,13 +106,13 @@ auto GlobalRobotAllocator::allocateHardConstraints(
     }
 
     RCLCPP_DEBUG_STREAM(
-      logger_, "ハード制約Tactic「" << req.name << "」に" << assigned_robots.size()
-                                    << "ロボットを割り当て: " << assigned_robots);
+      logger_, "ハード制約Session「" << req.name << "」に" << assigned_robots.size()
+                                     << "ロボットを割り当て: " << assigned_robots);
   }
 }
 
 auto GlobalRobotAllocator::allocateSoftConstraints(
-  const std::vector<TacticRequirement> & soft_requirements,
+  const std::vector<SessionRequirement> & soft_requirements,
   const std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
   const AllocationState & prev_state, const AllocationCostConfig & config,
   std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void
@@ -121,7 +121,7 @@ auto GlobalRobotAllocator::allocateSoftConstraints(
     return;
   }
 
-  // 仮想ターゲットを生成（各Tacticが必要とするロボット数分）
+  // 仮想ターゲットを生成（各Sessionが必要とするロボット数分）
   std::vector<VirtualTarget> virtual_targets;
   for (const auto & req : soft_requirements) {
     int num_targets = std::min(req.max_robots, static_cast<int>(remaining_robots.size()));
@@ -223,7 +223,7 @@ auto GlobalRobotAllocator::allocateSoftConstraints(
   }
 
   // 割当結果を集計
-  std::unordered_map<std::string, std::vector<uint8_t>> tactic_assignments;
+  std::unordered_map<std::string, std::vector<uint8_t>> session_assignments;
 
   if (needs_transpose) {
     // 転置モード: assignment[target_idx] = robot_idx
@@ -235,7 +235,7 @@ auto GlobalRobotAllocator::allocateSoftConstraints(
 
       const auto & target = virtual_targets[target_idx];
       uint8_t robot_id = remaining_robots[robot_idx];
-      tactic_assignments[target.tactic_name].push_back(robot_id);
+      session_assignments[target.session_name].push_back(robot_id);
     }
   } else {
     // 通常モード: assignment[robot_idx] = target_idx
@@ -247,32 +247,32 @@ auto GlobalRobotAllocator::allocateSoftConstraints(
 
       const auto & target = virtual_targets[target_idx];
       uint8_t robot_id = remaining_robots[robot_idx];
-      tactic_assignments[target.tactic_name].push_back(robot_id);
+      session_assignments[target.session_name].push_back(robot_id);
     }
   }
 
   // min_robotsの制約を満たしているか確認
   for (const auto & req : soft_requirements) {
-    auto it = tactic_assignments.find(req.name);
-    if (it != tactic_assignments.end()) {
+    auto it = session_assignments.find(req.name);
+    if (it != session_assignments.end()) {
       if (it->second.size() < req.min_robots) {
         RCLCPP_WARN(
-          logger_, "Tactic「%s」の最小ロボット数(%d)を満たせませんでした（実際: %lu）",
+          logger_, "Session「%s」の最小ロボット数(%d)を満たせませんでした（実際: %lu）",
           req.name.c_str(), req.min_robots, it->second.size());
       }
     } else if (req.min_robots > 0) {
       RCLCPP_WARN(
-        logger_, "Tactic「%s」にロボットを割り当てられませんでした（最小要求: %d）",
+        logger_, "Session「%s」にロボットを割り当てられませんでした（最小要求: %d）",
         req.name.c_str(), req.min_robots);
     }
   }
 
   // 結果をマージ
-  for (const auto & [tactic_name, robots] : tactic_assignments) {
-    result[tactic_name] = robots;
+  for (const auto & [session_name, robots] : session_assignments) {
+    result[session_name] = robots;
     RCLCPP_DEBUG_STREAM(
-      logger_, "ソフト制約Tactic「" << tactic_name << "」に" << robots.size()
-                                    << "ロボットを割り当て: " << robots);
+      logger_, "ソフト制約Session「" << session_name << "」に" << robots.size()
+                                     << "ロボットを割り当て: " << robots);
   }
 }
 
@@ -307,15 +307,15 @@ auto GlobalRobotAllocator::buildCostMatrix(
 
     // ヒステリシスコンテキストを構築
     AssignmentContext context;
-    context.was_assigned_to_same_tactic = state_copy.wasAssignedTo(robot_id, target.tactic_name);
-    context.tactic_priority = target.tactic_priority;
+    context.was_assigned_to_same_session = state_copy.wasAssignedTo(robot_id, target.session_name);
+    context.session_priority = target.session_priority;
 
     // 総コスト計算
-    double priority_cost = context.tactic_priority * config_copy.priority_cost_multiplier;
+    double priority_cost = context.session_priority * config_copy.priority_cost_multiplier;
     double hysteresis_bonus =
-      context.was_assigned_to_same_tactic ? config_copy.hysteresis_bonus : 0.0;
+      context.was_assigned_to_same_session ? config_copy.hysteresis_bonus : 0.0;
     double velocity_hysteresis = 0.0;
-    if (context.was_assigned_to_same_tactic) {
+    if (context.was_assigned_to_same_session) {
       velocity_hysteresis = robot->vel.linear.norm() * config_copy.velocity_hysteresis_factor;
     }
 

--- a/crane_session_coordinator/src/robot_allocator.cpp
+++ b/crane_session_coordinator/src/robot_allocator.cpp
@@ -21,7 +21,7 @@ RobotAllocator::RobotAllocator(
   std::shared_ptr<ConfigurationManager> config_manager,
   std::shared_ptr<SessionRegistry> tactic_registry, rclcpp::Logger logger)
 : config_manager_(config_manager),
-  tactic_registry_(tactic_registry),
+  session_registry_(tactic_registry),
   logger_(logger),
   global_allocator_(std::make_unique<GlobalRobotAllocator>(logger))
 {
@@ -45,11 +45,11 @@ auto RobotAllocator::allocate(
   const auto & session_capacities = session_capacities_opt.value();
 
   // 前回のプランナーリストを保存し、新しいリストをクリア
-  auto prev_available_planners = tactic_registry_->getAllPlanners();
-  tactic_registry_->clear();
+  auto prev_available_planners = session_registry_->getAllPlanners();
+  session_registry_->clear();
 
-  // TacticRequirementリストを構築
-  std::vector<TacticRequirement> requirements;
+  // SessionRequirementリストを構築
+  std::vector<SessionRequirement> requirements;
   int priority = 0;
   for (const auto & session_capacity : session_capacities) {
     if (session_capacity.max_robots <= 0) {
@@ -57,17 +57,17 @@ auto RobotAllocator::allocate(
     }
 
     // プランナー生成
-    auto tactic = tactic_registry_->getOrCreatePlanner(
+    auto session = session_registry_->getOrCreatePlanner(
       session_capacity.session_name, world_model, node, prev_available_planners,
       session_capacity.params);
 
     // 適性関数とハード制約フラグを取得
-    auto suitability_func = tactic->getRobotSuitabilityFunc();
-    bool is_hard = tactic->isHardConstraint();
+    auto suitability_func = session->getRobotSuitabilityFunc();
+    bool is_hard = session->isHardConstraint();
 
     // 動的ロボット数を取得してクランプ
     int desired =
-      tactic->getDesiredRobotNumber(session_capacity.min_robots, session_capacity.max_robots);
+      session->getDesiredRobotNumber(session_capacity.min_robots, session_capacity.max_robots);
     int effective_max =
       std::clamp(desired, session_capacity.min_robots, session_capacity.max_robots);
 
@@ -84,54 +84,54 @@ auto RobotAllocator::allocate(
 
   // 割当結果を適用
   crane_msgs::msg::RobotSelectResults results;
-  for (const auto & [tactic_name, robot_ids] : allocation) {
-    // Tacticを取得または再生成
-    auto tactic_it = std::find_if(
-      tactic_registry_->getAllPlanners().begin(), tactic_registry_->getAllPlanners().end(),
-      [&tactic_name](const auto & t) { return t->name == tactic_name; });
+  for (const auto & [session_name, robot_ids] : allocation) {
+    // Sessionを取得または再生成
+    auto session_it = std::find_if(
+      session_registry_->getAllPlanners().begin(), session_registry_->getAllPlanners().end(),
+      [&session_name](const auto & t) { return t->name == session_name; });
 
-    SessionBase::SharedPtr tactic;
-    if (tactic_it != tactic_registry_->getAllPlanners().end()) {
-      tactic = *tactic_it;
+    SessionBase::SharedPtr session;
+    if (session_it != session_registry_->getAllPlanners().end()) {
+      session = *session_it;
     } else {
       // 見つからない場合は新規生成（通常はここには来ない）
-      auto session_it = std::find_if(
+      auto capacity_it = std::find_if(
         session_capacities.begin(), session_capacities.end(),
-        [&tactic_name](const auto & s) { return s.session_name == tactic_name; });
-      if (session_it != session_capacities.end()) {
-        tactic = tactic_registry_->getOrCreatePlanner(
-          tactic_name, world_model, node, prev_available_planners, session_it->params);
+        [&session_name](const auto & s) { return s.session_name == session_name; });
+      if (capacity_it != session_capacities.end()) {
+        session = session_registry_->getOrCreatePlanner(
+          session_name, world_model, node, prev_available_planners, capacity_it->params);
       }
     }
 
-    if (tactic) {
-      // ロボット割当をTacticに反映
+    if (session) {
+      // ロボット割当をSessionに反映
       // GlobalRobotAllocatorが選択したロボットを直接設定（getSelectedRobotsをバイパス）
-      tactic->setAllocatedRobots(robot_ids);
+      session->setAllocatedRobots(robot_ids);
 
       // レジストリに追加
-      if (tactic_it == tactic_registry_->getAllPlanners().end()) {
-        tactic_registry_->addPlanner(tactic);
+      if (session_it == session_registry_->getAllPlanners().end()) {
+        session_registry_->addPlanner(session);
       }
 
       // AllocationStateを更新（ターゲット位置は現時点では不明なのでロボット位置を使用）
       for (auto id : robot_ids) {
         auto robot = world_model->getOurRobot(id);
-        allocation_state_.updateAssignment(id, tactic_name, robot->pose.pos);
-        prev_robot_roles_.insert_or_assign(id, RobotRole{tactic_name, ""});
+        allocation_state_.updateAssignment(id, session_name, robot->pose.pos);
+        prev_robot_roles_.insert_or_assign(id, RobotRole{session_name, ""});
       }
 
       // RobotSelectResult を構築
       crane_msgs::msg::RobotSelectResult result;
-      result.name = tactic_name;
+      result.name = session_name;
 
       // session_capacities から min/max を取得
-      auto session_it = std::find_if(
+      auto capacity_it = std::find_if(
         session_capacities.begin(), session_capacities.end(),
-        [&tactic_name](const auto & s) { return s.session_name == tactic_name; });
-      if (session_it != session_capacities.end()) {
-        result.min_robots_num = static_cast<uint8_t>(session_it->min_robots);
-        result.max_robots_num = static_cast<uint8_t>(session_it->max_robots);
+        [&session_name](const auto & s) { return s.session_name == session_name; });
+      if (capacity_it != session_capacities.end()) {
+        result.min_robots_num = static_cast<uint8_t>(capacity_it->min_robots);
+        result.max_robots_num = static_cast<uint8_t>(capacity_it->max_robots);
       }
 
       result.selectable_robots_num = static_cast<uint8_t>(selectable_robot_ids.size());
@@ -169,8 +169,8 @@ auto RobotAllocator::detectRobotChange(const std::vector<uint8_t> & observed_rob
 auto RobotAllocator::getAssignedRobotIds() const -> std::vector<uint8_t>
 {
   auto assigned_robot_ids =
-    tactic_registry_->getAllPlanners() |
-    ranges::views::transform([](const auto & tactic) { return tactic->getRobots(); }) |
+    session_registry_->getAllPlanners() |
+    ranges::views::transform([](const auto & session) { return session->getRobots(); }) |
     ranges::views::join | ranges::views::transform([](const auto & robot) { return robot.id; }) |
     ranges::to<std::vector>() | ranges::actions::sort;
   return assigned_robot_ids;
@@ -180,13 +180,13 @@ auto RobotAllocator::buildAssignmentLog() const -> std::string
 {
   std::stringstream assignment_log;
   bool first = true;
-  for (const auto & tactic : tactic_registry_->getAllPlanners()) {
+  for (const auto & session : session_registry_->getAllPlanners()) {
     if (!first) {
       assignment_log << ", ";
     }
     first = false;
-    assignment_log << tactic->name << ":[";
-    const auto & robots = tactic->getRobots();
+    assignment_log << session->name << ":[";
+    const auto & robots = session->getRobots();
     for (size_t i = 0; i < robots.size(); ++i) {
       if (i > 0) {
         assignment_log << ",";

--- a/crane_session_coordinator/src/session_registry.cpp
+++ b/crane_session_coordinator/src/session_registry.cpp
@@ -13,35 +13,35 @@
 namespace crane
 {
 auto SessionRegistry::getOrCreatePlanner(
-  const std::string & tactic_name, WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node,
+  const std::string & session_name, WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node,
   const std::vector<SessionBase::SharedPtr> & prev_planners,
   const std::unordered_map<std::string, SessionParameterType> & params) -> SessionBase::SharedPtr
 {
   // 前回のプランナーリストから名前で探す（新規生成を回避）
   auto matched_planner = std::ranges::find_if(
-    prev_planners, [&tactic_name](const auto & planner) { return planner->name == tactic_name; });
+    prev_planners, [&session_name](const auto & planner) { return planner->name == session_name; });
 
   // 見つかれば再利用、見つからなければ新規生成
   SessionBase::SharedPtr result_planner;
   if (matched_planner != prev_planners.end()) {
     RCLCPP_DEBUG(
-      rclcpp::get_logger("SessionRegistry"), "タクティクス再利用: %s", tactic_name.c_str());
+      rclcpp::get_logger("SessionRegistry"), "セッション再利用: %s", session_name.c_str());
     result_planner = *matched_planner;
   } else {
     RCLCPP_DEBUG(
-      rclcpp::get_logger("SessionRegistry"), "タクティクス新規生成: %s (prev_planners.size=%zu)",
-      tactic_name.c_str(), prev_planners.size());
-    result_planner = generatePlanner(tactic_name, world_model, node);
+      rclcpp::get_logger("SessionRegistry"), "セッション新規生成: %s (prev_planners.size=%zu)",
+      session_name.c_str(), prev_planners.size());
+    result_planner = generatePlanner(session_name, world_model, node);
   }
 
   // パラメータを設定（新規・再利用どちらでも）
   if (!params.empty()) {
     // SessionParameterType から SessionParameterType への変換
-    std::unordered_map<std::string, SessionParameterType> tactic_params;
+    std::unordered_map<std::string, SessionParameterType> session_params;
     for (const auto & [key, value] : params) {
-      std::visit([&tactic_params, &key](const auto & v) { tactic_params[key] = v; }, value);
+      std::visit([&session_params, &key](const auto & v) { session_params[key] = v; }, value);
     }
-    result_planner->setTacticParameters(tactic_params);
+    result_planner->setSessionParameters(session_params);
   }
 
   return result_planner;
@@ -49,19 +49,19 @@ auto SessionRegistry::getOrCreatePlanner(
 
 auto SessionRegistry::getAllPlanners() const -> const std::vector<SessionBase::SharedPtr> &
 {
-  return active_tactics_;
+  return active_sessions_;
 }
 
-auto SessionRegistry::addPlanner(const SessionBase::SharedPtr & tactic) -> void
+auto SessionRegistry::addPlanner(const SessionBase::SharedPtr & session) -> void
 {
-  active_tactics_.push_back(tactic);
+  active_sessions_.push_back(session);
 }
 
-auto SessionRegistry::clear() -> void { active_tactics_.clear(); }
+auto SessionRegistry::clear() -> void { active_sessions_.clear(); }
 
-auto SessionRegistry::setPlanners(const std::vector<SessionBase::SharedPtr> & tactics) -> void
+auto SessionRegistry::setPlanners(const std::vector<SessionBase::SharedPtr> & sessions) -> void
 {
-  active_tactics_ = tactics;
+  active_sessions_ = sessions;
 }
 
 }  // namespace crane

--- a/crane_sessions/include/crane_sessions/session_base.hpp
+++ b/crane_sessions/include/crane_sessions/session_base.hpp
@@ -32,7 +32,7 @@ using SessionParameterType = std::variant<double, bool, int, std::string>;
 
 struct RobotRole
 {
-  std::string tactic_name;
+  std::string session_name;
   std::string role_name;
   double score = 0.;
 };
@@ -53,7 +53,7 @@ public:
   explicit SessionBase(const std::string & name, WorldModelWrapper::SharedPtr & world_model)
   : name(name),
     world_model(world_model),
-    visualizer(std::make_shared<VisualizerMessageBuilder>("tactic_coordinator/" + name))
+    visualizer(std::make_shared<VisualizerMessageBuilder>("session_coordinator/" + name))
   {
   }
 
@@ -99,7 +99,7 @@ public:
     if (not wrong_ids.empty()) {
       RCLCPP_ERROR_STREAM(
         rclcpp::get_logger("SessionBase"),
-        "PositionCommands from " << name << " tactic includes wrong robot_id : " << wrong_ids);
+        "PositionCommands from " << name << " session includes wrong robot_id : " << wrong_ids);
     }
     status = latest_status;
     crane_msgs::msg::PositionCommands msg;
@@ -119,22 +119,22 @@ public:
     return msg;
   }
 
-  bool isSameConfiguration(SessionBase * other_tactic)
+  bool isSameConfiguration(SessionBase * other_session)
   {
     // 名前が異なる場合は別の設定
-    if (name != other_tactic->name) {
+    if (name != other_session->name) {
       return false;
     }
 
     // どちらかのrobotsが空の場合は、名前のみで判定（ロボット割り当て前の比較用）
-    if (robots.empty() || other_tactic->robots.empty()) {
+    if (robots.empty() || other_session->robots.empty()) {
       return true;
     }
 
     // 両方ともrobotsが設定されている場合は、ロボット構成も比較
-    return robots.size() == other_tactic->robots.size() && [&]() {
+    return robots.size() == other_session->robots.size() && [&]() {
       std::vector<RobotIdentifier> ours = this->robots;
-      std::vector<RobotIdentifier> others = other_tactic->robots;
+      std::vector<RobotIdentifier> others = other_session->robots;
       std::ranges::sort(ours, [](const auto & a, const auto & b) -> bool { return a.id < b.id; });
       std::ranges::sort(others, [](const auto & a, const auto & b) -> bool { return a.id < b.id; });
       return ours == others;
@@ -148,16 +148,16 @@ public:
   const std::string name;
 
   // セッションパラメータ管理
-  void setTacticParameters(const std::unordered_map<std::string, SessionParameterType> & params)
+  void setSessionParameters(const std::unordered_map<std::string, SessionParameterType> & params)
   {
-    tactic_params_ = params;
+    session_params_ = params;
   }
 
   template <typename T>
-  T getTacticParameter(const std::string & key, const T & default_value) const
+  T getSessionParameter(const std::string & key, const T & default_value) const
   {
-    auto it = tactic_params_.find(key);
-    if (it != tactic_params_.end()) {
+    auto it = session_params_.find(key);
+    if (it != session_params_.end()) {
       if (auto * val = std::get_if<T>(&it->second)) {
         return *val;
       }
@@ -168,7 +168,7 @@ public:
   /**
    * @brief ロボット適性評価関数を取得（GlobalRobotAllocator用）
    *
-   * 各Tacticに適したロボットを評価するための関数を返す。
+   * 各Sessionに適したロボットを評価するための関数を返す。
    * 返される関数は、ロボット情報を受け取り、適性コスト（小さいほど適している）を返す。
    *
    * @return ロボット適性評価関数
@@ -177,9 +177,9 @@ public:
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> = 0;
 
   /**
-   * @brief ハード制約Tacticかどうかを返す
+   * @brief ハード制約Sessionかどうかを返す
    *
-   * trueを返すTacticは優先的にロボットが割り当てられる（キーパーなど）。
+   * trueを返すSessionは優先的にロボットが割り当てられる（キーパーなど）。
    *
    * @return ハード制約の場合true
    */
@@ -188,7 +188,7 @@ public:
   /**
    * @brief 現在の状況に基づく推奨ロボット数を返す（動的ロボット割当用）
    *
-   * Tacticが状況に応じて必要なロボット数を動的に決定するためのメソッド。
+   * Sessionが状況に応じて必要なロボット数を動的に決定するためのメソッド。
    * 返される値は呼び出し側でmin_robots〜max_robotsの範囲にクランプされる。
    *
    * @param min_robots YAML設定の最小ロボット数
@@ -200,7 +200,7 @@ public:
   /**
    * @brief GameAnalysisメッセージを設定する
    *
-   * TacticCoordinatorから呼ばれ、game_analyzerが計算した分析結果を受け取る。
+   * SessionCoordinatorから呼ばれ、game_analyzerが計算した分析結果を受け取る。
    *
    * @param game_analysis GameAnalysisメッセージ
    */
@@ -270,7 +270,7 @@ protected:
 
   WorldModelWrapper::SharedPtr world_model;
 
-  std::unordered_map<std::string, SessionParameterType> tactic_params_;
+  std::unordered_map<std::string, SessionParameterType> session_params_;
 
   virtual std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) = 0;

--- a/crane_sessions/src/our_free_kick_session.cpp
+++ b/crane_sessions/src/our_free_kick_session.cpp
@@ -52,8 +52,8 @@ OurDirectFreeKickSession::calculatePositionCommand(
                               return true;  // roleが見つからない場合は含める
                             }
                             // defenderとキーパー以外を選択
-                            return role->second.tactic_name != "defender" &&
-                                   role->second.tactic_name.find("goalie") == std::string::npos;
+                            return role->second.session_name != "defender" &&
+                                   role->second.session_name.find("goalie") == std::string::npos;
                           }) |
                           ranges::to<std::vector>();
 

--- a/crane_sessions/src/session_factory.cpp
+++ b/crane_sessions/src/session_factory.cpp
@@ -38,7 +38,7 @@
 
 namespace crane
 {
-using TacticFactory =
+using SessionFactory =
   std::function<SessionBase::SharedPtr(WorldModelWrapper::SharedPtr &, rclcpp::Node &)>;
 
 namespace
@@ -48,9 +48,9 @@ namespace
 #define PLANNER_ENTRY(name, PlannerClass) \
   {name, [](auto & wm, auto & node) { return std::make_shared<PlannerClass>(wm, node); }}
 
-auto getTacticFactoryMap() -> const std::unordered_map<std::string, TacticFactory> &
+auto getSessionFactoryMap() -> const std::unordered_map<std::string, SessionFactory> &
 {
-  static const std::unordered_map<std::string, TacticFactory> factory_map{
+  static const std::unordered_map<std::string, SessionFactory> factory_map{
     PLANNER_ENTRY("attacker_skill", AttackerSkillSession),
     PLANNER_ENTRY("ball_nearby_positioner_skill", BallNearByPositionerSkillSession),
     PLANNER_ENTRY(
@@ -89,17 +89,17 @@ auto generatePlanner(
   const std::string & tactic_name, WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node)
   -> SessionBase::SharedPtr
 {
-  const auto & factory_map = getTacticFactoryMap();
+  const auto & factory_map = getSessionFactoryMap();
   auto it = factory_map.find(tactic_name);
   if (it != factory_map.end()) {
     return it->second(world_model, node);
   }
-  throw std::runtime_error("Unknown tactic name: " + tactic_name);
+  throw std::runtime_error("Unknown session name: " + tactic_name);
 }
 
 auto getAvailablePlannerNames() -> std::vector<std::string>
 {
-  const auto & factory_map = getTacticFactoryMap();
+  const auto & factory_map = getSessionFactoryMap();
   std::vector<std::string> names;
   names.reserve(factory_map.size());
   for (const auto & [name, _] : factory_map) {

--- a/crane_sessions/src/test_session.cpp
+++ b/crane_sessions/src/test_session.cpp
@@ -17,7 +17,7 @@ TestSession::TestSession(WorldModelWrapper::SharedPtr & world_model, rclcpp::Nod
 : SessionBase("test", world_model), topics_interface(node.get_node_topics_interface())
 {
   config_file_path =
-    (std::filesystem::path(ament_index_cpp::get_package_share_directory("crane_tactics")) /
+    (std::filesystem::path(ament_index_cpp::get_package_share_directory("crane_sessions")) /
      "config" / "test_planner.yaml")
       .string();
   if (not loadConfigFromFile(config_file_path)) {

--- a/crane_sessions/src/total_defense_session.cpp
+++ b/crane_sessions/src/total_defense_session.cpp
@@ -69,7 +69,7 @@ TotalDefenseSession::calculatePositionCommand(const std::vector<RobotIdentifier>
 
   // ディフェンダー数を決定（パラメータで制御可能、残りはMarkerへ）
   const size_t max_defense_line_robots =
-    static_cast<size_t>(getTacticParameter<int>("max_defense_line_robots", 3));
+    static_cast<size_t>(getSessionParameter<int>("max_defense_line_robots", 3));
   size_t num_defense_line_robots = std::min(defender_robots.size(), max_defense_line_robots);
 
   std::vector<Point> defense_points;
@@ -118,7 +118,7 @@ TotalDefenseSession::calculatePositionCommand(const std::vector<RobotIdentifier>
 
   // SecondThreatDefender用に1台確保
   const bool enable_second_threat_defender =
-    getTacticParameter<bool>("enable_second_threat_defender", true);
+    getSessionParameter<bool>("enable_second_threat_defender", true);
   constexpr double SECOND_THREAT_DEFENDER_OFFSET = 0.3;
 
   if (enable_second_threat_defender && not marker_robot_ids.empty()) {

--- a/utility/crane_physics/include/crane_physics/allocation_cost.hpp
+++ b/utility/crane_physics/include/crane_physics/allocation_cost.hpp
@@ -30,14 +30,14 @@ struct AllocationCostConfig
   // 例: 0.5 なら、1秒で0.5mの距離に相当
   double travel_time_weight = 0.5;
 
-  // ヒステリシスボーナス（同一Tactic継続時のコスト減少）[m]
+  // ヒステリシスボーナス（同一Session継続時のコスト減少）[m]
   double hysteresis_bonus = 0.5;
 
   // 速度ベースヒステリシス係数（高速移動中の再割当抑制）
   // 例: 0.2 なら、速度1m/sで0.2mのペナルティ
   double velocity_hysteresis_factor = 0.2;
 
-  // Tactic優先度によるコスト調整（優先度差1あたりのコスト増加）[m]
+  // Session優先度によるコスト調整（優先度差1あたりのコスト増加）[m]
   double priority_cost_multiplier = 10.0;
 
   // 最大加速度 [m/s^2]（到達時間計算用）
@@ -55,14 +55,14 @@ struct AllocationCostConfig
  */
 struct AssignmentContext
 {
-  // 前回同じTacticに割り当てられていたか
-  bool was_assigned_to_same_tactic = false;
+  // 前回同じSessionに割り当てられていたか
+  bool was_assigned_to_same_session = false;
 
   // 前回のターゲット位置（ヒステリシス計算用）
   std::optional<Point> prev_target_position;
 
-  // Tactic優先度（数値が小さいほど優先度が高い）
-  int tactic_priority = 100;
+  // Session優先度（数値が小さいほど優先度が高い）
+  int session_priority = 100;
 
   // デフォルトコンストラクタ
   AssignmentContext() = default;
@@ -105,22 +105,22 @@ inline double calculateAllocationCost(
     time_cost = travel_time * config.travel_time_weight;
   }
 
-  // ヒステリシスボーナス（同じTacticに継続割当の場合コスト減少）
+  // ヒステリシスボーナス（同じSessionに継続割当の場合コスト減少）
   double hysteresis_bonus = 0.0;
-  if (context.was_assigned_to_same_tactic) {
+  if (context.was_assigned_to_same_session) {
     hysteresis_bonus = config.hysteresis_bonus;
   }
 
   // 速度ベースヒステリシス（Sumatra参考）
   // 高速移動中のロボットの再割当にペナルティを課す
   double velocity_hysteresis = 0.0;
-  if (context.was_assigned_to_same_tactic) {
+  if (context.was_assigned_to_same_session) {
     double robot_speed = robot.vel.linear.norm();
     velocity_hysteresis = robot_speed * config.velocity_hysteresis_factor;
   }
 
-  // 優先度コスト（優先度の低いTacticへの割当はコスト増加）
-  double priority_cost = context.tactic_priority * config.priority_cost_multiplier;
+  // 優先度コスト（優先度の低いSessionへの割当はコスト増加）
+  double priority_cost = context.session_priority * config.priority_cost_multiplier;
 
   // 総合コスト
   // ボーナスは負の値として減算される


### PR DESCRIPTION
## 概要

クラス名・ファイル名は既に「Session」に移行済みだったが、内部実装に「Tactic」表記が多数残存していたため、コードベース全体で用語を統一しました。

## 変更内容

### C++ (crane_sessions)
- `SessionBase`: `tactic_name` → `session_name` (RobotRole構造体)
- `SessionBase`: `setTacticParameters()` → `setSessionParameters()`
- `SessionBase`: `getTacticParameter()` → `getSessionParameter()`
- `SessionBase`: `tactic_params_` → `session_params_`
- `SessionBase`: ビジュアライザ名前空間 `"tactic_coordinator/"` → `"session_coordinator/"`
- `SessionFactory`: `TacticFactory` → `SessionFactory`
- `test_session.cpp`: パッケージ名 `crane_tactics` → `crane_sessions`

### C++ (crane_session_coordinator)
- `GlobalRobotAllocator`: `TacticRequirement` → `SessionRequirement`
- `GlobalRobotAllocator`: `tactic_name` → `session_name`, `tactic_priority` → `session_priority`
- `ConfigurationManager`: `TacticSlot` → `SessionSlot`
- `AllocationState`: `robot_to_tactic_` → `robot_to_session_`
- `SessionRegistry`: `active_tactics_` → `active_sessions_`
- `CommandAggregator`: `tactic_registry_` → `session_registry_`
- `RobotAllocator`: `tactic_registry_` → `session_registry_`
- `DiagnosticsReporter`: `tactic_registry_` → `session_registry_`
- `SessionCoordinator`: `tactic_registry_` → `session_registry_`

### C++ (crane_physics)
- `AllocationCost`: `tactic_priority` → `session_priority`
- `AllocationCost`: `was_assigned_to_same_tactic` → `was_assigned_to_same_session`

### Python (crane_commentary)
- `intent_tracker.py`: `TACTIC_CHANGED` → `SESSION_CHANGED`
- `intent_tracker.py`: `tactic_name` → `session_name`
- `intent_tracker.py`: `_robot_to_tactic` → `_robot_to_session`
- `commentary_generator.py`: `tactics_map` → `sessions_map`
- `commentary_generator.py`: "タクティクス" → "セッション"

## テストプラン

- [x] crane_sessions パッケージのビルド成功
- [x] crane_session_coordinator パッケージのビルド成功
- [x] crane_commentary パッケージのビルド成功
- [x] 全19パッケージのビルド成功
- [x] pre-commit フック全てパス

## 影響範囲

- **破壊的変更**: なし（内部実装のリファクタリングのみ）
- **API変更**: `SessionBase` のパラメータ取得・設定メソッド名が変更されましたが、これは内部APIです
- **ビジュアライザ名前空間**: `"tactic_coordinator/"` → `"session_coordinator/"` に変更されたため、rviz設定の更新が必要になる可能性があります

## 補足

全23ファイルで235行の置換（挿入235行、削除235行）を実施しました。

🤖 Generated with [Claude Code](https://claude.ai/code)