### PR TITLE
refactor: full_build.yamlでsetup-rosアクションを使用

### DIFF
--- a/.github/workflows/full_build.yaml
+++ b/.github/workflows/full_build.yaml
@@ -43,41 +43,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install ROS 2 Jazzy
+      - name: Setup ROS 2 Jazzy
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: jazzy
+
+      - name: Install PowerShell
         run: |
-          # ロケール設定
-          sudo apt-get update
-          sudo apt-get install -y locales
-          sudo locale-gen en_US en_US.UTF-8
-          export LANG=en_US.UTF-8
-
-          # ROS 2リポジトリの追加
-          sudo apt-get install -y software-properties-common curl
-          sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
-            -o /usr/share/keyrings/ros-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
-            http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
-            | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-
-          # PowerShellのインストール（一部のパッケージで必要）
           sudo apt-get install -y wget apt-transport-https
           wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
           sudo dpkg -i packages-microsoft-prod.deb
           rm packages-microsoft-prod.deb
           sudo apt-get update
           sudo apt-get install -y powershell
+        shell: bash
 
-          # ROS 2パッケージのインストール
-          sudo apt-get update
-          sudo apt-get install -y \
-            ros-${{ matrix.rosdistro }}-desktop \
-            ros-${{ matrix.rosdistro }}-ament-package \
-            ros-dev-tools \
-            python3-colcon-common-extensions \
-            python3-rosdep
-
-          # rosdep初期化
-          sudo rosdep init || true
+      - name: Initialize rosdep
+        run: sudo rosdep init || true
         shell: bash
 
       - name: Clone dependency packages


### PR DESCRIPTION
## Summary

- 手動ROS 2インストール処理（約36行）を`ros-tooling/setup-ros@v0.7`アクションで置き換え
- コード量を50%削減（36行 → 18行）し保守性を向上
- GitHub Actions実行結果：ROS 2インストール、依存パッケージビルド、craneパッケージビルドが全て成功

## 変更内容

### Before
- ロケール設定、ROS 2リポジトリ追加、PowerShellインストール、ROS 2パッケージインストール、rosdep initを全て手動で実行（46-81行目、36行）

### After
- `setup-ros@v0.7`アクションでROS 2を自動インストール
- PowerShellインストールとrosdep initのみ手動実行（setup-rosが対応していないため）
- コードが簡潔で読みやすく、メンテナンスが容易

## メリット

1. **コードの簡素化**: 36行 → 18行（50%削減）
2. **保守性向上**: ROS公式アクションがリポジトリキー更新等を自動対応
3. **信頼性向上**: コミュニティで広く使われている公式GitHub Actionを使用

## Test plan

- [x] GitHub Actionsでfull_buildワークフローを手動実行
- [x] ROS 2 Jazzyが正しくインストールされることを確認
- [x] rosdep installが成功することを確認
- [x] 依存パッケージのビルドが成功することを確認
- [x] craneパッケージのビルドが成功することを確認

## 備考

テストステップで失敗が発生していますが、これは今回の変更とは無関係のPEP257（Pythonのdocstring規約）違反によるものです（`crane_commentary`パッケージの既存コード品質問題）。今回の変更目的であるROS 2インストールとビルドは全て正常に動作しています。

🤖 Generated with [Claude Code](https://claude.ai/code)