### PR TITLE
fix: ボールプレイスメント中のディフェンダーにゴールキーパーを割り当てないよう修正

### DIFF
--- a/crane_sessions/include/crane_sessions/defender_session.hpp
+++ b/crane_sessions/include/crane_sessions/defender_session.hpp
@@ -51,6 +51,9 @@ public:
     // 守備ライン位置に近いロボットを優先
     auto wm = world_model;  // shared_ptrをコピー
     return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      if (robot->id == wm->getOurGoalieId()) {
+        return GOALIE_EXCLUSION_COST;
+      }
       Segment ball_line{wm->goal(), wm->ball().pos};
       auto parameter = getDefenseLinePointParameter(ball_line, wm);
       if (not parameter) {


### PR DESCRIPTION
## Summary

- `DefenderSession::getRobotSuitabilityFunc()` にゴールキーパー除外チェックを追加

## 問題

`THEIR_BALL_PLACEMENT` 時はセッション設定に `goalie_skill` が含まれないため、ゴールキーパーが `defender` セッションに割り当てられる可能性があった。

## 修正内容

他のセッション（`OurFreeKickSession`、`BallPlacementSkillSession` 等）と同様に、`getRobotSuitabilityFunc()` 内でゴールキーパーIDを確認し `GOALIE_EXCLUSION_COST` を返すことで、ディフェンダー候補から除外する。

## Test plan

- [ ] `THEIR_BALL_PLACEMENT` 時にゴールキーパーがディフェンダーに割り当てられないことを確認
- [ ] `colcon build --packages-select crane_sessions` でビルド成功を確認