### PR TITLE
[バグ修正] local_plannerで送信停止する問題を修正

### DIFF
--- a/crane_local_planner/include/crane_local_planner/local_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/local_planner.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/float32.hpp>
+#include <string>
 
 #include "rvo2_planner.hpp"
 #include "visibility_control.h"
@@ -160,6 +161,11 @@ private:
   KickPowerCalculator kick_power_calculator;
 
   diagnostic_updater::Updater diagnostic_updater_;
+
+  size_t dropped_command_count_last_cycle_ = 0;
+  size_t dropped_command_count_total_ = 0;
+  size_t planner_exception_count_last_cycle_ = 0;
+  size_t planner_exception_count_total_ = 0;
 
   auto aggregateStates(const std::vector<crane_msgs::msg::NamedString> & planning_factors) const
     -> std::string;

--- a/crane_local_planner/src/crane_local_planner.cpp
+++ b/crane_local_planner/src/crane_local_planner.cpp
@@ -14,75 +14,142 @@ namespace crane
 auto LocalPlannerComponent::callbackPositionCommands(const crane_msgs::msg::PositionCommands & msg)
   -> void
 {
-  auto & world_model = planner->world_model;
-  if (not planner or not world_model or not world_model->hasUpdated()) {
+  if (!planner) {
     return;
   }
-  ScopedTimer process_timer(process_time_pub);
+  auto & world_model = planner->world_model;
+  if (!world_model || !world_model->hasUpdated()) {
+    return;
+  }
 
-  // 遅延監視用の遅延チェックポイント保存
-  auto delay_checkpoints = msg.delay_checkpoints;
-  DelayMonitorWrapper::addDelayCheckpoint(
-    delay_checkpoints, "local_planner_start", "commands_received");
+  dropped_command_count_last_cycle_ = 0;
+  planner_exception_count_last_cycle_ = 0;
 
-  // msg.robot_commands内のrobot_idダブリチェック
-  {
-    auto commands = msg.robot_commands;
-    ranges::sort(commands, [](const auto & a, const auto & b) { return a.robot_id < b.robot_id; });
-    for (size_t i = 1; i < commands.size(); i++) {
-      if (commands[i - 1].robot_id == commands[i].robot_id) {
-        RCLCPP_ERROR_STREAM(
-          get_logger(), "ロボット " << static_cast<int>(commands[i].robot_id)
-                                    << " が重複しています(" << commands[i].planner_name << ", "
-                                    << aggregateStates(commands[i].planning_factors) << " と "
-                                    << commands[i - 1].planner_name << ", "
-                                    << aggregateStates(commands[i - 1].planning_factors) << ")");
+  try {
+    ScopedTimer process_timer(process_time_pub);
+
+    // 遅延監視用の遅延チェックポイント保存
+    auto delay_checkpoints = msg.delay_checkpoints;
+    DelayMonitorWrapper::addDelayCheckpoint(
+      delay_checkpoints, "local_planner_start", "commands_received");
+
+    // msg.robot_commands内のrobot_idダブリチェック
+    {
+      auto duplicate_check_commands = msg.robot_commands;
+      ranges::sort(duplicate_check_commands, [](const auto & a, const auto & b) {
+        return a.robot_id < b.robot_id;
+      });
+      for (size_t i = 1; i < duplicate_check_commands.size(); i++) {
+        if (duplicate_check_commands[i - 1].robot_id == duplicate_check_commands[i].robot_id) {
+          RCLCPP_ERROR_STREAM(
+            get_logger(), "ロボット "
+                            << static_cast<int>(duplicate_check_commands[i].robot_id)
+                            << " が重複しています(" << duplicate_check_commands[i].planner_name
+                            << ", " << aggregateStates(duplicate_check_commands[i].planning_factors)
+                            << " と " << duplicate_check_commands[i - 1].planner_name << ", "
+                            << aggregateStates(duplicate_check_commands[i - 1].planning_factors)
+                            << ")");
+        }
       }
     }
+
+    // 位置指令を検証して処理
+    // 【座標系の設計】
+    // - 位置・速度のベクトル成分(x,y)：フィールド座標系のまま（theta_offset未適用）
+    // - 角度(theta)：theta_offsetを適用（half_court_practice_mode対応）
+    // - この設計により、位置・速度は元の座標系を保持しつつ、角度だけ変換できる
+    crane_msgs::msg::PositionCommands commands;
+    commands.robot_commands.reserve(msg.robot_commands.size());
+    for (const auto & raw_command : msg.robot_commands) {
+      try {
+        if (raw_command.robot_id >= world_model->ours().robots.size()) {
+          dropped_command_count_last_cycle_++;
+          dropped_command_count_total_++;
+          RCLCPP_WARN_THROTTLE(
+            get_logger(), *get_clock(), 1000,
+            "robot_id %d is out of range [0, %zu), command is dropped",
+            static_cast<int>(raw_command.robot_id), world_model->ours().robots.size());
+          continue;
+        }
+
+        // 位置目標の可視化
+        planner->visualizer->drawLine(
+          Point(raw_command.current_pose.x, raw_command.current_pose.y),
+          Point(raw_command.target_x, raw_command.target_y), "yellow", 20, 0.3);
+
+        crane_msgs::msg::PositionCommand command = raw_command;
+        auto robot = world_model->getOurRobot(command.robot_id);
+        command.current_pose.x = robot->pose.pos.x();                   // フィールド座標系
+        command.current_pose.y = robot->pose.pos.y();                   // フィールド座標系
+        command.current_pose.theta = robot->pose.theta + theta_offset;  // theta_offset適用
+        command.current_velocity.x = robot->vel.linear.x();             // フィールド座標系
+        command.current_velocity.y = robot->vel.linear.y();             // フィールド座標系
+        command.current_velocity.theta = robot->vel.omega;
+        command.target_theta += theta_offset;  // theta_offset適用
+        command.kick_power = kick_power_calculator.getKickPower(command);
+        commands.robot_commands.push_back(command);
+      } catch (const std::exception & e) {
+        dropped_command_count_last_cycle_++;
+        dropped_command_count_total_++;
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 1000, "Failed to process command for robot %d: %s",
+          static_cast<int>(raw_command.robot_id), e.what());
+      }
+    }
+
+    if (dropped_command_count_last_cycle_ > 0) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 1000, "Dropped %zu/%zu commands in this cycle",
+        dropped_command_count_last_cycle_, msg.robot_commands.size());
+    }
+
+    crane_msgs::msg::VelocityCommands pub_msg;
+    try {
+      pub_msg = planner->calculateRobotCommand(commands, theta_offset);
+    } catch (const std::exception & e) {
+      planner_exception_count_last_cycle_++;
+      planner_exception_count_total_++;
+      RCLCPP_ERROR_THROTTLE(
+        get_logger(), *get_clock(), 1000,
+        "Path planning failed. Publishing empty /robot_commands this cycle: %s", e.what());
+    }
+
+    pub_msg.header.stamp = now();
+    pub_msg.is_yellow = world_model->isYellow();
+
+    // 遅延監視: LocalPlanner処理完了、最終コマンド送信
+    pub_msg.delay_checkpoints = delay_checkpoints;
+    DelayMonitorWrapper::addDelayCheckpoint(
+      pub_msg.delay_checkpoints, "local_planner_end", "path_planned");
+
+    commands_pub.publish(pub_msg);
+
+    planner->visualizer->flush();
+    crane::CraneVisualizerBuffer::publish();
+  } catch (const std::exception & e) {
+    planner_exception_count_last_cycle_++;
+    planner_exception_count_total_++;
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "Unhandled exception in local_planner callback. Publishing empty /robot_commands: %s",
+      e.what());
+
+    crane_msgs::msg::VelocityCommands fallback_msg;
+    fallback_msg.header.stamp = now();
+    fallback_msg.is_yellow = world_model->isYellow();
+    commands_pub.publish(fallback_msg);
+  } catch (...) {
+    planner_exception_count_last_cycle_++;
+    planner_exception_count_total_++;
+    RCLCPP_ERROR_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "Unhandled unknown exception in local_planner callback. Publishing empty /robot_commands");
+
+    crane_msgs::msg::VelocityCommands fallback_msg;
+    fallback_msg.header.stamp = now();
+    fallback_msg.is_yellow = world_model->isYellow();
+    commands_pub.publish(fallback_msg);
   }
