### PR TITLE
fix: ペナルティエリア侵入防止をRVO2 Obstacle + 物理ブレーキング制約で全面改善

### DIFF
--- a/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
@@ -80,6 +80,8 @@ private:
     Point & target_pos, const Point & current_pos,
     const crane_msgs::msg::RobotCommand & command) const -> void;
 
+  auto initializePenaltyAreaObstacles() -> void;
+
   std::unique_ptr<RVO::RVOSimulator> rvo_sim;
 
   crane_msgs::msg::RobotCommands pre_commands;
@@ -106,6 +108,12 @@ private:
   double CRASH_SAFETY_MARGIN = 0.3;
   double CRASH_AVOIDANCE_DISTANCE = 1.0;
   double CRASH_AVOIDANCE_DECEL_DISTANCE = 0.5;
+
+  // ペナルティエリア回避パラメータ
+  double PENALTY_AREA_OFFSET = 0.1;  // ペナルティエリア判定マージン [m]（グローバル回避用）
+  float PENALTY_AREA_TIME_HORIZON_OBST = 0.5f;  // RVO2障害物回避の時間ホライズン [s]
+
+  bool penalty_area_obstacles_initialized = false;
 
   // 加速度は減速度の何倍にするかという係数
   ParameterWithEvent<double> acceleration_factor;

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -74,6 +74,12 @@ RVO2Planner::RVO2Planner(rclcpp::Node & node)
     CRASH_AVOIDANCE_DECEL_DISTANCE = 0.5;
   }
 
+  node.declare_parameter("penalty_area_offset", PENALTY_AREA_OFFSET);
+  PENALTY_AREA_OFFSET = node.get_parameter("penalty_area_offset").as_double();
+  node.declare_parameter("penalty_area_time_horizon_obst", PENALTY_AREA_TIME_HORIZON_OBST);
+  PENALTY_AREA_TIME_HORIZON_OBST =
+    static_cast<float>(node.get_parameter("penalty_area_time_horizon_obst").as_double());
+
   node.declare_parameter("enable_velocity_plan_trace", false);
   enable_velocity_plan_trace = node.get_parameter("enable_velocity_plan_trace").as_bool();
 
@@ -92,8 +98,41 @@ RVO2Planner::RVO2Planner(rclcpp::Node & node)
     [this](const crane_msgs::msg::RobotFeedbackArray & msg) { latest_feedback = msg; });
 }
 
+auto RVO2Planner::initializePenaltyAreaObstacles() -> void
+{
+  // ペナルティエリアをRVO2のポリゴン障害物として登録する。
+  // processObstacles()呼び出し後は変更不可なので、フィールド情報確定後に一度だけ呼ぶ。
+  // 頂点は反時計回り（RVO2の仕様）で指定する。
+  const Box our_area = world_model->getOurPenaltyArea();
+  const Box their_area = world_model->getTheirPenaltyArea();
+  auto addBoxObstacle = [&](const Box & box) {
+    const float xmin = static_cast<float>(box.min_corner().x());
+    const float xmax = static_cast<float>(box.max_corner().x());
+    const float ymin = static_cast<float>(box.min_corner().y());
+    const float ymax = static_cast<float>(box.max_corner().y());
+    // 反時計回り: 左下 → 右下 → 右上 → 左上
+    rvo_sim->addObstacle({{xmin, ymin}, {xmax, ymin}, {xmax, ymax}, {xmin, ymax}});
+  };
+  addBoxObstacle(our_area);
+  addBoxObstacle(their_area);
+  rvo_sim->processObstacles();
+  penalty_area_obstacles_initialized = true;
+  RCLCPP_INFO(
+    rclcpp::get_logger("rvo2_local_planner"),
+    "Penalty area obstacles initialized (our: [%.2f,%.2f]x[%.2f,%.2f], "
+    "their: [%.2f,%.2f]x[%.2f,%.2f])",
+    our_area.min_corner().x(), our_area.max_corner().x(), our_area.min_corner().y(),
+    our_area.max_corner().y(), their_area.min_corner().x(), their_area.max_corner().x(),
+    their_area.min_corner().y(), their_area.max_corner().y());
+}
+
 auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> void
 {
+  // ペナルティエリアObstacleの遅延初期化（フィールド情報が確定してから一度だけ）
+  if (!penalty_area_obstacles_initialized && world_model->fieldSize().squaredNorm() > 0.01) {
+    initializePenaltyAreaObstacles();
+  }
+
   const auto referee_command = world_model->getMsg().play_situation.referee_raw.command.value;
   if (referee_command == robocup_ssl_msgs::msg::RefereeCommand::STOP) {
     for (int i = 0; i < 40; i++) {
@@ -276,6 +315,56 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
         }
       }
     }
