### PR TITLE
refactor: crane_msg_wrappersのバグ修正・品質・効率改善

### DIFF
--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/ball_prediction_tracker.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/ball_prediction_tracker.hpp
@@ -11,6 +11,8 @@
 #include <crane_msgs/msg/ball_prediction_trace.hpp>
 #include <string>
 
+#include "tracker_base.hpp"
+
 namespace crane
 {
 
@@ -21,14 +23,9 @@ namespace crane
  * 物理モデルのパラメータ調整やデバッグに活用する。
  */
 class BallPredictionTracker
+: public TrackerBase<BallPredictionTracker, crane_msgs::msg::BallPredictionTrace>
 {
 public:
-  /**
-   * @brief 新しいトレースを作成
-   * @return 初期化されたBallPredictionTrace
-   */
-  static auto createTrace() -> crane_msgs::msg::BallPredictionTrace;
-
   /**
    * @brief 予測点を追加
    * @param trace トレースデータ
@@ -58,9 +55,6 @@ public:
     const Eigen::Vector3d & actual_vel, uint8_t actual_state);
 
 private:
-  // トレースID生成用のカウンター
-  static uint32_t trace_id_counter_;
-
   // リングバッファの最大サイズ
   static constexpr size_t MAX_ACTUALS = 10;
 };

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/command_wrapper_base.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/command_wrapper_base.hpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_MSG_WRAPPERS__COMMAND_WRAPPER_BASE_HPP_
+#define CRANE_MSG_WRAPPERS__COMMAND_WRAPPER_BASE_HPP_
+
+#include <algorithm>
+#include <crane_msgs/msg/robot_command.hpp>
+#include <string>
+
+namespace crane
+{
+
+/**
+ * @brief RobotCommandWrapper と VelocityCommandWrapper の共通メソッドを提供する CRTP 基底クラス
+ * @tparam Derived 派生クラス
+ *
+ * 派生クラスは以下のメソッドを提供する必要がある（friend宣言推奨）:
+ *   crane_msgs::msg::RobotCommand & getLatestMsg()
+ *   const crane_msgs::msg::RobotCommand & getLatestMsg() const
+ */
+template <typename Derived>
+class CommandWrapperBase
+{
+  auto & msg() { return static_cast<Derived &>(*this).getLatestMsg(); }
+  const auto & msg() const { return static_cast<const Derived &>(*this).getLatestMsg(); }
+
+public:
+  auto getMsg() const -> const crane_msgs::msg::RobotCommand & { return msg(); }
+
+  auto getEditableMsg() -> crane_msgs::msg::RobotCommand & { return msg(); }
+
+  auto dribble(double power) -> Derived &
+  {
+    msg().dribble_power = power;
+    msg().kick_power = 0.0;
+    return static_cast<Derived &>(*this);
+  }
+
+  auto withDribble(double power) -> Derived &
+  {
+    msg().dribble_power = power;
+    return static_cast<Derived &>(*this);
+  }
+
+  auto stopEmergency(bool flag = true) -> Derived &
+  {
+    msg().stop_flag = flag;
+    return static_cast<Derived &>(*this);
+  }
+
+  auto addPlanningFactor(const std::string & name, const std::string & state) -> void
+  {
+    auto it = std::find_if(
+      msg().planning_factors.begin(), msg().planning_factors.end(),
+      [&name](const auto & pf) { return pf.name == name; });
+    if (it == msg().planning_factors.end()) {
+      crane_msgs::msg::NamedString ns;
+      ns.name = name;
+      ns.value = state;
+      msg().planning_factors.emplace_back(ns);
+    } else if (it->value != state) {
+      it->value = state;
+    }
+  }
+
+  auto clearPlanningFactors() -> void { msg().planning_factors.clear(); }
+};
+
+}  // namespace crane
+
+#endif  // CRANE_MSG_WRAPPERS__COMMAND_WRAPPER_BASE_HPP_

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/delay_monitor_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/delay_monitor_wrapper.hpp
@@ -11,7 +11,9 @@
 #include <chrono>
 #include <crane_msgs/msg/delay_checkpoint.hpp>
 #include <crane_msgs/msg/delay_checkpoints.hpp>
+#include <format>
 #include <rclcpp/rclcpp.hpp>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -44,7 +46,7 @@ public:
     // 同じnameのチェックポイントが存在する場合は更新
     auto existing = std::find_if(
       checkpoints.begin(), checkpoints.end(),
-      [name](const auto & checkpoint) { return checkpoint.name == name; });
+      [&name](const auto & checkpoint) { return checkpoint.name == name; });
 
     // 注意: 旧API - 新しいDelayCheckpointsメッセージを使用することを推奨
     if (existing != checkpoints.end()) {
@@ -72,11 +74,11 @@ public:
   {
     auto start_it = std::find_if(
       checkpoints.begin(), checkpoints.end(),
-      [start_name](const auto & cp) { return cp.name == start_name; });
+      [&start_name](const auto & cp) { return cp.name == start_name; });
 
-    auto end_it = std::find_if(checkpoints.begin(), checkpoints.end(), [end_name](const auto & cp) {
-      return cp.name == end_name;
-    });
+    auto end_it = std::find_if(
+      checkpoints.begin(), checkpoints.end(),
+      [&end_name](const auto & cp) { return cp.name == end_name; });
 
     if (start_it == checkpoints.end() || end_it == checkpoints.end()) {
       return -1.0;
@@ -99,9 +101,9 @@ public:
       return -1.0;
     }
 
-    auto end_it = std::find_if(checkpoints.begin(), checkpoints.end(), [end_name](const auto & cp) {
-      return cp.name == end_name;
-    });
+    auto end_it = std::find_if(
+      checkpoints.begin(), checkpoints.end(),
+      [&end_name](const auto & cp) { return cp.name == end_name; });
 
     if (end_it == checkpoints.end()) {
       return -1.0;
@@ -123,7 +125,7 @@ public:
   {
     auto current_it = std::find_if(
       checkpoints.begin(), checkpoints.end(),
-      [current_name](const auto & cp) { return cp.name == current_name; });
+      [&current_name](const auto & cp) { return cp.name == current_name; });
 
     if (current_it == checkpoints.end() || current_it == checkpoints.begin()) {
       return -1.0;
@@ -145,27 +147,25 @@ public:
       return "[]";
     }
 
-    std::string result = "[";
+    std::ostringstream oss;
+    oss << "[";
     for (size_t i = 0; i < checkpoints.size(); ++i) {
       const auto & cp = checkpoints[i];
-      result += cp.name;
+      oss << cp.name;
       if (!cp.value.empty()) {
-        result += "(" + cp.value + ")";
+        oss << "(" << cp.value << ")";
       }
-
-      // 前のチェックポイントからの遅延を表示
       if (i > 0) {
-        auto delay_us = cp.relative_time_us - checkpoints[i - 1].relative_time_us;
-        auto delay_ms = static_cast<double>(delay_us) / 1000.0;
-        result += ":" + std::to_string(delay_ms) + "ms";
+        auto delay_ms =
+          static_cast<double>(cp.relative_time_us - checkpoints[i - 1].relative_time_us) / 1000.0;
+        oss << ":" << delay_ms << "ms";
       }
-
       if (i < checkpoints.size() - 1) {
-        result += ", ";
+        oss << ", ";
       }
     }
-    result += "]";
-    return result;
+    oss << "]";
+    return oss.str();
   }
 
   /**
@@ -185,12 +185,9 @@ public:
   static std::string formatVisionDelayInfo(
     double t_capture, double t_sent, [[maybe_unused]] const rclcpp::Time & ros_receive_time)
   {
-    // Vision内部処理時間
     double vision_processing_ms = (t_sent - t_capture) * 1000.0;
-
-    // Vision相対時刻の情報を文字列として返す
-    return "t_capture:" + std::to_string(t_capture) + "s, t_sent:" + std::to_string(t_sent) +
-           "s, vision_proc:" + std::to_string(vision_processing_ms) + "ms";
+    return std::format(
+      "t_capture:{}s, t_sent:{}s, vision_proc:{}ms", t_capture, t_sent, vision_processing_ms);
   }
 
   // ===== 新しいDelayCheckpointsメッセージ用API =====
@@ -216,7 +213,7 @@ public:
     // 同じnameのチェックポイントが存在する場合は更新
     auto existing = std::find_if(
       checkpoints.checkpoints.begin(), checkpoints.checkpoints.end(),
-      [name](const auto & checkpoint) { return checkpoint.name == name; });
+      [&name](const auto & checkpoint) { return checkpoint.name == name; });
 
     // 基準からの相対時間をマイクロ秒で計算
     auto relative_time_us =
@@ -247,11 +244,11 @@ public:
   {
     auto start_it = std::find_if(
       checkpoints.checkpoints.begin(), checkpoints.checkpoints.end(),
-      [start_name](const auto & cp) { return cp.name == start_name; });
+      [&start_name](const auto & cp) { return cp.name == start_name; });
 
     auto end_it = std::find_if(
       checkpoints.checkpoints.begin(), checkpoints.checkpoints.end(),
-      [end_name](const auto & cp) { return cp.name == end_name; });
+      [&end_name](const auto & cp) { return cp.name == end_name; });
 
     if (start_it == checkpoints.checkpoints.end() || end_it == checkpoints.checkpoints.end()) {
       return -1.0;
@@ -276,7 +273,7 @@ public:
 
     auto end_it = std::find_if(
       checkpoints.checkpoints.begin(), checkpoints.checkpoints.end(),
-      [end_name](const auto & cp) { return cp.name == end_name; });
+      [&end_name](const auto & cp) { return cp.name == end_name; });
 
     if (end_it == checkpoints.checkpoints.end()) {
       return -1.0;
@@ -296,7 +293,7 @@ public:
   {
     auto current_it = std::find_if(
       checkpoints.checkpoints.begin(), checkpoints.checkpoints.end(),
-      [current_name](const auto & cp) { return cp.name == current_name; });
+      [&current_name](const auto & cp) { return cp.name == current_name; });
 
     if (
       current_it == checkpoints.checkpoints.end() ||
@@ -320,31 +317,28 @@ public:
       return "[]";
     }
 
-    std::string result = "[";
+    std::ostringstream oss;
+    oss << "[";
     for (size_t i = 0; i < checkpoints.checkpoints.size(); ++i) {
       const auto & cp = checkpoints.checkpoints[i];
-      result += cp.name;
+      oss << cp.name;
       if (!cp.value.empty()) {
-        result += "(" + cp.value + ")";
+        oss << "(" << cp.value << ")";
       }
-
-      // 前のチェックポイントからの遅延を表示
       if (i > 0) {
-        auto delay_us = cp.relative_time_us - checkpoints.checkpoints[i - 1].relative_time_us;
-        auto delay_ms = static_cast<double>(delay_us) / 1000.0;
-        result += ":" + std::to_string(delay_ms) + "ms";
+        auto delay_ms = static_cast<double>(
+                          cp.relative_time_us - checkpoints.checkpoints[i - 1].relative_time_us) /
+                        1000.0;
+        oss << ":" << delay_ms << "ms";
       } else {
-        // 最初のチェックポイントは基準からの時間を表示
-        auto delay_ms = static_cast<double>(cp.relative_time_us) / 1000.0;
-        result += ":" + std::to_string(delay_ms) + "ms";
+        oss << ":" << static_cast<double>(cp.relative_time_us) / 1000.0 << "ms";
       }
-
       if (i < checkpoints.checkpoints.size() - 1) {
-        result += ", ";
+        oss << ", ";
       }
     }
-    result += "]";
-    return result;
+    oss << "]";
+    return oss.str();
   }
 
   /**

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/delay_monitor_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/delay_monitor_wrapper.hpp
@@ -28,150 +28,7 @@ class DelayMonitorWrapper
 {
 public:
   using DelayCheckpointMsg = crane_msgs::msg::DelayCheckpoint;
-  using DelayCheckpointArray = std::vector<DelayCheckpointMsg>;
   using DelayCheckpointsMsg = crane_msgs::msg::DelayCheckpoints;
-
-  /**
-   * @brief チェックポイントを追加する
-   * @param name チェックポイント名（例: "vision_received", "ekf_updated"）
-   * @param value 追加情報（オプション、例: "30Hz", "robot_id:3"）
-   */
-  static void addDelayCheckpoint(
-    DelayCheckpointArray & checkpoints, const std::string & name, const std::string & value = "")
-  {
-    auto now = std::chrono::steady_clock::now();
-    auto timestamp_ns =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
-
-    // 同じnameのチェックポイントが存在する場合は更新
-    auto existing = std::find_if(
-      checkpoints.begin(), checkpoints.end(),
-      [&name](const auto & checkpoint) { return checkpoint.name == name; });
-
-    // 注意: 旧API - 新しいDelayCheckpointsメッセージを使用することを推奨
-    if (existing != checkpoints.end()) {
-      existing->relative_time_us = static_cast<int32_t>(timestamp_ns / 1000);
-      existing->value = value;
-    } else {
-      DelayCheckpointMsg checkpoint;
-      checkpoint.name = name;
-      checkpoint.relative_time_us = static_cast<int32_t>(timestamp_ns / 1000);
-      checkpoint.value = value;
-      checkpoints.push_back(checkpoint);
-    }
-  }
-
-  /**
-   * @brief 指定したチェックポイント間の遅延を計算する（ミリ秒）
-   * @param checkpoints チェックポイント配列
-   * @param start_name 開始チェックポイント名
-   * @param end_name 終了チェックポイント名
-   * @return 遅延時間（ミリ秒）、チェックポイントが見つからない場合は-1
-   */
-  static double calculateDelayMs(
-    const DelayCheckpointArray & checkpoints, const std::string & start_name,
-    const std::string & end_name)
-  {
-    auto start_it = std::find_if(
-      checkpoints.begin(), checkpoints.end(),
-      [&start_name](const auto & cp) { return cp.name == start_name; });
-
-    auto end_it = std::find_if(
-      checkpoints.begin(), checkpoints.end(),
-      [&end_name](const auto & cp) { return cp.name == end_name; });
-
-    if (start_it == checkpoints.end() || end_it == checkpoints.end()) {
-      return -1.0;
-    }
-
-    auto delay_us = end_it->relative_time_us - start_it->relative_time_us;
-    return static_cast<double>(delay_us) / 1000.0;  // マイクロ秒をミリ秒に変換
-  }
-
-  /**
-   * @brief 最初のチェックポイントからの総遅延を計算する（ミリ秒）
-   * @param checkpoints チェックポイント配列
-   * @param end_name 終了チェックポイント名
-   * @return 総遅延時間（ミリ秒）、チェックポイントが見つからない場合は-1
-   */
-  static double calculateTotalDelayMs(
-    const DelayCheckpointArray & checkpoints, const std::string & end_name)
-  {
-    if (checkpoints.empty()) {
-      return -1.0;
-    }
-
-    auto end_it = std::find_if(
-      checkpoints.begin(), checkpoints.end(),
-      [&end_name](const auto & cp) { return cp.name == end_name; });
-
-    if (end_it == checkpoints.end()) {
-      return -1.0;
-    }
-
-    auto start_time = checkpoints.front().relative_time_us;
-    auto delay_us = end_it->relative_time_us - start_time;
-    return static_cast<double>(delay_us) / 1000.0;
-  }
-
-  /**
-   * @brief 直前のチェックポイントからの遅延を計算する（ミリ秒）
-   * @param checkpoints チェックポイント配列
-   * @param current_name 現在のチェックポイント名
-   * @return 直前からの遅延時間（ミリ秒）、適切なチェックポイントが見つからない場合は-1
-   */
-  static double calculateIncrementalDelayMs(
-    const DelayCheckpointArray & checkpoints, const std::string & current_name)
-  {
-    auto current_it = std::find_if(
-      checkpoints.begin(), checkpoints.end(),
-      [&current_name](const auto & cp) { return cp.name == current_name; });
-
-    if (current_it == checkpoints.end() || current_it == checkpoints.begin()) {
-      return -1.0;
-    }
-
-    auto prev_it = current_it - 1;
-    auto delay_us = current_it->relative_time_us - prev_it->relative_time_us;
-    return static_cast<double>(delay_us) / 1000.0;
-  }
-
-  /**
-   * @brief チェックポイント配列を文字列に変換（デバッグ用）
-   * @param checkpoints チェックポイント配列
-   * @return フォーマットされた文字列
-   */
-  static std::string checkpointsToString(const DelayCheckpointArray & checkpoints)
-  {
-    if (checkpoints.empty()) {
-      return "[]";
-    }
-
-    std::ostringstream oss;
-    oss << "[";
-    for (size_t i = 0; i < checkpoints.size(); ++i) {
-      const auto & cp = checkpoints[i];
-      oss << cp.name;
-      if (!cp.value.empty()) {
-        oss << "(" << cp.value << ")";
-      }
-      if (i > 0) {
-        auto delay_ms =
-          static_cast<double>(cp.relative_time_us - checkpoints[i - 1].relative_time_us) / 1000.0;
-        oss << ":" << delay_ms << "ms";
-      }
-      if (i < checkpoints.size() - 1) {
-        oss << ", ";
-      }
-    }
-    oss << "]";
-    return oss.str();
-  }
-
-  /**
-   * @brief チェックポイント配列をクリアする
-   */
-  static void clearCheckpoints(DelayCheckpointArray & checkpoints) { checkpoints.clear(); }
 
   // ===== Unix時刻変換用ユーティリティ =====
 
@@ -385,7 +242,7 @@ public:
     for (const auto & src_cp : source.checkpoints) {
       auto existing = std::find_if(
         target.checkpoints.begin(), target.checkpoints.end(),
-        [src_cp](const auto & cp) { return cp.name == src_cp.name; });
+        [&src_cp](const auto & cp) { return cp.name == src_cp.name; });
 
       DelayCheckpointMsg adjusted_cp = src_cp;
       adjusted_cp.relative_time_us += static_cast<int32_t>(source_offset_us);
@@ -400,26 +257,52 @@ public:
       }
     }
   }
