### PR TITLE
fix: Goalieの失点・排出不全パターンを修正

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/goalie.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/goalie.hpp
@@ -36,6 +36,8 @@ public:
 
   Kick kick_skill;
 
+  std::optional<Point> prev_wait_point;
+
 private:
   void initialize();
 

--- a/crane_robot_skills/src/goalie.cpp
+++ b/crane_robot_skills/src/goalie.cpp
@@ -105,6 +105,7 @@ void Goalie::inplay(bool enable_emit)
   if (not intersections.empty() && world_model()->ball().vel.norm() > 0.3f) {
     // シュートブロック
     phase = "シュートブロック";
+    prev_wait_point = std::nullopt;
     auto result = ball.getClosestPointToTrajectory(command->getRobot()->pose.pos);
     auto target = [&]() -> Point {
       if (not world_model()->point_checker.isFieldInside(result.closest_point)) {
@@ -116,15 +117,31 @@ void Goalie::inplay(bool enable_emit)
 
     command->setTargetPosition(target).lookAtBallFrom(target);
   } else {
-    if (
-      world_model()->ball().isStopped(0.2) &&
-      world_model()->point_checker.isFriendPenaltyArea(ball.pos) && enable_emit) {
-      // ボールが止まっていて，味方ペナルティエリア内にあるときは，ペナルティエリア外に出す
+    // 改善C: 敵が近くにいる場合は排出せず待ち受け
+    bool ball_in_penalty = world_model()->ball().isStopped(0.2) &&
+                           world_model()->point_checker.isFriendPenaltyArea(ball.pos) &&
+                           enable_emit;
+    bool should_emit = ball_in_penalty;
+    if (ball_in_penalty) {
+      auto enemies = world_model()->theirs().robotsWhere().available().get();
+      bool enemy_near = std::any_of(enemies.begin(), enemies.end(), [&](const auto & e) {
+        return e->getDistance(ball.pos) < 2.0;
+      });
+      if (enemy_near) {
+        should_emit = false;
+        phase = "排出危険→待ち受け";
+      }
+    }
+
+    if (should_emit) {
+      // ボールが止まっていて，味方ペナルティエリア内にあり，敵が近くにいないときは排出
       phase = "ボール排出";
       emitBallFromPenaltyArea();
     } else {
       const double BLOCK_DIST = getParameter<double>("block_distance");
-      phase += "ボールを待ち受ける";
+      if (phase.empty()) {
+        phase += "ボールを待ち受ける";
+      }
       // デフォルト位置設定
       command->setTargetPosition(goal_center * 0.9).lookAt(Point(0, 0));
       if (std::signbit(world_model()->ball().pos.x()) == std::signbit(world_model()->goal().x())) {
@@ -152,15 +169,19 @@ void Goalie::inplay(bool enable_emit)
             candidates, ranges::less{}, [](const auto & p) { return p.second; });
         }();
 
-        Point goal_center_adjusted = goal_center;
-        goal_center_adjusted << goals.first.x() - std::clamp(goals.first.x(), -0.1, 0.1), 0.0f;
+        Point threat_point;
 
         if (not world_model()->point_checker.isFieldInside(ball.pos)) {
-          // TODO(HansRobo): 一番近いフィールド内の点を警戒するようにする
-          phase += "(範囲外なので正面に構える)";
-          command->setTargetPosition(goal_center_adjusted, 0.1).lookAt(Point(0, 0));
+          // 改善A: フィールド外ボールはY座標をゴール幅内にクランプし
+          // ゴールライン上の点を脅威点として通常フローに合流させる
+          phase += "(範囲外→ボール方向を警戒)";
+          double clamped_y = std::clamp(
+            static_cast<double>(ball.pos.y()),
+            static_cast<double>(std::min(goals.first.y(), goals.second.y())),
+            static_cast<double>(std::max(goals.first.y(), goals.second.y())));
+          threat_point = Point(goal_center.x(), clamped_y);
         } else {
-          Point threat_point = world_model()->ball().pos;
+          threat_point = world_model()->ball().pos;
 
           if (distance < 2.0) {
             phase += "(敵のパス先警戒モード)";
@@ -208,52 +229,58 @@ void Goalie::inplay(bool enable_emit)
             phase += "(とりあえず0.5s先を警戒モード)";
             threat_point = ball.getPredictedPosition(0.5);
           }
-
-          auto [weak_point, dist] = [&]() {
-            if (auto other_robots = world_model()
-                                      ->ours()
-                                      .robotsWhere()
-                                      .available()
-                                      .excludeId(world_model()->getOurGoalieId())
-                                      .get();
-                not other_robots.empty()) {
-              auto goal = world_model()->getLargestGoalAngleRangeFromPoint(
-                threat_point, world_model()->getOurGoalPosts(), other_robots);
-              Segment expected_ball_line(
-                threat_point, threat_point + getNormVec(goal.center_angle) * 10);
-              Segment goal_line(goals.first, goals.second);
-              auto intersect_to_goal_line = getIntersections(expected_ball_line, goal_line);
-              if (intersect_to_goal_line.empty()) {
-                return std::make_pair(goal_center, BLOCK_DIST);
-              } else {
-                auto intersect_to_penalty_area =
-                  world_model()->getIntersectionOurPenaltyArea(expected_ball_line, -0.8, -0.8);
-                auto ratio = world_model()->getForwardDefenseRatio(expected_ball_line);
-                if (not intersect_to_penalty_area || not ratio) {
-                  return std::make_pair(goal_center, BLOCK_DIST);
-                }
-                // ペナルティエリアライン上にボールがあるときにペナルティエリア上まで前進すると
-                // シュートをずらして打たれて決められてしまう?
-                double dist =
-                  bg::distance(intersect_to_goal_line.front(), *intersect_to_penalty_area) *
-                  (*ratio);
-                visualizer->drawLine(
-                  intersect_to_goal_line.front(), *intersect_to_penalty_area, "red", 1.0);
-                phase += "(前進守備量可変)";
-                command->addPlanningFactor("goalie", "dist:" + std::to_string(dist));
-                return std::make_pair(intersect_to_goal_line.front(), dist);
-              }
-            } else {
-              return std::make_pair(goal_center, BLOCK_DIST);
-            }
-          }();
-          Point wait_point = weak_point + (threat_point - weak_point).normalized() * dist;
-
-          // ゴール侵入防止: ゴールラインより前方にあることを保証
-          wait_point = clampXToGoalLine(wait_point, 0.1);
-
-          command->setTargetPosition(wait_point).lookAtBallFrom(wait_point);
         }
+
+        auto [weak_point, dist] = [&]() {
+          if (auto other_robots = world_model()
+                                    ->ours()
+                                    .robotsWhere()
+                                    .available()
+                                    .excludeId(world_model()->getOurGoalieId())
+                                    .get();
+              not other_robots.empty()) {
+            auto goal = world_model()->getLargestGoalAngleRangeFromPoint(
+              threat_point, world_model()->getOurGoalPosts(), other_robots);
+            Segment expected_ball_line(
+              threat_point, threat_point + getNormVec(goal.center_angle) * 10);
+            Segment goal_line(goals.first, goals.second);
+            auto intersect_to_goal_line = getIntersections(expected_ball_line, goal_line);
+            if (intersect_to_goal_line.empty()) {
+              return std::make_pair(goal_center, BLOCK_DIST);
+            } else {
+              auto intersect_to_penalty_area =
+                world_model()->getIntersectionOurPenaltyArea(expected_ball_line, -0.8, -0.8);
+              auto ratio = world_model()->getForwardDefenseRatio(expected_ball_line);
+              if (not intersect_to_penalty_area || not ratio) {
+                return std::make_pair(goal_center, BLOCK_DIST);
+              }
+              // ペナルティエリアライン上にボールがあるときにペナルティエリア上まで前進すると
+              // シュートをずらして打たれて決められてしまう?
+              double dist =
+                bg::distance(intersect_to_goal_line.front(), *intersect_to_penalty_area) * (*ratio);
+              visualizer->drawLine(
+                intersect_to_goal_line.front(), *intersect_to_penalty_area, "red", 1.0);
+              phase += "(前進守備量可変)";
+              command->addPlanningFactor("goalie", "dist:" + std::to_string(dist));
+              return std::make_pair(intersect_to_goal_line.front(), dist);
+            }
+          } else {
+            return std::make_pair(goal_center, BLOCK_DIST);
+          }
+        }();
+        Point wait_point = weak_point + (threat_point - weak_point).normalized() * dist;
+
+        // 改善B: ローパスフィルタでターゲット振動を抑制
+        constexpr double SMOOTHING_ALPHA = 0.7;
+        if (prev_wait_point) {
+          wait_point = *prev_wait_point * SMOOTHING_ALPHA + wait_point * (1.0 - SMOOTHING_ALPHA);
+        }
+        prev_wait_point = wait_point;
+
+        // ゴール侵入防止: ゴールラインより前方にあることを保証
+        wait_point = clampXToGoalLine(wait_point, 0.1);
+
+        command->setTargetPosition(wait_point).lookAtBallFrom(wait_point);
       }
     }
   }

--- a/crane_robot_skills/src/goalie.cpp
+++ b/crane_robot_skills/src/goalie.cpp
@@ -117,12 +117,15 @@ void Goalie::inplay(bool enable_emit)
 
     command->setTargetPosition(target).lookAtBallFrom(target);
   } else {
-    // 改善C: 敵が近くにいる場合は排出せず待ち受け
-    bool ball_in_penalty = world_model()->ball().isStopped(0.2) &&
-                           world_model()->point_checker.isFriendPenaltyArea(ball.pos) &&
-                           enable_emit;
+    // ボールがフィールド外かつ自陣側（ゴール内）かどうか
+    bool ball_in_our_goal = not world_model()->point_checker.isFieldInside(ball.pos) &&
+                            std::signbit(ball.pos.x()) == std::signbit(goal_center.x());
+    // 改善C: 敵が近くにいる場合は排出せず待ち受け（ゴール内ボールは敵チェックなし）
+    bool ball_in_penalty =
+      world_model()->ball().isStopped(0.2) && enable_emit &&
+      (world_model()->point_checker.isFriendPenaltyArea(ball.pos) || ball_in_our_goal);
     bool should_emit = ball_in_penalty;
-    if (ball_in_penalty) {
+    if (ball_in_penalty && not ball_in_our_goal) {
       auto enemies = world_model()->theirs().robotsWhere().available().get();
       bool enemy_near = std::any_of(enemies.begin(), enemies.end(), [&](const auto & e) {
         return e->getDistance(ball.pos) < 2.0;
@@ -169,19 +172,18 @@ void Goalie::inplay(bool enable_emit)
             candidates, ranges::less{}, [](const auto & p) { return p.second; });
         }();
 
-        Point threat_point;
-
         if (not world_model()->point_checker.isFieldInside(ball.pos)) {
-          // 改善A: フィールド外ボールはY座標をゴール幅内にクランプし
-          // ゴールライン上の点を脅威点として通常フローに合流させる
-          phase += "(範囲外→ボール方向を警戒)";
+          // 改善A: フィールド外ボールはゴール幅内にクランプして直接ポジション
+          phase += "(範囲外→ゴール直接守備)";
           double clamped_y = std::clamp(
             static_cast<double>(ball.pos.y()),
             static_cast<double>(std::min(goals.first.y(), goals.second.y())),
             static_cast<double>(std::max(goals.first.y(), goals.second.y())));
-          threat_point = Point(goal_center.x(), clamped_y);
+          Point wait_point = clampXToGoalLine(Point(goal_center.x(), clamped_y), 0.1);
+          prev_wait_point = wait_point;
+          command->setTargetPosition(wait_point).lookAtBallFrom(wait_point);
         } else {
-          threat_point = world_model()->ball().pos;
+          Point threat_point = world_model()->ball().pos;
 
           if (distance < 2.0) {
             phase += "(敵のパス先警戒モード)";
@@ -229,58 +231,64 @@ void Goalie::inplay(bool enable_emit)
             phase += "(とりあえず0.5s先を警戒モード)";
             threat_point = ball.getPredictedPosition(0.5);
           }
-        }
 
-        auto [weak_point, dist] = [&]() {
-          if (auto other_robots = world_model()
-                                    ->ours()
-                                    .robotsWhere()
-                                    .available()
-                                    .excludeId(world_model()->getOurGoalieId())
-                                    .get();
-              not other_robots.empty()) {
-            auto goal = world_model()->getLargestGoalAngleRangeFromPoint(
-              threat_point, world_model()->getOurGoalPosts(), other_robots);
-            Segment expected_ball_line(
-              threat_point, threat_point + getNormVec(goal.center_angle) * 10);
-            Segment goal_line(goals.first, goals.second);
-            auto intersect_to_goal_line = getIntersections(expected_ball_line, goal_line);
-            if (intersect_to_goal_line.empty()) {
-              return std::make_pair(goal_center, BLOCK_DIST);
-            } else {
-              auto intersect_to_penalty_area =
-                world_model()->getIntersectionOurPenaltyArea(expected_ball_line, -0.8, -0.8);
-              auto ratio = world_model()->getForwardDefenseRatio(expected_ball_line);
-              if (not intersect_to_penalty_area || not ratio) {
+          auto [weak_point, dist] = [&]() {
+            if (auto other_robots = world_model()
+                                      ->ours()
+                                      .robotsWhere()
+                                      .available()
+                                      .excludeId(world_model()->getOurGoalieId())
+                                      .get();
+                not other_robots.empty()) {
+              auto goal = world_model()->getLargestGoalAngleRangeFromPoint(
+                threat_point, world_model()->getOurGoalPosts(), other_robots);
+              Segment expected_ball_line(
+                threat_point, threat_point + getNormVec(goal.center_angle) * 10);
+              Segment goal_line(goals.first, goals.second);
+              auto intersect_to_goal_line = getIntersections(expected_ball_line, goal_line);
+              if (intersect_to_goal_line.empty()) {
                 return std::make_pair(goal_center, BLOCK_DIST);
+              } else {
+                auto intersect_to_penalty_area =
+                  world_model()->getIntersectionOurPenaltyArea(expected_ball_line, -0.8, -0.8);
+                auto ratio = world_model()->getForwardDefenseRatio(expected_ball_line);
+                if (not intersect_to_penalty_area || not ratio) {
+                  return std::make_pair(goal_center, BLOCK_DIST);
+                }
+                // ペナルティエリアライン上にボールがあるときにペナルティエリア上まで前進すると
+                // シュートをずらして打たれて決められてしまう?
+                double dist =
+                  bg::distance(intersect_to_goal_line.front(), *intersect_to_penalty_area) *
+                  (*ratio);
+                visualizer->drawLine(
+                  intersect_to_goal_line.front(), *intersect_to_penalty_area, "red", 1.0);
+                phase += "(前進守備量可変)";
+                command->addPlanningFactor("goalie", "dist:" + std::to_string(dist));
+                return std::make_pair(intersect_to_goal_line.front(), dist);
               }
-              // ペナルティエリアライン上にボールがあるときにペナルティエリア上まで前進すると
-              // シュートをずらして打たれて決められてしまう?
-              double dist =
-                bg::distance(intersect_to_goal_line.front(), *intersect_to_penalty_area) * (*ratio);
-              visualizer->drawLine(
-                intersect_to_goal_line.front(), *intersect_to_penalty_area, "red", 1.0);
-              phase += "(前進守備量可変)";
-              command->addPlanningFactor("goalie", "dist:" + std::to_string(dist));
-              return std::make_pair(intersect_to_goal_line.front(), dist);
+            } else {
+              return std::make_pair(goal_center, BLOCK_DIST);
             }
-          } else {
-            return std::make_pair(goal_center, BLOCK_DIST);
+          }();
+          Point wait_point = weak_point + (threat_point - weak_point).normalized() * dist;
+
+          // 改善D: wait_pointのY座標をゴールポスト幅内にクランプ
+          double min_y = std::min(goals.first.y(), goals.second.y());
+          double max_y = std::max(goals.first.y(), goals.second.y());
+          wait_point.y() = std::clamp(wait_point.y(), min_y, max_y);
+
+          // 改善B: ローパスフィルタでターゲット振動を抑制
+          constexpr double SMOOTHING_ALPHA = 0.7;
+          if (prev_wait_point) {
+            wait_point = *prev_wait_point * SMOOTHING_ALPHA + wait_point * (1.0 - SMOOTHING_ALPHA);
           }
-        }();
-        Point wait_point = weak_point + (threat_point - weak_point).normalized() * dist;
+          prev_wait_point = wait_point;
 
-        // 改善B: ローパスフィルタでターゲット振動を抑制
-        constexpr double SMOOTHING_ALPHA = 0.7;
-        if (prev_wait_point) {
-          wait_point = *prev_wait_point * SMOOTHING_ALPHA + wait_point * (1.0 - SMOOTHING_ALPHA);
+          // ゴール侵入防止: ゴールラインより前方にあることを保証
+          wait_point = clampXToGoalLine(wait_point, 0.1);
+
+          command->setTargetPosition(wait_point).lookAtBallFrom(wait_point);
         }
-        prev_wait_point = wait_point;
-
-        // ゴール侵入防止: ゴールラインより前方にあることを保証
-        wait_point = clampXToGoalLine(wait_point, 0.1);
-
-        command->setTargetPosition(wait_point).lookAtBallFrom(wait_point);
       }
     }
   }


### PR DESCRIPTION
## 概要

rosbag解析（2試合分、計10失点）で特定した根本原因に基づくGoalieスキルの改善。

## 変更内容

### 改善A: フィールド外ボール時の守備位置計算を修正

**問題**: ボールがフィールド外（ゴール内含む）のとき、`weak_point` 計算フローに合流させていたため、`threat_point` がゴールライン上になる縮退ケースで `wait_point` がゴールポスト外（Y=±1.1m など）に飛ぶ問題があった。GKが誤方向に走り、ボールと逆側のポストが空く。

**修正**: `isFieldInside=false` の場合、`weak_point` 計算を完全スキップし、ボールのY座標をゴール幅内にクランプしたゴールライン上の位置に直接移動する。

### 改善B: wait_point のローパスフィルタ（EMA）

**問題**: シュートがポスト/壁に反射した後、ボール速度ベクトルが急変して毎フレームターゲットが大きく振動する。

**修正**: `prev_wait_point` にα=0.7の指数移動平均を適用。シュートブロックモード突入時はリセット。

### 改善C: ゴール内ボールの排出対応

**問題**: `isFriendPenaltyArea()` はフィールド外の点に対して `false` を返すため、ボールがゴール内（x>6.0）に入ると排出が一切トリガーされなかった。結果として相手ボールプレイスメントになる状況が頻発。

**修正**: フィールド外かつ自陣側のボール（`ball_in_our_goal`）を別途検出し排出条件に追加。ゴール内ボールは敵接近チェックをスキップして即排出する。

### 改善D: wait_point Y座標のゴールポスト幅内クランプ

**問題**: `getLargestGoalAngleRangeFromPoint` の計算結果によってはゴールポスト外のY値になる場合があり、GKがポスト外まで走り出てしまう。

**修正**: `wait_point.y()` をゴールポスト範囲（`goals.first.y()` ～ `goals.second.y()`）にクランプ。

## 修正ファイル

- `crane_robot_skills/include/crane_robot_skills/goalie.hpp` — `prev_wait_point` メンバ追加
- `crane_robot_skills/src/goalie.cpp` — 上記4改善の実装

## 検証

rosbag `rosbag2_2026_03_13-01_02_45`（6失点）および `rosbag2_2026_03_13-01_39_04`（4失点）の各シーンを解析して根本原因を特定し、それぞれのパターンに対応する修正を実装。

🤖 Generated with [Claude Code](https://claude.com/claude-code)