-
-  // 位置指令を検証して処理
-  // 【座標系の設計】
-  // - 位置・速度のベクトル成分(x,y)：フィールド座標系のまま（theta_offset未適用）
-  // - 角度(theta)：theta_offsetを適用（half_court_practice_mode対応）
-  // - この設計により、位置・速度は元の座標系を保持しつつ、角度だけ変換できる
-  crane_msgs::msg::PositionCommands commands;
-  for (const auto & raw_command : msg.robot_commands) {
-    // 位置目標の可視化
-    planner->visualizer->drawLine(
-      Point(raw_command.current_pose.x, raw_command.current_pose.y),
-      Point(raw_command.target_x, raw_command.target_y), "yellow", 20, 0.3);
-
-    crane_msgs::msg::PositionCommand command = raw_command;
-    auto robot = world_model->getOurRobot(command.robot_id);
-    command.current_pose.x = robot->pose.pos.x();                   // フィールド座標系
-    command.current_pose.y = robot->pose.pos.y();                   // フィールド座標系
-    command.current_pose.theta = robot->pose.theta + theta_offset;  // theta_offset適用
-    command.current_velocity.x = robot->vel.linear.x();             // フィールド座標系
-    command.current_velocity.y = robot->vel.linear.y();             // フィールド座標系
-    command.current_velocity.theta = robot->vel.omega;
-    command.target_theta += theta_offset;  // theta_offset適用
-    commands.robot_commands.push_back(command);
-  }
-
-  // キックパワーの調整
-  for (auto & command : commands.robot_commands) {
-    command.kick_power = kick_power_calculator.getKickPower(command);
-  }
-
-  auto pub_msg = planner->calculateRobotCommand(commands, theta_offset);
-  pub_msg.header.stamp = rclcpp::Clock().now();
-  pub_msg.is_yellow = world_model->isYellow();
-
-  // 遅延監視: LocalPlanner処理完了、最終コマンド送信
-  pub_msg.delay_checkpoints = delay_checkpoints;
-  DelayMonitorWrapper::addDelayCheckpoint(
-    pub_msg.delay_checkpoints, "local_planner_end", "path_planned");
-
-  commands_pub.publish(pub_msg);
-
-  planner->visualizer->flush();
-  crane::CraneVisualizerBuffer::publish();
 
   // 診断情報を更新
   diagnostic_updater_.force_update();