+};
 
-  /**
-   * @brief 既存のチェックポイント配列に別の配列をマージする
-   * 同名のチェックポイントがある場合は、より新しいタイムスタンプのものを保持
-   */
-  static void mergeCheckpoints(DelayCheckpointArray & target, const DelayCheckpointArray & source)
+/**
+ * @brief 遅延監視関連メソッドを提供する CRTP ミックスイン
+ * @tparam Derived 派生クラス
+ *
+ * 派生クラスは以下のメソッドを提供する必要がある（friend宣言推奨）:
+ *   crane_msgs::msg::DelayCheckpoints & getDelayCheckpoints()
+ *   const crane_msgs::msg::DelayCheckpoints & getDelayCheckpoints() const
+ */
+template <typename Derived>
+class DelayMonitorMixin
+{
+  auto & checkpoints() { return static_cast<Derived &>(*this).getDelayCheckpoints(); }
+  const auto & checkpoints() const
   {
-    for (const auto & src_cp : source) {
-      auto existing = std::find_if(
-        target.begin(), target.end(), [src_cp](const auto & cp) { return cp.name == src_cp.name; });
+    return static_cast<const Derived &>(*this).getDelayCheckpoints();
+  }
 
-      if (existing != target.end()) {
-        // より新しいタイムスタンプのものを保持
-        if (src_cp.relative_time_us > existing->relative_time_us) {
-          *existing = src_cp;
-        }
-      } else {
-        target.push_back(src_cp);
-      }
-    }
+public:
+  auto addDelayCheckpoint(const std::string & name, const std::string & value = "") -> void
+  {
+    DelayMonitorWrapper::addDelayCheckpoint(checkpoints(), name, value);
+  }
+
+  auto clearDelayCheckpoints() -> void { DelayMonitorWrapper::clearCheckpoints(checkpoints()); }
+
+  auto calculateDelayMs(const std::string & start_name, const std::string & end_name) const
+    -> double
+  {
+    return DelayMonitorWrapper::calculateDelayMs(checkpoints(), start_name, end_name);
+  }
+
+  auto calculateTotalDelayMs(const std::string & end_name) const -> double
+  {
+    return DelayMonitorWrapper::calculateTotalDelayMs(checkpoints(), end_name);
+  }
+
+  auto getDelayCheckpointsString() const -> std::string
+  {
+    return DelayMonitorWrapper::checkpointsToString(checkpoints());
+  }
+
+  auto mergeDelayCheckpoints(const crane_msgs::msg::DelayCheckpoints & source) -> void
+  {
+    DelayMonitorWrapper::mergeCheckpoints(checkpoints(), source);
   }
 };
 

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/in_play_situation_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/in_play_situation_wrapper.hpp
@@ -9,6 +9,9 @@
 
 #include <crane_msgs/msg/in_play_situation.hpp>
 
