### PR TITLE
refactor: crane_robot_skillsのバグ修正・冗長計算排除・コード品質改善

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/attacker.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/attacker.hpp
@@ -24,7 +24,6 @@ enum class AttackerState {
   FORCED_PASS,
   RECEIVE,
   KICK,
-  FINAL_GUARD,
 };
 
 class Attacker : public SkillBaseWithState
@@ -68,8 +67,6 @@ public:
   GoalKick goal_kick_skill;
 
   Receive receive_skill;
-
-  std::optional<Point> goal_front_dance_target = std::nullopt;
 
   struct OverDribbleInfo
   {

--- a/crane_robot_skills/include/crane_robot_skills/forward.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/forward.hpp
@@ -11,8 +11,6 @@
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
 
-#include "skill_base.hpp"
-
 namespace crane::skills
 {
 class Forward : public SkillBase

--- a/crane_robot_skills/include/crane_robot_skills/single_ball_placement.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/single_ball_placement.hpp
@@ -48,6 +48,15 @@ private:
 
   double pull_back_angle;
 
+  int contact_count_ = 0;
+
+  Point getPlacementTarget() const
+  {
+    Point p;
+    p << getParameter<double>("placement_x"), getParameter<double>("placement_y");
+    return p;
+  }
+
 public:
   template <typename... Args>
   explicit SingleBallPlacement(Args &&... args)

--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -158,8 +158,8 @@ void Attacker::initialize()
       }
     }();
 
-    double goal_angle_width = evaluateGoalAngle(robot()->pose.pos);
-    auto [best_angle, _] = world_model()->getLargestGoalAngleRangeFromPoint(robot()->pose.pos);
+    auto [best_angle, goal_angle_width] =
+      world_model()->getLargestGoalAngleRangeFromPoint(robot()->pose.pos);
     double angle_diff_deg =
       std::abs(getAngleDiff(getAngle(world_model()->ball().pos - robot()->pose.pos), best_angle)) *
       180.0 / M_PI;
@@ -363,17 +363,17 @@ double Attacker::calculatePassScore(const Point & target)
                                          (world_model()->fieldSize().x() * 0.5);
   score *= (1.0 - normed_distance_to_their_goal);
 
-  // パスがブロックされている場合は諦める
-  if (isPassBlocked(target)) {
-    return 0.0;
-  }
-
-  // パスラインに敵がいるときはスコアを下げる
+  // パスがブロックされているかチェックし、ブロックされていたら諦め、近くにいるときはスコアを下げる
   Segment ball_to_target{world_model()->ball().pos, target};
   const auto enemy_robots = world_model()->theirs().robotsWhere().available().get();
   if (auto nearest_enemy =
         world_model()->getNearestRobotWithDistanceFromSegment(ball_to_target, enemy_robots);
       nearest_enemy) {
+    if (
+      nearest_enemy->robot->getDistance(world_model()->ball().pos) > BALL_CONTROL_DISTANCE &&
+      nearest_enemy->distance < PASS_OBSTACLE_DISTANCE) {
+      return 0.0;  // パスがブロックされている
+    }
     score *= std::clamp(nearest_enemy->distance / 2.0, 0.0, 1.0);
   }
 

