### PR TITLE
[ビルド] crane_physicsのPCH伝播を防止

### DIFF
--- a/utility/crane_physics/CMakeLists.txt
+++ b/utility/crane_physics/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(${PROJECT_NAME}
 
 # プリコンパイル済みヘッダでビルド時間を短縮
 target_precompile_headers(${PROJECT_NAME}
-  PUBLIC
+  PRIVATE
     "<crane_geometry/boost_geometry.hpp>"
     "<crane_geometry/geometry_operations.hpp>"
     "<Eigen/Core>"


### PR DESCRIPTION
## 概要
crane_physics の target_precompile_headers の可視性を PUBLIC から PRIVATE に変更し、テストターゲットへPCH設定が伝播しないようにします。

## 変更内容
- utility/crane_physics/CMakeLists.txt
- target_precompile_headers(${PROJECT_NAME} PUBLIC ...) を PRIVATE に変更

## 背景
PUBLIC のままだと BUILD_TESTING=ON 時に各テストターゲットで巨大な cmake_pch.hxx.gch が生成され、build/crane_physics が大きく膨らみます。

## 効果
- 実測: build/crane_physics が 5.2G から 543M に減少
- cmake_pch.hxx.gch が 10個から 1個（ライブラリ本体分のみ）に減少

## 影響範囲
- ビルド設定のみ（ランタイム挙動への影響なし）
- テストターゲットのPCHは無効になるため、テストのコンパイル時間は増える可能性があります