### PR TITLE
fix: ディフェンダーをハード制約化してロール割当の安定性を改善

### DIFF
--- a/crane_session_coordinator/src/global_robot_allocator.cpp
+++ b/crane_session_coordinator/src/global_robot_allocator.cpp
@@ -74,11 +74,14 @@ auto GlobalRobotAllocator::allocateHardConstraints(
       break;
     }
 
-    // 適性評価でロボットをソート
+    // 適性評価でロボットをソート（ヒステリシスボーナスを適用して安定化）
     std::vector<std::pair<uint8_t, double>> robot_scores;
     for (const auto & robot_id : remaining_robots) {
       auto robot = world_model->getOurRobot(robot_id);
       double score = req.suitability_func(robot);
+      if (prev_state.wasAssignedTo(robot_id, req.name)) {
+        score -= config.hysteresis_bonus;
+      }
       robot_scores.emplace_back(robot_id, score);
     }
 

--- a/crane_sessions/include/crane_sessions/defender_session.hpp
+++ b/crane_sessions/include/crane_sessions/defender_session.hpp
@@ -45,6 +45,8 @@ public:
     return min_robots;
   }
 
+  bool isHardConstraint() const override { return true; }
+
   auto getRobotSuitabilityFunc() const
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {

--- a/crane_sessions/include/crane_sessions/second_threat_defender_session.hpp
+++ b/crane_sessions/include/crane_sessions/second_threat_defender_session.hpp
@@ -26,8 +26,6 @@ public:
   {
   }
 
-  bool isHardConstraint() const override { return true; }
-
   auto getRobotSuitabilityFunc() const
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {

--- a/crane_sessions/include/crane_sessions/second_threat_defender_session.hpp
+++ b/crane_sessions/include/crane_sessions/second_threat_defender_session.hpp
@@ -26,6 +26,8 @@ public:
   {
   }
 
+  bool isHardConstraint() const override { return true; }
+
   auto getRobotSuitabilityFunc() const
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {


### PR DESCRIPTION
## 概要

rosbagの分析により、Defenderがソフト制約であったため、48秒間に**59回**（ピーク8回/秒）の頻繁な割当入れ替わりが発生していた問題を修正する。

## 原因

`DefenderSession`がソフト制約として動作していたため、ハンガリアン法でmarker/forward/pass_receive等と同時に最適化されていた。ボール位置の変化に伴い守備ポイントが動くと、僅かなコスト変動で毎フレーム割当が入れ替わるチャタリングが発生。

## 変更内容

- `DefenderSession::isHardConstraint()` → `true` に変更
- `GlobalRobotAllocator::allocateHardConstraints()` にヒステリシスボーナスを追加（前フレームで同一セッションに割当されていたロボットのスコアを`hysteresis_bonus`分減少）

SecondThreatDefenderSessionはソフト制約のまま変更なし。

## 優先度

YAMLの記述順でpriorityが決まるため、以下の順序が保証される:
- Goalie (priority 0) → Attacker (priority 2) → **Defender (priority 3)**

Attacker・Goalieより低優先度でのハード制約処理となる。