+namespace crane
+{
+
 struct InPlaySituationWrapper
 {
   struct NearestToBallRobotID
@@ -32,4 +35,6 @@ struct InPlaySituationWrapper
     ball_possession.theirs = msg.ball_possession_theirs;
   }
 };
+
+}  // namespace crane
 #endif  // CRANE_MSG_WRAPPERS__IN_PLAY_SITUATION_WRAPPER_HPP_

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/kick_prediction_tracker.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/kick_prediction_tracker.hpp
@@ -11,6 +11,8 @@
 #include <crane_msgs/msg/kick_prediction_trace.hpp>
 #include <string>
 
+#include "tracker_base.hpp"
+
 namespace crane
 {
 
@@ -21,14 +23,9 @@ namespace crane
  * 物理モデルのパラメータ調整やデバッグに活用する。
  */
 class KickPredictionTracker
+: public TrackerBase<KickPredictionTracker, crane_msgs::msg::KickPredictionTrace>
 {
 public:
-  /**
-   * @brief 新しいトレースを作成
-   * @return 初期化されたKickPredictionTrace
-   */
-  static auto createTrace() -> crane_msgs::msg::KickPredictionTrace;
-
   /**
    * @brief キック予測を記録
    * @param trace トレースデータ
@@ -55,10 +52,6 @@ public:
   static void recordActual(
     crane_msgs::msg::KickPredictionTrace & trace, double actual_ball_speed,
     double actual_stop_distance);
-
-private:
-  // トレースID生成用のカウンター
-  static uint32_t trace_id_counter_;
 };
 
 }  // namespace crane

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
@@ -7,22 +7,27 @@
 #ifndef CRANE_MSG_WRAPPERS__ROBOT_COMMAND_WRAPPER_HPP_
 #define CRANE_MSG_WRAPPERS__ROBOT_COMMAND_WRAPPER_HPP_
 
-#include <algorithm>
 #include <crane_geometry/boost_geometry.hpp>
 #include <crane_geometry/geometry_operations.hpp>
-#include <crane_msgs/msg/robot_command.hpp>
 #include <crane_physics/kicker_model.hpp>
 #include <memory>
 #include <vector>
 
+#include "command_wrapper_base.hpp"
 #include "delay_monitor_wrapper.hpp"
 #include "velocity_plan_tracker.hpp"
 #include "world_model_wrapper.hpp"
 
 namespace crane
 {
-class RobotCommandWrapper
+class RobotCommandWrapper : public CommandWrapperBase<RobotCommandWrapper>,
+                            public DelayMonitorMixin<RobotCommandWrapper>,
+                            public VelocityPlanTraceMixin<RobotCommandWrapper>
 {
+  friend class CommandWrapperBase<RobotCommandWrapper>;
+  friend class DelayMonitorMixin<RobotCommandWrapper>;
+  friend class VelocityPlanTraceMixin<RobotCommandWrapper>;
+
 public:
   using SharedPtr = std::shared_ptr<RobotCommandWrapper>;
 
@@ -32,6 +37,25 @@ private:
   std::shared_ptr<RobotInfo> robot;
 
   WorldModelWrapper::SharedPtr world_model;
+
+  auto getLatestMsg() -> crane_msgs::msg::RobotCommand & { return latest_msg; }
+  auto getLatestMsg() const -> const crane_msgs::msg::RobotCommand & { return latest_msg; }
+  auto getDelayCheckpoints() -> crane_msgs::msg::DelayCheckpoints &
+  {
+    return latest_msg.delay_checkpoints;
+  }
+  auto getDelayCheckpoints() const -> const crane_msgs::msg::DelayCheckpoints &
+  {
+    return latest_msg.delay_checkpoints;
+  }
+  auto getVelocityPlanTrace() -> decltype(latest_msg.velocity_plan_trace) &
+  {
+    return latest_msg.velocity_plan_trace;
+  }
+  auto getVelocityPlanTrace() const -> const decltype(latest_msg.velocity_plan_trace) &
+  {
+    return latest_msg.velocity_plan_trace;
+  }
 
   // キッカーモデル（停止距離指定キック用）
   std::shared_ptr<KickerModel> kicker_model;
@@ -84,11 +108,6 @@ public:
 
   // 現在のモードを返す
   auto getCurrentMode() const -> uint8_t { return current_mode; }
-
-  // メッセージを取得
-  auto getMsg() const -> const crane_msgs::msg::RobotCommand & { return latest_msg; }
-
-  auto getEditableMsg() -> crane_msgs::msg::RobotCommand & { return latest_msg; }
 
   auto getRobot() const -> std::shared_ptr<RobotInfo> { return robot; }
 
@@ -176,19 +195,6 @@ public:
 
     double kick_power = kicker_model->calculateStraightKickPower(initial_speed);
     return kicker_model->predictStopDistance(kick_power);
-  }
-
-  auto dribble(double power) -> RobotCommandWrapper &
-  {
-    latest_msg.dribble_power = power;
-    latest_msg.kick_power = 0.0;
-    return *this;
-  }
-
-  auto withDribble(double power) -> RobotCommandWrapper &
-  {
-    latest_msg.dribble_power = power;
-    return *this;
   }
 
   auto setTargetTheta(double theta, double tolerance = 0.0) -> RobotCommandWrapper &
@@ -363,12 +369,6 @@ public:
     return *this;
   }
 
-  auto stopEmergency(bool flag = true) -> RobotCommandWrapper &
-  {
-    latest_msg.stop_flag = flag;
-    return *this;
-  }
-
   // auto setLatencyMs(double latency_ms) -> RobotCommandWrapper &
   // {
   //   latest_msg.latency_ms = latency_ms;
@@ -394,110 +394,6 @@ public:
   {
     return setTargetTheta(getAngle(at - from), tolerance);
   }
-
-  auto addPlanningFactor(const std::string & name, const std::string & state) -> void
-  {
-    auto planning_factor = std::find_if(
-      latest_msg.planning_factors.begin(), latest_msg.planning_factors.end(),
-      [&name](const auto & pf) { return pf.name == name; });
-    if (planning_factor == latest_msg.planning_factors.end()) {
-      crane_msgs::msg::NamedString msg;
-      msg.name = name;
-      msg.value = state;
-      latest_msg.planning_factors.emplace_back(msg);
-    } else if (planning_factor->value != state) {
-      planning_factor->value = state;
-    }
-  }
-
-  auto clearPlanningFactors() -> void { latest_msg.planning_factors.clear(); }
-
-  // ===== 遅延監視関連メソッド =====
-
-  auto addDelayCheckpoint(const std::string & name, const std::string & value = "") -> void
-  {
-    DelayMonitorWrapper::addDelayCheckpoint(latest_msg.delay_checkpoints, name, value);
-  }
-
-  auto clearDelayCheckpoints() -> void
-  {
-    DelayMonitorWrapper::clearCheckpoints(latest_msg.delay_checkpoints);
-  }
-
-  auto calculateDelayMs(const std::string & start_name, const std::string & end_name) -> double
-  {
-    return DelayMonitorWrapper::calculateDelayMs(
-      latest_msg.delay_checkpoints, start_name, end_name);
-  }
-
-  auto calculateTotalDelayMs(const std::string & end_name) -> double
-  {
-    return DelayMonitorWrapper::calculateTotalDelayMs(latest_msg.delay_checkpoints, end_name);
-  }
-
-  auto getDelayCheckpointsString() -> std::string
-  {
-    return DelayMonitorWrapper::checkpointsToString(latest_msg.delay_checkpoints);
-  }
-
-  auto mergeDelayCheckpoints(const crane_msgs::msg::DelayCheckpoints & source_checkpoints) -> void
-  {
-    DelayMonitorWrapper::mergeCheckpoints(latest_msg.delay_checkpoints, source_checkpoints);
-  }
-
-  // ===== 速度計画トレース関連メソッド =====
-
-  /**
-   * @brief 速度計画トレースを有効化（新規トレースを作成）
-   */
-  auto enableVelocityPlanTrace() -> RobotCommandWrapper &
-  {
-    if (latest_msg.velocity_plan_trace.empty()) {
-      latest_msg.velocity_plan_trace.push_back(VelocityPlanTracker::createTrace());
-    }
-    return *this;
-  }
-
-  /**
-   * @brief 計画点を追加
-   * @param source 計画作成元 ("skill", "session", "local_planner", "sender")
-   * @param predicted_pos 予測位置（フィールド座標 m）
-   * @param predicted_vel 予測速度（フィールド座標 m/s）
-   * @param target_time_us 予測対象時刻（基準からの相対時間 us）
-   * @param estimated_arrival_time_us 目標到達予定時刻（us）
-   */
-  auto addVelocityPlanPoint(
-    const std::string & source, const Eigen::Vector2d & predicted_pos,
-    const Eigen::Vector2d & predicted_vel, int32_t target_time_us,
-    int32_t estimated_arrival_time_us = 0) -> void
-  {
-    if (!latest_msg.velocity_plan_trace.empty()) {
-      VelocityPlanTracker::addPlanPoint(
-        latest_msg.velocity_plan_trace[0], source, predicted_pos, predicted_vel, target_time_us,
-        estimated_arrival_time_us);
-    }
-  }
-
-  /**
-   * @brief 速度修正を記録
-   * @param source 修正元 ("rvo2", "sender_accel_limit", "feedback_control")
-   * @param before_vel 修正前の希望速度（m/s）
-   * @param after_vel 修正後の実際の速度（m/s）
-   */
-  auto addVelocityCorrection(
-    const std::string & source, const Eigen::Vector2d & before_vel,
-    const Eigen::Vector2d & after_vel) -> void
-  {
-    if (!latest_msg.velocity_plan_trace.empty()) {
-      VelocityPlanTracker::addCorrection(
-        latest_msg.velocity_plan_trace[0], source, before_vel, after_vel);
-    }
-  }
-
-  /**
-   * @brief 速度計画トレースが有効かどうかを確認
-   */
-  auto hasVelocityPlanTrace() const -> bool { return !latest_msg.velocity_plan_trace.empty(); }
 
   // ===== KickerModel管理メソッド =====
 

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
@@ -397,15 +397,16 @@ public:
 
   auto addPlanningFactor(const std::string & name, const std::string & state) -> void
   {
-    // 同じnameのものが存在しなければ追加。存在すれば、更新
-    if (auto planning_factor = std::find_if(
-          latest_msg.planning_factors.begin(), latest_msg.planning_factors.end(),
-          [name](const auto & planning_factor) { return planning_factor.name == name; });
-        planning_factor == latest_msg.planning_factors.end() || planning_factor->value != state) {
+    auto planning_factor = std::find_if(
+      latest_msg.planning_factors.begin(), latest_msg.planning_factors.end(),
+      [&name](const auto & pf) { return pf.name == name; });
+    if (planning_factor == latest_msg.planning_factors.end()) {
       crane_msgs::msg::NamedString msg;
       msg.name = name;
       msg.value = state;
       latest_msg.planning_factors.emplace_back(msg);
+    } else if (planning_factor->value != state) {
+      planning_factor->value = state;
     }
   }
 

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/tracker_base.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/tracker_base.hpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_MSG_WRAPPERS__TRACKER_BASE_HPP_
+#define CRANE_MSG_WRAPPERS__TRACKER_BASE_HPP_
+
+#include <chrono>
+#include <cstdint>
+
+namespace crane
+{
+
+/**
+ * @brief トレースID生成と createTrace() の共通実装を提供する CRTP 基底クラス
+ * @tparam Derived 派生クラス
+ * @tparam TraceMsg トレースメッセージ型（reference_timestamp_ns と trace_id フィールドが必要）
+ */
+template <typename Derived, typename TraceMsg>
+class TrackerBase
+{
+public:
+  static auto createTrace() -> TraceMsg
+  {
+    TraceMsg trace;
+    auto now = std::chrono::system_clock::now();
+    trace.reference_timestamp_ns =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
+    trace.trace_id = ++trace_id_counter_;
+    return trace;
+  }
+
+protected:
+  static uint32_t trace_id_counter_;
+};
+
+template <typename Derived, typename TraceMsg>
+uint32_t TrackerBase<Derived, TraceMsg>::trace_id_counter_ = 0;
+
+}  // namespace crane
+
+#endif  // CRANE_MSG_WRAPPERS__TRACKER_BASE_HPP_

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/velocity_command_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/velocity_command_wrapper.hpp
@@ -10,12 +10,11 @@
 #include <cmath>
 #include <crane_geometry/boost_geometry.hpp>
 #include <crane_geometry/geometry_operations.hpp>
-#include <crane_msgs/msg/robot_command.hpp>
 #include <limits>
 #include <memory>
-#include <range/v3/algorithm/find_if.hpp>
 #include <vector>
 
+#include "command_wrapper_base.hpp"
 #include "delay_monitor_wrapper.hpp"
 #include "velocity_plan_tracker.hpp"
 
@@ -24,23 +23,43 @@ namespace crane
 /**
  * @brief local_planner → sender 用の速度指令ラッパー
  */
-class VelocityCommandWrapper
+class VelocityCommandWrapper : public CommandWrapperBase<VelocityCommandWrapper>,
+                               public DelayMonitorMixin<VelocityCommandWrapper>,
+                               public VelocityPlanTraceMixin<VelocityCommandWrapper>
 {
+  friend class CommandWrapperBase<VelocityCommandWrapper>;
+  friend class DelayMonitorMixin<VelocityCommandWrapper>;
+  friend class VelocityPlanTraceMixin<VelocityCommandWrapper>;
+
 public:
   using SharedPtr = std::shared_ptr<VelocityCommandWrapper>;
 
 private:
   crane_msgs::msg::RobotCommand latest_msg;
 
+  auto getLatestMsg() -> crane_msgs::msg::RobotCommand & { return latest_msg; }
+  auto getLatestMsg() const -> const crane_msgs::msg::RobotCommand & { return latest_msg; }
+  auto getDelayCheckpoints() -> crane_msgs::msg::DelayCheckpoints &
+  {
+    return latest_msg.delay_checkpoints;
+  }
+  auto getDelayCheckpoints() const -> const crane_msgs::msg::DelayCheckpoints &
+  {
+    return latest_msg.delay_checkpoints;
+  }
+  auto getVelocityPlanTrace() -> decltype(latest_msg.velocity_plan_trace) &
+  {
+    return latest_msg.velocity_plan_trace;
+  }
+  auto getVelocityPlanTrace() const -> const decltype(latest_msg.velocity_plan_trace) &
+  {
+    return latest_msg.velocity_plan_trace;
+  }
+
 public:
   VelocityCommandWrapper() = default;
 
   explicit VelocityCommandWrapper(uint8_t robot_id) { latest_msg.robot_id = robot_id; }
-
-  // メッセージを取得
-  auto getMsg() const -> const crane_msgs::msg::RobotCommand & { return latest_msg; }
-
-  auto getEditableMsg() -> crane_msgs::msg::RobotCommand & { return latest_msg; }
 
   // ===== 速度指令固有の関数 =====
 
@@ -128,19 +147,6 @@ public:
     return *this;
   }
 
-  auto dribble(double power) -> VelocityCommandWrapper &
-  {
-    latest_msg.dribble_power = power;
-    latest_msg.kick_power = 0.0;
-    return *this;
-  }
-
-  auto withDribble(double power) -> VelocityCommandWrapper &
-  {
-    latest_msg.dribble_power = power;
-    return *this;
-  }
-
   auto setTargetTheta(double theta) -> VelocityCommandWrapper &
   {
     latest_msg.target_theta = theta;
@@ -150,12 +156,6 @@ public:
   auto setOmegaLimit(double omega_limit) -> VelocityCommandWrapper &
   {
     latest_msg.omega_limit = omega_limit;
-    return *this;
-  }
-
-  auto stopEmergency(bool flag = true) -> VelocityCommandWrapper &
-  {
-    latest_msg.stop_flag = flag;
     return *this;
   }
 
@@ -207,59 +207,10 @@ public:
     return *this;
   }
 
-  auto addPlanningFactor(const std::string & name, const std::string & state) -> void
-  {
-    auto planning_factor = ranges::find_if(
-      latest_msg.planning_factors, [&name](const auto & pf) { return pf.name == name; });
-    if (planning_factor == latest_msg.planning_factors.end()) {
-      crane_msgs::msg::NamedString msg;
-      msg.name = name;
-      msg.value = state;
-      latest_msg.planning_factors.emplace_back(msg);
-    } else if (planning_factor->value != state) {
-      planning_factor->value = state;
-    }
-  }
-
-  auto clearPlanningFactors() -> void { latest_msg.planning_factors.clear(); }
-
   auto setPlannerName(const std::string & planner_name) -> VelocityCommandWrapper &
   {
     latest_msg.planner_name = planner_name;
     return *this;
-  }
-
-  // ===== 遅延監視関連メソッド =====
-
-  auto addDelayCheckpoint(const std::string & name, const std::string & value = "") -> void
-  {
-    DelayMonitorWrapper::addDelayCheckpoint(latest_msg.delay_checkpoints, name, value);
-  }
-
-  auto clearDelayCheckpoints() -> void
-  {
-    DelayMonitorWrapper::clearCheckpoints(latest_msg.delay_checkpoints);
-  }
-
-  auto calculateDelayMs(const std::string & start_name, const std::string & end_name) -> double
-  {
-    return DelayMonitorWrapper::calculateDelayMs(
-      latest_msg.delay_checkpoints, start_name, end_name);
-  }
-
-  auto calculateTotalDelayMs(const std::string & end_name) -> double
-  {
-    return DelayMonitorWrapper::calculateTotalDelayMs(latest_msg.delay_checkpoints, end_name);
-  }
-
-  auto getDelayCheckpointsString() -> std::string
-  {
-    return DelayMonitorWrapper::checkpointsToString(latest_msg.delay_checkpoints);
-  }
-
-  auto mergeDelayCheckpoints(const crane_msgs::msg::DelayCheckpoints & source_checkpoints) -> void
-  {
-    DelayMonitorWrapper::mergeCheckpoints(latest_msg.delay_checkpoints, source_checkpoints);
   }
 
   auto setLocalPlannerConfig(const crane_msgs::msg::LocalPlannerConfig & config)
@@ -268,52 +219,6 @@ public:
     latest_msg.local_planner_config = config;
     return *this;
   }
-
-  // ===== 速度計画トレース関連メソッド =====
-
-  /**
-   * @brief 速度計画トレースを有効化（新規トレースを作成）
-   */
-  auto enableVelocityPlanTrace() -> VelocityCommandWrapper &
-  {
-    if (latest_msg.velocity_plan_trace.empty()) {
-      latest_msg.velocity_plan_trace.push_back(VelocityPlanTracker::createTrace());
-    }
-    return *this;
-  }
-
-  /**
-   * @brief 計画点を追加
-   */
-  auto addVelocityPlanPoint(
-    const std::string & source, const Eigen::Vector2d & predicted_pos,
-    const Eigen::Vector2d & predicted_vel, int32_t target_time_us,
-    int32_t estimated_arrival_time_us = 0) -> void
-  {
-    if (!latest_msg.velocity_plan_trace.empty()) {
-      VelocityPlanTracker::addPlanPoint(
-        latest_msg.velocity_plan_trace[0], source, predicted_pos, predicted_vel, target_time_us,
-        estimated_arrival_time_us);
-    }
-  }
-
-  /**
-   * @brief 速度修正を記録
-   */
-  auto addVelocityCorrection(
-    const std::string & source, const Eigen::Vector2d & before_vel,
-    const Eigen::Vector2d & after_vel) -> void
-  {
-    if (!latest_msg.velocity_plan_trace.empty()) {
-      VelocityPlanTracker::addCorrection(
-        latest_msg.velocity_plan_trace[0], source, before_vel, after_vel);
-    }
-  }
-
-  /**
-   * @brief 速度計画トレースが有効かどうかを確認
-   */
-  auto hasVelocityPlanTrace() const -> bool { return !latest_msg.velocity_plan_trace.empty(); }
 
   /**
    * @brief 速度計画トレースをコピー（RobotCommandからRobotCommandへの伝播用）

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/velocity_command_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/velocity_command_wrapper.hpp
@@ -209,14 +209,15 @@ public:
 
   auto addPlanningFactor(const std::string & name, const std::string & state) -> void
   {
-    if (auto planning_factor = ranges::find_if(
-          latest_msg.planning_factors,
-          [name](const auto & planning_factor) { return planning_factor.name == name; });
-        planning_factor == latest_msg.planning_factors.end() || planning_factor->value != state) {
+    auto planning_factor = ranges::find_if(
+      latest_msg.planning_factors, [&name](const auto & pf) { return pf.name == name; });
+    if (planning_factor == latest_msg.planning_factors.end()) {
       crane_msgs::msg::NamedString msg;
       msg.name = name;
       msg.value = state;
       latest_msg.planning_factors.emplace_back(msg);
+    } else if (planning_factor->value != state) {
+      planning_factor->value = state;
     }
   }
 

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/velocity_plan_tracker.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/velocity_plan_tracker.hpp
@@ -10,6 +10,9 @@
 #include <Eigen/Dense>
 #include <crane_msgs/msg/velocity_plan_trace.hpp>
 #include <string>
+#include <vector>
+
+#include "tracker_base.hpp"
 
 namespace crane
 {
@@ -21,14 +24,9 @@ namespace crane
  * 計画された速度と実際の速度を比較・検証できるようにする。
  */
 class VelocityPlanTracker
+: public TrackerBase<VelocityPlanTracker, crane_msgs::msg::VelocityPlanTrace>
 {
 public:
-  /**
-   * @brief 新しいトレースを作成
-   * @return 初期化されたVelocityPlanTrace
-   */
-  static auto createTrace() -> crane_msgs::msg::VelocityPlanTrace;
-
   /**
    * @brief 計画点を追加
    * @param trace トレースデータ
@@ -68,11 +66,55 @@ public:
     const Eigen::Vector2d & actual_vel);
 
 private:
-  // トレースID生成用のカウンター
-  static uint32_t trace_id_counter_;
-
   // リングバッファの最大サイズ
   static constexpr size_t MAX_ACTUALS = 10;
+};
+
+/**
+ * @brief 速度計画トレース関連メソッドを提供する CRTP ミックスイン
+ * @tparam Derived 派生クラス
+ *
+ * 派生クラスは以下のメソッドを提供する必要がある（friend宣言推奨）:
+ *   std::vector<crane_msgs::msg::VelocityPlanTrace> & getVelocityPlanTrace()
+ *   const std::vector<crane_msgs::msg::VelocityPlanTrace> & getVelocityPlanTrace() const
+ */
+template <typename Derived>
+class VelocityPlanTraceMixin
+{
+  auto & trace() { return static_cast<Derived &>(*this).getVelocityPlanTrace(); }
+  const auto & trace() const { return static_cast<const Derived &>(*this).getVelocityPlanTrace(); }
+
+public:
+  auto enableVelocityPlanTrace() -> Derived &
+  {
+    if (trace().empty()) {
+      trace().push_back(VelocityPlanTracker::createTrace());
+    }
+    return static_cast<Derived &>(*this);
+  }
+
+  auto addVelocityPlanPoint(
+    const std::string & source, const Eigen::Vector2d & predicted_pos,
+    const Eigen::Vector2d & predicted_vel, int32_t target_time_us,
+    int32_t estimated_arrival_time_us = 0) -> void
+  {
+    if (!trace().empty()) {
+      VelocityPlanTracker::addPlanPoint(
+        trace()[0], source, predicted_pos, predicted_vel, target_time_us,
+        estimated_arrival_time_us);
+    }
+  }
+
+  auto addVelocityCorrection(
+    const std::string & source, const Eigen::Vector2d & before_vel,
+    const Eigen::Vector2d & after_vel) -> void
+  {
+    if (!trace().empty()) {
+      VelocityPlanTracker::addCorrection(trace()[0], source, before_vel, after_vel);
+    }
+  }
+
+  auto hasVelocityPlanTrace() const -> bool { return !trace().empty(); }
 };
 
 }  // namespace crane

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
@@ -40,7 +40,7 @@ struct BallOwnerScore
   double min_slack = 100.;
   double min_slack_pos_distance = 100.;
   double max_slack = -100.;
-  double score;
+  double score = 0.0;
 };
 
 struct TeamInfo

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
@@ -65,8 +65,9 @@ struct TeamInfo
   [[nodiscard]] auto robotsWhere() const -> RobotsQuery { return RobotsQuery(robots, goalie_id); }
 };
 
