### PR TITLE
refactor: crane_robot_receiver コード品質改善

### DIFF
--- a/crane_robot_receiver/CMakeLists.txt
+++ b/crane_robot_receiver/CMakeLists.txt
@@ -26,12 +26,11 @@ ament_auto_add_executable(robot_receiver_node
   src/robot_receiver_node.cpp
 )
 add_backward(robot_receiver_node)
+target_link_libraries(robot_receiver_node atomic)
 
 ament_auto_add_executable(ping_status_node
         src/ping_status_node.cpp
 )
-target_link_libraries(robot_receiver_node atomic)
-add_backward(robot_receiver_node)
 
 ament_auto_add_executable(diagnostic_publisher_node
         src/diagnostic_publisher.cpp

--- a/crane_robot_receiver/include/crane_robot_receiver/diagnostic_publisher.hpp
+++ b/crane_robot_receiver/include/crane_robot_receiver/diagnostic_publisher.hpp
@@ -49,6 +49,10 @@ public:
   // エラーマップからエラーを削除
   auto removeError(const std::string & error_type) -> bool;
 
+  // ロボットがVision/Trackerで検出されているか確認
+  auto isRobotDetected(const WorldModelWrapper & world_model, bool require_feedback = false) const
+    -> bool;
+
   uint8_t robot_id;
 
   RobotState state = RobotState::INACTIVE;

--- a/crane_robot_receiver/include/crane_robot_receiver/robot_feedback_protocol.hpp
+++ b/crane_robot_receiver/include/crane_robot_receiver/robot_feedback_protocol.hpp
@@ -102,17 +102,21 @@ inline auto readByte(const std::vector<uint8_t> & buffer, int offset) -> uint8_t
 // std::vector<char> 版のオーバーロード
 inline auto readFloat(const std::vector<char> & buffer, int offset) -> float
 {
-  return readFloat(reinterpret_cast<const std::vector<uint8_t> &>(buffer), offset);
+  float value;
+  std::memcpy(&value, &buffer[offset], sizeof(float));
+  return value;
 }
 
 inline auto readUint16(const std::vector<char> & buffer, int offset) -> uint16_t
 {
-  return readUint16(reinterpret_cast<const std::vector<uint8_t> &>(buffer), offset);
+  uint16_t value;
+  std::memcpy(&value, &buffer[offset], sizeof(uint16_t));
+  return value;
 }
 
 inline auto readByte(const std::vector<char> & buffer, int offset) -> uint8_t
 {
-  return readByte(reinterpret_cast<const std::vector<uint8_t> &>(buffer), offset);
+  return static_cast<uint8_t>(buffer[offset]);
 }
 }  // namespace protocol
 
@@ -138,19 +142,19 @@ struct RobotFeedback
 
   bool ball_sensor = false;
 
-  float_t yaw_angle = 0.0f;
+  float yaw_angle = 0.0f;
 
-  float_t diff_angle = 0.0f;
+  float diff_angle = 0.0f;
 
-  std::array<float_t, 2> odom = {0.0f, 0.0f};
+  std::array<float, 2> odom = {0.0f, 0.0f};
 
-  std::array<float_t, 2> odom_speed = {0.0f, 0.0f};
+  std::array<float, 2> odom_speed = {0.0f, 0.0f};
 
-  std::array<float_t, 2> mouse_odom = {0.0f, 0.0f};
+  std::array<float, 2> mouse_odom = {0.0f, 0.0f};
 
-  std::array<float_t, 2> mouse_vel = {0.0f, 0.0f};
+  std::array<float, 2> mouse_vel = {0.0f, 0.0f};
 
-  std::array<float_t, 2> voltage = {0.0f, 0.0f};
+  std::array<float, 2> voltage = {0.0f, 0.0f};
 
   uint8_t check_ver = 0;
 

