### PR TITLE
fix: Kickスキルのボール弾き防止のため角度チェックをkick_vec_gainに追加

### DIFF
--- a/crane_robot_skills/src/kick.cpp
+++ b/crane_robot_skills/src/kick.cpp
@@ -95,9 +95,17 @@ void Kick::initialize()
         ball_pos, safe_target, robot()->pose.pos, interval, max_interval);
     }();
 
+    command->disableBallAvoidance();
+    using boost::math::constants::degree;
+    const double angle_threshold = getParameter<double>("angle_threshold_deg") * degree<double>();
+    const bool angle_ok =
+      std::abs(getAngleDiff(getAngle(kick_vec), getAngle(ball_pos - robot()->pose.pos))) <
+      angle_threshold;
+
     double kick_vec_gain = [&]() {
       Segment ball_kick_zone{ball_pos, ball_pos - kick_vec * interval};
-      if (bg::distance(ball_kick_zone, robot()->pose.pos) < 0.1) {
+      // 角度が合っている場合のみキックゾーンに入ったと判断し、ボールに向かって押し込む
+      if (angle_ok && bg::distance(ball_kick_zone, robot()->pose.pos) < 0.15) {
         command->disableCollisionAvoidance();
         return 0.5;
       } else {
@@ -107,12 +115,7 @@ void Kick::initialize()
 
     command->lookAtFrom(safe_target, ball_pos)
       .setDribblerTargetPosition(approach + kick_vec * kick_vec_gain);
-    command->disableBallAvoidance();
-    using boost::math::constants::degree;
-    const double angle_threshold = getParameter<double>("angle_threshold_deg") * degree<double>();
-    if (
-      std::abs(getAngleDiff(getAngle(kick_vec), getAngle(ball_pos - robot()->pose.pos))) <
-      angle_threshold) {
+    if (angle_ok) {
       if (getParameter<bool>("chip_kick")) {
         kickWithChip();
       } else {
@@ -125,8 +128,13 @@ void Kick::initialize()
     if (getParameter<bool>("with_dribble")) {
       command->withDribble(getParameter<double>("dribble_power"));
     } else {
-      // ドリブラーを止める
-      command->withDribble(0.0);
+      // ボール近傍では予防的にドリブラーを弱く起動し、接触時の弾きを防止
+      double ball_dist = (ball_pos - robot()->pose.pos).norm();
+      if (ball_dist < 0.3) {
+        command->withDribble(0.3);
+      } else {
+        command->withDribble(0.0);
+      }
     }
     return Status::RUNNING;
   });


### PR DESCRIPTION
## Summary

- `kick_vec_gain`の発動条件に角度チェックを追加し、キッカーがボール方向を正面に向いている場合のみ押し込み動作を行うよう修正
- `angle_ok`変数を共通化してキック判定とkick_vec_gainで再利用（重複計算の除去）
- `with_dribble=false`時もボール近傍(0.3m以内)でドリブラーを弱起動し、接触時の弾きを低減

## 問題と原因

rosbag解析（`rosbag2_2026_03_12-23_01_28`）でAttackerのキックオフ時にkick_power=0がbag全体を通じて続く事象を確認。

**根本原因**: `kick_vec_gain`の発動条件が距離のみで角度未考慮のため、回り込み途中（角度-37°など）でも押し込みが発動→ボールを斜めから押す→弾く→永遠に回り込む、という悪循環が発生していた。

## 変更内容

`crane_robot_skills/src/kick.cpp`:

```cpp
// 追加: 角度チェック
const bool angle_ok =
  std::abs(getAngleDiff(getAngle(kick_vec), getAngle(ball_pos - robot()->pose.pos))) <
  angle_threshold;

// 変更: 距離のみ → 角度OK && 距離の両条件
if (angle_ok && bg::distance(ball_kick_zone, robot()->pose.pos) < 0.15) {
  command->disableCollisionAvoidance();
  return 0.5;
}
```

## Test plan

- [x] rosbag `rosbag2_2026_03_12-23_01_28`（変更前）: kick_power=0、キック0回
- [x] rosbag `rosbag2_2026_03_12-23_23_56`（around_interval=0.25の誤修正）: kick_power=0、旋回ループ
- [x] rosbag `rosbag2_2026_03_13-00_17_09`（本修正適用後）: kick_power>0、6.96 m/sのゴールキックを複数回確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)