@@ -106,6 +173,26 @@ auto LocalPlannerComponent::updateDiagnostics(diagnostic_updater::DiagnosticStat
   if (not world_model->hasUpdated()) {
     stat.summary(
       diagnostic_msgs::msg::DiagnosticStatus::WARN, "ワールドモデルがまだ更新されていません");
+    return;
+  }
+
+  stat.add("dropped_command_count_last_cycle", std::to_string(dropped_command_count_last_cycle_));
+  stat.add("dropped_command_count_total", std::to_string(dropped_command_count_total_));
+  stat.add(
+    "planner_exception_count_last_cycle", std::to_string(planner_exception_count_last_cycle_));
+  stat.add("planner_exception_count_total", std::to_string(planner_exception_count_total_));
+
+  if (planner_exception_count_last_cycle_ > 0) {
+    stat.summary(
+      diagnostic_msgs::msg::DiagnosticStatus::WARN,
+      "例外が発生しましたが、空のrobot_commandsで継続しています");
+    return;
+  }
+
+  if (dropped_command_count_last_cycle_ > 0) {
+    stat.summary(
+      diagnostic_msgs::msg::DiagnosticStatus::WARN,
+      "一部コマンドを除外しつつ経路計画を継続しています");
     return;
   }
 

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -11,7 +11,6 @@
 #include <range/v3/algorithm/find_if.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <robocup_ssl_msgs/msg/referee.hpp>
-#include <sstream>
 
 #include "crane_physics/bang_bang_trajectory.hpp"
 
@@ -494,13 +493,15 @@ auto RVO2Planner::adjustForPenaltyAreaAvoidance(
         } else if (isInBox(penalty_area, closest_point_2, PENALTY_AREA_OFFSET)) {
           target_pos = around_corner_2;
         } else {
-          std::stringstream what;
-          what << "Failed to find a target position outside the penalty area.";
-          what << " current_pos: " << current_pos.x() << ", " << current_pos.y();
-          what << " target_pos: " << target_pos.x() << ", " << target_pos.y();
-          what << " closest_point_1: " << closest_point_1.x() << ", " << closest_point_1.y();
-          what << " closest_point_2: " << closest_point_2.x() << ", " << closest_point_2.y();
-          throw std::runtime_error(what.str());
+          static rclcpp::Clock steady_clock(RCL_STEADY_TIME);
+          RCLCPP_WARN_THROTTLE(
+            rclcpp::get_logger("rvo2_local_planner"), steady_clock, 1000,
+            "Failed to find a target position outside the penalty area. Fallback to current "
+            "position. current_pos:(%.3f, %.3f) target_pos:(%.3f, %.3f) "
+            "closest_point_1:(%.3f, %.3f) closest_point_2:(%.3f, %.3f)",
+            current_pos.x(), current_pos.y(), target_pos.x(), target_pos.y(), closest_point_1.x(),
+            closest_point_1.y(), closest_point_2.x(), closest_point_2.y());
+          target_pos = current_pos;
         }
       }
     };


### PR DESCRIPTION
## 概要
control_targets が更新されていても robot_commands のpublishが停止することがある問題を修正しました。

## 変更内容
- LocalPlanner の callback で例外を捕捉し、空メッセージでも publish を継続
- ロボット単位で異常コマンドのみを除外し、他コマンドは継続処理
- penalty area回避処理の throw をフォールバック処理に変更
- dropped / exception カウンタを diagnostics に追加

## 確認
- colcon build --packages-select crane_local_planner
- colcon test --packages-select crane_local_planner --event-handlers console_cohesion+