### PR TITLE
refactor: crane_local_plannerのコード品質・再利用性・効率性を改善

### DIFF
--- a/crane_local_planner/include/crane_local_planner/local_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/local_planner.hpp
@@ -25,12 +25,6 @@
 namespace crane
 {
 
-struct Obstacle
-{
-  Point center;
-  float radius;
-};
-
 struct KickPowerCalculator
 {
 private:
@@ -112,11 +106,8 @@ public:
 
     // 練習用モードの設定
     bool half_court_practice_mode = false;
-    bool half_court_is_positive_side = true;  // 使用している半面がポジティブ側かどうか
     declare_parameter("half_court_practice_mode", half_court_practice_mode);
     get_parameter("half_court_practice_mode", half_court_practice_mode);
-    declare_parameter("half_court_is_positive_side", half_court_is_positive_side);
-    get_parameter("half_court_is_positive_side", half_court_is_positive_side);
 
     if (half_court_practice_mode) {
       theta_offset = -M_PI / 2.;
@@ -137,13 +128,6 @@ public:
   auto callbackPositionCommands(const crane_msgs::msg::RobotCommands &) -> void;
 
   auto updateDiagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat) -> void;
-
-protected:
-  static auto resolveMaxAccelerationFactors(
-    crane_msgs::msg::RobotCommand & command, const float default_max_acceleration = 5.0) -> double;
-
-  static auto resolveMaxVelocityFactors(
-    crane_msgs::msg::RobotCommand & command, const float default_max_velocity = 5.0) -> double;
 
 private:
   rclcpp::Subscription<crane_msgs::msg::RobotCommands>::SharedPtr control_targets_sub;
@@ -167,11 +151,6 @@ private:
 
   auto aggregateStates(const std::vector<crane_msgs::msg::NamedString> & planning_factors) const
     -> std::string;
-
-  auto logValidationError(
-    uint8_t robot_id, const std::string & mode_name,
-    const std::vector<crane_msgs::msg::NamedString> & planning_factors,
-    const std::string & error_detail) const -> void;
 };
 
 }  // namespace crane

--- a/crane_local_planner/include/crane_local_planner/planner_base.hpp
+++ b/crane_local_planner/include/crane_local_planner/planner_base.hpp
@@ -40,14 +40,9 @@ public:
     const crane_msgs::msg::RobotCommands & msg, double theta_offset)
     -> crane_msgs::msg::RobotCommands = 0;
 
-  VisualizerMessageBuilder::SharedPtr visualizer;
+  auto getWorldModel() const -> WorldModelWrapper::SharedPtr { return world_model; }
 
-  WorldModelWrapper::SharedPtr world_model;
-
-  // 経路計画用の減速度パラメータ
-  double planning_deceleration_high_speed;
-  double planning_deceleration_low_speed;
-  double planning_deceleration_velocity_threshold;
+  auto getVisualizer() const -> VisualizerMessageBuilder::SharedPtr { return visualizer; }
 
   static auto resolveMaxAccelerationFactors(
     crane_msgs::msg::RobotCommand & command, const float default_max_acceleration) -> double
@@ -76,6 +71,16 @@ public:
     command.local_planner_config.final_planned_max_velocity = minimum_max_velocity_factor;
     return command.local_planner_config.final_planned_max_velocity.value;
   }
+
+protected:
+  VisualizerMessageBuilder::SharedPtr visualizer;
+
+  WorldModelWrapper::SharedPtr world_model;
+
+  // 経路計画用の減速度パラメータ
+  double planning_deceleration_high_speed;
+  double planning_deceleration_low_speed;
+  double planning_deceleration_velocity_threshold;
 };
 }  // namespace crane
 #endif  // CRANE_LOCAL_PLANNER__PLANNER_BASE_HPP_

