### PR TITLE
refactor: crane_world_model_publisherのコード品質・効率性を改善

### DIFF
--- a/crane_world_model_publisher/include/crane_world_model_publisher/visualization_manager.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/visualization_manager.hpp
@@ -46,17 +46,11 @@ public:
     const std::string & command_text) -> void;
   auto drawBallPlacement(const WorldModelWrapper::SharedPtr & world_model) -> void;
 
-  // 軌跡履歴データ構造
-  struct TrajectoryHistoryData
-  {
-    std::array<std::deque<crane_msgs::msg::RobotInfo>, 20> friend_history;
-    std::array<std::deque<crane_msgs::msg::RobotInfo>, 20> enemy_history;
-    std::deque<crane_msgs::msg::BallInfo> ball_info_history;
-    bool is_yellow;
-  };
-
   // 軌跡履歴可視化
-  auto drawTrajectoryHistory(const TrajectoryHistoryData & trajectory_data) -> void;
+  auto drawTrajectoryHistory(
+    const std::array<std::deque<crane_msgs::msg::RobotInfo>, 20> & friend_history,
+    const std::array<std::deque<crane_msgs::msg::RobotInfo>, 20> & enemy_history,
+    const std::deque<crane_msgs::msg::BallInfo> & ball_info_history) -> void;
 
   // 各用途別の専用Builder
   crane::VisualizerMessageBuilder::SharedPtr geometry_builder;

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -229,19 +229,6 @@ private:
 
   rclcpp::Time last_ball_detect_time;
 
