### PR TITLE
[バグ修正] matplotlib vendorのNumPy競合を回避

### DIFF
--- a/3rdparty/matplotlib_cpp_17_vendor/CMakeLists.txt
+++ b/3rdparty/matplotlib_cpp_17_vendor/CMakeLists.txt
@@ -48,6 +48,7 @@ macro(build_matplotlibcpp17)
   endif()
 
   include(ExternalProject)
+  message(STATUS "Configure/build/install external matplotlibcpp17 with PYTHONNOUSERSITE=1")
   externalproject_add(matplotlib-cpp-ext
     GIT_REPOSITORY https://github.com/soblin/matplotlibcpp17.git
     GIT_TAG 4d025b5975b701598fce8487cd8feaf82eb5923f
@@ -55,6 +56,15 @@ macro(build_matplotlibcpp17)
     ${UPDATE_DISCONNECTED_FLAG}
     GIT_SUBMODULES_RECURSE OFF
     TIMEOUT 6000
+    CONFIGURE_COMMAND
+      ${CMAKE_COMMAND} -E env PYTHONNOUSERSITE=1
+      ${CMAKE_COMMAND} <SOURCE_DIR> ${cmake_configure_args}
+    BUILD_COMMAND
+      ${CMAKE_COMMAND} -E env PYTHONNOUSERSITE=1
+      ${CMAKE_COMMAND} --build <BINARY_DIR>
+    INSTALL_COMMAND
+      ${CMAKE_COMMAND} -E env PYTHONNOUSERSITE=1
+      ${CMAKE_COMMAND} --install <BINARY_DIR>
     ${cmake_commands}
     CMAKE_ARGS
       ${cmake_configure_args}


### PR DESCRIPTION
## 概要
- matplotlib_cpp_17_vendor の ExternalProject で Python 実行時に user site-packages が混入し、NumPy ABI 不整合で configure 失敗する問題を修正しました。

## 変更内容
- 3rdparty/matplotlib_cpp_17_vendor/CMakeLists.txt の externalproject_add(matplotlib-cpp-ext) に以下を追加。
- CONFIGURE_COMMAND を PYTHONNOUSERSITE=1 付きで実行
- BUILD_COMMAND を PYTHONNOUSERSITE=1 付きで実行
- INSTALL_COMMAND を PYTHONNOUSERSITE=1 付きで実行
- 対策が有効であることをログで判別できる message(STATUS ...) を追加

## 背景
- apt 版 matplotlib（NumPy 1.x ABI）と、~/.local の NumPy 2.x が混在すると import matplotlib が失敗し、Could not check matplotlib.__version__ でビルドが止まります。
- vendor 側の configure/build/install のみ PYTHONNOUSERSITE=1 を適用することで、ビルド時の Python 解決を安定化しました。

## 確認内容
- /home/hans/workspace/ibis_ws_2 で以下を実行し成功
- colcon build --packages-select matplotlib_cpp_17_vendor
- colcon build --packages-select matplotlib_cpp_17_vendor --cmake-clean-first

## 影響範囲
- matplotlib_cpp_17_vendor のビルド手順のみ
- ROSトピック・メッセージ・ランタイム挙動への変更はありません。