--- a/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
@@ -22,6 +22,31 @@
 // cspell: ignore OBST
 namespace crane
 {
+
+enum class ZeroVelocityReason {
+  NONE,
+  POSITION_TOLERANCE,
+  DEFAULT_3CM_TOLERANCE,
+  RVO_COLLISION_OR_CONSTRAINT,
+  PREF_VELOCITY_ZERO,
+};
+
+inline auto toString(ZeroVelocityReason reason) -> std::string
+{
+  switch (reason) {
+    case ZeroVelocityReason::POSITION_TOLERANCE:
+      return "POSITION_TOLERANCE";
+    case ZeroVelocityReason::DEFAULT_3CM_TOLERANCE:
+      return "DEFAULT_3CM_TOLERANCE";
+    case ZeroVelocityReason::RVO_COLLISION_OR_CONSTRAINT:
+      return "RVO_COLLISION_OR_CONSTRAINT";
+    case ZeroVelocityReason::PREF_VELOCITY_ZERO:
+      return "PREF_VELOCITY_ZERO";
+    default:
+      return "NONE";
+  }
+}
+
 class RVO2Planner : public LocalPlannerBase
 {
 public:
@@ -72,7 +97,6 @@ private:
   float RVO_MAX_SPEED = 10.0f;
 
   double MAX_VEL = 5.0;
-  double ACCELERATION = 4.0;
   double STOP_STATE_MAX_VELOCITY = 1.0;
   double FIELD_BOUNDARY_OFFSET = 0.2;
   // 加速度は減速度の何倍にするかという係数

--- a/crane_local_planner/src/crane_local_planner.cpp
+++ b/crane_local_planner/src/crane_local_planner.cpp
@@ -17,13 +17,22 @@ auto LocalPlannerComponent::callbackPositionCommands(const crane_msgs::msg::Robo
   if (!planner) {
     return;
   }
-  auto & world_model = planner->world_model;
+  auto world_model = planner->getWorldModel();
   if (!world_model || !world_model->hasUpdated()) {
     return;
   }
 
   dropped_command_count_last_cycle_ = 0;
   planner_exception_count_last_cycle_ = 0;
+
+  auto publishFallback = [&]() {
+    planner_exception_count_last_cycle_++;
+    planner_exception_count_total_++;
+    crane_msgs::msg::RobotCommands fallback_msg;
+    fallback_msg.header.stamp = now();
+    fallback_msg.is_yellow = planner->getWorldModel()->isYellow();
+    commands_pub.publish(fallback_msg);
+  };
 
   try {
     ScopedTimer process_timer(process_time_pub);
@@ -33,22 +42,24 @@ auto LocalPlannerComponent::callbackPositionCommands(const crane_msgs::msg::Robo
     DelayMonitorWrapper::addDelayCheckpoint(
       delay_checkpoints, "local_planner_start", "commands_received");
 
-    // msg.robot_commands内のrobot_idダブリチェック
+    // msg.robot_commands内のrobot_idダブリチェック（インデックスのみソートしてディープコピーを回避）
     {
-      auto duplicate_check_commands = msg.robot_commands;
-      ranges::sort(duplicate_check_commands, [](const auto & a, const auto & b) {
-        return a.robot_id < b.robot_id;
-      });
-      for (size_t i = 1; i < duplicate_check_commands.size(); i++) {
-        if (duplicate_check_commands[i - 1].robot_id == duplicate_check_commands[i].robot_id) {
+      std::vector<std::pair<uint8_t, size_t>> id_pairs;
+      id_pairs.reserve(msg.robot_commands.size());
+      for (size_t i = 0; i < msg.robot_commands.size(); ++i) {
+        id_pairs.emplace_back(msg.robot_commands[i].robot_id, i);
+      }
+      std::sort(id_pairs.begin(), id_pairs.end());
+      for (size_t i = 1; i < id_pairs.size(); i++) {
+        if (id_pairs[i - 1].first == id_pairs[i].first) {
+          const auto & prev = msg.robot_commands[id_pairs[i - 1].second];
+          const auto & curr = msg.robot_commands[id_pairs[i].second];
           RCLCPP_ERROR_STREAM(
-            get_logger(), "ロボット "
-                            << static_cast<int>(duplicate_check_commands[i].robot_id)
-                            << " が重複しています(" << duplicate_check_commands[i].planner_name
-                            << ", " << aggregateStates(duplicate_check_commands[i].planning_factors)
-                            << " と " << duplicate_check_commands[i - 1].planner_name << ", "
-                            << aggregateStates(duplicate_check_commands[i - 1].planning_factors)
-                            << ")");
+            get_logger(), "ロボット " << static_cast<int>(curr.robot_id) << " が重複しています("
+                                      << curr.planner_name << ", "
+                                      << aggregateStates(curr.planning_factors) << " と "
+                                      << prev.planner_name << ", "
+                                      << aggregateStates(prev.planning_factors) << ")");
         }
       }
     }
@@ -86,14 +97,11 @@ auto LocalPlannerComponent::callbackPositionCommands(const crane_msgs::msg::Robo
         const auto target_y = raw_pos_mode.target_y;
 
         // 位置目標の可視化
-        planner->visualizer->drawLine(
+        planner->getVisualizer()->drawLine(
           Point(raw_command.current_pose.x, raw_command.current_pose.y), Point(target_x, target_y),
           "yellow", 20, 0.3);
 
         crane_msgs::msg::RobotCommand command = raw_command;
-        if (command.position_target_mode.empty()) {
-          command.position_target_mode.emplace_back(raw_pos_mode);
-        }
         auto & pos_mode = command.position_target_mode.front();
         pos_mode.target_x = target_x;
         pos_mode.target_y = target_y;
@@ -145,31 +153,19 @@ auto LocalPlannerComponent::callbackPositionCommands(const crane_msgs::msg::Robo
 
     commands_pub.publish(pub_msg);
 
-    planner->visualizer->flush();
+    planner->getVisualizer()->flush();
     crane::CraneVisualizerBuffer::publish();
   } catch (const std::exception & e) {
-    planner_exception_count_last_cycle_++;
-    planner_exception_count_total_++;
     RCLCPP_ERROR_THROTTLE(
       get_logger(), *get_clock(), 1000,
       "Unhandled exception in local_planner callback. Publishing empty /robot_commands: %s",
       e.what());
-
-    crane_msgs::msg::RobotCommands fallback_msg;
-    fallback_msg.header.stamp = now();
-    fallback_msg.is_yellow = world_model->isYellow();
-    commands_pub.publish(fallback_msg);
+    publishFallback();
   } catch (...) {
-    planner_exception_count_last_cycle_++;
-    planner_exception_count_total_++;
     RCLCPP_ERROR_THROTTLE(
       get_logger(), *get_clock(), 1000,
       "Unhandled unknown exception in local_planner callback. Publishing empty /robot_commands");
-
-    crane_msgs::msg::RobotCommands fallback_msg;
-    fallback_msg.header.stamp = now();
-    fallback_msg.is_yellow = world_model->isYellow();
-    commands_pub.publish(fallback_msg);
+    publishFallback();
   }
   // 診断情報を更新
   diagnostic_updater_.force_update();
@@ -184,7 +180,7 @@ auto LocalPlannerComponent::updateDiagnostics(diagnostic_updater::DiagnosticStat
     return;
   }
 
-  auto & world_model = planner->world_model;
+  auto world_model = planner->getWorldModel();
   if (not world_model) {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "ワールドモデルが利用できません");
     return;
@@ -231,16 +227,6 @@ auto LocalPlannerComponent::aggregateStates(
   return ss.str();
 }
 
-auto LocalPlannerComponent::logValidationError(
-  uint8_t robot_id, const std::string & mode_name,
-  const std::vector<crane_msgs::msg::NamedString> & planning_factors,
-  const std::string & error_detail) const -> void
-{
-  RCLCPP_ERROR_STREAM(
-    get_logger(), "ロボット " << static_cast<int>(robot_id) << " は \""
-                              << aggregateStates(planning_factors) << "\" スキルにより "
-                              << mode_name << " に指定されていますが、" << error_detail);
-}
 }  // namespace crane
 
 #include <rclcpp_components/register_node_macro.hpp>

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <boost/stacktrace.hpp>
 #include <crane_local_planner/visualization_helpers.hpp>
-#include <iomanip>
+#include <crane_msg_wrappers/command_wrapper_base.hpp>
 #include <range/v3/algorithm/find_if.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <robocup_ssl_msgs/msg/referee.hpp>
@@ -22,30 +22,6 @@ namespace crane
 {
 namespace
 {
-auto formatPlanningDouble(double value, int precision = 3) -> std::string
-{
-  std::ostringstream oss;
-  oss << std::fixed << std::setprecision(precision) << value;
-  return oss.str();
-}
-
-template <typename CommandT>
-auto addOrUpdatePlanningFactor(
-  CommandT & command, const std::string & name, const std::string & value) -> void
-{
-  auto it = std::find_if(
-    command.planning_factors.begin(), command.planning_factors.end(),
-    [&](const auto & factor) { return factor.name == name; });
-  if (it == command.planning_factors.end()) {
-    crane_msgs::msg::NamedString factor;
-    factor.name = name;
-    factor.value = value;
-    command.planning_factors.emplace_back(factor);
-  } else {
-    it->value = value;
-  }
-}
-
 auto pointChanged(const Point & before, const Point & after, double epsilon = 1e-4) -> bool
 {
   return (before - after).norm() > epsilon;
@@ -100,9 +76,8 @@ RVO2Planner::RVO2Planner(rclcpp::Node & node)
 
 auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> void
 {
-  if (
-    world_model->getMsg().play_situation.referee_raw.command.value ==
-    robocup_ssl_msgs::msg::RefereeCommand::STOP) {
+  const auto referee_command = world_model->getMsg().play_situation.referee_raw.command.value;
+  if (referee_command == robocup_ssl_msgs::msg::RefereeCommand::STOP) {
     for (int i = 0; i < 40; i++) {
       rvo_sim->setAgentMaxSpeed(i, STOP_STATE_MAX_VELOCITY);
     }
@@ -159,8 +134,7 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
         return std::hypot(
                  it->position_target_mode.front().target_x - current_position.x(),
                  it->position_target_mode.front().target_y - current_position.y()) > 0.01
-                 ? static_cast<double>(
-                     std::hypot(command.current_velocity.x, command.current_velocity.y))
+                 ? vel
                  : 0.0;
       } else {
         return 0.0;
@@ -186,9 +160,7 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
       crane_msgs::msg::NamedFloat()
         .set__name("RVO2Planner::max_vel from parameter")
         .set__value(MAX_VEL));
-    if (
-      world_model->getMsg().play_situation.referee_raw.command.value ==
-      robocup_ssl_msgs::msg::RefereeCommand::STOP) {
+    if (referee_command == robocup_ssl_msgs::msg::RefereeCommand::STOP) {
       command.local_planner_config.max_velocity_factors.emplace_back(
         crane_msgs::msg::NamedFloat()
           .set__name("RVO2Planner STOP制限")
@@ -315,23 +287,24 @@ auto RVO2Planner::extractVelocityCommandsFromRVOSim(
     addOrUpdatePlanningFactor(command, "RVO2DistanceToTarget", formatPlanningDouble(distance));
     addOrUpdatePlanningFactor(
       command, "RVO2PositionTolerance", formatPlanningDouble(original_pos_mode.position_tolerance));
-    std::string zero_velocity_reason = "NONE";
+    ZeroVelocityReason zero_velocity_reason = ZeroVelocityReason::NONE;
     if (distance < original_pos_mode.position_tolerance) {
       vel = Velocity::Zero();
-      zero_velocity_reason = "POSITION_TOLERANCE";
+      zero_velocity_reason = ZeroVelocityReason::POSITION_TOLERANCE;
     } else if (
       original_command.local_planner_config.terminal_velocity == 0. &&
       original_pos_mode.position_tolerance == 0. && distance < 0.03) {
       // terminal_velocityが0のときはデフォルトで3cmのトレランス
       vel = Velocity::Zero();
-      zero_velocity_reason = "DEFAULT_3CM_TOLERANCE";
+      zero_velocity_reason = ZeroVelocityReason::DEFAULT_3CM_TOLERANCE;
     }
-    if (zero_velocity_reason == "NONE" && vel.norm() < 1e-4) {
-      zero_velocity_reason =
-        (pref_vel.norm() > 1e-3) ? "RVO_COLLISION_OR_CONSTRAINT" : "PREF_VELOCITY_ZERO";
+    if (zero_velocity_reason == ZeroVelocityReason::NONE && vel.norm() < 1e-4) {
+      zero_velocity_reason = (pref_vel.norm() > 1e-3)
+                               ? ZeroVelocityReason::RVO_COLLISION_OR_CONSTRAINT
+                               : ZeroVelocityReason::PREF_VELOCITY_ZERO;
     }
     addOrUpdatePlanningFactor(command, "RVO2OutputSpeed", formatPlanningDouble(vel.norm()));
-    addOrUpdatePlanningFactor(command, "RVO2ZeroVelocityReason", zero_velocity_reason);
+    addOrUpdatePlanningFactor(command, "RVO2ZeroVelocityReason", toString(zero_velocity_reason));
 
     // 座標系の設計について：
     // - target_velocity_thetaはtheta_offsetを含む（half_court_practice_mode対応）
@@ -376,9 +349,8 @@ auto RVO2Planner::calculateRobotCommand(
   const crane_msgs::msg::RobotCommands & msg, double theta_offset) -> crane_msgs::msg::RobotCommands
 {
   crane_msgs::msg::RobotCommands commands = msg;
-  if (
-    world_model->getMsg().play_situation.referee_raw.command.value !=
-    robocup_ssl_msgs::msg::RefereeCommand::HALT) {
+  const auto referee_command = world_model->getMsg().play_situation.referee_raw.command.value;
+  if (referee_command != robocup_ssl_msgs::msg::RefereeCommand::HALT) {
     overrideTargetPosition(commands);
   }
   reflectWorldToRVOSim(commands);
@@ -520,13 +492,16 @@ auto RVO2Planner::adjustForPenaltyAreaAvoidance(
     constexpr double PENALTY_AREA_OFFSET = 0.1;
 
     auto avoidPenaltyArea = [&](const Box & penalty_area, const Point & goal_pos) {
+      constexpr int MAX_ITERATIONS = 100;
       if (isInBox(penalty_area, current_pos, PENALTY_AREA_OFFSET)) {
         if (std::abs(current_pos.x()) > world_model->fieldSize().x() / 2.0) {
           target_pos.x() = std::copysign(world_model->fieldSize().x() / 2.0, target_pos.x());
         }
-        // 目標点をペナルティエリアの外に出るようにする (二番目の条件は無限ループ防止)
-        while (isInBox(penalty_area, target_pos, PENALTY_AREA_OFFSET) and
-               target_pos != current_pos) {
+        // 目標点をペナルティエリアの外に出るようにする (反復上限で無限ループ防止)
+        for (int iter = 0;
+             iter < MAX_ITERATIONS && isInBox(penalty_area, target_pos, PENALTY_AREA_OFFSET) &&
+             target_pos != current_pos;
+             ++iter) {
           target_pos += (target_pos - current_pos).normalized() * 0.05;  // 5cmずつ離れていく
         }
       } else if (isInBox(penalty_area, target_pos, PENALTY_AREA_OFFSET)) {
@@ -535,7 +510,10 @@ auto RVO2Planner::adjustForPenaltyAreaAvoidance(
           target_pos.x() = std::copysign(world_model->fieldSize().x() / 2.0, target_pos.x());
         }
         // 目標点をペナルティエリアの外に出るようにする
-        while (isInBox(penalty_area, target_pos, PENALTY_AREA_OFFSET) and target_pos != goal_pos) {
+        for (int iter = 0;
+             iter < MAX_ITERATIONS && isInBox(penalty_area, target_pos, PENALTY_AREA_OFFSET) &&
+             target_pos != goal_pos;
+             ++iter) {
           target_pos += (target_pos - goal_pos).normalized() * 0.05;
         }
       }

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/command_wrapper_base.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/command_wrapper_base.hpp
@@ -9,10 +9,41 @@
 
 #include <algorithm>
 #include <crane_msgs/msg/robot_command.hpp>
+#include <cstdio>
 #include <string>
 
 namespace crane
 {
+
+/**
+ * @brief planning_factors の文字列フォーマット（snprintf ベース）
+ */
+inline auto formatPlanningDouble(double value, int precision = 3) -> std::string
+{
+  char buf[32];
+  std::snprintf(buf, sizeof(buf), "%.*f", precision, value);
+  return std::string(buf);
+}
+
+/**
+ * @brief raw RobotCommand の planning_factors を追加または更新するフリー関数
+ */
+inline auto addOrUpdatePlanningFactor(
+  crane_msgs::msg::RobotCommand & command, const std::string & name, const std::string & value)
+  -> void
+{
+  auto it = std::find_if(
+    command.planning_factors.begin(), command.planning_factors.end(),
+    [&name](const auto & factor) { return factor.name == name; });
+  if (it == command.planning_factors.end()) {
+    crane_msgs::msg::NamedString factor;
+    factor.name = name;
+    factor.value = value;
+    command.planning_factors.emplace_back(factor);
+  } else if (it->value != value) {
+    it->value = value;
+  }
+}
 
 /**
  * @brief RobotCommandWrapper と VelocityCommandWrapper の共通メソッドを提供する CRTP 基底クラス
@@ -54,17 +85,7 @@ public:
 
   auto addPlanningFactor(const std::string & name, const std::string & state) -> void
   {
-    auto it = std::find_if(
-      msg().planning_factors.begin(), msg().planning_factors.end(),
-      [&name](const auto & pf) { return pf.name == name; });
-    if (it == msg().planning_factors.end()) {
-      crane_msgs::msg::NamedString ns;
-      ns.name = name;
-      ns.value = state;
-      msg().planning_factors.emplace_back(ns);
-    } else if (it->value != state) {
-      it->value = state;
-    }
+    addOrUpdatePlanningFactor(msg(), name, state);
   }
 
   auto clearPlanningFactors() -> void { msg().planning_factors.clear(); }


### PR DESCRIPTION
## 概要

`crane_local_planner` パッケージのコード品質・再利用性・効率性を改善するリファクタリング。行動変更を伴わない純粋な品質改善です。

## 変更内容

### デッドコード削除
- 未使用の `Obstacle` 構造体を削除 (`local_planner.hpp`)
- 未使用の `logValidationError` メソッドを削除
- `LocalPlannerComponent` の重複宣言 `resolveMaxAccelerationFactors`/`resolveMaxVelocityFactors` を削除（実装は `planner_base.hpp` にのみ存在）
- 未使用の `ACCELERATION` メンバ変数を削除 (`rvo2_planner.hpp`)
- 到達不能な `position_target_mode.empty()` チェックを削除
- 読み込むが使用しない `half_court_is_positive_side` パラメータを削除

### アクセス制御改善
- `visualizer`・`world_model`・減速度パラメータを `LocalPlannerBase` で `public` → `protected` に変更
- `getWorldModel()`・`getVisualizer()` の public アクセサを追加

### コード重複解消
- catch ブロックの重複フォールバック処理を `publishFallback` ラムダに共通化

### `addOrUpdatePlanningFactor` / `formatPlanningDouble` 共通化
- `command_wrapper_base.hpp` にフリー関数 `addOrUpdatePlanningFactor` と `formatPlanningDouble` を追加
- `rvo2_planner.cpp` のローカル実装を削除して共通版を使用
- `CommandWrapperBase::addPlanningFactor` の内部実装もフリー関数経由に統一
- `formatPlanningDouble` を `ostringstream` から `snprintf` ベースに変更（効率化）

### 効率改善
- `duplicate_check_commands` で `RobotCommand` 全体のディープコピーを回避し `(robot_id, index)` ペアのみソート
- `std::hypot(current_velocity)` の重複計算を `vel` 変数で再利用
- referee command value をローカル変数に1回キャッシュして `getMsg()` 呼び出しを削減

### 安全性改善
- `adjustForPenaltyAreaAvoidance` の `while` ループを `for` ループに変更し反復上限 (`MAX_ITERATIONS=100`) を追加

### stringly-typed 解消
- `zero_velocity_reason` 文字列リテラルを `enum class ZeroVelocityReason` + `toString()` に変更

## 影響ファイル
- `crane_local_planner/include/crane_local_planner/local_planner.hpp`
- `crane_local_planner/include/crane_local_planner/planner_base.hpp`
- `crane_local_planner/include/crane_local_planner/rvo2_planner.hpp`
- `crane_local_planner/src/crane_local_planner.cpp`
- `crane_local_planner/src/rvo2_planner.cpp`
- `utility/crane_msg_wrappers/include/crane_msg_wrappers/command_wrapper_base.hpp`

## 検証
- `colcon build --packages-select crane_msg_wrappers crane_local_planner` でビルド成功を確認済み
- 行動変更なし（デッドコード削除・効率改善・型安全性向上のみ）

🤖 Generated with [Claude Code](https://claude.ai/code)