### PR TITLE
feat: ペナルティエリア迂回を考慮したロボット割当コスト計算を追加

### DIFF
--- a/crane_sessions/include/crane_sessions/defender_session.hpp
+++ b/crane_sessions/include/crane_sessions/defender_session.hpp
@@ -10,6 +10,7 @@
 #include <crane_geometry/boost_geometry.hpp>
 #include <crane_msg_wrappers/position_command_wrapper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_physics/penalty_aware_distance.hpp>
 #include <crane_physics/position_assignments.hpp>
 #include <crane_sessions/defense_functions.hpp>
 #include <crane_sessions/session_base.hpp>
@@ -62,7 +63,9 @@ public:
         return 1000.0;  // パラメータが無効な場合は大きなコスト
       }
       const auto defense_point = getDefenseLinePoint(parameter.value(), wm);
-      return robot->getDistance(defense_point);
+      return estimatePenaltyAwareDistance(
+        robot->pose.pos, defense_point, wm->getOurPenaltyArea(), wm->getOurGoalCenter(),
+        wm->getTheirPenaltyArea(), wm->getTheirGoalCenter(), wm->penaltyAreaSize());
     };
   }
 };

--- a/crane_sessions/include/crane_sessions/forward_session.hpp
+++ b/crane_sessions/include/crane_sessions/forward_session.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <crane_msg_wrappers/position_command_wrapper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_physics/penalty_aware_distance.hpp>
 #include <crane_robot_skills/forward.hpp>
 #include <crane_sessions/session_base.hpp>
 #include <memory>
@@ -42,8 +43,10 @@ public:
     // フォワードライン（敵ゴール前）に近いロボットを優先
     auto wm = world_model;  // shared_ptrをコピー
     return [wm](const std::shared_ptr<RobotInfo> & robot) {
-      // 敵ゴール位置に近いほど適している
-      return robot->getDistance(wm->getTheirGoalCenter());
+      // 敵ゴール位置に近いほど適している（敵陣ペナルティエリア迂回を考慮）
+      return estimatePenaltyAwareDistance(
+        robot->pose.pos, wm->getTheirGoalCenter(), wm->getOurPenaltyArea(), wm->getOurGoalCenter(),
+        wm->getTheirPenaltyArea(), wm->getTheirGoalCenter(), wm->penaltyAreaSize());
     };
   }
 

--- a/crane_sessions/include/crane_sessions/second_threat_defender_session.hpp
+++ b/crane_sessions/include/crane_sessions/second_threat_defender_session.hpp
@@ -8,6 +8,7 @@
 #define CRANE_SESSIONS__SECOND_THREAT_DEFENDER_SESSION_HPP_
 
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_physics/penalty_aware_distance.hpp>
 #include <crane_robot_skills/second_threat_defender.hpp>
 #include <crane_sessions/single_skill_session.hpp>
 #include <memory>
@@ -34,7 +35,9 @@ public:
     return [wm](const std::shared_ptr<RobotInfo> & robot) {
       constexpr double offset = 0.3;
       auto target = skills::SecondThreatDefender::getDefaultPoint(wm, offset);
-      return robot->getDistance(target);
+      return estimatePenaltyAwareDistance(
+        robot->pose.pos, target, wm->getOurPenaltyArea(), wm->getOurGoalCenter(),
+        wm->getTheirPenaltyArea(), wm->getTheirGoalCenter(), wm->penaltyAreaSize());
     };
   }
 

--- a/crane_sessions/include/crane_sessions/total_defense_session.hpp
+++ b/crane_sessions/include/crane_sessions/total_defense_session.hpp
@@ -10,6 +10,7 @@
 #include <crane_geometry/boost_geometry.hpp>
 #include <crane_msg_wrappers/position_command_wrapper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_physics/penalty_aware_distance.hpp>
 #include <crane_robot_skills/goalie.hpp>
 #include <crane_robot_skills/marker.hpp>
 #include <crane_robot_skills/second_threat_defender.hpp>