--- a/crane_robot_skills/src/ball_nearby_positioner.cpp
+++ b/crane_robot_skills/src/ball_nearby_positioner.cpp
@@ -10,19 +10,7 @@ namespace crane::skills
 {
 auto BallNearByPositioner::update() -> Status
 {
-  auto situation = world_model()->getMsg().play_situation.command.value;
-  double distance_from_target = [&]() {
-    switch (situation) {
-      case crane_msgs::msg::PlaySituation::THEIR_DIRECT_FREE:
-        return 0.5;
-      case crane_msgs::msg::PlaySituation::STOP:
-        return 0.5;
-      case crane_msgs::msg::PlaySituation::THEIR_BALL_PLACEMENT:
-        return 0.5;
-      default:
-        return 0.5;
-    }
-  }();
+  double distance_from_target = 0.5;
 
   distance_from_target += getParameter<double>("margin_distance");
   double normalized_offset =

--- a/crane_robot_skills/src/single_ball_placement.cpp
+++ b/crane_robot_skills/src/single_ball_placement.cpp
@@ -35,6 +35,7 @@ void SingleBallPlacement::initialize()
     static_cast<int>(SingleBallPlacementStates::ENTRY_POINT),
     static_cast<int>(SingleBallPlacementStates::ENTRY_POINT), [this]() {
       pull_back_target = std::nullopt;
+      contact_count_ = 0;
       return false;
     });
 
@@ -255,8 +256,6 @@ void SingleBallPlacement::initialize()
   addTransition(
     static_cast<int>(SingleBallPlacementStates::PULL_BACK_FROM_EDGE_OVER_LEAVE),
     static_cast<int>(SingleBallPlacementStates::ENTRY_POINT), [this]() {
-      Point placement_target;
-      placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
       // pull_back_targetからはなれたらENTRY_POINTへ移動
       return robot()->getDistance(pull_back_target.value()) > 0.3;
     });
@@ -270,8 +269,7 @@ void SingleBallPlacement::initialize()
 
   addStateFunction(static_cast<int>(SingleBallPlacementStates::GO_OVER_BALL), [this]() {
     command->setMaxVelocity("SingleBallPlacementStates::GO_OVER_BALL", 1.5);
-    Point placement_target;
-    placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
+    auto placement_target = getPlacementTarget();
     const auto & ball_pos = world_model()->ball().pos;
 
     constexpr double INTERVAL = 0.15;
@@ -316,8 +314,7 @@ void SingleBallPlacement::initialize()
       if (not getParameter<bool>("pass_enable")) {
         return false;
       }
-      Point placement_target;
-      placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
+      auto placement_target = getPlacementTarget();
       return (placement_target - world_model()->ball().pos).norm() > 2.0;
     });
 
@@ -326,13 +323,11 @@ void SingleBallPlacement::initialize()
     command->disableBallAvoidance();
     command->setMaxVelocity("SingleBallPlacementStates::PASS_TO_TARGET", 0.2);
     command->setMaxAcceleration("SingleBallPlacementStates::PASS_TO_TARGET", 1.0);
-    Point placement_target;
-    placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
+    auto placement_target = getPlacementTarget();
     command->lookAtFrom(placement_target, robot()->pose.pos);
     command->setTargetPosition(
       world_model()->ball().pos +
       (placement_target - world_model()->ball().pos).normalized() * 0.3);
-    command->kickStraight(0.3);
     command->kickStraight(0.3);
 
     return Status::RUNNING;
@@ -348,8 +343,7 @@ void SingleBallPlacement::initialize()
     command->disableBallAvoidance();
     command->setMaxVelocity("SingleBallPlacementStates::CONTACT_BALL", 0.2);
     command->setMaxAcceleration("SingleBallPlacementStates::CONTACT_BALL", 1.0);
-    Point placement_target;
-    placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
+    auto placement_target = getPlacementTarget();
     command->lookAtFrom(placement_target, world_model()->ball().pos);
     command->setTargetPosition(world_model()->ball().pos);
 
@@ -360,26 +354,25 @@ void SingleBallPlacement::initialize()
     static_cast<int>(SingleBallPlacementStates::CONTACT_BALL),
     static_cast<int>(SingleBallPlacementStates::MOVE_TO_TARGET), [this]() {
       auto now = rclcpp::Clock(RCL_ROS_TIME).now();
-      static int count = 0;
 
       // ボールセンサーが利用可能な場合は必ずセンサー反応を待つ
       if (robot()->getBallSensorAvailable(now, rclcpp::Duration::from_seconds(0.1))) {
         // センサーが反応している場合のみカウント
         if (robot()->ball_sensor) {
-          if (++count > 2) {
-            count = 0;
+          if (++contact_count_ > 2) {
+            contact_count_ = 0;
             return true;
           } else {
             return false;
           }
         } else {
           // センサーは利用可能だが反応していない → まだ接触していない
-          count = 0;
+          contact_count_ = 0;
           return false;
         }
       } else {
         // センサーが利用不可の場合のみ距離で判定（フォールバック）
-        count = 0;
+        contact_count_ = 0;
         return robot()->getDistance(world_model()->ball().pos) < 0.15;
       }
     });
@@ -395,8 +388,7 @@ void SingleBallPlacement::initialize()
     });
 
   addStateFunction(static_cast<int>(SingleBallPlacementStates::MOVE_TO_TARGET), [this]() {
-    Point placement_target;
-    placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
+    auto placement_target = getPlacementTarget();
 
     [[maybe_unused]] Point ball_pos = [&]() -> Point {
       if (robot()->ball_sensor) {
@@ -445,8 +437,7 @@ void SingleBallPlacement::initialize()
       if (sleep) {
         sleep.reset();
       }
-      Point placement_target;
-      placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
+      auto placement_target = getPlacementTarget();
       if (skill_status == Status::SUCCESS) {
         return true;
       } else if (
@@ -515,8 +506,7 @@ void SingleBallPlacement::initialize()
     // ボール判定15cm + ロボット判定50cm + ロボット半径10cm + マージン5com = 80cm
     Vector2 diff = -getNormVec(robot()->pose.theta) * 0.8;
     Point leave_pos = robot()->pose.pos + diff;
-    Point placement_target;
-    placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
+    auto placement_target = getPlacementTarget();
 
     if ((robot()->pose.pos - placement_target).norm() > 0.8) {
       // 離れたならば、その場に留まる
@@ -534,8 +524,7 @@ void SingleBallPlacement::initialize()
   addTransition(
     static_cast<int>(SingleBallPlacementStates::LEAVE_BALL),
     static_cast<int>(SingleBallPlacementStates::ENTRY_POINT), [this]() {
-      Point placement_target;
-      placement_target << getParameter<double>("placement_x"), getParameter<double>("placement_y");
+      auto placement_target = getPlacementTarget();
       // ルール 5.2 0.15m以内で認められる。再配置が必要場合のみ、 ENTRY_POINTへ移動
       // return (world_model()->ball().pos - placement_target).norm() > 0.15;
       return ((world_model()->ball().pos - placement_target).norm() > 0.15) &&

--- a/crane_robot_skills/src/sub_attacker.cpp
+++ b/crane_robot_skills/src/sub_attacker.cpp
@@ -86,19 +86,13 @@ Status SubAttacker::update()
       }
     }
     command->setTargetPosition(best_position);
+    // ゴールとボールの中間方向を向く
+    auto [goal_angle, width] = world_model()->getLargestGoalAngleRangeFromPoint(best_position);
+    auto to_goal = getNormVec(goal_angle);
+    auto to_ball = (world_model()->ball().pos - best_position).normalized();
+    command->setTargetTheta(getAngle(to_goal + to_ball));
+    command->kickStraight(getParameter<double>("kicker_power"));
   }
-
-  // ゴールとボールの中間方向を向く
-  Point target_pos = robot()->pose.pos;
-  if (!command->getMsg().position_target_mode.empty()) {
-    target_pos << command->getMsg().position_target_mode.front().target_x,
-      command->getMsg().position_target_mode.front().target_y;
-  }
-  auto [goal_angle, width] = world_model()->getLargestGoalAngleRangeFromPoint(target_pos);
-  auto to_goal = getNormVec(goal_angle);
-  auto to_ball = (world_model()->ball().pos - target_pos).normalized();
-  command->setTargetTheta(getAngle(to_goal + to_ball));
-  command->kickStraight(getParameter<double>("kicker_power"));
 
   return Status::RUNNING;
 }


### PR DESCRIPTION
## 概要

`crane_robot_skills` パッケージのコードレビューで発見したバグ・冗長計算・コード品質問題を修正します。

## バグ修正

### SubAttacker: `setTargetTheta`/`kickStraight` の無条件上書き（重大バグ）

if-else 分岐の外に `setTargetTheta` と `kickStraight` が置かれており、全分岐で無条件に上書きされていた問題を修正。

- ボールラインから遠ざかる分岐でも `kickStraight` が呼ばれていた
- ボールの進路上移動分岐で設定した `setTargetTheta(2*to_goal+to_ball)` が `(to_goal+to_ball)` に上書きされていた

ゴール方向計算とキック指令を「ベストポジションへ移動」分岐の末尾に移動。

### SingleBallPlacement: `static int count` の複数インスタンス共有バグ

`CONTACT_BALL→MOVE_TO_TARGET` 遷移ラムダ内の `static int count` がクラスの全インスタンスで共有される問題を修正。

- メンバ変数 `contact_count_` に変更
- `ENTRY_POINT` の self-transition でリセット処理を追加

### SingleBallPlacement: `kickStraight` の二重呼び出し

`PASS_TO_TARGET` ステートで `command->kickStraight(0.3)` が連続2回呼ばれていたため1つ削除。

## 冗長計算の排除

### Attacker RECEIVE: `getLargestGoalAngleRangeFromPoint` の二重呼び出しを統合

`evaluateGoalAngle()` が内部で呼ぶのと同じ `getLargestGoalAngleRangeFromPoint` を直後に再度呼んでいた。1回の呼び出しで `best_angle` と `goal_angle_width` を同時に取得するよう統合。

### Attacker `calculatePassScore`: `Segment`/敵ロボットリストの二重作成を解消

`isPassBlocked(target)` と直後のコードで同じ `Segment`・敵ロボットリストを2回作成していた。`isPassBlocked` をインライン展開し、1回の `getNearestRobot` 呼び出しでブロック判定とスコア減算を処理するよう統合。

## コード品質改善

- **forward.hpp**: `skill_base.hpp` の重複インクルードを削除（L11とL14で2回インクルード）
- **SingleBallPlacement**: `getPlacementTarget()` ヘルパーを追加し、8箇所の `placement_x/y` 読み取りを一元化。未使用の呼び出し1件も削除
- **BallNearByPositioner**: 全ケースで `0.5` を返す無意味な `switch` 文を `double distance_from_target = 0.5;` に置換
- **Attacker**: 未使用の `goal_front_dance_target` メンバと未使用の `FINAL_GUARD` enum値を削除

## 検証

- `colcon build --packages-select crane_robot_skills` でビルド成功を確認
- 既存の警告（`skill_base.hpp` の `[[nodiscard]]`）は今回の変更と無関係

## スコープ外（別PR）

- `SubAttacker::getPointScore` の未使用 `next_target` パラメータ（外部公開API）
- `Attacker::shouldUseChipKick` のシグネチャ変更
- `CenterStopKick` / `BallCalibrationDataCollector` の共通基底クラス抽出