### PR TITLE
fix: パス判断ロジックとRECEIVE競合判定を全面的に改善

### DIFF
--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
@@ -26,7 +26,7 @@ public:
 
   [[nodiscard]] auto getDependencies() const -> std::vector<MetricId> override
   {
-    return {MetricId::OUR_SLACK, MetricId::BALL_THREAT};
+    return {MetricId::OUR_SLACK, MetricId::THEIR_SLACK, MetricId::BALL_THREAT};
   }
 
   auto compute(MetricContext & ctx) -> void override;

--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/pass_target_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/pass_target_metrics.hpp
@@ -48,11 +48,13 @@ public:
     });
   }
 
-  auto setEnemySlackConfig(const SlackTimeConfig & config, double slack_scale = 0.5) -> void
+  auto setEnemySlackConfig(const SlackTimeConfig & config, double slack_scale = 1.0) -> void
   {
     enemy_slack_config_ = config;
     slack_scale_ = slack_scale;
   }
+
+  auto setMinPassScore(double min_score) -> void { min_pass_score_ = min_score; }
 
 private:
   // パス起点の計算
@@ -73,7 +75,8 @@ private:
     .robot_max_acceleration = 3.0,  // 敵は自チームより高め（安全マージン）
     .robot_max_velocity = 5.5       // 敵は自チームより高め（安全マージン）
   };
-  double slack_scale_ = 0.5;  // スコア正規化用
+  double slack_scale_ = 1.0;     // スコア正規化用（1.0s余裕で満点）
+  double min_pass_score_ = 0.5;  // この閾値未満のスコアはパス不可
 };
 
 }  // namespace crane::metrics

--- a/crane_game_analyzer/src/metrics/attacker_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/attacker_metrics.cpp
@@ -39,6 +39,15 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
     double score;
   };
 
+  // 敵チームの中で最も有利なslack（ループ外で1回だけ計算）
+  constexpr double ENEMY_SLACK_SCORE_THRESHOLD = 0.2;  // スコア減算用: 敵がこの秒数以上早いと不利
+  double best_enemy_slack = -100.0;
+  for (const auto & ts : ctx.analysis.their_slack) {
+    if (ts.min.slack_time > best_enemy_slack) {
+      best_enemy_slack = ts.min.slack_time;
+    }
+  }
+
   std::vector<RobotScore> robot_scores;
 
   for (const auto & robot : available_robots) {
@@ -47,6 +56,7 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
     // Slack情報を取得
     double metric_distance = distance;
     bool has_valid_intercept = false;
+    double my_slack = -100.0;
 
     for (const auto & slack : ctx.analysis.our_slack) {
       if (slack.id == robot->id) {
@@ -57,6 +67,7 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
           metric_distance = (robot->pose.pos - intercept_pos).norm();
           has_valid_intercept = true;
         }
+        my_slack = slack.min.slack_time;
         break;
       }
     }
@@ -68,6 +79,11 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
     // インターセプト計算ができなかった（ボールに追いつけない等）場合はスコアを大幅に下げる
     if (!has_valid_intercept) {
       score *= 0.3;  // 0.5 -> 0.3に強化（インターセプト不可能なロボットの優先度を下げる）
+    }
+
+    // 敵slackとの比較: 敵が先にボールに到達できる場合はスコアを大幅に下げる
+    if (best_enemy_slack > my_slack + ENEMY_SLACK_SCORE_THRESHOLD) {
+      score *= 0.2;
     }
 
     double total_score = score;
@@ -138,8 +154,17 @@ auto AttackerCandidateMetric::compute(MetricContext & ctx) -> void
   ctx.analysis.recommended_attacker_id = attacker_hysteresis_.currentId().value_or(-1);
   ctx.analysis.attacker_suitability_score = best_score;
 
-  // recommended_pass_receiver_idは未使用（-1固定）
+  // recommended_pass_receiver_id: Attacker以外で最もスコアの高いロボットを推薦
   ctx.analysis.recommended_pass_receiver_id = -1;
