### PR TITLE
fix: crane_commentaryとcrane_physicsのテスト失敗を修正

### DIFF
--- a/crane_commentary/crane_commentary/self_commentary/intent_tracker.py
+++ b/crane_commentary/crane_commentary/self_commentary/intent_tracker.py
@@ -7,7 +7,7 @@
 """Intent tracking for self-commentary mode."""
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from enum import Enum
 
 
@@ -55,7 +55,7 @@ class IntentChange:
     robot_id: int
     old_value: str
     new_value: str
-    context: Dict[str, any] = field(default_factory=dict)
+    context: Dict[str, Any] = field(default_factory=dict)
 
     def priority(self) -> int:
         """Get priority of this change (higher = more important)."""
@@ -93,7 +93,7 @@ class IntentTracker:
         # Session mapping (robot_id -> session_name)
         self._robot_to_session: Dict[int, str] = {}
 
-    def update_from_robot_select_results(self, msg: any) -> None:
+    def update_from_robot_select_results(self, msg: Any) -> None:
         """Update session information from RobotSelectResults message.
 
         Args:
@@ -108,7 +108,7 @@ class IntentTracker:
             for robot_id in result.selected_robots:
                 self._robot_to_session[robot_id] = session_name
 
-    def update_from_control_targets(self, msg: any) -> None:
+    def update_from_control_targets(self, msg: Any) -> None:
         """Update intent information from PositionCommands message.
 
         Args:

--- a/crane_commentary/package.xml
+++ b/crane_commentary/package.xml
@@ -18,7 +18,7 @@
   <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>crane_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/utility/crane_physics/include/crane_physics/position_assignments.hpp
+++ b/utility/crane_physics/include/crane_physics/position_assignments.hpp
@@ -224,19 +224,37 @@ inline auto getOptimalAssignments(
     return {0};
   }
 
-  // make cost
-  auto cost = robot_positions | ranges::views::transform([&](const auto & robot_pos) {
-                return targets | ranges::views::transform([&](const auto & target) {
-                         return bg::distance(robot_pos, target);
-                       }) |
-                       ranges::to<std::vector>();
-              }) |
-              ranges::to<std::vector>();
+  // Hungarianアルゴリズムは行数 >= 列数を要求するため、
+  // ターゲット数の方が多い場合はダミーロボットを追加してコスト行列を正方行列にする
+  size_t num_robots = robot_positions.size();
+  size_t num_targets = targets.size();
+  size_t matrix_size = std::max(num_robots, num_targets);
+
+  // make cost matrix (square matrix)
+  std::vector<std::vector<double>> cost(matrix_size, std::vector<double>(matrix_size, 0.0));
+
+  for (size_t i = 0; i < num_robots; ++i) {
+    for (size_t j = 0; j < num_targets; ++j) {
+      cost[i][j] = bg::distance(robot_positions[i], targets[j]);
+    }
+    // ダミーターゲットへのコストは大きな値に設定
+    for (size_t j = num_targets; j < matrix_size; ++j) {
+      cost[i][j] = 1e9;
+    }
+  }
+
+  // ダミーロボットのコストは0に設定（実際には使用されない）
+  for (size_t i = num_robots; i < matrix_size; ++i) {
+    for (size_t j = 0; j < matrix_size; ++j) {
+      cost[i][j] = 1e9;
+    }
+  }
 
   math::Hungarian<double> hungarian_solver(cost);
   const auto [solution_cost, solution_index] = hungarian_solver.solve();
 
-  return solution_index;
+  // 実際のロボット分のみ返す
+  return std::vector<int>(solution_index.begin(), solution_index.begin() + num_robots);
 }
 
 /**
@@ -262,18 +280,34 @@ inline auto getOptimalAssignmentsWithCost(
     return {0};
   }
 
-  // コスト行列を構築
-  std::vector<std::vector<double>> cost(num_robots, std::vector<double>(num_targets));
+  // Hungarianアルゴリズムは行数 >= 列数を要求するため、
+  // ターゲット数の方が多い場合はダミーロボットを追加してコスト行列を正方行列にする
+  size_t matrix_size = std::max(num_robots, num_targets);
+
+  // コスト行列を構築（正方行列）
+  std::vector<std::vector<double>> cost(matrix_size, std::vector<double>(matrix_size, 0.0));
   for (size_t i = 0; i < num_robots; ++i) {
     for (size_t j = 0; j < num_targets; ++j) {
       cost[i][j] = cost_func(i, j);
+    }
+    // ダミーターゲットへのコストは大きな値に設定
+    for (size_t j = num_targets; j < matrix_size; ++j) {
+      cost[i][j] = 1e9;
+    }
+  }
+
+  // ダミーロボットのコストは大きな値に設定（実際には使用されない）
+  for (size_t i = num_robots; i < matrix_size; ++i) {
+    for (size_t j = 0; j < matrix_size; ++j) {
+      cost[i][j] = 1e9;
     }
   }
 
   math::Hungarian<double> hungarian_solver(cost);
   const auto [solution_cost, solution_index] = hungarian_solver.solve();
 
-  return solution_index;
+  // 実際のロボット分のみ返す
+  return std::vector<int>(solution_index.begin(), solution_index.begin() + num_robots);
 }
 
 }  // namespace crane


### PR DESCRIPTION
## 概要
crane_commentaryとcrane_physicsパッケージのテスト失敗を修正しました。

## 修正内容

### crane_commentary
- **型アノテーションエラー修正**
  - `any` → `Any` に修正（`intent_tracker.py`）
  - `typing.Any`のインポートを追加
- **テスト設定変更**
  - `ament_lint_common` → `crane_lint_common` に変更
  - craneプロジェクトの標準lint設定を採用

### crane_physics
- **Hungarianアルゴリズムの制約対応**
  - ロボット数 < ターゲット数のケースに対応
  - コスト行列を正方行列に拡張（ダミー行/列を追加）
  - `getOptimalAssignments`と`getOptimalAssignmentsWithCost`の両方を修正

## テスト結果
```
Summary: 447 tests, 0 errors, 0 failures, 0 skipped ✅
```

crane全25パッケージのすべてのテストが成功しています。

## 変更ファイル
- `crane_commentary/crane_commentary/self_commentary/intent_tracker.py`
- `crane_commentary/package.xml`
- `utility/crane_physics/include/crane_physics/position_assignments.hpp`

🤖 Generated with [Claude Code](https://claude.ai/code)