### PR TITLE
feat: ボールプレイスメント時のフィールド境界制限を解除可能にする

### DIFF
--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -445,6 +445,9 @@ auto RVO2Planner::adjustForFieldBoundary(
   Point & target_pos, const Point & current_pos,
   const crane_msgs::msg::RobotCommand & command) const -> void
 {
+  if (command.local_planner_config.disable_field_boundary) {
+    return;
+  }
   const double max_x = world_model->fieldSize().x() / 2.0 + FIELD_BOUNDARY_OFFSET;
   const double max_y = world_model->fieldSize().y() / 2.0 + FIELD_BOUNDARY_OFFSET;
 

--- a/crane_msgs/msg/LocalPlannerConfig.msg
+++ b/crane_msgs/msg/LocalPlannerConfig.msg
@@ -2,6 +2,7 @@ bool disable_collision_avoidance false
 bool disable_goal_area_avoidance false
 bool disable_placement_avoidance false
 bool disable_ball_avoidance false
+bool disable_field_boundary false
 bool enable_rotation_stop_on_accel true
 
 NamedFloat[] max_velocity_factors

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
@@ -279,6 +279,18 @@ public:
     return *this;
   }
 
+  auto disableFieldBoundary() -> RobotCommandWrapper &
+  {
+    latest_msg.local_planner_config.disable_field_boundary = true;
+    return *this;
+  }
+
+  auto enableFieldBoundary() -> RobotCommandWrapper &
+  {
+    latest_msg.local_planner_config.disable_field_boundary = false;
+    return *this;
+  }
+
   auto enableRotationStopOnAccel() -> RobotCommandWrapper &
   {
     latest_msg.local_planner_config.enable_rotation_stop_on_accel = true;
@@ -293,12 +305,18 @@ public:
 
   auto disableAnyAreaAvoidance() -> RobotCommandWrapper &
   {
-    return disableGoalAreaAvoidance().disableBallAvoidance().disablePlacementAvoidance();
+    return disableGoalAreaAvoidance()
+      .disableBallAvoidance()
+      .disablePlacementAvoidance()
+      .disableFieldBoundary();
   }
 
   auto enableAnyAreaAvoidance() -> RobotCommandWrapper &
   {
-    return enableGoalAreaAvoidance().enableBallAvoidance().enablePlacementAvoidance();
+    return enableGoalAreaAvoidance()
+      .enableBallAvoidance()
+      .enablePlacementAvoidance()
+      .enableFieldBoundary();
   }
 
   auto disableBasicAvoidances() -> RobotCommandWrapper &


### PR DESCRIPTION
## Summary

- `LocalPlannerConfig.msg` に `disable_field_boundary` フラグを追加
- `adjustForFieldBoundary` にフラグチェックによる早期リターンを追加
- `RobotCommandWrapper` に `disableFieldBoundary()` / `enableFieldBoundary()` メソッドを追加
- `disableAnyAreaAvoidance()` / `enableAnyAreaAvoidance()` にフィールド境界制限の解除を含める

## Background

ボールプレイスメント時、ボールがフィールド境界付近にある場合、ロボットはフィールド外に出てボールを回収する必要がある。しかし `adjustForFieldBoundary` がフィールド外への目標位置を常に強制クランプしており、無効化する手段がなかった。

他の回避ロジック（ゴールエリア・ボール・プレイスメント）はすべて `disable_xxx` フラグに対応しているため、同じパターンでフィールド境界制限も無効化可能にした。

`single_ball_placement.cpp` では既に `disableAnyAreaAvoidance()` を呼んでいるため、変更なしでボールプレイスメント時に自動的にフィールド境界制限が解除される。

## Test plan

- [ ] `colcon build` が通ること（済み）
- [ ] シミュレーションでボールをフィールド境界付近に配置し、ボールプレイスメントが正常に動作すること