+  {
+    int selected_attacker = ctx.analysis.recommended_attacker_id;
+    for (const auto & rs : robot_scores) {
+      if (static_cast<int>(rs.id) != selected_attacker) {
+        ctx.analysis.recommended_pass_receiver_id = rs.id;
+        break;
+      }
+    }
+  }
 }
 
 }  // namespace crane::metrics

--- a/crane_game_analyzer/src/metrics/pass_target_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/pass_target_metrics.cpp
@@ -51,9 +51,19 @@ auto PassTargetMetric::calcScore(
 {
   double score = 1.0;
 
-  // 距離（0〜4mで上昇）
+  // 距離評価（山型：1.5〜4.0mが最適ゾーン）
   const double pass_distance = (p - pass_origin).norm();
-  score += std::clamp(pass_distance * 0.5, 0.0, 2.0);
+  {
+    double distance_factor;
+    if (pass_distance < 1.5) {
+      distance_factor = pass_distance / 1.5;  // 0m→0.0, 1.5m→1.0
+    } else if (pass_distance <= 4.0) {
+      distance_factor = 1.0;  // 最適ゾーン
+    } else {
+      distance_factor = std::max(0.2, 1.0 - (pass_distance - 4.0) * 0.15);  // 漸減
+    }
+    score *= distance_factor;
+  }
 
   // ゴール角度（敵ゴールに対する見通し）
   {
@@ -76,15 +86,16 @@ auto PassTargetMetric::calcScore(
     score *= (1.0 - normed_distance_to_their_goal * 0.5);
   }
 
-  constexpr double KICK_SPEED = 3.0;
+  // 実際のキック速度に合わせて距離依存（attacker.cpp の configurePassKick と同じ式）
+  const double kick_speed = std::clamp(pass_distance, 2.0, 4.0);
   const Segment pass_line{pass_origin, p};
   const Vector2 pass_dir = p - pass_origin;
   const Vector2 ball_velocity =
-    (pass_distance > 1e-6) ? Vector2(pass_dir / pass_distance * KICK_SPEED) : Vector2::Zero();
+    (pass_distance > 1e-6) ? Vector2(pass_dir / pass_distance * kick_speed) : Vector2::Zero();
 
   auto calc_slack_time = [&](const auto & enemy) -> double {
     const auto closest = getClosestPointAndDistance(enemy->pose.pos, pass_line);
-    const double ball_time = (closest.closest_point - pass_origin).norm() / KICK_SPEED;
+    const double ball_time = (closest.closest_point - pass_origin).norm() / kick_speed;
 
     auto slack_result = ctx.world_model->getBallSlackTime(
       pass_origin, ball_velocity, ball_time, {enemy}, enemy_slack_config_);
@@ -154,6 +165,12 @@ auto PassTargetMetric::compute(MetricContext & ctx) -> void
     const auto & best = ctx.analysis.pass_scores.front();
     const int best_id = static_cast<int>(best.id);
     const double best_score = static_cast<double>(best.value);
+
+    // 最低スコア閾値チェック: パス品質が低すぎる場合はパス不可
+    if (best_score < min_pass_score_) {
+      pass_hysteresis_.reset();
+      return;
+    }
 
     double prev_score = 0.0;
     const auto prev_id = pass_hysteresis_.currentId();

--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -27,6 +27,8 @@ constexpr double BALL_CONTROL_DISTANCE = 1.0;
 constexpr double CHIP_KICK_DISTANCE = 2.0;
 constexpr double MOVING_BALL_VELOCITY = 1.0;
 constexpr double ENEMY_NEAR_BALL_DISTANCE = 2.0;
+constexpr double ENEMY_SLACK_RECEIVE_THRESHOLD = 0.3;  // RECEIVE抑制: 敵がこの秒数以上早いと諦める
+constexpr double MIN_PASS_SCORE_ATTACKER = 0.2;        // パス品質の下限（二重チェック用）
 }  // namespace
 void Attacker::initialize()
 {
@@ -116,6 +118,22 @@ void Attacker::initialize()
         robot()->getDistance(world_model()->ball().pos) > BALL_CONTROL_DISTANCE &&
         world_model()->ball().isMoving(MOVING_BALL_VELOCITY) &&
         world_model()->ball().isMovingTowards(robot()->pose.pos)) {
+        // GameAnalysisの既存slackデータで敵との競合チェック（追加計算コストなし）
+        const auto & ga = world_model()->getMsg().game_analysis;
+        double my_min_slack = -100.0;
+        for (const auto & s : ga.our_slack) {
+          if (s.id == robot()->id) {
+            my_min_slack = s.min.slack_time;
+            break;
+          }
+        }
+        double best_enemy_slack = -100.0;
+        for (const auto & s : ga.their_slack) {
+          best_enemy_slack = std::max(best_enemy_slack, static_cast<double>(s.min.slack_time));
+        }
+        if (best_enemy_slack > my_min_slack + ENEMY_SLACK_RECEIVE_THRESHOLD) {
+          return false;
+        }
         return true;
       } else {
         return false;
@@ -136,6 +154,16 @@ void Attacker::initialize()
         // 受取に成功してドリブラで触れている
         return true;
       } else {
+        // 敵がボールに明らかに近い場合は諦めてENTRY_POINTへ（再割り当て待ち）
+        auto enemies = world_model()->theirs().robotsWhere().available().get();
+        auto nearest_enemy =
+          world_model()->getNearestRobotWithDistanceFromPoint(world_model()->ball().pos, enemies);
+        if (nearest_enemy.has_value()) {
+          double my_dist = robot()->getDistance(world_model()->ball().pos);
+          if (nearest_enemy->distance < my_dist * 0.7) {
+            return true;
+          }
+        }
         return false;
       }
     });
@@ -198,8 +226,21 @@ void Attacker::initialize()
     if (world_model()->getMsg().game_analysis.pass_target_id >= 0) {
       auto target_id = static_cast<uint8_t>(world_model()->getMsg().game_analysis.pass_target_id);
       if (target_id != robot()->id) {
-        pass_receiver_id = target_id;
-        kick_target = world_model()->getOurRobot(target_id)->pose.pos;
+        // pass_scores からスコアを参照して低品質パスを拒否
+        const auto & pass_scores = world_model()->getMsg().game_analysis.pass_scores;
+        double target_score = 0.0;
+        for (const auto & s : pass_scores) {
+          if (s.id == target_id) {
+            target_score = s.value;
+            break;
+          }
+        }
+        if (target_score >= MIN_PASS_SCORE_ATTACKER) {
+          pass_receiver_id = target_id;
+          kick_target = world_model()->getOurRobot(target_id)->pose.pos;
+        } else {
+          pass_receiver_id = std::nullopt;
+        }
       } else {
         pass_receiver_id = std::nullopt;
       }
@@ -243,9 +284,14 @@ void Attacker::initialize()
       command->disableBallAvoidance();
       return kick_skill.run();
     } else {
-      // FINAL_GUARD
+      // FINAL_GUARD: ゴール角度が不十分なのでチップキックで前方クリア
       printTextOnRobot("KICK::FINAL_GUARD");
-      return goal_kick_skill.run();
+      kick_skill.setParameter("target", world_model()->getTheirGoalCenter());
+      kick_skill.setParameter("chip_kick", true);
+      kick_skill.setParameter("use_target_chip_distance", true);
+      kick_skill.setParameter("target_chip_distance", CHIP_KICK_DISTANCE);
+      command->disableBallAvoidance();
+      return kick_skill.run();
     }
   });
 }