@@ -66,10 +67,14 @@ public:
       auto parameter = getDefenseLinePointParameter(ball_line, wm);
       if (not parameter) {
         // パラメータが取得できない場合はゴール位置への距離を使用
-        return robot->getDistance(wm->getOurGoalCenter());
+        return estimatePenaltyAwareDistance(
+          robot->pose.pos, wm->getOurGoalCenter(), wm->getOurPenaltyArea(), wm->getOurGoalCenter(),
+          wm->getTheirPenaltyArea(), wm->getTheirGoalCenter(), wm->penaltyAreaSize());
       }
       const auto defense_point = getDefenseLinePoint(parameter.value(), wm);
-      return robot->getDistance(defense_point);
+      return estimatePenaltyAwareDistance(
+        robot->pose.pos, defense_point, wm->getOurPenaltyArea(), wm->getOurGoalCenter(),
+        wm->getTheirPenaltyArea(), wm->getTheirGoalCenter(), wm->penaltyAreaSize());
     };
   }
 };

--- a/utility/crane_physics/CMakeLists.txt
+++ b/utility/crane_physics/CMakeLists.txt
@@ -77,6 +77,10 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_bang_bang_trajectory test/test_bang_bang_trajectory.cpp)
   target_include_directories(test_bang_bang_trajectory PUBLIC include)
   target_link_libraries(test_bang_bang_trajectory Eigen3::Eigen)
+
+  ament_auto_add_gtest(test_penalty_aware_distance test/test_penalty_aware_distance.cpp)
+  target_include_directories(test_penalty_aware_distance PUBLIC include)
+  target_link_libraries(test_penalty_aware_distance Eigen3::Eigen)
 endif()
 
 ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/utility/crane_physics/include/crane_physics/penalty_aware_distance.hpp
+++ b/utility/crane_physics/include/crane_physics/penalty_aware_distance.hpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_PHYSICS__PENALTY_AWARE_DISTANCE_HPP_
+#define CRANE_PHYSICS__PENALTY_AWARE_DISTANCE_HPP_
+
+#include <algorithm>
+#include <crane_geometry/boost_geometry.hpp>
+
+namespace crane
+{
+
+/// @brief ペナルティエリア迂回を考慮した移動距離推定
+///
+/// ロボットが start から target まで移動する際、経路がペナルティエリアを横切る場合は
+/// ローカルプランナー（adjustForPenaltyAreaAvoidance）と同等のロジックで
+/// ペナルティエリアの角を経由する迂回距離を返す。
+/// 交差しない場合はユークリッド距離をそのまま返す。
+///
+/// @param start       ロボット現在位置
+/// @param target      移動目標位置
+/// @param our_pa      自陣ペナルティエリア（Box）
+/// @param our_goal    自陣ゴールセンター位置
+/// @param their_pa    敵陣ペナルティエリア（Box）
+/// @param their_goal  敵陣ゴールセンター位置
+/// @param pa_size     ペナルティエリアサイズ（x: depth, y: width）
+/// @return 推定移動距離 [m]
+inline double estimatePenaltyAwareDistance(
+  const Point & start, const Point & target, const Box & our_pa, const Point & our_goal,
+  const Box & their_pa, const Point & their_goal, const Point & pa_size)
+{
+  // rvo2_planner と同じオフセット値
+  constexpr double PENALTY_AREA_OFFSET = 0.1;
+  constexpr double SURROUNDING_OFFSET = 0.2;
+
+  double distance = (target - start).norm();
+
+  // Segment は2つのエリアで共通なので一度だけ構築する
+  const Segment path(start, target);
+
+  // 各ペナルティエリアに対して迂回が必要か判定し、必要なら迂回距離を採用
+  auto applyDetourIfNeeded = [&](const Box & area, const Point & goal_pos) {
+    // ペナルティエリアをオフセット分拡張してから交差判定
+    Box expanded = area;
+    expanded.min_corner() -= Point(PENALTY_AREA_OFFSET, PENALTY_AREA_OFFSET);
+    expanded.max_corner() += Point(PENALTY_AREA_OFFSET, PENALTY_AREA_OFFSET);
+
+    if (!bg::intersects(path, expanded)) {
+      return;  // 経路がペナルティエリアを通らない → 変更不要
+    }
+
+    // rvo2_planner の adjustForPenaltyAreaAvoidance と同じ角計算
+    // goal_pos からペナルティエリアの前端（フィールド中央側）の角2点を算出し
+    // SURROUNDING_OFFSET 分外側に出た点を迂回ポイントとする
+    const double x_offset = std::copysign(pa_size.x() + SURROUNDING_OFFSET, -goal_pos.x());
+    const double half_height = pa_size.y() * 0.5 + SURROUNDING_OFFSET;
+    const Point around_corner_1 = goal_pos + Point(x_offset, half_height);
+    const Point around_corner_2 = goal_pos + Point(x_offset, -half_height);
+
+    const double dist_via_1 = (around_corner_1 - start).norm() + (target - around_corner_1).norm();
+    const double dist_via_2 = (around_corner_2 - start).norm() + (target - around_corner_2).norm();
+
+    distance = std::min(dist_via_1, dist_via_2);
+  };
+
+  applyDetourIfNeeded(our_pa, our_goal);
+  applyDetourIfNeeded(their_pa, their_goal);
+
+  return distance;
+}
+
+}  // namespace crane
+
+#endif  // CRANE_PHYSICS__PENALTY_AWARE_DISTANCE_HPP_

