### PR TITLE
feat: grSimのDocker構成とSSL Vision設定を追加

### DIFF
--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -1,4 +1,16 @@
 services:
+  grsim:
+    image: ghcr.io/ibis-ssl/grsim:latest
+    container_name: grsim
+    network_mode: host
+    command: |
+      grSim --headless -platform offscreen
+    tty: true
+    stdin_open: true
+    restart: "no"
+    profiles:
+      - sim
+
   ssl-game-controller:
     image: robocupssl/ssl-game-controller:3.11.2
     command:

--- a/docker/ssl-vision-client-config.json
+++ b/docker/ssl-vision-client-config.json
@@ -1,0 +1,5 @@
+{
+  "visionPort": 10020,
+  "trackedPort": 11010,
+  "refereePort": 11003
+}


### PR DESCRIPTION
## 概要
開発環境でgrSimをDockerコンテナとして実行できるように構成を追加

## 変更内容

### docker-compose.yamlへのgrSimサービス追加
- イメージ: `ghcr.io/ibis-ssl/grsim:latest`
- 起動モード: ヘッドレス（`--headless -platform offscreen`）
- ネットワーク: ホストネットワークモード
- プロファイル: `sim`（`docker compose --profile sim up`で起動）

### SSL Vision設定ファイル追加
- `docker/ssl-vision-client-config.json`を新規作成
- ポート設定:
  - visionPort: 10020
  - trackedPort: 11010
  - refereePort: 11003

## 使用方法

```bash
# grSimをバックグラウンドで起動
docker compose --profile sim up -d grsim

# 停止
docker compose --profile sim down
```

## メリット
- シミュレーション環境のセットアップが簡素化
- 開発者間で一貫したgrSim環境を共有可能
- ホストへのgrSimインストールが不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)