--- a/crane_sessions/include/crane_sessions/pass_receiver_session.hpp
+++ b/crane_sessions/include/crane_sessions/pass_receiver_session.hpp
@@ -79,9 +79,16 @@ public:
   auto getRobotSuitabilityFunc() const
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {
-    // PassReceiverはgame_analysisのpass_target_idで指定されるため
-    // 適性関数でのフィルタリングは不要（デフォルトコスト0.0を返す）
-    return [](const std::shared_ptr<RobotInfo> &) { return 0.0; };
+    auto game_analysis = getGameAnalysis();
+    return [game_analysis](const std::shared_ptr<RobotInfo> & robot) {
+      // recommended_pass_receiver_id が設定されている場合そのロボットを最優先
+      if (
+        game_analysis.recommended_pass_receiver_id >= 0 &&
+        robot->id == static_cast<uint8_t>(game_analysis.recommended_pass_receiver_id)) {
+        return 0.0;
+      }
+      return 10.0;  // その他は低優先
+    };
   }
 
 protected:

--- a/utility/crane_physics/include/crane_physics/pass_evaluation.hpp
+++ b/utility/crane_physics/include/crane_physics/pass_evaluation.hpp
@@ -37,7 +37,7 @@ namespace crane
 inline auto evaluatePassShadow(
   const Point & ball_pos, const Point & target_pos,
   const std::vector<std::shared_ptr<RobotInfo>> & enemies, const double robot_radius = 0.09,
-  const double shadow_threshold = 0.3) -> double
+  const double shadow_threshold = 0.5) -> double
 {
   const Segment pass_line{ball_pos, target_pos};
   const Vector2 pass_dir = (target_pos - ball_pos).normalized();
@@ -70,6 +70,12 @@ inline auto evaluatePassShadow(
       continue;
     }
 
+    // パスライン上にロボット半径以内の敵は完全遮蔽
+    if (result.distance <= robot_radius) {
+      penalty_factor *= 0.0;
+      continue;
+    }
+
     // 遮蔽角度: atan2(robot_radius, dist_to_ball)
     const double shadow_angle = std::atan2(robot_radius, dist_to_ball);
 
@@ -81,7 +87,7 @@ inline auto evaluatePassShadow(
       // 遮蔽度に応じてペナルティを適用
       // 完全遮蔽(角度0)で0.0、遮蔽角度の境界で1.0
       const double shadow_ratio = 1.0 - (angle_to_target / shadow_angle);
-      const double shadow_penalty = 1.0 - shadow_ratio * 0.8;  // 最大80%減
+      const double shadow_penalty = 1.0 - shadow_ratio * 0.95;  // 最大95%減
       penalty_factor *= shadow_penalty;
     }
   }