--- a/utility/crane_physics/test/test_penalty_aware_distance.cpp
+++ b/utility/crane_physics/test/test_penalty_aware_distance.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <gtest/gtest.h>
+
+#include <crane_physics/penalty_aware_distance.hpp>
+
+namespace crane
+{
+
+// SSL Division A のフィールド標準値
+// ペナルティエリア: depth=1.8m, width=3.6m
+// フィールド: 12m x 9m、ゴール位置 x=±6m
+static constexpr double FIELD_HALF_X = 6.0;
+static constexpr double PA_DEPTH = 1.8;
+static constexpr double PA_HALF_WIDTH = 1.8;
+
+// テスト用ペナルティエリア設定（自陣: x<0側, 敵陣: x>0側）
+static Box makeOurPA()
+{
+  // 自陣ゴール = (-6, 0), PAは x: -6 ~ -4.2, y: -1.8 ~ 1.8
+  return Box(Point(-FIELD_HALF_X, -PA_HALF_WIDTH), Point(-FIELD_HALF_X + PA_DEPTH, PA_HALF_WIDTH));
+}
+
+static Box makeTheirPA()
+{
+  // 敵陣ゴール = (6, 0), PAは x: 4.2 ~ 6, y: -1.8 ~ 1.8
+  return Box(Point(FIELD_HALF_X - PA_DEPTH, -PA_HALF_WIDTH), Point(FIELD_HALF_X, PA_HALF_WIDTH));
+}
+
+static Point ourGoal() { return Point(-FIELD_HALF_X, 0.0); }
+static Point theirGoal() { return Point(FIELD_HALF_X, 0.0); }
+static Point paSize() { return Point(PA_DEPTH, PA_HALF_WIDTH * 2.0); }
+
+// ユーティリティ: テスト用 estimatePenaltyAwareDistance の呼び出しヘルパー
+double estimate(const Point & start, const Point & target)
+{
+  return estimatePenaltyAwareDistance(
+    start, target, makeOurPA(), ourGoal(), makeTheirPA(), theirGoal(), paSize());
+}
+
+/// ケース1: 経路がペナルティエリアを横切らない → ユークリッド距離と一致
+TEST(PenaltyAwareDistanceTest, NoIntersection_ReturnsEuclidean)
+{
+  // フィールド中央付近の2点（ペナルティエリアから離れている）
+  Point start(0.0, 0.0);
+  Point target(1.0, 0.0);
+
+  double result = estimate(start, target);
+  double euclidean = (target - start).norm();
+
+  EXPECT_DOUBLE_EQ(result, euclidean);
+}
+
+/// ケース2: 経路が自陣ペナルティエリアを横切る場合 → ユークリッドより大きい
+TEST(PenaltyAwareDistanceTest, CrossesOurPA_ReturnsLargerThanEuclidean)
+{
+  // 自陣ゴール裏 → フィールド中央 (直線がPAを横切る)
+  Point start(-5.5, 2.5);    // PA外の上方
+  Point target(-5.5, -2.5);  // PA外の下方（直線がPAを横切る）
+
+  double result = estimate(start, target);
+  double euclidean = (target - start).norm();
+
+  // 迂回が発生するので距離は増大するはず
+  EXPECT_GT(result, euclidean);
+}
+
+/// ケース3: 経路が敵陣ペナルティエリアを横切る場合 → ユークリッドより大きい
+TEST(PenaltyAwareDistanceTest, CrossesTheirPA_ReturnsLargerThanEuclidean)
+{
+  // 敵陣PA付近の上側 → 下側（直線がPAを横切る）
+  Point start(5.5, 2.5);
+  Point target(5.5, -2.5);
+
+  double result = estimate(start, target);
+  double euclidean = (target - start).norm();
+
+  EXPECT_GT(result, euclidean);
+}
+
+/// ケース4: ペナルティエリアを横切らないフィールド端の移動
+TEST(PenaltyAwareDistanceTest, AlongSideLine_NoDetour)
+{
+  // y軸方向の移動（x=0）ならPAを通らない
+  Point start(0.0, -3.0);
+  Point target(0.0, 3.0);
+
+  double result = estimate(start, target);
+  double euclidean = (target - start).norm();
+
+  EXPECT_DOUBLE_EQ(result, euclidean);
+}
+
+/// ケース5: 対称性テスト（上/下どちらの迂回が選択されるか）
+TEST(PenaltyAwareDistanceTest, ChoosesShorterDetour)
+{
+  // ロボットが上側にいてターゲットが下側 → 上側の角を迂回する方が近い
+  Point start(-3.0, 3.0);   // フィールド中央、y>0側
+  Point target(-5.5, 0.0);  // 自陣PA前端付近
+
+  double result = estimate(start, target);
+
+  // 上側の角を経由する距離
+  constexpr double surr_off = 0.2;
+  Point our_goal = ourGoal();
+  Point pa_sz = paSize();
+  Point corner_upper =
+    our_goal +
+    Point(std::copysign(pa_sz.x() + surr_off, -our_goal.x()), pa_sz.y() * 0.5 + surr_off);
+  Point corner_lower =
+    our_goal +
+    Point(std::copysign(pa_sz.x() + surr_off, -our_goal.x()), -(pa_sz.y() * 0.5 + surr_off));
+
+  double dist_upper = (corner_upper - start).norm() + (target - corner_upper).norm();
+  double dist_lower = (corner_lower - start).norm() + (target - corner_lower).norm();
+
+  // 結果は2つの迂回距離の小さい方と一致するはず（交差する場合）
+  Segment path(start, target);
+  Box our_pa = makeOurPA();
+  our_pa.min_corner() -= Point(0.1, 0.1);
+  our_pa.max_corner() += Point(0.1, 0.1);
+  if (bg::intersects(path, our_pa)) {
+    EXPECT_DOUBLE_EQ(result, std::min(dist_upper, dist_lower));
+  } else {
+    EXPECT_DOUBLE_EQ(result, (target - start).norm());
+  }
+}
+
+/// ケース6: 距離ゼロの場合
+TEST(PenaltyAwareDistanceTest, ZeroDistance)
+{
+  Point pos(0.0, 0.0);
+  double result = estimate(pos, pos);
+  EXPECT_DOUBLE_EQ(result, 0.0);
+}
+
+}  // namespace crane


### PR DESCRIPTION
## Summary

- `crane_physics` に `estimatePenaltyAwareDistance()` ユーティリティ関数を新設
- ローカルプランナーの迂回ロジック（`adjustForPenaltyAreaAvoidance`）と同等の算出方法で、経路がペナルティエリアを横切る場合にコーナー経由の迂回距離を返す
- Defender / TotalDefense / SecondThreatDefender / Forward の4Sessionで直線距離から迂回考慮距離に置換

## Background

ロボット割当のコスト計算は直線距離ベースだったが、ペナルティエリア周辺では実際には回り込みが発生するため、割当コストが実移動コストと乖離していた。例えばディフェンダーがペナルティエリアを挟んで守備位置の反対側にいる場合、過小評価されたコストで誤って割り当てられるケースがあった。

## Test plan

- [x] `crane_physics` の単体テスト全通過（6ケース新規追加）
- [x] `crane_sessions` 依存を含むビルド成功
- [x] シミュレータで、ペナルティエリアを挟んで迂回が必要なシナリオにおけるロボット割当が改善されることを確認