### PR TITLE
fix: ボールプレイスメント中にゴールキーパーが担当ロボットに選ばれる問題を修正

### DIFF
--- a/crane_sessions/include/crane_sessions/placement_avoidance_session.hpp
+++ b/crane_sessions/include/crane_sessions/placement_avoidance_session.hpp
@@ -38,10 +38,6 @@ public:
   {
     auto wm = world_model;
     return [wm](const std::shared_ptr<RobotInfo> & robot) {
-      // ゴールキーパーは除外
-      if (robot->id == wm->getOurGoalieId()) {
-        return GOALIE_EXCLUSION_COST;
-      }
       // ボール配置エリアへの距離（近いほど優先）
       if (auto placement_area = wm->getBallPlacementArea(); placement_area) {
         return bg::distance(robot->pose.pos, placement_area.value());


### PR DESCRIPTION
## 問題

`OUR_BALL_PLACEMENT` 状態でゴールキーパーが `ball_placement_skill` に割り当てられる問題が発生していた（rosbag `rosbag2_2026_03_13-00_42_30` で確認）。

## 原因

`BallPlacementSkillSession` と `BallPlacementAvoidanceSession` の両方がゴールキーパーに `GOALIE_EXCLUSION_COST = 1e9` を返していた。

ハンガリアン法によるグローバルコスト最小化では、ゴーリーの両セッションへのコストが同値（1e9）のため、他のロボットの配置最適化を優先してゴーリーを `ball_placement_skill` に割り当ててしまっていた。

なお、`goalie_skill` はボールプレイスメント中の妨害・反則を避けるため意図的に `OUR_BALL_PLACEMENT` から除外されている。

## 修正

`BallPlacementAvoidanceSession::getRobotSuitabilityFunc()` から `GOALIE_EXCLUSION_COST` を削除。

これにより：
- ゴーリーの `ball_placement_skill` コスト: `1e9`（変更なし）
- ゴーリーの `ball_placement_avoidance` コスト: 通常の距離ベース（小さい値）

ハンガリアン法が確実にゴーリーを `ball_placement_avoidance` に割り当て、`ball_placement_skill` には他のロボットが選ばれるようになる。

## 変更ファイル

- `crane_sessions/include/crane_sessions/placement_avoidance_session.hpp`: ゴーリー除外コストを削除（4行削除）

🤖 Generated with [Claude Code](https://claude.com/claude-code)