--- a/crane_robot_receiver/src/diagnostic_publisher.cpp
+++ b/crane_robot_receiver/src/diagnostic_publisher.cpp
@@ -27,7 +27,7 @@ auto RobotData::updateErrorMap(
   const rclcpp::Time & timestamp) -> bool
 {
   // エラーが既存または変更された場合のみ更新
-  bool is_new = (error_map.count(error_type) == 0) || (error_map[error_type].level != level) ||
+  bool is_new = !error_map.contains(error_type) || (error_map[error_type].level != level) ||
                 (error_map[error_type].message != message);
 
   if (is_new) {
@@ -45,10 +45,23 @@ auto RobotData::updateErrorMap(
 
 auto RobotData::removeError(const std::string & error_type) -> bool
 {
-  if (error_map.count(error_type) > 0) {
+  if (error_map.contains(error_type)) {
     error_map.erase(error_type);
     has_error_changed = true;
     return true;
+  }
+  return false;
+}
+
+auto RobotData::isRobotDetected(const WorldModelWrapper & world_model, bool require_feedback) const
+  -> bool
+{
+  for (const auto & robot_info : world_model.getMsg().robot_info_ours) {
+    if (robot_info.id == robot_id) {
+      return require_feedback ? (robot_info.available_vision || robot_info.available_feedback ||
+                                 robot_info.available_tracker)
+                              : (robot_info.available_vision || robot_info.available_tracker);
+    }
   }
   return false;
 }
@@ -68,17 +81,7 @@ auto RobotData::initializeDiagnostics(
   updater->add(
     diagnostic_prefix + "communication", [this, node, world_model, sim_mode, latest_ping_msg](
                                            diagnostic_updater::DiagnosticStatusWrapper & stat) {
-      const auto & msg = world_model->getMsg();
-      bool detected = false;
-      for (const auto & robot_info : msg.robot_info_ours) {
-        if (robot_info.id == robot_id) {
-          detected = robot_info.available_vision || robot_info.available_tracker;
-          break;
-        }
-      }
-
-      if (!detected) {
-        // 検出されていない場合はOKとして扱う（診断エラーをクリア）
+      if (!isRobotDetected(*world_model)) {
         stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Robot not detected");
         removeError("communication");
         return;
@@ -87,23 +90,11 @@ auto RobotData::initializeDiagnostics(
     });
 
   // バッテリー状態の診断
+  // 【循環参照回避】available_vision/feedback/trackerは診断結果に依存しないため安全
   updater->add(
     diagnostic_prefix + "battery", [this, node, world_model, sim_mode, latest_feedback_msg](
                                      diagnostic_updater::DiagnosticStatusWrapper & stat) {
-      // 【循環参照回避】WorldModelからビジョン検出状態のみをチェック
-      // available_vision/feedback/trackerは診断結果に依存しないため、循環参照を回避できる
-      const auto & msg = world_model->getMsg();
-      bool detected = false;
-      for (const auto & robot_info : msg.robot_info_ours) {
-        if (robot_info.id == robot_id) {
-          detected = robot_info.available_vision || robot_info.available_feedback ||
-                     robot_info.available_tracker;
-          break;
-        }
-      }
-
-      if (!detected) {
-        // 検出されていない場合はOKとして扱う（診断エラーをクリア）
+      if (!isRobotDetected(*world_model, true)) {
         stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Robot not detected");
         removeError("battery");
         return;
@@ -112,23 +103,11 @@ auto RobotData::initializeDiagnostics(
     });
 
   // ロボットエラーの診断
+  // 【循環参照回避】available_vision/feedback/trackerは診断結果に依存しないため安全
   updater->add(
     diagnostic_prefix + "robot_error", [this, node, world_model, sim_mode, latest_feedback_msg](
                                          diagnostic_updater::DiagnosticStatusWrapper & stat) {
-      // WorldModelからビジョン検出状態のみをチェック
-      // available_vision/feedback/trackerは診断結果に依存しないため、循環参照を回避できる
-      const auto & msg = world_model->getMsg();
-      bool detected = false;
-      for (const auto & robot_info : msg.robot_info_ours) {
-        if (robot_info.id == robot_id) {
-          detected = robot_info.available_vision || robot_info.available_feedback ||
-                     robot_info.available_tracker;
-          break;
-        }
-      }
-
-      if (!detected) {
-        // 検出されていない場合はOKとして扱う（診断エラーをクリア）
+      if (!isRobotDetected(*world_model, true)) {
         stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Robot not detected");
         removeError("robot_error");
         return;
@@ -410,7 +389,7 @@ auto DiagnosticPublisherNode::visualizeRobotErrors() -> void
       uint8_t robot_id = robot_data->robot_id;
 
       // ロボット位置が有効な場合のみ表示
-      if (robot_positions.count(robot_id) > 0 && robot_positions[robot_id].valid) {
+      if (robot_positions.contains(robot_id) && robot_positions[robot_id].valid) {
         // 最初のエラーでマーカー円を表示
         if (text_offset == 0.0) {
           // エラーレベルに応じた色を設定
@@ -429,7 +408,6 @@ auto DiagnosticPublisherNode::visualizeRobotErrors() -> void
 
         // エラーメッセージを表示
         std::string color = utils::getColorForErrorLevel(error_info.level);
-        constexpr double opacity = 0.8;
 
         visualizer_error->drawCenteredLabel(
           Point(

--- a/crane_robot_receiver/src/grsim_robot_status_node.cpp
+++ b/crane_robot_receiver/src/grsim_robot_status_node.cpp
@@ -57,8 +57,8 @@ protected:
   auto on_timer() -> void
   {
     auto process = [this](auto & receiver, auto & msg) {
+      std::vector<char> buf(2048);
       while (receiver->available()) {
-        std::vector<char> buf(2048);
         const size_t size = receiver->receive(buf);
 
         if (size > 0) {

--- a/crane_robot_receiver/src/robot_receiver_node.cpp
+++ b/crane_robot_receiver/src/robot_receiver_node.cpp
@@ -47,9 +47,6 @@ public:
   auto updateFeedback() -> void
   {
     RobotFeedback feedback;
-    // 最新のデータでリセット
-    feedback = robot_feedback;
-
     // 受信タイムスタンプを更新
     feedback.received_stamp = clock.now();
 
@@ -201,46 +198,31 @@ public:
           robot_feedback_msg.packet_frequency_hz = receiver->getPacketFrequency();
           robot_feedback_msg.counter = robot_feedback.counter;
           robot_feedback_msg.kick_state = robot_feedback.kick_state;
-          for (auto temperature : robot_feedback.temperature) {
-            robot_feedback_msg.temperatures.push_back(temperature);
-          }
+          robot_feedback_msg.temperatures.assign(
+            std::begin(robot_feedback.temperature), std::end(robot_feedback.temperature));
 
           robot_feedback_msg.error_id = robot_feedback.error_id;
           robot_feedback_msg.error_info = robot_feedback.error_info;
-
           robot_feedback_msg.error_value = robot_feedback.error_value;
 
-          for (auto motor_current : robot_feedback.motor_current) {
-            robot_feedback_msg.motor_current.push_back(motor_current);
-          }
-          for (auto ball_detection : robot_feedback.ball_detection) {
-            robot_feedback_msg.ball_detection.push_back(ball_detection);
-          }
-          robot_feedback_msg.ball_sensor =
-            static_cast<bool>(robot_feedback_msg.ball_detection[0] == 1);
+          robot_feedback_msg.motor_current.assign(
+            std::begin(robot_feedback.motor_current), std::end(robot_feedback.motor_current));
+          robot_feedback_msg.ball_detection.assign(
+            std::begin(robot_feedback.ball_detection), std::end(robot_feedback.ball_detection));
+          robot_feedback_msg.ball_sensor = (robot_feedback_msg.ball_detection[0] == 1);
           robot_feedback_msg.yaw_angle = robot_feedback.yaw_angle;
           robot_feedback_msg.diff_angle = robot_feedback.diff_angle;
-          for (auto odom : robot_feedback.odom) {
-            robot_feedback_msg.odom.push_back(odom);
-          }
-          for (auto odom_speed : robot_feedback.odom_speed) {
-            robot_feedback_msg.odom_speed.push_back(odom_speed);
-          }
-          for (auto mouse_odom : robot_feedback.mouse_odom) {
-            robot_feedback_msg.mouse_odom.push_back(mouse_odom);
-          }
-
-          for (auto mouse_vel : robot_feedback.mouse_vel) {
-            robot_feedback_msg.mouse_vel.push_back(mouse_vel);
-          }
-          for (auto voltage : robot_feedback.voltage) {
-            robot_feedback_msg.voltage.push_back(voltage);
-          }
+          robot_feedback_msg.odom.assign(robot_feedback.odom.begin(), robot_feedback.odom.end());
+          robot_feedback_msg.odom_speed.assign(
+            robot_feedback.odom_speed.begin(), robot_feedback.odom_speed.end());
+          robot_feedback_msg.mouse_odom.assign(
+            robot_feedback.mouse_odom.begin(), robot_feedback.mouse_odom.end());
+          robot_feedback_msg.mouse_vel.assign(
+            robot_feedback.mouse_vel.begin(), robot_feedback.mouse_vel.end());
+          robot_feedback_msg.voltage.assign(
+            robot_feedback.voltage.begin(), robot_feedback.voltage.end());
           robot_feedback_msg.check_ver = robot_feedback.check_ver;
-
-          for (const auto & value : robot_feedback.values) {
-            robot_feedback_msg.values.push_back(value);
-          }
+          robot_feedback_msg.values = robot_feedback.values;
           msg.feedback.push_back(robot_feedback_msg);
         }
       }


### PR DESCRIPTION
## 概要

`crane_robot_receiver` パッケージ全体のコード品質を改善。
未定義動作の修正、C++20対応、重複コード排除、パフォーマンス改善を実施。

## 変更内容

### 未定義動作の修正（重大）
- `robot_feedback_protocol.hpp`: `std::vector<char>` を `std::vector<uint8_t>` に `reinterpret_cast` していた箇所を `std::memcpy` による直接読み取りに変更

### C++20 対応
- `diagnostic_publisher.cpp`: `error_map.count()` / `robot_positions.count()` を C++20 の `contains()` に統一

### 型の統一
- `robot_feedback_protocol.hpp`: `RobotFeedback` 構造体の `float_t`（環境依存で `double` になり得る）を `float` に統一

### 重複コード排除
- `diagnostic_publisher.hpp/.cpp`: 3つの診断コールバックで同一だったロボット検出ロジックを `isRobotDetected()` ヘルパーメソッドに抽出

### CMakeLists.txt 修正
- `add_backward` と `target_link_libraries` が重複・誤った位置に配置されていたのを修正

### パフォーマンス改善
- `grsim_robot_status_node.cpp`: `while` ループ内での毎回のバッファ確保をループ外に移動
- `robot_receiver_node.cpp`: `updateFeedback()` の不要なコピー代入を削除
- `robot_receiver_node.cpp`: 固定サイズ配列への `push_back` ループを `assign(begin, end)` に置換

## テスト

- `colcon build --packages-select crane_robot_receiver` でビルド確認済み
- 既存の関数シグネチャ変更なし、振る舞いは同一