### PR TITLE
fix: robot_receiver_nodeのdouble freeバグを修正

### DIFF
--- a/crane_robot_receiver/src/robot_receiver_node.cpp
+++ b/crane_robot_receiver/src/robot_receiver_node.cpp
@@ -257,7 +257,7 @@ public:
   rclcpp::Publisher<crane_msgs::msg::RobotFeedbackArray>::SharedPtr publisher;
 
   crane::VisualizerMessageBuilder::SharedPtr visualizer =
-    std::make_unique<crane::VisualizerMessageBuilder>("robot_receiver");
+    std::make_shared<crane::VisualizerMessageBuilder>("robot_receiver");
 
   rclcpp::Clock clock;
 };


### PR DESCRIPTION
## 概要
robot_receiver_nodeで発生していた「double free or corruption」エラーを修正

## 問題
VisualizerMessageBuilderは`std::enable_shared_from_this`を継承しているが、
`std::make_unique`で生成していたため、`shared_from_this()`呼び出し時に
未定義動作（double free）が発生していた。

## 修正内容
- robot_receiver_node.cpp:260で`std::make_unique`を`std::make_shared`に変更

## 検証方法
```bash
colcon build --packages-select crane_robot_receiver
ros2 run crane_robot_receiver robot_receiver_node --ros-args -p sim_mode:=true
```

クラッシュせずに起動し、「double free or corruption」エラーが発生しないことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)