### PR TITLE
[バグ修正]/robot_commandsの型混在を解消

### DIFF
--- a/crane_world_model_publisher/include/crane_world_model_publisher/kick_event_detector.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/kick_event_detector.hpp
@@ -12,7 +12,8 @@
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 #include <crane_msgs/msg/kick.hpp>
 #include <crane_msgs/msg/kick_prediction_trace.hpp>
-#include <crane_msgs/msg/robot_commands.hpp>
+#include <crane_msgs/msg/velocity_command.hpp>
+#include <crane_msgs/msg/velocity_commands.hpp>
 #include <memory>
 #include <queue>
 
@@ -51,7 +52,7 @@ public:
 
   auto setKickerModel(std::shared_ptr<KickerModel> kicker_model) -> void;
 
-  auto updateRobotCommands(const crane_msgs::msg::RobotCommands & commands) -> void;
+  auto updateRobotCommands(const crane_msgs::msg::VelocityCommands & commands) -> void;
 
   // 一番古いデータがthresholdより近く、それ以外の全てがthresholdより遠いロボットを検出する
   // つまり、ボールが遠ざかっているときにキックイベントを検出する
@@ -79,7 +80,7 @@ public:
 
   struct RobotCommandRecord
   {
-    crane_msgs::msg::RobotCommands commands;
+    crane_msgs::msg::VelocityCommands commands;
     rclcpp::Time timestamp;
   };
 
@@ -103,13 +104,13 @@ private:
   Point kick_origin_pos_;                      // キック開始位置を記録
   std::shared_ptr<KickerModel> kicker_model_;  // キック予測用モデル
 
-  // RobotCommandsリングバッファ
+  // VelocityCommandsリングバッファ
   std::deque<RobotCommandRecord> robot_command_records_;
   static constexpr int COMMAND_QUEUE_SIZE = 30;  // 約1秒分（30Hz想定）
 
   // 指定ロボットIDの最新コマンドを取得
   auto getLatestCommandForRobot(uint8_t robot_id) const
-    -> std::optional<crane_msgs::msg::RobotCommand>;
+    -> std::optional<crane_msgs::msg::VelocityCommand>;
 };
 }  // namespace crane
 

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_publisher.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_publisher.hpp
@@ -49,8 +49,8 @@ extern "C" {
 #include <array>
 #include <crane_comm/diagnosed_publisher.hpp>
 #include <crane_msgs/msg/ball_info.hpp>
-#include <crane_msgs/msg/robot_commands.hpp>
 #include <crane_msgs/msg/robot_info.hpp>
+#include <crane_msgs/msg/velocity_commands.hpp>
 #include <crane_msgs/msg/world_model.hpp>
 #include <deque>
 #include <diagnostic_updater/diagnostic_updater.hpp>
@@ -128,7 +128,7 @@ private:
 
   std::unique_ptr<PassTargetSelector> pass_target_selector_;
 
-  rclcpp::Subscription<crane_msgs::msg::RobotCommands>::SharedPtr sub_robot_commands_;
+  rclcpp::Subscription<crane_msgs::msg::VelocityCommands>::SharedPtr sub_robot_commands_;
 };
 }  // namespace crane
 #endif  // CRANE_WORLD_MODEL_PUBLISHER__WORLD_MODEL_PUBLISHER_HPP_

--- a/crane_world_model_publisher/src/kick_event_detector.cpp
+++ b/crane_world_model_publisher/src/kick_event_detector.cpp
@@ -339,7 +339,8 @@ auto KickEventDetector::setKickerModel(std::shared_ptr<KickerModel> kicker_model
   kicker_model_ = kicker_model;
 }
 