### PR DESCRIPTION
## Summary

- **望み薄なパスを出す問題**と**パスを出すべきでない場面でパスを出す問題**を解消
- **RECEIVEモードで明らかに敵に先取られる状況でも受け取ろうとする問題**を解消

## 変更内容

### パス品質改善

| 変更 | 内容 |
|------|------|
| 最低スコア閾値 | PassTargetMetric 0.5 / Attacker 0.2 で二重チェック |
| キック速度修正 | 固定3.0 m/s → 距離依存 2.0〜4.0 m/s（短距離パスのリスクを正確に評価） |
| slack_scale | 0.5 → 1.0（1.0秒余裕で満点、従来の0.5秒では甘すぎた） |
| 距離評価 | 加算方式 → 山型乗算方式（1.5〜4.0mを最適ゾーン） |
| シャドウ評価 | 検出閾値 0.3m → 0.5m、最大ペナルティ 80% → 95%、完全遮蔽判定を追加 |
| FINAL_GUARD | ゴールキック → チップキッククリアに変更（無謀なシュートを回避） |

### RECEIVE競合判定

| 変更 | 内容 |
|------|------|
| AttackerCandidateMetric | 敵slackとの比較を追加（敵が0.2秒以上早いとスコア×0.2） |
| RECEIVE遷移条件 | 敵が0.3秒以上早い場合はRECEIVEに入らない |
| RECEIVE離脱条件 | 敵が自分のボール距離の70%未満に接近したら諦める |
| PassReceiverSession | `recommended_pass_receiver_id` を活用してより適切なロボットを優先 |
