### PR TITLE
STOP時のForward割当で発生するbad_allocクラッシュを修正

### DIFF
--- a/crane_robot_skills/src/forward.cpp
+++ b/crane_robot_skills/src/forward.cpp
@@ -4,6 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include <algorithm>
+#include <cmath>
 #include <crane_robot_skills/forward.hpp>
 #include <range/v3/algorithm/max_element.hpp>
 #include <range/v3/range/conversion.hpp>
@@ -14,14 +16,24 @@ namespace crane::skills
 {
 auto Forward::update() -> Status
 {
-  auto their_robots = world_model()->theirs().robotsWhere().available().get();
   Point front_point = getParameter<Point>("front_point");
   Point back_point = getParameter<Point>("back_point");
   auto max_ball_distance = getParameter<double>("max_ball_distance");
   auto max_vel = getParameter<double>("max_vel");
   auto & ball = world_model()->ball();
+
+  const double line_length = (back_point - front_point).norm();
+  if (!std::isfinite(line_length)) {
+    command->stopHere();
+    return Status::RUNNING;
+  }
+
+  max_ball_distance = std::max(max_ball_distance, 0.1);
+
   // front_point -> back_pointの0.1mごとのポイントを生成
-  int num_points = static_cast<int>(std::ceil((back_point - front_point).norm() / 0.1));
+  constexpr int MAX_SAMPLING_POINTS = 200;
+  int num_points =
+    std::clamp(static_cast<int>(std::ceil(line_length / 0.1)), 1, MAX_SAMPLING_POINTS);
 
   std::vector<std::pair<Point, double>> points_with_score =
     ranges::views::iota(0, num_points) | ranges::views::transform([&](int i) -> Point {

--- a/crane_sessions/include/crane_sessions/forward_session.hpp
+++ b/crane_sessions/include/crane_sessions/forward_session.hpp
@@ -7,6 +7,7 @@
 #ifndef CRANE_SESSIONS__FORWARD_SESSION_HPP_
 #define CRANE_SESSIONS__FORWARD_SESSION_HPP_
 
+#include <algorithm>
 #include <crane_msg_wrappers/position_command_wrapper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 #include <crane_robot_skills/forward.hpp>
@@ -44,6 +45,12 @@ public:
       // 敵ゴール位置に近いほど適している
       return robot->getDistance(wm->getTheirGoalCenter());
     };
+  }
+
+  int getDesiredRobotNumber(int /* min_robots */, int max_robots) const override
+  {
+    // Forwardは生成可能なライン数以上のロボットを扱えないため、動的に上限を調整する
+    return std::min<int>(static_cast<int>(createForwardLines().size()), max_robots);
   }
 
 protected:

--- a/crane_sessions/src/forward_session.cpp
+++ b/crane_sessions/src/forward_session.cpp
@@ -53,31 +53,63 @@ auto ForwardSession::createForwardLines() const -> std::vector<Segment>
 auto ForwardSession::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
   -> std::pair<Status, std::vector<crane_msgs::msg::PositionCommand>>
 {
+  if (robots.empty()) {
+    forward_skills.clear();
+    return {SessionBase::Status::RUNNING, {}};
+  }
+
   // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
   if (forward_skills.size() != robots.size()) {
     forward_skills.clear();
 
     auto forward_lines = createForwardLines();
-    if (forward_lines.size() > robots.size()) {
-      forward_lines.resize(robots.size());
-    }
 
-    std::vector<Point> robot_positions =
-      robots | ranges::views::transform([this](const auto & robot_id) -> Point {
-        return world_model->getRobot(robot_id)->pose.pos;
-      }) |
-      ranges::to<std::vector>;
+    if (forward_lines.empty()) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("ForwardSession"),
+        "Forward lines are empty. Falling back to stop-like commands.");
 
-    auto solution = getOptimalAssignments(robot_positions, forward_lines);
+      for (const auto & robot_id : robots) {
+        auto skill = std::make_shared<skills::Forward>(robot_id.id, world_model);
+        const auto robot_pos = world_model->getRobot(robot_id)->pose.pos;
+        skill->setParameter("front_point", robot_pos);
+        skill->setParameter("back_point", robot_pos);
+        skill->setParameter("max_vel", 1.5);
+        skill->planner_visualizer = visualizer;
+        forward_skills.emplace_back(skill);
+      }
+    } else {
+      if (forward_lines.size() > robots.size()) {
+        forward_lines.resize(robots.size());
+      }
 
-    for (const auto & [index, robot_id] : robots | ranges::views::enumerate) {
-      auto skill = std::make_shared<skills::Forward>(robot_id.id, world_model);
-      auto line = forward_lines[solution[index]];
-      skill->setParameter("front_point", line.second);
-      skill->setParameter("back_point", line.first);
-      skill->setParameter("max_vel", 1.5);
-      skill->planner_visualizer = visualizer;
-      forward_skills.emplace_back(skill);
+      std::vector<Point> robot_positions =
+        robots | ranges::views::transform([this](const auto & robot_id) -> Point {
+          return world_model->getRobot(robot_id)->pose.pos;
+        }) |
+        ranges::to<std::vector>;
+
+      auto solution = getOptimalAssignments(robot_positions, forward_lines);
+
+      for (const auto & [index, robot_id] : robots | ranges::views::enumerate) {
+        auto skill = std::make_shared<skills::Forward>(robot_id.id, world_model);
+
+        int line_index = solution[index];
+        if (line_index < 0 || static_cast<size_t>(line_index) >= forward_lines.size()) {
+          line_index = static_cast<int>(index % forward_lines.size());
+          RCLCPP_WARN(
+            rclcpp::get_logger("ForwardSession"),
+            "Invalid assignment index (%d). Using fallback line index (%d).", solution[index],
+            line_index);
+        }
+
+        const auto & line = forward_lines[line_index];
+        skill->setParameter("front_point", line.second);
+        skill->setParameter("back_point", line.first);
+        skill->setParameter("max_vel", 1.5);
+        skill->planner_visualizer = visualizer;
+        forward_skills.emplace_back(skill);
+      }
     }
   }
 


### PR DESCRIPTION
## 概要
STOP時にForwardSessionへ過剰なロボットが割り当てられた際、無効な割当インデックス参照でクラッシュする問題を修正しました。

## 変更内容
- ForwardSessionの希望ロボット数を生成可能ライン数で上限制御
- ライン0本時と割当インデックス異常時のフォールバックを追加
- Forwardスキルに異常値ガードとサンプリング点数上限を追加

## 動作確認
- colcon build --packages-select crane_robot_skills crane_sessions --symlink-install
- 対象2パッケージのビルド成功