-auto KickEventDetector::updateRobotCommands(const crane_msgs::msg::RobotCommands & commands) -> void
+auto KickEventDetector::updateRobotCommands(const crane_msgs::msg::VelocityCommands & commands)
+  -> void
 {
   RobotCommandRecord record;
   record.commands = commands;
@@ -352,7 +353,7 @@ auto KickEventDetector::updateRobotCommands(const crane_msgs::msg::RobotCommands
 }
 
 auto KickEventDetector::getLatestCommandForRobot(uint8_t robot_id) const
-  -> std::optional<crane_msgs::msg::RobotCommand>
+  -> std::optional<crane_msgs::msg::VelocityCommand>
 {
   // 新しい順に検索
   for (auto it = robot_command_records_.rbegin(); it != robot_command_records_.rend(); ++it) {

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -9,7 +9,7 @@
 #include <crane_geometry/geometry_operations.hpp>
 #include <crane_msg_wrappers/crane_visualizer_wrapper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
-#include <crane_msgs/msg/robot_commands.hpp>
+#include <crane_msgs/msg/velocity_commands.hpp>
 #include <crane_physics/ball_physics_model.hpp>
 #include <crane_physics/kicker_model.hpp>
 #include <crane_world_model_publisher/kick_event_detector.hpp>
@@ -166,8 +166,8 @@ WorldModelPublisherComponent::WorldModelPublisherComponent(const rclcpp::NodeOpt
   kick_event_detector_->setKickerModel(kicker_model);
 
   // robot_commandsをsubscribeしてKickEventDetectorに渡す
-  sub_robot_commands_ = create_subscription<crane_msgs::msg::RobotCommands>(
-    "/robot_commands", 10, [this](const crane_msgs::msg::RobotCommands::SharedPtr msg) {
+  sub_robot_commands_ = create_subscription<crane_msgs::msg::VelocityCommands>(
+    "/robot_commands", 10, [this](const crane_msgs::msg::VelocityCommands::SharedPtr msg) {
       kick_event_detector_->updateRobotCommands(*msg);
     });
 

--- a/utility/crane_teleop/include/crane_teleop/joystick_component.hpp
+++ b/utility/crane_teleop/include/crane_teleop/joystick_component.hpp
@@ -7,7 +7,7 @@
 #ifndef CRANE_TELEOP__JOYSTICK_COMPONENT_HPP_
 #define CRANE_TELEOP__JOYSTICK_COMPONENT_HPP_
 
-#include <crane_msgs/msg/robot_commands.hpp>
+#include <crane_msgs/msg/velocity_commands.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joy.hpp>
@@ -23,7 +23,7 @@ public:
   explicit JoystickComponent(const rclcpp::NodeOptions & options);
 
 private:
-  rclcpp::Publisher<crane_msgs::msg::RobotCommands>::SharedPtr pub_commands;
+  rclcpp::Publisher<crane_msgs::msg::VelocityCommands>::SharedPtr pub_commands;
 
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr sub_joy;
 

--- a/utility/crane_teleop/src/joystick_component.cpp
+++ b/utility/crane_teleop/src/joystick_component.cpp
@@ -6,6 +6,7 @@
 
 #include "crane_teleop/joystick_component.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <memory>
@@ -34,7 +35,7 @@ JoystickComponent::JoystickComponent(const rclcpp::NodeOptions & options)
     publish_robot_commands(msg);
   };
 
-  pub_commands = create_publisher<crane_msgs::msg::RobotCommands>("/robot_commands", 10);
+  pub_commands = create_publisher<crane_msgs::msg::VelocityCommands>("/robot_commands", 10);
   sub_joy = create_subscription<sensor_msgs::msg::Joy>("joy", 10, callback);
 }
 
@@ -131,17 +132,22 @@ auto JoystickComponent::publish_robot_commands(const sensor_msgs::msg::Joy::Shar
     }
   }
 
-  crane_msgs::msg::RobotCommand command;
+  crane_msgs::msg::VelocityCommand command;
 
   command.robot_id = robot_id;
-  command.control_mode = crane_msgs::msg::RobotCommand::SIMPLE_VELOCITY_TARGET_MODE;
-  command.simple_velocity_target_mode.emplace_back();
+  constexpr double TELEOP_DT = 1.0 / 60.0;
+  const double target_vx = msg->axes[AXIS_VEL_SURGE] * MAX_VEL_SURGE;
+  const double target_vy = msg->axes[AXIS_VEL_SWAY] * MAX_VEL_SWAY;
+  const double target_omega = msg->axes[AXIS_VEL_ANGULAR] * MAX_VEL_ANGULAR;
 
-  // run
-  command.simple_velocity_target_mode.front().target_vx = msg->axes[AXIS_VEL_SURGE] * MAX_VEL_SURGE;
-  command.simple_velocity_target_mode.front().target_vy = msg->axes[AXIS_VEL_SWAY] * MAX_VEL_SWAY;
-  command.omega_limit = msg->axes[AXIS_VEL_ANGULAR] * MAX_VEL_ANGULAR;
-  //  command.target_theta =
+  command.target_velocity_r = std::hypot(target_vx, target_vy);
+  command.target_velocity_theta = std::atan2(target_vy, target_vx);
+  theta += target_omega * TELEOP_DT;
+  theta = std::atan2(std::sin(theta), std::cos(theta));
+  command.target_theta = theta;
+  command.omega_limit = MAX_VEL_ANGULAR;
+  command.max_velocity = std::max(std::hypot(MAX_VEL_SURGE, MAX_VEL_SWAY), MAX_VEL_SURGE);
+  command.max_acceleration = 2.5;
 
   // dribble
   if (is_dribble_enable) {
@@ -159,17 +165,16 @@ auto JoystickComponent::publish_robot_commands(const sensor_msgs::msg::Joy::Shar
 
   RCLCPP_INFO(
     get_logger(), "ID=%d Vx=%.3f Vy=%.3f theta=%.3f kick=%s, %.1f dribble=%s, %.1f chip=%s",
-    command.robot_id, command.simple_velocity_target_mode.front().target_vx,
-    command.simple_velocity_target_mode.front().target_vy, command.omega_limit,
-    is_kick_enable ? "ON" : "OFF", kick_power, is_dribble_enable ? "ON" : "OFF", dribble_power,
-    command.chip_enable ? "ON" : "OFF");
+    command.robot_id, target_vx, target_vy, target_omega, is_kick_enable ? "ON" : "OFF", kick_power,
+    is_dribble_enable ? "ON" : "OFF", dribble_power, command.chip_enable ? "ON" : "OFF");
 
   if (not msg->buttons[BUTTON_POWER_ENABLE]) {
-    crane_msgs::msg::RobotCommand empty_command;
+    crane_msgs::msg::VelocityCommand empty_command;
     command = empty_command;
   }
 
-  crane_msgs::msg::RobotCommands robot_commands;
+  crane_msgs::msg::VelocityCommands robot_commands;
+  robot_commands.header.stamp = this->get_clock()->now();
 
   robot_commands.robot_commands.emplace_back(command);
 


### PR DESCRIPTION
## 概要
- /robot_commands トピックの型を VelocityCommands に統一
- world_model_publisher の購読型を RobotCommands から VelocityCommands に変更
- KickEventDetector の保持型/取得型を VelocityCommands 系へ変更
- crane_teleop の publish 型を VelocityCommands に変更

## 変更理由
- 同一トピック /robot_commands に複数型（RobotCommands, VelocityCommands）が存在し、ros2 topic hz /robot_commands が失敗するため

## 確認
- colcon build --packages-select crane_world_model_publisher crane_teleop
