### PR TITLE
refactor: crane_game_analyzer + crane_msg_wrappersのコード品質・効率性・再利用性を改善

### DIFF
--- a/crane_game_analyzer/include/crane_game_analyzer/game_analyzer.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/game_analyzer.hpp
@@ -90,18 +90,17 @@ private:
     BallPositionStamped record;
     record.position = world_model->ball().pos;
     record.stamp = now();
-    static std::deque<BallPositionStamped> ball_records;
-    ball_records.push_front(record);
+    ball_records_.push_front(record);
 
-    auto latest_time = ball_records.front().stamp;
-    auto latest_position = ball_records.front().position;
+    auto latest_time = ball_records_.front().stamp;
+    auto latest_position = ball_records_.front().position;
     // 一定時間以上前の履歴を削除
-    std::erase_if(ball_records, [&](auto & ball_record) {
+    std::erase_if(ball_records_, [&](auto & ball_record) {
       return (latest_time - ball_record.stamp) > config.ball_idle.threshold_duration * 2;
     });
 
     // ボール履歴（新しいほど，indexが若い）のチェックして，ボールがストップしているかを確認
-    return not std::ranges::any_of(ball_records, [&](const auto & ball_record) {
+    return not std::ranges::any_of(ball_records_, [&](const auto & ball_record) {
       bool distance_cond = (latest_position - ball_record.position).norm() <
                            config.ball_idle.move_distance_threshold_meter;
       bool time_cond = (latest_time - ball_record.stamp) < config.ball_idle.threshold_duration;
@@ -242,6 +241,9 @@ private:
   GameAnalyzerConfig config;
 
   VisualizerMessageBuilder::SharedPtr visualizer;
+
+  // ボール位置の履歴
+  std::deque<BallPositionStamped> ball_records_;
 
   // ロボット位置の履歴
   std::deque<RobotPositionStamped> robot_records_;

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
@@ -7,6 +7,7 @@
 #ifndef CRANE_GAME_ANALYZER__METRICS__ATTACKER_METRICS_HPP_
 #define CRANE_GAME_ANALYZER__METRICS__ATTACKER_METRICS_HPP_
 
+#include "crane_game_analyzer/selection_hysteresis.hpp"
 #include "metric_base.hpp"
 
 namespace crane::metrics
@@ -31,19 +32,19 @@ public:
   auto compute(MetricContext & ctx) -> void override;
 
 private:
-  // ヒステリシス用の内部状態
-  int last_attacker_id_ = -1;
-  rclcpp::Time last_switch_time_{static_cast<int64_t>(0), RCL_ROS_TIME};
-  rclcpp::Clock ros_clock_{RCL_ROS_TIME};
+  // ヒステリシス管理
+  SelectionHysteresis<int> attacker_hysteresis_{SelectionHysteresis<int>::Config{
+    .min_hold_duration_sec = 0.2,
+    .min_improvement_ratio = 0.01,
+    .emergency_switch_ratio = 1.03,
+    .force_switch_timeout = 3.0,
+    .absolute_threshold = 2.0}};
 
   // EMAスコア管理用マップ
   std::unordered_map<uint8_t, double> ema_scores_;
 
-  // ヒステリシスパラメータ
-  static constexpr double MIN_HOLD_DURATION_SEC = 0.2;    // 0.2秒に短縮（より素早い応答）
-  static constexpr double MIN_IMPROVEMENT_RATIO = 0.01;   // 1%改善で切り替え（より敏感に）
-  static constexpr double EMERGENCY_SWITCH_RATIO = 1.03;  // 3%良ければ即切り替え
-  static constexpr double EMA_ALPHA = 0.7;  // スムージング係数（新スコア70%、古いスコア30%）
+  // EMAスムージング係数
+  static constexpr double EMA_ALPHA = 0.7;  // 新スコア70%、古いスコア30%
 };
 
 }  // namespace crane::metrics

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/pass_target_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/pass_target_metrics.hpp
@@ -9,6 +9,7 @@
 
 #include <crane_physics/slack_time_config.hpp>
 
+#include "crane_game_analyzer/selection_hysteresis.hpp"
 #include "metric_base.hpp"
 
 namespace crane::metrics
@@ -37,12 +38,14 @@ public:
   /**
    * @brief ヒステリシスパラメータを設定
    * @param min_hold_sec ターゲット保持の最短秒数
-   * @param min_improvement 早期切替のための最小スコア改善幅
+   * @param min_improvement 保持期間後の切替に必要な最小改善率
    */
   auto setHysteresisParams(double min_hold_sec, double min_improvement) -> void
   {
-    min_hold_duration_sec_ = min_hold_sec;
-    min_improvement_margin_ = min_improvement;
+    pass_hysteresis_.setConfig({
+      .min_hold_duration_sec = min_hold_sec,
+      .min_improvement_ratio = min_improvement,
+    });
   }
 
   auto setEnemySlackConfig(const SlackTimeConfig & config, double slack_scale = 0.5) -> void
@@ -59,14 +62,11 @@ private:
   [[nodiscard]] auto calcScore(
     MetricContext & ctx, const Point & pass_origin, const Point & p) const -> double;
 
-  // ヒステリシス用の内部状態
-  std::optional<int> last_pass_target_id_{std::nullopt};
-  rclcpp::Time last_switch_time_{static_cast<int64_t>(0), RCL_ROS_TIME};
-  rclcpp::Clock ros_clock_{RCL_ROS_TIME};
-
-  // ヒステリシスパラメータ
-  double min_hold_duration_sec_ = 0.5;
-  double min_improvement_margin_ = 0.2;
+  // ヒステリシス管理
+  SelectionHysteresis<int> pass_hysteresis_{SelectionHysteresis<int>::Config{
+    .min_hold_duration_sec = 0.5,
+    .min_improvement_ratio = 0.2,
+  }};
 
   // 敵インターセプト評価用パラメータ
   SlackTimeConfig enemy_slack_config_{

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/threat_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/threat_metrics.hpp
@@ -21,7 +21,7 @@ namespace crane::metrics
 class BallThreatMetric : public MetricBase
 {
 public:
-  BallThreatMetric();
+  explicit BallThreatMetric(std::shared_ptr<ThreatEvaluator> evaluator);
 
   [[nodiscard]] auto getDependencies() const -> std::vector<MetricId> override { return {}; }
 
@@ -34,7 +34,7 @@ public:
   [[nodiscard]] auto getLastBallThreat() const -> const BallThreat & { return last_ball_threat_; }
 
 private:
-  ThreatEvaluator evaluator_;
+  std::shared_ptr<ThreatEvaluator> evaluator_;
   BallThreat last_ball_threat_;
 };
 
@@ -47,7 +47,9 @@ private:
 class RobotThreatsMetric : public MetricBase
 {
 public:
-  explicit RobotThreatsMetric(std::shared_ptr<BallThreatMetric> ball_threat_metric);
+  RobotThreatsMetric(
+    std::shared_ptr<BallThreatMetric> ball_threat_metric,
+    std::shared_ptr<ThreatEvaluator> evaluator);
 
   [[nodiscard]] auto getDependencies() const -> std::vector<MetricId> override
   {
@@ -67,7 +69,7 @@ public:
 
 private:
   std::shared_ptr<BallThreatMetric> ball_threat_metric_;
-  ThreatEvaluator evaluator_;
+  std::shared_ptr<ThreatEvaluator> evaluator_;
   std::vector<RobotThreat> last_robot_threats_;
 
   /// 脅威度に応じた色を返すヘルパー
@@ -85,7 +87,8 @@ class RecommendedDefendersMetric : public MetricBase
 public:
   RecommendedDefendersMetric(
     std::shared_ptr<BallThreatMetric> ball_threat_metric,
-    std::shared_ptr<RobotThreatsMetric> robot_threats_metric);
+    std::shared_ptr<RobotThreatsMetric> robot_threats_metric,
+    std::shared_ptr<ThreatEvaluator> evaluator);
 
   [[nodiscard]] auto getDependencies() const -> std::vector<MetricId> override
   {
@@ -100,7 +103,7 @@ public:
 private:
   std::shared_ptr<BallThreatMetric> ball_threat_metric_;
   std::shared_ptr<RobotThreatsMetric> robot_threats_metric_;
-  ThreatEvaluator evaluator_;
+  std::shared_ptr<ThreatEvaluator> evaluator_;
 };
 
 }  // namespace crane::metrics

--- a/crane_game_analyzer/include/crane_game_analyzer/selection_hysteresis.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/selection_hysteresis.hpp
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_GAME_ANALYZER__SELECTION_HYSTERESIS_HPP_
+#define CRANE_GAME_ANALYZER__SELECTION_HYSTERESIS_HPP_
+
+#include <optional>
+#include <rclcpp/rclcpp.hpp>
+
+namespace crane
+{
+
+/**
+ * @brief 選択ヒステリシス管理テンプレートクラス
+ *
+ * 「前回ID保持 + 切替時刻 + 保持時間 + 改善判定」をカプセル化する。
+ * 各フラグが0の場合はその条件をスキップする。
+ */
+template <typename IdType>
+class SelectionHysteresis
+{
+public:
+  struct Config
+  {
+    double min_hold_duration_sec = 0.0;   ///< 保持時間（秒）
+    double min_improvement_ratio = 0.0;   ///< 保持期間後の切替に必要な最小改善率（0=制限なし）
+    double emergency_switch_ratio = 0.0;  ///< この倍率以上良ければ即切替（0=未使用）
+    double force_switch_timeout = 0.0;    ///< このタイムアウト後は小改善でも切替（0=未使用）
+    double absolute_threshold = 0.0;      ///< スコア差がこの値以上なら即切替（0=未使用）
+  };
+
+  explicit SelectionHysteresis(
+    Config config, rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME))
+  : config_(config), clock_(std::move(clock))
+  {
+  }
+
+  /**
+   * @brief 切替判定を行い、内部状態を更新する
+   * @param best_id 最高スコアのID
+   * @param best_score 最高スコア値
+   * @param current_score 現在選択中のIDのスコア（不明の場合は0.0）
+   * @return true なら切替実施済み
+   */
+  auto shouldSwitch(IdType best_id, double best_score, double current_score) -> bool
+  {
+    const auto now = clock_->now();
+
+    if (!current_id_.has_value()) {
+      current_id_ = best_id;
+      last_switch_time_ = now;
+      return true;
+    }
+
+    if (best_id == *current_id_) {
+      return false;
+    }
+
+    const double time_since_switch = (now - last_switch_time_).seconds();
+    const double score_diff = best_score - current_score;
+    const double improvement_ratio = score_diff / std::max(current_score, 0.1);
+
+    bool should = false;
+
+    if (config_.force_switch_timeout > 0.0 && time_since_switch >= config_.force_switch_timeout) {
+      should = (score_diff > 0.1);
+    } else if (config_.absolute_threshold > 0.0 && score_diff >= config_.absolute_threshold) {
+      should = true;
+    } else if (
+      config_.emergency_switch_ratio > 0.0 &&
+      best_score >= current_score * config_.emergency_switch_ratio) {
+      should = true;
+    } else if (time_since_switch >= config_.min_hold_duration_sec) {
+      should = (config_.min_improvement_ratio <= 0.0) ||
+               (improvement_ratio >= config_.min_improvement_ratio);
+    }
+
+    if (should) {
+      current_id_ = best_id;
+      last_switch_time_ = now;
+    }
+
+    return should;
+  }
+
+  [[nodiscard]] auto currentId() const -> std::optional<IdType> { return current_id_; }
+
+  [[nodiscard]] auto timeSinceSwitch() const -> double
+  {
+    return (clock_->now() - last_switch_time_).seconds();
+  }
+
+  auto forceSwitch(IdType id) -> void
+  {
+    current_id_ = id;
+    last_switch_time_ = clock_->now();
+  }
+
+  auto reset() -> void
+  {
+    current_id_ = std::nullopt;
+    last_switch_time_ = rclcpp::Time(static_cast<int64_t>(0), RCL_ROS_TIME);
+  }
+
+  auto setConfig(Config config) -> void { config_ = config; }
+
+private:
+  Config config_;
+  std::shared_ptr<rclcpp::Clock> clock_;
+  std::optional<IdType> current_id_;
+  rclcpp::Time last_switch_time_{static_cast<int64_t>(0), RCL_ROS_TIME};
+};
+
+}  // namespace crane
+
+#endif  // CRANE_GAME_ANALYZER__SELECTION_HYSTERESIS_HPP_

--- a/crane_game_analyzer/src/crane_game_analyzer.cpp
+++ b/crane_game_analyzer/src/crane_game_analyzer.cpp
@@ -19,6 +19,7 @@
 #include "crane_game_analyzer/metrics/slack_metrics.hpp"
 #include "crane_game_analyzer/metrics/sub_attacker_metrics.hpp"
 #include "crane_game_analyzer/metrics/threat_metrics.hpp"
+#include "crane_game_analyzer/threat_evaluator.hpp"
 
 namespace crane
 {
@@ -153,16 +154,19 @@ GameAnalyzerComponent::GameAnalyzerComponent(const rclcpp::NodeOptions & options
   metric_engine_->registerMetric(std::make_shared<metrics::TheirSlackMetric>());
   metric_engine_->registerMetric(std::make_shared<metrics::OngoingKickMetric>());
 
-  // 脅威評価メトリクス
-  auto ball_threat_metric = std::make_shared<metrics::BallThreatMetric>();
+  // 脅威評価メトリクス（共有ThreatEvaluatorインスタンス）
+  auto shared_threat_evaluator = std::make_shared<ThreatEvaluator>(ThreatEvaluatorConfig{});
+
+  auto ball_threat_metric = std::make_shared<metrics::BallThreatMetric>(shared_threat_evaluator);
   metric_engine_->registerMetric(ball_threat_metric);
 
-  auto robot_threats_metric = std::make_shared<metrics::RobotThreatsMetric>(ball_threat_metric);
+  auto robot_threats_metric =
+    std::make_shared<metrics::RobotThreatsMetric>(ball_threat_metric, shared_threat_evaluator);
   metric_engine_->registerMetric(robot_threats_metric);
 
   metric_engine_->registerMetric(
     std::make_shared<metrics::RecommendedDefendersMetric>(
-      ball_threat_metric, robot_threats_metric));
+      ball_threat_metric, robot_threats_metric, shared_threat_evaluator));
 
   // 役割決定メトリクス（新規）
   auto attacker_metric = std::make_shared<metrics::AttackerCandidateMetric>();
@@ -283,6 +287,15 @@ auto GameAnalyzerComponent::onPlaySituationChanged(const crane_msgs::msg::PlaySi
     their_team_name_ = msg.their_team_info.name;
   }
 
+  using PlaySituation = crane_msgs::msg::PlaySituation;
+  auto is_stop = [](uint8_t cmd) {
+    return cmd == PlaySituation::STOP || (cmd >= PlaySituation::STOP_PRE_OUR_PENALTY_PREPARATION &&
+                                          cmd <= PlaySituation::STOP_PRE_FORCE_START);
+  };
+  auto is_inplay = [](uint8_t cmd) {
+    return cmd >= PlaySituation::INPLAY && cmd <= PlaySituation::AMBIGUOUS_INPLAY;
+  };
+
   uint8_t current = static_cast<uint8_t>(msg.command.value);
 
   // 初回は状態を保存するのみ
@@ -300,34 +313,34 @@ auto GameAnalyzerComponent::onPlaySituationChanged(const crane_msgs::msg::PlaySi
 
   std::optional<crane_msgs::msg::RonarEvent> event;
 
-  // HALT (0)
-  if (current == 0 && last != 0) {
+  if (current == PlaySituation::HALT && last != PlaySituation::HALT) {
     event = createPlaySituationEvent(crane_msgs::msg::RonarEvent::EVENT_HALT, msg);
     event->metadata_json =
       std::format(R"({{"previous_command": {}, "reason": "{}"}})", last, msg.reason_text);
-  } else if (  // STOP (1, 60-66)
-    (current == 1 || (current >= 60 && current <= 66)) &&
-    !(last == 1 || (last >= 60 && last <= 66))) {
+  } else if (is_stop(current) && !is_stop(last)) {
     event = createPlaySituationEvent(crane_msgs::msg::RonarEvent::EVENT_STOP, msg);
-    std::string stop_type = (current >= 60 && current <= 66) ? "STOP_PRE" : "STOP";
+    std::string stop_type = (current >= PlaySituation::STOP_PRE_OUR_PENALTY_PREPARATION &&
+                             current <= PlaySituation::STOP_PRE_FORCE_START)
+                              ? "STOP_PRE"
+                              : "STOP";
     int32_t next_cmd = msg.next_command_raw.empty() ? -1 : msg.next_command_raw[0].value;
     event->metadata_json = std::format(
       R"({{"stop_type": "{}", "command_value": {}, "next_command": {}, "reason": "{}"}})",
       stop_type, current, next_cmd, msg.reason_text);
-  } else if ((current >= 50 && current <= 53) && !(last >= 50 && last <= 53)) {  // INPLAY (50-53)
+  } else if (is_inplay(current) && !is_inplay(last)) {
     event = createPlaySituationEvent(crane_msgs::msg::RonarEvent::EVENT_INPLAY_START, msg);
     std::string inplay_type;
     switch (current) {
-      case 50:
+      case PlaySituation::INPLAY:
         inplay_type = "INPLAY";
         break;
-      case 51:
+      case PlaySituation::OUR_INPLAY:
         inplay_type = "OUR_INPLAY";
         break;
-      case 52:
+      case PlaySituation::THEIR_INPLAY:
         inplay_type = "THEIR_INPLAY";
         break;
-      case 53:
+      case PlaySituation::AMBIGUOUS_INPLAY:
         inplay_type = "AMBIGUOUS_INPLAY";
         break;
       default:
@@ -336,18 +349,20 @@ auto GameAnalyzerComponent::onPlaySituationChanged(const crane_msgs::msg::PlaySi
     }
     event->metadata_json =
       std::format(R"({{"inplay_type": "{}", "previous_command": {}}})", inplay_type, last);
-  } else if ((current == 17 || current == 27) && last != 17 && last != 27) {  // TIMEOUT (17, 27)
+  } else if (
+    (current == PlaySituation::OUR_TIMEOUT || current == PlaySituation::THEIR_TIMEOUT) &&
+    last != PlaySituation::OUR_TIMEOUT && last != PlaySituation::THEIR_TIMEOUT) {
     event = createPlaySituationEvent(crane_msgs::msg::RonarEvent::EVENT_TIMEOUT, msg);
-    bool is_ours = (current == 17);
+    bool is_ours = (current == PlaySituation::OUR_TIMEOUT);
     const auto & team_info = is_ours ? msg.our_team_info : msg.their_team_info;
     event->metadata_json = std::format(
       R"({{"team": "{}", "timeouts_left": {}}})", is_ours ? "ours" : "theirs", team_info.timeouts);
-  } else if (current == 100 && last != 100) {  // HALF_TIME (100)
+  } else if (current == PlaySituation::HALF_TIME && last != PlaySituation::HALF_TIME) {
     event = createPlaySituationEvent(crane_msgs::msg::RonarEvent::EVENT_HALF_TIME, msg);
     event->metadata_json = std::format(
       R"({{"our_score": {}, "their_score": {}, "stage": "{}"}})", msg.our_team_info.score,
       msg.their_team_info.score, msg.stage.name);
-  } else if (current == 101 && last != 101) {  // GAME_END (101)
+  } else if (current == PlaySituation::POST_GAME && last != PlaySituation::POST_GAME) {
     event = createPlaySituationEvent(crane_msgs::msg::RonarEvent::EVENT_GAME_END, msg);
     std::string result;
     if (msg.our_team_info.score > msg.their_team_info.score) {

--- a/crane_game_analyzer/src/metrics/attacker_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/attacker_metrics.cpp
@@ -102,96 +102,40 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
   int best_id = robot_scores[0].id;
   double best_score = robot_scores[0].score;
 
-  // ヒステリシス処理
-  auto current_time = ros_clock_.now();
-  bool should_switch = false;
-
-  if (last_attacker_id_ < 0) {
-    // 初回は即座にスイッチ
-    should_switch = true;
-  } else if (best_id == last_attacker_id_) {
-    // 同じロボットなら継続
-    should_switch = false;
-  } else {
-    // 異なるロボットの場合
-    double time_since_switch = (current_time - last_switch_time_).seconds();
-
-    // 現在のロボットのスコアを取得
-    double current_score = 0.0;
+  // 現在選択中ロボットのスコアを取得するラムダ
+  auto find_current_score = [&](int id) -> double {
     for (const auto & rs : robot_scores) {
-      if (static_cast<int>(rs.id) == last_attacker_id_) {
-        current_score = rs.score;
-        break;
-      }
+      if (static_cast<int>(rs.id) == id) return rs.score;
     }
+    return 0.0;
+  };
 
-    // スコア差を計算
-    double score_diff = best_score - current_score;
-    double improvement_ratio = (best_score - current_score) / std::max(current_score, 0.1);
+  // ヒステリシス処理
+  const auto prev_id = attacker_hysteresis_.currentId();
+  const double current_score = find_current_score(prev_id.value_or(-1));
+  const double time_before_switch = attacker_hysteresis_.timeSinceSwitch();
+  const bool switched = attacker_hysteresis_.shouldSwitch(best_id, best_score, current_score);
 
-    // 絶対値判定の閾値とタイムアウト
-    constexpr double absolute_threshold = 2.0;    // スコア差2.0以上（約0.2m距離差に相当）
-    constexpr double force_switch_timeout = 3.0;  // 3秒経過後は強制再評価
-
-    // 切り替え判定（優先度順）
-    if (time_since_switch >= force_switch_timeout) {
-      // 1. タイムアウト: わずかでも良ければ切り替え
-      should_switch = (score_diff > 0.1);
-    } else if (score_diff >= absolute_threshold) {
-      // 2. 絶対値判定: 大きな差がある場合は即座に切り替え
-      should_switch = true;
-    } else if (best_score >= current_score * EMERGENCY_SWITCH_RATIO) {
-      // 3. 緊急切り替え: 相対的に大幅に良い場合は即座に切り替え
-      should_switch = true;
-    } else if (time_since_switch >= MIN_HOLD_DURATION_SEC) {
-      // 4. 通常切り替え: 保持時間経過後、相対的に改善がある場合のみ切り替え
-      if (improvement_ratio >= MIN_IMPROVEMENT_RATIO) {
-        should_switch = true;
-      }
-    }
-  }
-
-  if (should_switch) {
-    // スイッチ実行時のログ
-    if (last_attacker_id_ >= 0) {
-      double current_score = 0.0;
-      for (const auto & rs : robot_scores) {
-        if (static_cast<int>(rs.id) == last_attacker_id_) {
-          current_score = rs.score;
-          break;
-        }
-      }
+  if (switched) {
+    if (prev_id.has_value()) {
       double improvement_ratio = (best_score - current_score) / std::max(current_score, 0.1);
-      double time_since_switch = (current_time - last_switch_time_).seconds();
       RCLCPP_INFO(
         rclcpp::get_logger("AttackerMetric"),
         "SWITCH: %d -> %d (old_score=%.2f, new_score=%.2f, improvement=%.1f%%, time=%.2fs)",
-        last_attacker_id_, best_id, current_score, best_score, improvement_ratio * 100,
-        time_since_switch);
+        *prev_id, best_id, current_score, best_score, improvement_ratio * 100, time_before_switch);
     } else {
       RCLCPP_INFO(
         rclcpp::get_logger("AttackerMetric"), "INITIAL: selected robot %d (score=%.2f)", best_id,
         best_score);
     }
-    last_attacker_id_ = best_id;
-    last_switch_time_ = current_time;
-  } else if (last_attacker_id_ >= 0 && best_id != last_attacker_id_) {
-    // ホールド時のログ（異なるロボットが最適だが切り替えない場合）
-    double current_score = 0.0;
-    for (const auto & rs : robot_scores) {
-      if (static_cast<int>(rs.id) == last_attacker_id_) {
-        current_score = rs.score;
-        break;
-      }
-    }
-    double time_since_switch = (current_time - last_switch_time_).seconds();
+  } else if (prev_id.has_value() && best_id != *prev_id) {
     RCLCPP_DEBUG(
       rclcpp::get_logger("AttackerMetric"),
-      "HOLD: robot %d (best=%d, best_score=%.2f, current=%.2f, time=%.2fs)", last_attacker_id_,
-      best_id, best_score, current_score, time_since_switch);
+      "HOLD: robot %d (best=%d, best_score=%.2f, current=%.2f, time=%.2fs)", *prev_id, best_id,
+      best_score, current_score, attacker_hysteresis_.timeSinceSwitch());
   }
 
-  ctx.analysis.recommended_attacker_id = last_attacker_id_;
+  ctx.analysis.recommended_attacker_id = attacker_hysteresis_.currentId().value_or(-1);
   ctx.analysis.attacker_suitability_score = best_score;
 
   // recommended_pass_receiver_idは未使用（-1固定）

--- a/crane_game_analyzer/src/metrics/pass_target_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/pass_target_metrics.cpp
@@ -155,40 +155,17 @@ auto PassTargetMetric::compute(MetricContext & ctx) -> void
     const int best_id = static_cast<int>(best.id);
     const double best_score = static_cast<double>(best.value);
 
-    const rclcpp::Time now_time = ros_clock_.now();
-    const bool hold_active = (now_time - last_switch_time_).seconds() < min_hold_duration_sec_;
-
-    double prev_score = -1.0;
-    if (last_pass_target_id_.has_value()) {
-      auto it =
-        ranges::find_if(ctx.analysis.pass_scores, [&](const crane_msgs::msg::FloatWithID & s) {
-          return s.id == last_pass_target_id_.value();
-        });
+    double prev_score = 0.0;
+    const auto prev_id = pass_hysteresis_.currentId();
+    if (prev_id.has_value()) {
+      auto it = ranges::find_if(
+        ctx.analysis.pass_scores,
+        [&](const crane_msgs::msg::FloatWithID & s) { return s.id == prev_id.value(); });
       if (it != ranges::end(ctx.analysis.pass_scores)) prev_score = it->value;
     }
 
-    bool should_switch = true;
-    if (last_pass_target_id_.has_value()) {
-      if (best_id == last_pass_target_id_.value()) {
-        should_switch = false;  // 同一なら切替不要
-      } else if (hold_active) {
-        if (prev_score >= 0.0) {
-          should_switch = (best_score - prev_score) > min_improvement_margin_;
-        } else {
-          should_switch = false;  // 前回スコア不明
-        }
-      }
-    }
-
-    if (!last_pass_target_id_.has_value()) {
-      last_pass_target_id_ = best_id;
-      last_switch_time_ = now_time;
-    } else if (should_switch) {
-      last_pass_target_id_ = best_id;
-      last_switch_time_ = now_time;
-    }
-
-    ctx.analysis.pass_target_id = last_pass_target_id_.value();
+    pass_hysteresis_.shouldSwitch(best_id, best_score, prev_score);
+    ctx.analysis.pass_target_id = pass_hysteresis_.currentId().value_or(-1);
   }
 }
 

--- a/crane_game_analyzer/src/metrics/slack_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/slack_metrics.cpp
@@ -8,19 +8,16 @@
 
 #include <string>
 
-namespace crane::metrics
+namespace
 {
-
-// OurSlackMetric実装
-
-OurSlackMetric::OurSlackMetric() : MetricBase(MetricId::OUR_SLACK, "OurSlack") {}
-
-auto OurSlackMetric::compute(MetricContext & ctx) -> void
+void computeSlackForTeam(
+  const std::vector<std::shared_ptr<crane::RobotInfo>> & robots,
+  crane::WorldModelWrapper * world_model, std::vector<crane_msgs::msg::Slack> & output)
 {
-  for (const auto & robot : ctx.world_model->ours().robotsWhere().available().get()) {
-    RobotList single_robot{robot};
+  for (const auto & robot : robots) {
+    crane::RobotList single_robot{robot};
     auto [min_slack, max_slack] =
-      ctx.world_model->getMinMaxSlackInterceptPointAndSlackTime(single_robot);
+      world_model->getMinMaxSlackInterceptPointAndSlackTime(single_robot);
 
     crane_msgs::msg::Slack slack_msg;
     slack_msg.id = robot->id;
@@ -37,8 +34,23 @@ auto OurSlackMetric::compute(MetricContext & ctx) -> void
       slack_msg.max.y = max_slack->intercept_point.y();
     }
 
-    ctx.analysis.our_slack.push_back(slack_msg);
+    output.push_back(slack_msg);
   }
+}
+}  // namespace
+
+namespace crane::metrics
+{
+
+// OurSlackMetric実装
+
+OurSlackMetric::OurSlackMetric() : MetricBase(MetricId::OUR_SLACK, "OurSlack") {}
+
+auto OurSlackMetric::compute(MetricContext & ctx) -> void
+{
+  computeSlackForTeam(
+    ctx.world_model->ours().robotsWhere().available().get(), ctx.world_model,
+    ctx.analysis.our_slack);
 }
 
 auto OurSlackMetric::visualize(
@@ -49,35 +61,40 @@ auto OurSlackMetric::visualize(
   }
 
   for (const auto & robot : ctx.world_model->ours().robotsWhere().available().get()) {
-    RobotList single_robot{robot};
-    auto [min_slack, max_slack] =
-      ctx.world_model->getMinMaxSlackInterceptPointAndSlackTime(single_robot);
+    const crane_msgs::msg::Slack * slack_data = nullptr;
+    for (const auto & s : ctx.analysis.our_slack) {
+      if (s.id == robot->id) {
+        slack_data = &s;
+        break;
+      }
+    }
+    if (!slack_data) continue;
 
-    if (min_slack) {
+    if (slack_data->min.slack_time != 0.0) {
       visualizer->text()
         .position(robot->pose.pos.x(), robot->pose.pos.y() - 0.3)
-        .text("min slack: " + std::to_string(min_slack->slack_time))
+        .text("min slack: " + std::to_string(slack_data->min.slack_time))
         .fill("white")
         .fontSize(100)
         .build();
       visualizer->line()
         .start(robot->pose.pos)
-        .end(min_slack->intercept_point)
+        .end(Point(slack_data->min.x, slack_data->min.y))
         .stroke("red", 0.5)
         .strokeWidth(5)
         .build();
     }
 
-    if (max_slack && max_slack->slack_time > 0.0) {
+    if (slack_data->max.slack_time > 0.0) {
       visualizer->text()
         .position(robot->pose.pos.x(), robot->pose.pos.y() - 0.5)
-        .text("max slack: " + std::to_string(max_slack->slack_time))
+        .text("max slack: " + std::to_string(slack_data->max.slack_time))
         .fill("white")
         .fontSize(100)
         .build();
       visualizer->line()
         .start(robot->pose.pos)
-        .end(max_slack->intercept_point)
+        .end(Point(slack_data->max.x, slack_data->max.y))
         .stroke("red", 0.5)
         .strokeWidth(5)
         .build();
@@ -91,28 +108,9 @@ TheirSlackMetric::TheirSlackMetric() : MetricBase(MetricId::THEIR_SLACK, "TheirS
 
 auto TheirSlackMetric::compute(MetricContext & ctx) -> void
 {
-  for (const auto & robot : ctx.world_model->theirs().robotsWhere().available().get()) {
-    RobotList single_robot{robot};
-    auto [min_slack, max_slack] =
-      ctx.world_model->getMinMaxSlackInterceptPointAndSlackTime(single_robot);
-
-    crane_msgs::msg::Slack slack_msg;
-    slack_msg.id = robot->id;
-
-    if (min_slack) {
-      slack_msg.min.slack_time = min_slack->slack_time;
-      slack_msg.min.x = min_slack->intercept_point.x();
-      slack_msg.min.y = min_slack->intercept_point.y();
-    }
-
-    if (max_slack) {
-      slack_msg.max.slack_time = max_slack->slack_time;
-      slack_msg.max.x = max_slack->intercept_point.x();
-      slack_msg.max.y = max_slack->intercept_point.y();
-    }
-
-    ctx.analysis.their_slack.push_back(slack_msg);
-  }
+  computeSlackForTeam(
+    ctx.world_model->theirs().robotsWhere().available().get(), ctx.world_model,
+    ctx.analysis.their_slack);
 }
 
 }  // namespace crane::metrics

--- a/crane_game_analyzer/src/metrics/sub_attacker_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/sub_attacker_metrics.cpp
@@ -7,7 +7,7 @@
 #include "crane_game_analyzer/metrics/sub_attacker_metrics.hpp"
 
 #include <crane_geometry/ddps.hpp>
-#include <crane_geometry/geometry_operations.hpp>
+#include <crane_msg_wrappers/sub_attacker_evaluation.hpp>
 
 namespace crane::metrics
 {
@@ -16,84 +16,6 @@ SubAttackerPositionMetric::SubAttackerPositionMetric()
 : MetricBase(MetricId::SUB_ATTACKER_POSITION, "SubAttackerPosition")
 {
 }
-
-namespace
-{
-// SubAttacker::getPointScoreのロジックを再実装
-// TODO(ibis-ssl): 将来的にはcrane_geometryなど共通パッケージに移動すべき
-double evaluateSubAttackerPosition(const Point & p, const WorldModelWrapper * world_model)
-{
-  Segment line{world_model->ball().pos, p};
-
-  // 敵ロボットとの最短距離を計算
-  double min_enemy_dist = std::numeric_limits<double>::max();
-  Point closest_enemy_point = world_model->ball().pos;
-
-  for (const auto & robot : world_model->theirs().robotsWhere().available().get()) {
-    auto result = getClosestPointAndDistance(robot->pose.pos, line);
-    if (result.distance < min_enemy_dist) {
-      min_enemy_dist = result.distance;
-      closest_enemy_point = result.closest_point;
-    }
-  }
-
-  auto [angle, width] = world_model->getLargestGoalAngleRangeFromPoint(p);
-  // ゴールが見える角度が大きいほどよい
-  double score = width;
-
-  // 敵が動いてボールをブロック出来るかどうか
-  double enemy_closest_to_ball_dist = (closest_enemy_point - world_model->ball().pos).norm();
-  double ratio = min_enemy_dist / enemy_closest_to_ball_dist;
-  // ratioが大きいほどよい / 0.1以下は厳しい
-  if (ratio < 0.1) {
-    score = 0.;
-  } else {
-    score *= std::clamp(ratio * 5, 0.0, 1.0);
-  }
-
-  if (
-    std::abs(world_model->ball().pos.x() - world_model->goal().x()) >
-    std::abs(world_model->goal().x())) {
-    // 反射角　小さいほどよい（敵ゴールに近い場合のみ）
-    auto reflect_angle = std::abs(getAngleDiff(angle, getAngle(world_model->ball().pos - p)));
-    score *= (1.0 - std::min(reflect_angle * 0.5, 1.0));
-  }
-
-  // 距離評価: 最小距離制約と適度な距離を評価
-  const double dist = (world_model->ball().pos - p).norm();
-  // 最小距離制約: 1.5m未満は大幅減点
-  constexpr double MIN_PASS_DISTANCE = 1.5;
-  if (dist < MIN_PASS_DISTANCE) {
-    score *= dist / MIN_PASS_DISTANCE;  // 1.0mなら0.67倍、0.5mなら0.33倍
-  }
-  // 距離が遠すぎても減点（10m以上はスコア0）
-  score = score * std::max(1.0 - dist / 10.0, 0.0);
-
-  // シュートラインに近すぎる場所は避ける
-  Segment shoot_line{world_model->getOurGoalCenter(), world_model->ball().pos};
-  const auto dist_to_shoot_line = bg::distance(p, shoot_line);
-  if (dist_to_shoot_line < 0.5) {
-    score = 0.0;
-  }
-
-  // 自分とボールの延長線上にゴールがある場合は避ける
-  Segment robot_to_ball_and_more{
-    p, world_model->ball().pos + (world_model->ball().pos - p).normalized() * 10.0};
-  Segment goal_line{
-    world_model->getTheirGoalPosts().first, world_model->getTheirGoalPosts().second};
-  if (double distance = bg::distance(robot_to_ball_and_more, goal_line); distance < 1.0) {
-    score *= distance;
-  }
-
-  // ボールの後側にには行かない
-  double dot = (world_model->getTheirGoalCenter() - world_model->ball().pos)
-                 .normalized()
-                 .dot((p - world_model->ball().pos).normalized());
-  score *= std::max((dot + 0.5), 0.0);
-
-  return score;
-}
-}  // namespace
 
 auto SubAttackerPositionMetric::compute(MetricContext & ctx) -> void
 {
@@ -130,7 +52,7 @@ auto SubAttackerPositionMetric::compute(MetricContext & ctx) -> void
   Point best_position{0.0, 0.0};
 
   for (const auto & candidate : valid_candidates) {
-    double score = evaluateSubAttackerPosition(candidate, wm);
+    double score = crane::evaluateSubAttackerPosition(candidate, *wm);
 
     if (score > best_score) {
       best_score = score;

--- a/crane_game_analyzer/src/metrics/threat_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/threat_metrics.cpp
@@ -13,15 +13,15 @@ namespace crane::metrics
 
 // BallThreatMetric実装
 
-BallThreatMetric::BallThreatMetric()
-: MetricBase(MetricId::BALL_THREAT, "BallThreat"), evaluator_(ThreatEvaluatorConfig{})
+BallThreatMetric::BallThreatMetric(std::shared_ptr<ThreatEvaluator> evaluator)
+: MetricBase(MetricId::BALL_THREAT, "BallThreat"), evaluator_(std::move(evaluator))
 {
 }
 
 auto BallThreatMetric::compute(MetricContext & ctx) -> void
 {
-  last_ball_threat_ = evaluator_.calculateBallThreat(*ctx.world_model);
-  ctx.analysis.ball_threat = evaluator_.toThreatInfoMsg(last_ball_threat_);
+  last_ball_threat_ = evaluator_->calculateBallThreat(*ctx.world_model);
+  ctx.analysis.ball_threat = evaluator_->toThreatInfoMsg(last_ball_threat_);
 }
 
 auto BallThreatMetric::visualize(
@@ -54,21 +54,22 @@ auto BallThreatMetric::visualize(
 
 // RobotThreatsMetric実装
 
-RobotThreatsMetric::RobotThreatsMetric(std::shared_ptr<BallThreatMetric> ball_threat_metric)
+RobotThreatsMetric::RobotThreatsMetric(
+  std::shared_ptr<BallThreatMetric> ball_threat_metric, std::shared_ptr<ThreatEvaluator> evaluator)
 : MetricBase(MetricId::ROBOT_THREATS, "RobotThreats"),
   ball_threat_metric_(ball_threat_metric),
-  evaluator_(ThreatEvaluatorConfig{})
+  evaluator_(std::move(evaluator))
 {
 }
 
 auto RobotThreatsMetric::compute(MetricContext & ctx) -> void
 {
   const auto & ball_threat = ball_threat_metric_->getLastBallThreat();
-  last_robot_threats_ = evaluator_.calculateRobotThreats(*ctx.world_model, ball_threat);
+  last_robot_threats_ = evaluator_->calculateRobotThreats(*ctx.world_model, ball_threat);
 
   ctx.analysis.robot_threats.clear();
   for (const auto & threat : last_robot_threats_) {
-    ctx.analysis.robot_threats.push_back(evaluator_.toThreatInfoMsg(threat));
+    ctx.analysis.robot_threats.push_back(evaluator_->toThreatInfoMsg(threat));
   }
 }
 
@@ -160,11 +161,12 @@ auto RobotThreatsMetric::threatToColor(double threat_rating) -> std::string
 
 RecommendedDefendersMetric::RecommendedDefendersMetric(
   std::shared_ptr<BallThreatMetric> ball_threat_metric,
-  std::shared_ptr<RobotThreatsMetric> robot_threats_metric)
+  std::shared_ptr<RobotThreatsMetric> robot_threats_metric,
+  std::shared_ptr<ThreatEvaluator> evaluator)
 : MetricBase(MetricId::RECOMMENDED_DEFENDERS, "RecommendedDefenders"),
   ball_threat_metric_(ball_threat_metric),
   robot_threats_metric_(robot_threats_metric),
-  evaluator_(ThreatEvaluatorConfig{})
+  evaluator_(std::move(evaluator))
 {
 }
 
@@ -176,7 +178,7 @@ auto RecommendedDefendersMetric::compute(MetricContext & ctx) -> void
   int available_robots =
     static_cast<int>(ctx.world_model->ours().robotsWhere().available().get().size());
   ctx.analysis.recommended_num_defenders = static_cast<uint8_t>(
-    evaluator_.calculateRecommendedDefenders(ball_threat, robot_threats, available_robots));
+    evaluator_->calculateRecommendedDefenders(ball_threat, robot_threats, available_robots));
 }
 
 auto RecommendedDefendersMetric::visualize(

--- a/crane_robot_skills/src/sub_attacker.cpp
+++ b/crane_robot_skills/src/sub_attacker.cpp
@@ -5,7 +5,7 @@
 // https://opensource.org/licenses/MIT.
 
 #include <crane_geometry/ddps.hpp>
-#include <crane_geometry/geometry_operations.hpp>
+#include <crane_msg_wrappers/sub_attacker_evaluation.hpp>
 #include <crane_robot_skills/sub_attacker.hpp>
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view/filter.hpp>
@@ -119,72 +119,6 @@ double SubAttacker::getPointScore(
   const Point & p, [[maybe_unused]] const Point & next_target,
   const WorldModelWrapper::SharedPtr & world_model)
 {
-  Segment line{world_model->ball().pos, p};
-  auto closest_result = [&]() -> ClosestPoint {
-    ClosestPoint closest_result;
-    closest_result.distance = std::numeric_limits<double>::max();
-    for (const auto & robot : world_model->theirs().robotsWhere().available().get()) {
-      auto result = getClosestPointAndDistance(robot->pose.pos, line);
-      if (result.distance < closest_result.distance) {
-        closest_result = result;
-      }
-    }
-    return closest_result;
-  }();
-
-  auto [angle, width] = world_model->getLargestGoalAngleRangeFromPoint(p);
-  // ゴールが見える角度が大きいほどよい
-  double score = width;
-
-  // 敵が動いてボールをブロック出来るかどうか
-  double enemy_closest_to_ball_dist =
-    (closest_result.closest_point - world_model->ball().pos).norm();
-  double ratio = closest_result.distance / enemy_closest_to_ball_dist;
-  // ratioが大きいほどよい / 0.1以下は厳しい
-  if (ratio < 0.1) {
-    score = 0.;
-  } else {
-    score *= std::clamp(ratio * 5, 0.0, 1.0);
-  }
-
-  if (
-    std::abs(world_model->ball().pos.x() - world_model->goal().x()) >
-    std::abs(world_model->goal().x())) {
-    // 反射角　小さいほどよい（敵ゴールに近い場合のみ）
-    auto reflect_angle = std::abs(getAngleDiff(angle, getAngle(world_model->ball().pos - p)));
-    score *= (1.0 - std::min(reflect_angle * 0.5, 1.0));
-  }
-  // 距離評価: 最小距離制約と適度な距離を評価
-  const double dist = (world_model->ball().pos - p).norm();
-  // 最小距離制約: 1.5m未満は大幅減点
-  constexpr double MIN_PASS_DISTANCE = 1.5;
-  if (dist < MIN_PASS_DISTANCE) {
-    score *= dist / MIN_PASS_DISTANCE;  // 1.0mなら0.67倍、0.5mなら0.33倍
-  }
-  // 距離が遠すぎても減点（10m以上はスコア0）
-  score = score * std::max(1.0 - dist / 10.0, 0.0);
-
-  // シュートラインに近すぎる場所は避ける
-  Segment shoot_line{world_model->getOurGoalCenter(), world_model->ball().pos};
-  const auto dist_to_shoot_line = bg::distance(p, shoot_line);
-  if (dist_to_shoot_line < 0.5) {
-    score = 0.0;
-  }
-
-  // 自分とボールの延長線上にゴールがある場合は避ける
-  Segment robot_to_ball_and_more{
-    p, world_model->ball().pos + (world_model->ball().pos - p).normalized() * 10.0};
-  Segment goal_line{
-    world_model->getTheirGoalPosts().first, world_model->getTheirGoalPosts().second};
-  if (double distance = bg::distance(robot_to_ball_and_more, goal_line); distance < 1.0) {
-    score *= distance;
-  }
-
-  // ボールの後側にには行かない
-  double dot = (world_model->getTheirGoalCenter() - world_model->ball().pos)
-                 .normalized()
-                 .dot((p - world_model->ball().pos).normalized());
-  score *= std::max((dot + 0.5), 0.0);
-  return score;
+  return crane::evaluateSubAttackerPosition(p, *world_model);
 }
 }  // namespace crane::skills

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/sub_attacker_evaluation.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/sub_attacker_evaluation.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_MSG_WRAPPERS__SUB_ATTACKER_EVALUATION_HPP_
+#define CRANE_MSG_WRAPPERS__SUB_ATTACKER_EVALUATION_HPP_
+
+#include <crane_msg_wrappers/world_model_wrapper.hpp>
+
+namespace crane
+{
+
+/**
+ * @brief SubAttacker配置の評価スコアを計算する
+ *
+ * ゴール可視角度・敵ブロック率・パス距離・シュートライン等を総合評価する。
+ *
+ * @param p 評価する候補位置
+ * @param world_model ワールドモデル参照
+ * @return スコア（高いほど良い配置）
+ */
+double evaluateSubAttackerPosition(const Point & p, const WorldModelWrapper & world_model);
+
+}  // namespace crane
+
+#endif  // CRANE_MSG_WRAPPERS__SUB_ATTACKER_EVALUATION_HPP_

--- a/utility/crane_msg_wrappers/src/crane_visualizer_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/crane_visualizer_wrapper.cpp
@@ -264,7 +264,6 @@ auto VisualizerMessageBuilder::drawRobot(
   const std::string & stroke_color, double stroke_opacity, double stroke_width, double radius,
   double center_to_dribbler) -> void
 {
-  // ロボット形状の計算（SvgRobotBuilderと同じロジック）
   double corner_angle = std::acos(center_to_dribbler / radius);
   auto botRightX = [&](double orientation) {
     return radius * std::cos(orientation + corner_angle);

--- a/utility/crane_msg_wrappers/src/sub_attacker_evaluation.cpp
+++ b/utility/crane_msg_wrappers/src/sub_attacker_evaluation.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "crane_msg_wrappers/sub_attacker_evaluation.hpp"
+
+#include <crane_geometry/geometry_operations.hpp>
+
+namespace crane
+{
+
+double evaluateSubAttackerPosition(const Point & p, const WorldModelWrapper & world_model)
+{
+  Segment line{world_model.ball().pos, p};
+
+  // 敵ロボットとの最短距離を計算
+  double min_enemy_dist = std::numeric_limits<double>::max();
+  Point closest_enemy_point = world_model.ball().pos;
+
+  for (const auto & robot : world_model.theirs().robotsWhere().available().get()) {
+    auto result = getClosestPointAndDistance(robot->pose.pos, line);
+    if (result.distance < min_enemy_dist) {
+      min_enemy_dist = result.distance;
+      closest_enemy_point = result.closest_point;
+    }
+  }
+
+  auto [angle, width] = world_model.getLargestGoalAngleRangeFromPoint(p);
+  // ゴールが見える角度が大きいほどよい
+  double score = width;
+
+  // 敵が動いてボールをブロック出来るかどうか
+  double enemy_closest_to_ball_dist = (closest_enemy_point - world_model.ball().pos).norm();
+  double ratio = min_enemy_dist / enemy_closest_to_ball_dist;
+  // ratioが大きいほどよい / 0.1以下は厳しい
+  if (ratio < 0.1) {
+    score = 0.;
+  } else {
+    score *= std::clamp(ratio * 5, 0.0, 1.0);
+  }
+
+  if (
+    std::abs(world_model.ball().pos.x() - world_model.goal().x()) >
+    std::abs(world_model.goal().x())) {
+    // 反射角　小さいほどよい（敵ゴールに近い場合のみ）
+    auto reflect_angle = std::abs(getAngleDiff(angle, getAngle(world_model.ball().pos - p)));
+    score *= (1.0 - std::min(reflect_angle * 0.5, 1.0));
+  }
+
+  // 距離評価: 最小距離制約と適度な距離を評価
+  const double dist = (world_model.ball().pos - p).norm();
+  // 最小距離制約: 1.5m未満は大幅減点
+  constexpr double MIN_PASS_DISTANCE = 1.5;
+  if (dist < MIN_PASS_DISTANCE) {
+    score *= dist / MIN_PASS_DISTANCE;  // 1.0mなら0.67倍、0.5mなら0.33倍
+  }
+  // 距離が遠すぎても減点（10m以上はスコア0）
+  score = score * std::max(1.0 - dist / 10.0, 0.0);
+
+  // シュートラインに近すぎる場所は避ける
+  Segment shoot_line{world_model.getOurGoalCenter(), world_model.ball().pos};
+  const auto dist_to_shoot_line = bg::distance(p, shoot_line);
+  if (dist_to_shoot_line < 0.5) {
+    score = 0.0;
+  }
+
+  // 自分とボールの延長線上にゴールがある場合は避ける
+  Segment robot_to_ball_and_more{
+    p, world_model.ball().pos + (world_model.ball().pos - p).normalized() * 10.0};
+  Segment goal_line{world_model.getTheirGoalPosts().first, world_model.getTheirGoalPosts().second};
+  if (double distance = bg::distance(robot_to_ball_and_more, goal_line); distance < 1.0) {
+    score *= distance;
+  }
+
+  // ボールの後側には行かない
+  double dot = (world_model.getTheirGoalCenter() - world_model.ball().pos)
+                 .normalized()
+                 .dot((p - world_model.ball().pos).normalized());
+  score *= std::max((dot + 0.5), 0.0);
+
+  return score;
+}
+
+}  // namespace crane


### PR DESCRIPTION
## Summary

- `crane_visualizer_wrapper.cpp` の古い `SvgRobotBuilderと同じロジック` コメントを削除
- OurSlack/TheirSlackMetric の `computeSlackForTeam()` ヘルパー抽出で重複解消、`visualize()` の二重計算をキャッシュ参照に変更
- `getBallIdle()` の static ローカル変数を `ball_records_` メンバ変数化、`onPlaySituationChanged()` のマジックナンバーを `crane_msgs::msg::PlaySituation` 定数に置換
- `BallThreatMetric` / `RobotThreatsMetric` / `RecommendedDefendersMetric` が各自保持していた同一設定の `ThreatEvaluator` を1つの `shared_ptr` で共有
- `SelectionHysteresis<T>` テンプレートクラス新設（`selection_hysteresis.hpp`）、`AttackerCandidateMetric` と `PassTargetMetric` の重複ヒステリシスロジックを統一
- `evaluateSubAttackerPosition()` を `crane_msg_wrappers` 共通関数に移動（`crane_game_analyzer` / `crane_robot_skills` 両パッケージの重複実装 ~70行を解消）
