### PR TITLE
fix: Markerの割当・移動を線分ベースに最適化

### DIFF
--- a/crane_robot_skills/src/marker.cpp
+++ b/crane_robot_skills/src/marker.cpp
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include <crane_geometry/geometry_operations.hpp>
 #include <crane_robot_skills/marker.hpp>
 
 namespace crane::skills
@@ -12,6 +13,7 @@ void Marker::initialize()
 {
   setParameter("marking_robot_id", 0);
   setParameter("mark_distance", 0.5);
+  setParameter("max_mark_distance", 1.5);
   setParameter("mark_mode", std::string("save_goal"));
 }
 
@@ -19,20 +21,34 @@ Status Marker::update()
 {
   auto marked_robot = world_model()->getTheirRobot(getParameter<int>("marking_robot_id"));
   auto enemy_pos = marked_robot->pose.pos;
-
   std::string mode = getParameter<std::string>("mark_mode");
-  Point marking_point;
+  double mark_distance = getParameter<double>("mark_distance");
+  double max_mark_distance = getParameter<double>("max_mark_distance");
 
+  // 基準点（ゴール中心 or ボール位置）
+  Point reference;
   if (mode == "save_goal") {
-    marking_point = enemy_pos + (world_model()->getOurGoalCenter() - enemy_pos).normalized() *
-                                  getParameter<double>("mark_distance");
+    reference = world_model()->getOurGoalCenter();
   } else if (mode == "intercept_pass") {
-    marking_point = enemy_pos + (world_model()->ball().pos - enemy_pos).normalized() *
-                                  getParameter<double>("mark_distance");
+    reference = world_model()->ball().pos;
   } else {
     throw std::runtime_error("unknown mark mode");
   }
-  command->setTargetPosition(marking_point, 0.1).lookAtBall();
+
+  // マーキングセグメントを定義: 敵からmark_distance〜max_mark_distanceの範囲
+  auto dir = (reference - enemy_pos).normalized();
+  Point near_end = enemy_pos + dir * mark_distance;     // 敵に近い端（理想位置）
+  Point far_end = enemy_pos + dir * max_mark_distance;  // 遠い端
+  Segment marking_segment{near_end, far_end};
+
+  // 自ロボットからセグメントへの最近傍点と距離
+  auto cp = getClosestPointAndDistance(robot()->pose.pos, marking_segment);
+
+  // セグメントから離れているときは最近傍点を優先、近いときはnear_end（敵寄り）を優先
+  double pull_ratio = std::clamp(1.0 - cp.distance * 2.0, 0.0, 1.0);
+  Point target = cp.closest_point * (1.0 - pull_ratio) + near_end * pull_ratio;
+
+  command->setTargetPosition(target, 0.1).lookAtBall();
   return Status::RUNNING;
 }
 }  // namespace crane::skills

--- a/crane_sessions/src/marker_functions.cpp
+++ b/crane_sessions/src/marker_functions.cpp
@@ -5,6 +5,7 @@
 // https://opensource.org/licenses/MIT.
 
 #include <boost/math/constants/constants.hpp>
+#include <crane_geometry/geometry_operations.hpp>
 #include <crane_sessions/marker_functions.hpp>
 #include <range/v3/algorithm/find_if.hpp>
 #include <range/v3/algorithm/min.hpp>
@@ -85,7 +86,15 @@ auto assignMarkersToEnemies(
       break;
     }
     auto best_robot = ranges::min(remaining_robots, ranges::less{}, [&](const auto & robot) {
-      return (robot->pose.pos - enemy_robot->pose.pos).norm();
+      // 割当コスト: 敵に対するマーキングセグメントへの距離（固定点ではなく線分ベース）
+      Point reference = world_model->ball().pos;
+      constexpr double mark_dist = 0.5;
+      constexpr double max_mark_dist = 1.5;
+      auto dir = (reference - enemy_robot->pose.pos).normalized();
+      Point near_end = enemy_robot->pose.pos + dir * mark_dist;
+      Point far_end = enemy_robot->pose.pos + dir * max_mark_dist;
+      Segment marking_segment{near_end, far_end};
+      return getClosestPointAndDistance(robot->pose.pos, marking_segment).distance;
     });
 
     result.selected_robot_ids.push_back(best_robot->id);
@@ -101,10 +110,13 @@ auto assignMarkersToEnemies(
     result.markers.push_back(marker);
 
     visualizer->drawCircle(enemy_robot->pose.pos, 0.3, "black", 10);
-    visualizer->drawLine(
-      best_robot->pose.pos,
-      enemy_robot->pose.pos + (enemy_robot->pose.pos - best_robot->pose.pos).normalized() * 0.3,
-      "black", 20);
+    // マーキングセグメントを可視化
+    {
+      auto dir = (world_model->ball().pos - enemy_robot->pose.pos).normalized();
+      visualizer->drawLine(
+        enemy_robot->pose.pos + dir * 0.5, enemy_robot->pose.pos + dir * 1.5, "green", 10);
+    }
+    visualizer->drawLine(best_robot->pose.pos, enemy_robot->pose.pos, "black", 20);
   }
 
   // assign_remaining=trueのとき、マーク対象のいない残余ロボットにもMarkerを生成


### PR DESCRIPTION
## 概要

Markerロボットの割当コスト計算と移動目標を、固定点から**線分（セグメント）ベース**に変更した。

## 背景

従来は「敵ロボットから基準点方向に0.5mの固定点」を目標にしていたが、守備上はボール-敵ロボット間（またはゴール-敵ロボット間）の線分上のどこでも機能を果たせる。固定点を使うと、線分のすぐ近くにいる味方ロボットを有効活用できず、割当・移動が非効率だった。

## 変更内容

### crane_robot_skills/src/marker.cpp（移動ロジック）
- パラメータ `max_mark_distance`（デフォルト1.5m）を追加
- マーキングセグメントを `near_end`（敵から0.5m）〜 `far_end`（敵から1.5m）の区間として定義
- `getClosestPointAndDistance` でセグメントへの最近傍点と距離を計算
- ブレンド移動: `pull_ratio = clamp(1.0 - distance * 2.0, 0, 1)`
  - セグメントから≥0.5m → 最近傍点を優先（素早く線分上へ）
  - セグメント上（距離0） → `near_end`（敵寄り理想位置）を優先
  - その間は線形補間で滑らかに遷移

### crane_sessions/src/marker_functions.cpp（割当コスト）
- 割当コストを「敵ロボットとの距離」→「マーキングセグメントへの距離」に変更
- 線分に近いロボットが優先的に割り当てられるように
- ビジュアライザに緑色のマーキングセグメント表示を追加

## テスト計画

- [x] シミュレーションでMarkerが線分上に素早く移動するか確認
- [x] 線分上に乗った後、敵ロボット側に寄っていくか確認
- [x] 線分に近いロボットが優先的に割り当てられるか確認
- [x] ビジュアライザに緑色のセグメントが表示されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)