+
+    // ペナルティエリア物理ブレーキング制約
+    // ORCA（速度空間制約）はコマンド速度を制限するが、ロボットの物理慣性は考慮できない。
+    // 境界までの距離に基づく「物理的に停止可能な最大接近速度」を計算してprefVelocityを制限する。
+    //   max_approach_vel = sqrt(2 * planning_deceleration_high_speed * dist_to_boundary)
+    if (!command.local_planner_config.disable_goal_area_avoidance) {
+      auto applyPhysicalBrakingConstraint = [&](const Box & area) {
+        const double xmin = area.min_corner().x() - PENALTY_AREA_OFFSET;
+        const double xmax = area.max_corner().x() + PENALTY_AREA_OFFSET;
+        const double ymin = area.min_corner().y() - PENALTY_AREA_OFFSET;
+        const double ymax = area.max_corner().y() + PENALTY_AREA_OFFSET;
+        // ロボットがエリア内にいる場合はグローバル回避に任せる
+        if (
+          current_position.x() >= xmin && current_position.x() <= xmax &&
+          current_position.y() >= ymin && current_position.y() <= ymax) {
+          return;
+        }
+
+        // 各境界面への距離を計算し、接近方向速度成分を物理制動距離内に制限する
+        // 左面: ロボットが左(x < xmin)にいてxmin方向に接近中
+        if (const double d = xmin - current_position.x(); d > 0.0 && target_vel.x() > 0.0) {
+          const double v_max = std::sqrt(2.0 * planning_deceleration_high_speed * d);
+          target_vel.x() = std::min(target_vel.x(), v_max);
+        }
+        // 右面: ロボットが右(x > xmax)にいてxmax方向に接近中
+        if (const double d = current_position.x() - xmax; d > 0.0 && target_vel.x() < 0.0) {
+          const double v_max = std::sqrt(2.0 * planning_deceleration_high_speed * d);
+          target_vel.x() = std::max(target_vel.x(), -v_max);
+        }
+        // 下面: ロボットが下(y < ymin)にいてymin方向に接近中
+        if (const double d = ymin - current_position.y(); d > 0.0 && target_vel.y() > 0.0) {
+          const double v_max = std::sqrt(2.0 * planning_deceleration_high_speed * d);
+          target_vel.y() = std::min(target_vel.y(), v_max);
+        }
+        // 上面: ロボットが上(y > ymax)にいてymax方向に接近中
+        if (const double d = current_position.y() - ymax; d > 0.0 && target_vel.y() < 0.0) {
+          const double v_max = std::sqrt(2.0 * planning_deceleration_high_speed * d);
+          target_vel.y() = std::max(target_vel.y(), -v_max);
+        }
+      };
+      applyPhysicalBrakingConstraint(world_model->getOurPenaltyArea());
+      applyPhysicalBrakingConstraint(world_model->getTheirPenaltyArea());
+    }
+
+    // ペナルティエリア障害物回避のtimeHorizonObstをフラグに応じて設定
+    // disable_goal_area_avoidance=trueのロボット（GKなど）は障害物回避を無効化
+    rvo_sim->setAgentTimeHorizonObst(
+      command.robot_id, command.local_planner_config.disable_goal_area_avoidance
+                          ? 0.0f
+                          : PENALTY_AREA_TIME_HORIZON_OBST);
 
     rvo_sim->setAgentPrefVelocity(command.robot_id, toRVO(target_vel));
     rvo_sim->setAgentMaxSpeed(command.robot_id, max_vel);
@@ -562,7 +651,6 @@ auto RVO2Planner::adjustForPenaltyAreaAvoidance(
 {
   if (not command.local_planner_config.disable_goal_area_avoidance) {
     constexpr double SURROUNDING_OFFSET = 0.2;
-    constexpr double PENALTY_AREA_OFFSET = 0.1;
 
     auto avoidPenaltyArea = [&](const Box & penalty_area, const Point & goal_pos) {
       constexpr int MAX_ITERATIONS = 100;


### PR DESCRIPTION
## 問題

ロボットがペナルティエリアに高速で飛び込みファールを取られるケースが頻発していた。rosbag解析により、役割切り替え時に目標がペナルティエリア境界付近（0.2m外側）へ変更され、ロボットが2.74 m/sで接近・侵入するパターンを特定。

旧実装（速度クランプ方式）は接近距離を固定値で線形補間しており、高速接近時に制動が間に合わなかった。

## 変更内容

### RVO2 Obstacle APIによる速度空間制約
- `initializePenaltyAreaObstacles()` を新設し、自陣・敵陣両ペナルティエリアをRVO2のポリゴン障害物として登録
- フィールド情報確定後に一度だけ `processObstacles()` を呼ぶ遅延初期化
- GK（`disable_goal_area_avoidance=true`）は `timeHorizonObst=0` で障害物回避を無効化

### 物理ブレーキング制約（prefVelocity事前制限）
ORCA制約はコマンド速度を制限するが、ロボットの物理慣性は考慮できない。境界まで距離 `d` の時の最大接近速度を物理ブレーキング式で算出し、`setAgentPrefVelocity` 前に適用する:

```
max_approach_vel = sqrt(2 * planning_deceleration_high_speed * d)
```

| 境界までの距離 | 最大接近速度（decel=4.5 m/s²） |
|---|---|
| 1.2m | 3.29 m/s |
| 0.7m | 2.51 m/s |
| 0.2m | 1.34 m/s |

### 旧コード削除
- `applyPenaltyAreaVelocityConstraint`（速度クランプ方式）を削除
- `extractVelocityCommandsFromRVOSim` 内の安全弁コード（`clampVelocityForArea`）を削除

## 新規ROSパラメータ

| パラメータ | デフォルト | 説明 |
|---|---|---|
| `penalty_area_offset` | 0.1m | グローバル・ローカル共通マージン |
| `penalty_area_time_horizon_obst` | 0.5s | ORCA障害物回避の時間ホライズン |

## テスト方法

- [ ] `colcon build --packages-select crane_local_planner` でビルド確認
- [ ] シミュレーションで高速接近時のペナルティエリア侵入が発生しないことを確認
- [ ] GKがペナルティエリア内で正常動作することを確認
- [ ] ディフェンダーが守備ライン上で正常動作することを確認