-  struct BallAnalysis
-  {
-    bool is_our_ball;
-
-    bool is_their_ball;
-
-    bool ball_event_detected;
-
-    enum class BallEvent { NONE, OUR_BALL, THEIR_BALL };
-
-    BallEvent last_ball_event;
-  };
-
   rclcpp::Subscription<crane_msgs::msg::PlaySituation>::SharedPtr sub_play_situation;
 
   crane_msgs::msg::PlaySituation latest_play_situation;

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_publisher.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_publisher.hpp
@@ -57,15 +57,9 @@ extern "C" {
 #include <memory>
 #include <mutex>
 #include <rclcpp/rclcpp.hpp>
-#include <std_msgs/msg/float32.hpp>
 
 namespace crane
 {
-enum class Color : uint8_t {
-  BLUE,
-  YELLOW,
-};
-
 class WorldModelDataProvider;
 class VisualizationManager;
 class WorldModelWrapper;
@@ -95,13 +89,9 @@ private:
 
   std::unique_ptr<WorldModelDataProvider> data_provider_;
 
-  static constexpr float DISAPPEARED_TIME_THRESH = 3.0f;
-
   diagnostic_updater::Updater diagnostic_updater_;
 
   DiagnosedPublisher<crane_msgs::msg::WorldModel> pub_world_model;
-
-  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pub_process_time;
 
   rclcpp::TimerBase::SharedPtr timer;
 
@@ -114,12 +104,6 @@ private:
   std::deque<crane_msgs::msg::BallInfo> ball_info_history;
 
   int history_size{};
-
-  enum class BallEvent {
-    NONE,
-    OUR_BALL,
-    THEIR_BALL,
-  } last_ball_event = BallEvent::NONE;
 
   WorldModelWrapperPtr wrapper_;
   rclcpp::Subscription<crane_msgs::msg::GameAnalysis>::SharedPtr sub_game_analysis_;

--- a/crane_world_model_publisher/src/visualization_manager.cpp
+++ b/crane_world_model_publisher/src/visualization_manager.cpp
@@ -27,88 +27,6 @@ inline std::string speedToColor(double s)
 namespace crane
 {
 
-struct SvgRobotBuilder
-{
-  SvgRobotBuilder() : corner_angle(std::acos(center_to_dribbler / radius)) {}
-
-  std::string getSvgString() const
-  {
-    std::ostringstream path;
-    path << "<path d=\"";
-    path << "M " << (robot_position.x() + botRightX(theta)) * 1000. << " "
-         << (robot_position.y() + botRightY(theta)) * -1000.;
-    path << " A " << radius * 1000. << " " << radius * 1000. << " 0 1 0 "
-         << (robot_position.x() + botLeftX(theta)) * 1000. << " "
-         << (robot_position.y() + botLeftY(theta)) * -1000.;
-    path << " Z";
-    path << "\" fill=\"" << fill_color << "\" fill-opacity=\"" << fill_opacity;
-    path << "\" stroke=\"" << stroke_color << "\" stroke-opacity=\"" << stroke_opacity;
-    path << "\" stroke-width=\"" << stroke_width << "\"/>";
-    return path.str();
-  }
-
-  SvgRobotBuilder & position(Point p, double theta)
-  {
-    this->robot_position = p;
-    this->theta = theta;
-    return *this;
-  }
-
-  SvgRobotBuilder & position(double x, double y, double theta)
-  {
-    return position(Point(x, y), theta);
-  }
-
-  SvgRobotBuilder & fill(const std::string & color, double opacity = 1.0)
-  {
-    fill_color = color;
-    fill_opacity = opacity;
-    return *this;
-  }
-
-  SvgRobotBuilder & stroke(const std::string & color, double opacity = 1.0)
-  {
-    stroke_color = color;
-    stroke_opacity = opacity;
-    return *this;
-  }
-
-  SvgRobotBuilder & strokeWidth(double width)
-  {
-    stroke_width = width;
-    return *this;
-  }
-
-private:
-  Point robot_position;
-  double theta = 0.0;
-  std::string fill_color = "none";
-  double fill_opacity = 1.0;
-  std::string stroke_color = "black";
-  double stroke_opacity = 1.0;
-  double stroke_width = 1.0;
-
-  double botRightX(double orientation) const
-  {
-    return radius * std::cos(orientation + corner_angle);
-  }
-  double botRightY(double orientation) const
-  {
-    return radius * std::sin(orientation + corner_angle);
-  }
-  double botLeftX(double orientation) const
-  {
-    return radius * std::cos(orientation - corner_angle);
-  }
-  double botLeftY(double orientation) const
-  {
-    return radius * std::sin(orientation - corner_angle);
-  }
-  const double radius = 0.085;
-  const double center_to_dribbler = 0.055;
-  const double corner_angle;
-};
-
 VisualizationManager::VisualizationManager(rclcpp::Node & node) : node_(node)
 {
   geometry_builder = std::make_shared<crane::VisualizerMessageBuilder>("world_model/geometry");
@@ -367,8 +285,10 @@ auto VisualizationManager::drawBallPlacement(const WorldModelWrapper::SharedPtr 
   }
 }
 
-auto VisualizationManager::drawTrajectoryHistory(const TrajectoryHistoryData & trajectory_data)
-  -> void
+auto VisualizationManager::drawTrajectoryHistory(
+  const std::array<std::deque<crane_msgs::msg::RobotInfo>, 20> & friend_history,
+  const std::array<std::deque<crane_msgs::msg::RobotInfo>, 20> & enemy_history,
+  const std::deque<crane_msgs::msg::BallInfo> & ball_info_history) -> void
 {
   static constexpr int SAMPLING_NUM = 4;
 
@@ -397,29 +317,26 @@ auto VisualizationManager::drawTrajectoryHistory(const TrajectoryHistoryData & t
   };
 
   // 味方・敵の履歴描画（共通処理）
-  draw_team_history(trajectory_data.friend_history, "green");
-  draw_team_history(trajectory_data.enemy_history, "red");
+  draw_team_history(friend_history, "green");
+  draw_team_history(enemy_history, "red");
 
   // ボール軌跡描画
-  if (trajectory_data.ball_info_history.size() > SAMPLING_NUM + 1) {
+  if (ball_info_history.size() > SAMPLING_NUM + 1) {
     for (int i = 0; i < 10; i++) {
-      int start = static_cast<int>((trajectory_data.ball_info_history.size() / 10.) * i);
-      int end = static_cast<int>((trajectory_data.ball_info_history.size() / 10.) * (i + 1));
+      int start = static_cast<int>((ball_info_history.size() / 10.) * i);
+      int end = static_cast<int>((ball_info_history.size() / 10.) * (i + 1));
 
       std::vector<Point> points;
       for (int index = start; index < end; index += SAMPLING_NUM) {
         points.emplace_back(
-          trajectory_data.ball_info_history.at(index).position.x,
-          trajectory_data.ball_info_history.at(index).position.y);
+          ball_info_history.at(index).position.x, ball_info_history.at(index).position.y);
       }
       if (i != 9) {
         points.emplace_back(
-          trajectory_data.ball_info_history.at(end).position.x,
-          trajectory_data.ball_info_history.at(end).position.y);
+          ball_info_history.at(end).position.x, ball_info_history.at(end).position.y);
       }
       trajectory_builder->drawPolyline(
-        points, "orange", start / static_cast<double>(trajectory_data.ball_info_history.size()),
-        30);
+        points, "orange", start / static_cast<double>(ball_info_history.size()), 30);
     }
   }
 

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -163,10 +163,8 @@ WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
     [this](const crane_msgs::msg::PlaySituation msg) { latest_play_situation = msg; });
 
   sub_robot_feedback = node.create_subscription<crane_msgs::msg::RobotFeedbackArray>(
-    "/robot_feedback", 1, [this](const crane_msgs::msg::RobotFeedbackArray::SharedPtr msg) {
-      robot_feedback = *msg;
-      auto now = rclcpp::Clock(RCL_ROS_TIME).now();
-    });
+    "/robot_feedback", 1,
+    [this](const crane_msgs::msg::RobotFeedbackArray::SharedPtr msg) { robot_feedback = *msg; });
 
   node.declare_parameter("team_name", "ibis-ssl");
   game_data.team_name = node.get_parameter("team_name").as_string();
