### PR TITLE
[バグ修正] セッション割当の過剰ログを抑制

### DIFF
--- a/crane_session_coordinator/include/crane_session_coordinator/configuration_manager.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/configuration_manager.hpp
@@ -22,7 +22,7 @@ using SessionParameterType = std::variant<double, bool, int, std::string>;
 struct SessionSlot
 {
   std::string session_name;
-  int min_robots = 1;
+  int min_robots = 0;
   int max_robots;
   std::unordered_map<std::string, SessionParameterType> params;
 };

--- a/crane_session_coordinator/src/configuration_manager.cpp
+++ b/crane_session_coordinator/src/configuration_manager.cpp
@@ -82,7 +82,7 @@ auto ConfigurationManager::loadUnifiedConfig(const std::filesystem::path & confi
         if (session_node["min_robots"]) {
           session_capacity.min_robots = session_node["min_robots"].as<int>();
         } else {
-          session_capacity.min_robots = 1;  // デフォルト: 1
+          session_capacity.min_robots = 0;  // デフォルト: 0
         }
 
         // max_robotsの読み込みとデフォルト値設定

--- a/crane_session_coordinator/src/global_robot_allocator.cpp
+++ b/crane_session_coordinator/src/global_robot_allocator.cpp
@@ -199,10 +199,8 @@ auto GlobalRobotAllocator::allocateSoftConstraints(
 
   // Hungarian法は非負のコスト行列を要求するため、負の値がある場合はオフセットを追加
   if (min_cost < 0.0) {
-    RCLCPP_WARN(
-      logger_, "[allocateSoftConstraints] 負のコスト値を検出: %f。オフセットを追加します",
-      min_cost);
-    double offset = -min_cost + 1.0;
+    // 最小値がちょうど0になるように平行移動し、相対的なコスト差を保つ
+    double offset = -min_cost;
     for (size_t i = 0; i < matrix_rows; ++i) {
       for (size_t j = 0; j < matrix_cols; ++j) {
         cost_matrix[i][j] += offset;


### PR DESCRIPTION
## 概要
セッション割当周辺で発生していた過剰な警告ログを抑制し、通常運用時のログノイズを減らします。

## 変更内容
- crane_session_coordinator/include/crane_session_coordinator/configuration_manager.hpp
  - SessionSlot.min_robots のデフォルト値を 1 から 0 に変更
- crane_session_coordinator/src/configuration_manager.cpp
  - unified config 読み込み時、min_robots 未指定時のデフォルト値を 1 から 0 に変更
- crane_session_coordinator/src/global_robot_allocator.cpp
  - 負コスト補正時の警告ログを削除
  - 補正オフセットを -min_cost に変更し、最小値が0になるように調整

## 背景
min_robots のデフォルトが 1 のままだと、明示指定のないセッションでも最小台数要求が有効になり、割当時に不要な警告が出やすい状態でした。
また、負コスト補正は正常系でも起こりうるため、毎回警告を出す必要性が低い状況でした。

## 確認
- colcon build --packages-select crane_session_coordinator を実行し、ビルド成功を確認済み