### PR TITLE
fix: 敵パスに対するパスカット失敗を複数の問題修正で改善

### DIFF
--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -113,11 +113,13 @@ void Attacker::initialize()
   addTransition(
     static_cast<int>(AttackerState::ENTRY_POINT), static_cast<int>(AttackerState::RECEIVE),
     [this]() -> bool {
-      // ボールが遠くにいる/動いている/自分に向かってきている
+      // ボールが遠くにいる/動いている/ボール軌道の近く(<2.0m)にいる
       if (
         robot()->getDistance(world_model()->ball().pos) > BALL_CONTROL_DISTANCE &&
-        world_model()->ball().isMoving(MOVING_BALL_VELOCITY) &&
-        world_model()->ball().isMovingTowards(robot()->pose.pos)) {
+        world_model()->ball().isMoving(MOVING_BALL_VELOCITY) && [&]() {
+          auto result = world_model()->ball().getClosestPointToTrajectory(robot()->pose.pos, 10.0);
+          return (result.closest_point - robot()->pose.pos).norm() < 2.0;
+        }()) {
         // GameAnalysisの既存slackデータで敵との競合チェック（追加計算コストなし）
         const auto & ga = world_model()->getMsg().game_analysis;
         double my_min_slack = -100.0;
@@ -147,8 +149,16 @@ void Attacker::initialize()
       if (world_model()->ball().isStopped(MOVING_BALL_VELOCITY)) {
         // ボールが止まっている
         return true;
-      } else if (world_model()->ball().isMovingAwayFrom(robot()->pose.pos)) {
-        // ボールが自分から離れていっている（多分受取に失敗した）
+      } else if ([&]() {
+                   // ボール軌道の最近接点がボール現在位置より後方 = ボールが通り過ぎた
+                   if (!world_model()->ball().isMoving(MOVING_BALL_VELOCITY)) return false;
+                   auto result =
+                     world_model()->ball().getClosestPointToTrajectory(robot()->pose.pos, 5.0);
+                   Vector2 ball_dir = world_model()->ball().vel.normalized();
+                   double proj = (result.closest_point - world_model()->ball().pos).dot(ball_dir);
+                   return proj < -0.1;
+                 }()) {
+        // ボールが通り過ぎた（受取に失敗した）
         return true;
       } else if (robot()->ball_contact.getContactDuration() > 0.2s) {
         // 受取に成功してドリブラで触れている
@@ -200,12 +210,12 @@ void Attacker::initialize()
       printTextOnRobot("RECEIVE::REDIRECT");
       receive_skill.setParameter("enable_redirect", true);
       receive_skill.setParameter("redirect_target", redirect_target);
-      receive_skill.setParameter("policy", std::string("closest"));
+      receive_skill.setParameter("policy", std::string("min_slack"));
       receive_skill.setParameter("redirect_kick_power", 0.4);
     } else {
       printTextOnRobot("RECEIVE::NORMAL");
       receive_skill.setParameter("enable_redirect", false);
-      receive_skill.setParameter("policy", std::string("closest"));
+      receive_skill.setParameter("policy", std::string("min_slack"));
       receive_skill.setParameter("dribble_power", 0.0);
       receive_skill.setParameter("enable_software_bumper", false);
     }

--- a/crane_session_coordinator/src/global_robot_allocator.cpp
+++ b/crane_session_coordinator/src/global_robot_allocator.cpp
@@ -316,7 +316,7 @@ auto GlobalRobotAllocator::buildCostMatrix(
     double hysteresis_bonus =
       context.was_assigned_to_same_session ? config_copy.hysteresis_bonus : 0.0;
     double velocity_hysteresis = 0.0;
-    if (context.was_assigned_to_same_session) {
+    if (!context.was_assigned_to_same_session) {
       velocity_hysteresis = robot->vel.linear.norm() * config_copy.velocity_hysteresis_factor;
     }
 

--- a/crane_sessions/include/crane_sessions/marker_session.hpp
+++ b/crane_sessions/include/crane_sessions/marker_session.hpp
@@ -64,7 +64,12 @@ public:
   {
     // 危険な敵の数に基づいてロボット数を決定
     auto danger_enemies = getDangerEnemies(world_model);
-    return static_cast<int>(danger_enemies.size());
+    int count = static_cast<int>(danger_enemies.size());
+    // ボールが高速移動中はマーキング需要を下げてパスカット要員を確保
+    if (world_model->ball().isMoving(1.0)) {
+      count = std::max(0, count - 2);
+    }
+    return count;
   }
 
 private:

--- a/utility/crane_physics/include/crane_physics/allocation_cost.hpp
+++ b/utility/crane_physics/include/crane_physics/allocation_cost.hpp
@@ -31,11 +31,11 @@ struct AllocationCostConfig
   double travel_time_weight = 0.5;
 
   // ヒステリシスボーナス（同一Session継続時のコスト減少）[m]
-  double hysteresis_bonus = 0.5;
+  double hysteresis_bonus = 1.5;
 
   // 速度ベースヒステリシス係数（高速移動中の再割当抑制）
-  // 例: 0.2 なら、速度1m/sで0.2mのペナルティ
-  double velocity_hysteresis_factor = 0.2;
+  // 例: 0.5 なら、速度1m/sで0.5mのペナルティ
+  double velocity_hysteresis_factor = 0.5;
 
   // Session優先度によるコスト調整（優先度差1あたりのコスト増加）[m]
   double priority_cost_multiplier = 10.0;
@@ -112,9 +112,9 @@ inline double calculateAllocationCost(
   }
 
   // 速度ベースヒステリシス（Sumatra参考）
-  // 高速移動中のロボットの再割当にペナルティを課す
+  // 高速移動中のロボットの再割当にペナルティを課す（別Sessionに移る場合のコスト増）
   double velocity_hysteresis = 0.0;
-  if (context.was_assigned_to_same_session) {
+  if (!context.was_assigned_to_same_session) {
     double robot_speed = robot.vel.linear.norm();
     velocity_hysteresis = robot_speed * config.velocity_hysteresis_factor;
   }


### PR DESCRIPTION
## Summary

rosbag解析（試合時間残り4:36-39）で、敵の斜めパス（4.72m/s）に対してロボット8,7番がパスカットを失敗した原因を特定し、複数の問題を修正する。

### 特定された問題

**最重要: `isMovingAwayFrom`によるRECEIVE→KICK誤遷移**
- R7がボールに0.25mまで接近していたのに、横からインターセプト中にボール速度方向の角度判定が`true`になりKICK状態に遷移
- KICKは「ボールの背後に回り込む」動作なので逆方向に移動し始め、ボールを取り逃がした

**Receiveポリシーのタイミング問題**
- "closest"ポリシーは空間的最近接点を選択。ボールが0.04秒で通過する地点をターゲットにしており到達不可能

**velocity_hysteresisのバグ**
- コメント「再割当にペナルティ」と逆に、同一Session継続時にコスト加算
- 速度2.42m/sのR8でhysteresis_bonus(0.5)がほぼ打ち消され、実質ヒステリシス=0
- ボール追跡中のR8がMarkerに引き剥がされ、追跡を放棄

### 修正内容

| # | ファイル | 変更内容 |
|---|---------|---------|
| 1 | `crane_robot_skills/src/attacker.cpp` | RECEIVE→ENTRY_POINT: `isMovingAwayFrom`→ボール軌道通過判定に変更 |
| 2 | `crane_robot_skills/src/attacker.cpp` | Receiveポリシー: `"closest"` → `"min_slack"` |
| 3 | `crane_robot_skills/src/attacker.cpp` | ENTRY_POINT→RECEIVE: `isMovingTowards(60°)` → 軌道距離2.0m以内 |
| 4 | `utility/crane_physics/include/crane_physics/allocation_cost.hpp` | velocity_hysteresisバグ修正: 条件を反転 |
| 5 | `utility/crane_physics/include/crane_physics/allocation_cost.hpp` | hysteresis_bonus: 0.5→1.5、velocity_hysteresis_factor: 0.2→0.5 |
| 6 | `crane_session_coordinator/src/global_robot_allocator.cpp` | velocity_hysteresisバグ修正: 条件を反転 |
| 7 | `crane_sessions/include/crane_sessions/marker_session.hpp` | ボール高速移動中はmarker要求数を2減らす |