-struct WorldModelWrapper
+struct WorldModelWrapper : public DelayMonitorMixin<WorldModelWrapper>
 {
+  friend class DelayMonitorMixin<WorldModelWrapper>;
   using SharedPtr = std::shared_ptr<WorldModelWrapper>;
 
   using UniquePtr = std::unique_ptr<WorldModelWrapper>;
@@ -319,37 +320,11 @@ public:
 
   PointChecker point_checker;
 
-  // ===== 遅延監視関連メソッド =====
+  // ===== 遅延監視関連メソッド（DelayMonitorMixin経由） =====
 
-  auto addDelayCheckpoint(const std::string & name, const std::string & value = "") -> void
+  auto getDelayCheckpoints() -> crane_msgs::msg::DelayCheckpoints &
   {
-    DelayMonitorWrapper::addDelayCheckpoint(latest_msg.delay_checkpoints, name, value);
-  }
-
-  auto clearDelayCheckpoints() -> void
-  {
-    DelayMonitorWrapper::clearCheckpoints(latest_msg.delay_checkpoints);
-  }
-
-  auto calculateDelayMs(const std::string & start_name, const std::string & end_name) -> double
-  {
-    return DelayMonitorWrapper::calculateDelayMs(
-      latest_msg.delay_checkpoints, start_name, end_name);
-  }
-
-  auto calculateTotalDelayMs(const std::string & end_name) -> double
-  {
-    return DelayMonitorWrapper::calculateTotalDelayMs(latest_msg.delay_checkpoints, end_name);
-  }
-
-  auto getDelayCheckpointsString() -> std::string
-  {
-    return DelayMonitorWrapper::checkpointsToString(latest_msg.delay_checkpoints);
-  }
-
-  auto mergeDelayCheckpoints(const crane_msgs::msg::DelayCheckpoints & source_checkpoints) -> void
-  {
-    DelayMonitorWrapper::mergeCheckpoints(latest_msg.delay_checkpoints, source_checkpoints);
+    return latest_msg.delay_checkpoints;
   }
 
   [[nodiscard]] auto getDelayCheckpoints() const -> const crane_msgs::msg::DelayCheckpoints &

--- a/utility/crane_msg_wrappers/src/ball_prediction_tracker.cpp
+++ b/utility/crane_msg_wrappers/src/ball_prediction_tracker.cpp
@@ -6,29 +6,10 @@
 
 #include "crane_msg_wrappers/ball_prediction_tracker.hpp"
 
-#include <chrono>
 #include <cmath>
 
 namespace crane
 {
-
-// トレースID生成用のカウンター初期化
-uint32_t BallPredictionTracker::trace_id_counter_ = 0;
-
-auto BallPredictionTracker::createTrace() -> crane_msgs::msg::BallPredictionTrace
-{
-  crane_msgs::msg::BallPredictionTrace trace;
-
-  // 基準タイムスタンプを設定（現在時刻のナノ秒）
-  auto now = std::chrono::system_clock::now();
-  trace.reference_timestamp_ns =
-    std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
-
-  // トレースIDを割り当て
-  trace.trace_id = ++trace_id_counter_;
-
-  return trace;
-}
 
 void BallPredictionTracker::addPredictionPoint(
   crane_msgs::msg::BallPredictionTrace & trace, const std::string & source,

--- a/utility/crane_msg_wrappers/src/crane_visualizer_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/crane_visualizer_wrapper.cpp
@@ -14,10 +14,9 @@ auto VisualizerMessageBuilder::flush() -> void
     SvgLayerUpdate update_msg;
     update_msg.layer = layer;
     update_msg.operation = operation;
-    update_msg.svg_primitives = message_buffer;
+    update_msg.svg_primitives = std::move(message_buffer);
     update_msg.duration = duration;
     CraneVisualizerBuffer::buffer->message_buffer.updates.push_back(update_msg);
-    message_buffer.clear();
   }
 }
 
@@ -219,14 +218,8 @@ auto VisualizerMessageBuilder::drawFieldRect(
   Point corner1, Point corner2, const std::string & color, double stroke_width) -> void
 {
   Point top_left(std::min(corner1.x(), corner2.x()), std::max(corner1.y(), corner2.y()));
-  Point top_right(std::max(corner1.x(), corner2.x()), std::max(corner1.y(), corner2.y()));
   Point bottom_right(std::max(corner1.x(), corner2.x()), std::min(corner1.y(), corner2.y()));
-  Point bottom_left(std::min(corner1.x(), corner2.x()), std::min(corner1.y(), corner2.y()));
-
-  line().start(top_left).end(top_right).stroke(color).strokeWidth(stroke_width).build();
-  line().start(top_right).end(bottom_right).stroke(color).strokeWidth(stroke_width).build();
-  line().start(bottom_right).end(bottom_left).stroke(color).strokeWidth(stroke_width).build();
-  line().start(bottom_left).end(top_left).stroke(color).strokeWidth(stroke_width).build();
+  rectangle(top_left, bottom_right, color, stroke_width);
 }
 
 auto VisualizerMessageBuilder::drawGoal(

--- a/utility/crane_msg_wrappers/src/kick_prediction_tracker.cpp
+++ b/utility/crane_msg_wrappers/src/kick_prediction_tracker.cpp
@@ -12,24 +12,6 @@
 namespace crane
 {
 
-// トレースID生成用のカウンター初期化
-uint32_t KickPredictionTracker::trace_id_counter_ = 0;
-
-auto KickPredictionTracker::createTrace() -> crane_msgs::msg::KickPredictionTrace
-{
-  crane_msgs::msg::KickPredictionTrace trace;
-
-  // 基準タイムスタンプを設定（現在時刻のナノ秒）
-  auto now = std::chrono::system_clock::now();
-  trace.reference_timestamp_ns =
-    std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
-
-  // トレースIDを割り当て
-  trace.trace_id = ++trace_id_counter_;
-
-  return trace;
-}
-
 void KickPredictionTracker::recordPrediction(
   crane_msgs::msg::KickPredictionTrace & trace, const std::string & source, double kick_power,
   bool is_chip_kick, double predicted_ball_speed, double predicted_stop_distance,

--- a/utility/crane_msg_wrappers/src/play_situation_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/play_situation_wrapper.cpp
@@ -86,7 +86,11 @@ static std::map<int, std::string> situation_command_map = {
   CMD_STRING_MAPPING(crane_msgs::msg::PlaySituation, HALF_TIME),
   CMD_STRING_MAPPING(crane_msgs::msg::PlaySituation, POST_GAME)};
 
-auto getStageText(uint32_t id) -> std::string { return stage_map[id]; }
+auto getStageText(uint32_t id) -> std::string
+{
+  auto it = stage_map.find(id);
+  return it != stage_map.end() ? it->second : "UNKNOWN";
+}
 
 auto getStageNamedInt(uint32_t id) -> crane_msgs::msg::NamedInt
 {
@@ -102,7 +106,11 @@ auto getStageTextList() -> std::vector<std::string>
          ranges::to<std::vector>();
 }
 
-auto getRefereeCommandText(uint32_t id) -> std::string { return referee_command_map[id]; }
+auto getRefereeCommandText(uint32_t id) -> std::string
+{
+  auto it = referee_command_map.find(id);
+  return it != referee_command_map.end() ? it->second : "UNKNOWN";
+}
 
 auto getRefereeCommandNamedInt(uint32_t id) -> crane_msgs::msg::NamedInt
 {
@@ -119,7 +127,11 @@ auto getRefereeCommandTextList() -> std::vector<std::string>
          ranges::to<std::vector>();
 }
 
-auto getSituationCommandText(uint32_t id) -> std::string { return situation_command_map[id]; }
+auto getSituationCommandText(uint32_t id) -> std::string
+{
+  auto it = situation_command_map.find(id);
+  return it != situation_command_map.end() ? it->second : "UNKNOWN";
+}
 
 auto getSituationCommandNamedInt(uint32_t id) -> crane_msgs::msg::NamedInt
 {

--- a/utility/crane_msg_wrappers/src/point_checker.cpp
+++ b/utility/crane_msg_wrappers/src/point_checker.cpp
@@ -6,6 +6,7 @@
 
 #include "crane_msg_wrappers/point_checker.hpp"
 
+#include <cmath>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 
 namespace crane
@@ -129,9 +130,9 @@ auto PointChecker::checkDistance(
   double distance = (p - target).norm();
   switch (rule) {
     case Rule::EQUAL_TO:
-      return distance == threshold;
+      return std::abs(distance - threshold) < 1e-9;
     case Rule::NOT_EQUAL_TO:
-      return distance != threshold;
+      return std::abs(distance - threshold) >= 1e-9;
     case Rule::LESS_THAN:
       return distance < threshold;
     case Rule::GREATER_THAN:

--- a/utility/crane_msg_wrappers/src/robots_query.cpp
+++ b/utility/crane_msg_wrappers/src/robots_query.cpp
@@ -77,14 +77,6 @@ auto RobotsQuery::get() const -> RobotList
          ranges::to<std::vector>();
 }
 
-auto RobotsQuery::getIds() const -> std::vector<uint8_t>
-{
-  auto robots = get();
-  return robots |
-         ranges::views::transform([](const RobotInfo::SharedPtr & robot) { return robot->id; }) |
-         ranges::to<std::vector>();
-}
-
 auto RobotsQuery::getView() const -> decltype(auto)
 {
   return robots_ | ranges::views::filter([this](const RobotInfo::SharedPtr & robot) {
@@ -94,8 +86,23 @@ auto RobotsQuery::getView() const -> decltype(auto)
          });
 }
 
-auto RobotsQuery::count() const -> size_t { return get().size(); }
+auto RobotsQuery::getIds() const -> std::vector<uint8_t>
+{
+  return getView() |
+         ranges::views::transform([](const RobotInfo::SharedPtr & robot) { return robot->id; }) |
+         ranges::to<std::vector>();
+}
 
-auto RobotsQuery::empty() const -> bool { return count() == 0; }
+auto RobotsQuery::count() const -> size_t
+{
+  auto view = getView();
+  return static_cast<size_t>(std::distance(view.begin(), view.end()));
+}
+
+auto RobotsQuery::empty() const -> bool
+{
+  auto view = getView();
+  return view.begin() == view.end();
+}
 
 }  // namespace crane

--- a/utility/crane_msg_wrappers/src/velocity_plan_tracker.cpp
+++ b/utility/crane_msg_wrappers/src/velocity_plan_tracker.cpp
@@ -6,30 +6,11 @@
 
 #include "crane_msg_wrappers/velocity_plan_tracker.hpp"
 
-#include <chrono>
 #include <cmath>
 #include <crane_geometry/geometry_operations.hpp>
 
 namespace crane
 {
-
-// トレースID生成用のカウンター初期化
-uint32_t VelocityPlanTracker::trace_id_counter_ = 0;
-
-auto VelocityPlanTracker::createTrace() -> crane_msgs::msg::VelocityPlanTrace
-{
-  crane_msgs::msg::VelocityPlanTrace trace;
-
-  // 基準タイムスタンプを設定（現在時刻のナノ秒）
-  auto now = std::chrono::system_clock::now();
-  trace.reference_timestamp_ns =
-    std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
-
-  // トレースIDを割り当て
-  trace.trace_id = ++trace_id_counter_;
-
-  return trace;
-}
 
 void VelocityPlanTracker::addPlanPoint(
   crane_msgs::msg::VelocityPlanTrace & trace, const std::string & source,

--- a/utility/crane_msg_wrappers/src/velocity_plan_tracker.cpp
+++ b/utility/crane_msg_wrappers/src/velocity_plan_tracker.cpp
@@ -8,6 +8,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <crane_geometry/geometry_operations.hpp>
 
 namespace crane
 {
@@ -67,11 +68,7 @@ void VelocityPlanTracker::addCorrection(
   // 方向変化を計算（度）
   double before_angle = std::atan2(before_vel.y(), before_vel.x());
   double after_angle = std::atan2(after_vel.y(), after_vel.x());
-  double angle_diff = after_angle - before_angle;
-
-  // -π ~ π の範囲に正規化
-  while (angle_diff > M_PI) angle_diff -= 2.0 * M_PI;
-  while (angle_diff < -M_PI) angle_diff += 2.0 * M_PI;
+  double angle_diff = normalizeAngle(after_angle - before_angle);
 
   correction.direction_delta_deg = static_cast<float>(angle_diff * 180.0 / M_PI);
 

--- a/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <crane_geometry/geometry_operations.hpp>
 #include <crane_physics/travel_time.hpp>
-#include <iostream>
 #include <range/v3/algorithm/max.hpp>
 #include <range/v3/algorithm/min.hpp>
 #include <range/v3/range/conversion.hpp>
@@ -178,7 +177,7 @@ auto WorldModelWrapper::update(const crane_msgs::msg::WorldModel & world_model) 
     }
   }
 
-  for (auto robot : world_model.robot_info_theirs) {
+  for (const auto & robot : world_model.robot_info_theirs) {
     auto & info = theirs_.robots.at(robot.id);
 
     // 敵ロボットはビジョン検出のみで判定（診断情報なし）
@@ -264,6 +263,9 @@ auto WorldModelWrapper::update(const crane_msgs::msg::WorldModel & world_model) 
 auto WorldModelWrapper::generateFieldPoints(float grid_size) const
 {
   std::vector<Point> points;
+  const auto nx = static_cast<size_t>(fieldSize().x() / 2.f / grid_size) + 2;
+  const auto ny = static_cast<size_t>(fieldSize().y() / 2.f / grid_size) + 2;
+  points.reserve(nx * ny);
   for (float x = 0.f; x <= fieldSize().x() / 2.f; x += grid_size) {
     for (float y = 0.f; y <= fieldSize().y() / 2.f; y += grid_size) {
       points.emplace_back(x, y);


### PR DESCRIPTION
## 概要

`crane_msg_wrappers` パッケージのコードレビューで発見されたバグ・重複・効率問題を段階的に修正。

## 変更内容

### Phase 1: バグ修正
- **`addPlanningFactor` ロジックバグ修正** (`robot_command_wrapper.hpp`, `velocity_command_wrapper.hpp`)
  - 同名ファクターが存在して値が異なる場合、新エントリを追加する代わりに既存エントリを更新するよう修正
- **`BallOwnerScore::score` 未初期化修正** (`world_model_wrapper.hpp`)
  - `double score;` → `double score = 0.0;`
- **`operator[]` による未定義キーアクセス修正** (`play_situation_wrapper.cpp`)
  - `stage_map[id]` 等 → `find()` + フォールバック `"UNKNOWN"` に変更

### Phase 2: 低リスク改善
- ループ変数コピー → `const auto &` 参照に修正
- ラムダの文字列コピーキャプチャ → 参照キャプチャに変更（全10箇所）
- `flush()` で `std::move` を使用してバッファコピーを排除
- 角度正規化の `while` ループ → `normalizeAngle()` 既存関数に置換
- `generateFieldPoints` に `reserve()` 追加
- 不要な `<iostream>` インクルード削除

### Phase 3: 中規模リファクタリング
- `RobotsQuery::count()` / `empty()` の効率化（`getView()` を直接使用、中間ベクタ排除）
- `RobotsQuery::getIds()` の中間ベクタ排除
- `drawFieldRect` を既存の `rectangle()` を呼び出す形に簡略化
- 浮動小数点の厳密比較 → イプシロン比較（`1e-9`）に修正

### Phase 4: 大規模リファクタリング（CRTPミックスイン）

#### 新規ファイル
- **`command_wrapper_base.hpp`**: `CommandWrapperBase<Derived>` CRTPベースクラス
  - `getMsg`, `getEditableMsg`, `dribble`, `withDribble`, `stopEmergency`, `addPlanningFactor`, `clearPlanningFactors` を共通化
- **`tracker_base.hpp`**: `TrackerBase<Derived, TraceMsg>` CRTPベースクラス
  - `createTrace()` と `trace_id_counter_` を共通化

#### ミックスインの追加
- **`DelayMonitorMixin<Derived>`** を `delay_monitor_wrapper.hpp` に追加（Phase 4-1）
  - 6つの遅延監視メソッドを CRTP で提供
  - 旧API（`DelayCheckpointArray` ベース）を廃止（Phase 4-4）
- **`VelocityPlanTraceMixin<Derived>`** を `velocity_plan_tracker.hpp` に追加（Phase 4-2）
  - `enableVelocityPlanTrace`, `addVelocityPlanPoint`, `addVelocityCorrection`, `hasVelocityPlanTrace` を提供

#### 既存クラスのリファクタリング
- **`RobotCommandWrapper` / `VelocityCommandWrapper`**（Phase 4-3）
  - `CommandWrapperBase`, `DelayMonitorMixin`, `VelocityPlanTraceMixin` を継承
  - 重複していた全メソッドを削除
- **`WorldModelWrapper`**（Phase 4-1）
  - `DelayMonitorMixin` を継承し、重複していた6メソッドを削除
- **`VelocityPlanTracker` / `BallPredictionTracker` / `KickPredictionTracker`**（Phase 4-5）
  - `TrackerBase` を継承し、`createTrace()` と `trace_id_counter_` の重複定義を削除
- **`InPlaySituationWrapper`**（Phase 4-6）
  - `namespace crane` を追加（名前空間の統一）