@@ -304,13 +302,6 @@ auto WorldModelDataProvider::on_udp_timer() -> void
     }
   }
 
-  // デバッグ用ログ出力（5秒間隔）
-  static rclcpp::Time last_debug_log = node.get_clock()->now();
-  auto now = node.get_clock()->now();
-  if ((now - last_debug_log).seconds() > 5.0) {
-    last_debug_log = now;
-  }
-
   // 設定ファイルで初期化済みでも、Vision geometry受信後の更新を反映するため毎周期評価する
   updateGeometryIfNeeded();
 }
@@ -444,9 +435,9 @@ crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
     }
 
     if (team_idx == 0) {
-      team_0_robots = vision_robots;
+      team_0_robots = std::move(vision_robots);
     } else {
-      team_1_robots = vision_robots;
+      team_1_robots = std::move(vision_robots);
     }
   }
 

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -4,14 +4,12 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#include <crane_geometry/ddps.hpp>
 #include <crane_msg_wrappers/crane_visualizer_wrapper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 #include <crane_world_model_publisher/visualization_manager.hpp>
 #include <crane_world_model_publisher/world_model_data_provider.hpp>
 #include <crane_world_model_publisher/world_model_publisher.hpp>
 #include <deque>
-#include <robocup_ssl_msgs/msg/robot_id.hpp>
 #include <robocup_ssl_msgs/msg/ssl_detection_frame.hpp>
 #include <sstream>
 
@@ -69,8 +67,6 @@ WorldModelPublisherComponent::WorldModelPublisherComponent(const rclcpp::NodeOpt
       std::scoped_lock lock(latest_game_analysis_msg_mutex_);
       latest_game_analysis_msg_ = *msg;
     });
-
-  pub_process_time = create_publisher<std_msgs::msg::Float32>("~/process_time", 10);
 
   // 自動/world_modelサブスクライブはOFF
   wrapper_ = std::make_shared<WorldModelWrapper>(*this, false);
@@ -189,14 +185,8 @@ auto WorldModelPublisherComponent::publishVisualization(WorldModelWrapperPtr wor
   // VisualizationManagerによる統合可視化処理
   visualization_manager_->drawTrackedObjects(world_model);
 
-  // 軌跡履歴データをVisualizationManagerに渡す
-  VisualizationManager::TrajectoryHistoryData trajectory_data;
-  trajectory_data.friend_history = friend_history;
-  trajectory_data.enemy_history = enemy_history;
-  trajectory_data.ball_info_history = ball_info_history;
-  trajectory_data.is_yellow = world_model->isYellow();
-
-  visualization_manager_->drawTrajectoryHistory(trajectory_data);
+  // 軌跡履歴データをVisualizationManagerに渡す（コピーなし）
+  visualization_manager_->drawTrajectoryHistory(friend_history, enemy_history, ball_info_history);
 
   visualization_manager_->drawBallPlacement(world_model);
 


### PR DESCRIPTION
## 概要

`crane_world_model_publisher` パッケージのコードレビューで発見された、効率性・品質の問題を修正。

## 変更内容

### 効率化

- **60Hz軌跡履歴コピーの排除**: `drawTrajectoryHistory()` の引数を `TrajectoryHistoryData` 構造体（値コピー）から3つの `const &` 引数に変更
  - `std::array<std::deque<RobotInfo>, 20>` × 2 + `std::deque<BallInfo>` の毎フレームコピーが不要に
  - `TrajectoryHistoryData` 構造体自体も廃止
- **ベクターコピーの排除**: `getMsg()` 内の `vision_robots` 代入を `std::move` に変更

### 未使用コードの削除

| 削除対象 | ファイル | 備考 |
|----------|----------|------|
| `enum class Color : uint8_t` | `world_model_publisher.hpp` | どこからも参照なし |
| `DISAPPEARED_TIME_THRESH` | `world_model_publisher.hpp` | 未使用定数 |
| `pub_process_time` パブリッシャー | `world_model_publisher.hpp/.cpp` | 一度もpublishされない |
| `BallEvent` enum・`last_ball_event` | `world_model_publisher.hpp` | 宣言のみで未使用 |
| `BallAnalysis` 構造体 | `world_model_data_provider.hpp` | 定義のみで未使用 |
| `SvgRobotBuilder` 構造体 | `visualization_manager.cpp` | 定義のみで未使用（80行） |
| 未使用ローカル変数 `now` | `world_model_data_provider.cpp` | robot_feedbackコールバック内 |
| 空デバッグログブロック | `world_model_data_provider.cpp` | 5秒間隔判定の中身が空 |
| `#include <crane_geometry/ddps.hpp>` | `world_model_publisher.cpp` | 未使用 |
| `#include <robocup_ssl_msgs/msg/robot_id.hpp>` | `world_model_publisher.cpp` | 未使用 |

## テスト

- [x] `colcon build --packages-select crane_world_model_publisher` でビルド成功
- [x] pre-commitフック（clang-format、cpplint）が全てPassed