### PR TITLE
fix: Attacker停滞問題を修正（アロケータ二重ヒステリシスとKICKタイムアウト）

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/attacker.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/attacker.hpp
@@ -7,6 +7,7 @@
 #ifndef CRANE_ROBOT_SKILLS__ATTACKER_HPP_
 #define CRANE_ROBOT_SKILLS__ATTACKER_HPP_
 
+#include <chrono>
 #include <crane_geometry/boost_geometry.hpp>
 #include <crane_geometry/interval.hpp>
 #include <crane_robot_skills/goal_kick.hpp>
@@ -82,6 +83,10 @@ protected:
 
 private:
   void configurePassKick(const Point & target, Kick & kick_skill);
+
+  // KICK状態の進捗タイムアウト用
+  std::chrono::steady_clock::time_point kick_state_entry_time{};
+  bool in_kick_state = false;
 
   bool shouldUseChipKick(const Point & target);
 

--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -29,6 +29,9 @@ constexpr double MOVING_BALL_VELOCITY = 1.0;
 constexpr double ENEMY_NEAR_BALL_DISTANCE = 2.0;
 constexpr double ENEMY_SLACK_RECEIVE_THRESHOLD = 0.3;  // RECEIVE抑制: 敵がこの秒数以上早いと諦める
 constexpr double MIN_PASS_SCORE_ATTACKER = 0.2;        // パス品質の下限（二重チェック用）
+constexpr double KICK_TIMEOUT_SEC = 3.0;               // KICK状態でボール無接触の場合のタイムアウト
+constexpr double KICK_NO_CONTACT_THRESHOLD_SEC = 0.1;  // ボール接触とみなす最小継続時間
+constexpr double KICK_BALL_STOPPED_VEL = 0.3;          // タイムアウト判定でのボール停止閾値
 }  // namespace
 void Attacker::initialize()
 {
@@ -52,6 +55,7 @@ void Attacker::initialize()
   addTransition(
     static_cast<int>(AttackerState::ENTRY_POINT), static_cast<int>(AttackerState::ENTRY_POINT),
     [this]() -> bool {
+      in_kick_state = false;
       pass_receiver_id = std::nullopt;
       receive_skill.clearVisualizer();
       kick_skill.clearVisualizer();
@@ -230,7 +234,28 @@ void Attacker::initialize()
     static_cast<int>(AttackerState::KICK), static_cast<int>(AttackerState::ENTRY_POINT),
     [this]() -> bool { return world_model()->ball().isMoving(MOVING_BALL_VELOCITY); });
 
+  // KICK状態でボールに触れずKICK_TIMEOUT_SEC以上経過した場合、ENTRY_POINTへ戻って再割当を待つ
+  addTransition(
+    static_cast<int>(AttackerState::KICK), static_cast<int>(AttackerState::ENTRY_POINT),
+    [this]() -> bool {
+      using std::chrono_literals::operator""s;
+      if (!in_kick_state) return false;
+      // 安価な条件を先に評価して早期リターン
+      bool no_contact = robot()->ball_contact.getContactDuration() <
+                        std::chrono::duration<double>(KICK_NO_CONTACT_THRESHOLD_SEC);
+      if (!no_contact) return false;
+      bool ball_stopped = world_model()->ball().isStopped(KICK_BALL_STOPPED_VEL);
+      if (!ball_stopped) return false;
+      auto elapsed = std::chrono::steady_clock::now() - kick_state_entry_time;
+      return elapsed > std::chrono::duration<double>(KICK_TIMEOUT_SEC);
+    });
+
   addStateFunction(static_cast<int>(AttackerState::KICK), [this]() -> Status {
+    // KICK状態進入時にタイマー開始
+    if (!in_kick_state) {
+      kick_state_entry_time = std::chrono::steady_clock::now();
+      in_kick_state = true;
+    }
     double goal_angle_width = evaluateGoalAngle(world_model()->ball().pos);
 
     // パスは pass_target_id がある場合のみ検討

--- a/crane_sessions/include/crane_sessions/attacker_skill_session.hpp
+++ b/crane_sessions/include/crane_sessions/attacker_skill_session.hpp
@@ -30,6 +30,9 @@ namespace crane
 {
 class AttackerSkillSession : public SessionBase
 {
+  // アロケータのhysteresis_bonus(1.5m)を確実に上回り、game_analyzer推奨の切替を保証するマージン
+  static constexpr double RECOMMENDED_ATTACKER_MARGIN = 2.0;
+
 public:
   std::shared_ptr<skills::Attacker> skill = nullptr;
 
@@ -101,10 +104,13 @@ public:
 
       // それ以外はボール距離ベース
       double distance = robot->getDistance(wm->ball().pos);
+      // game_analyzerのSelectionHysteresisが安定性を担保済みのため、
+      // アロケータのhysteresis_bonus(1.5m)を確実に上回るマージンを付与して推奨切替を阻害しない
+      double cost = distance + RECOMMENDED_ATTACKER_MARGIN;
       RCLCPP_DEBUG(
-        rclcpp::get_logger("AttackerSkillSession"), "Robot %d cost: %.2f (ball distance)",
-        robot->id, distance);
-      return distance;
+        rclcpp::get_logger("AttackerSkillSession"), "Robot %d cost: %.2f (ball distance + margin)",
+        robot->id, cost);
+      return cost;
     };
   }
 


### PR DESCRIPTION
## 概要

rosbag `rosbag2_2026_03_14-21_04_12` で確認されたAttacker停滞バグ（ロボット4がボール近くで約6秒停止）の根本原因2件を修正。

## 問題

INPLAY中、game_analyzerがロボット10（ボールから0.16m）を推奨attackerとして継続出力していたが、attacker_skillの割当がロボット4から切り替わらなかった。

## 根本原因と修正

### 修正1: アロケータの二重ヒステリシス問題 (`attacker_skill_session.hpp`)

`GlobalRobotAllocator` が前回割当ロボットに `hysteresis_bonus` (1.5m) を適用するため、非推奨ロボット4のコスト (0.47 - 1.5 = **-1.03**) が推奨ロボット10のコスト (0.0) を下回り切替が阻害されていた。

game_analyzerの `SelectionHysteresis` が安定性を担保済みであるため、非推奨ロボットのコストに `RECOMMENDED_ATTACKER_MARGIN` (+2.0m) を加算し、`hysteresis_bonus` を確実に上回るようにした。

| ロボット | 修正前コスト | 修正後コスト |
|---------|------------|------------|
| 推奨ロボット10 | 0.0 | 0.0 |
| 非推奨ロボット4 | 0.47 - 1.5 = **-1.03** | 0.47 + 2.0 - 1.5 = **+0.97** |

### 修正2: KICK状態の進捗タイムアウト追加 (`attacker.cpp`, `attacker.hpp`)

ボール停止中にロボットが回り込めない場合、`ball().isMoving()` が真にならず永久にKICK状態に留まる問題を修正。

ボール無接触かつ停止状態で `KICK_TIMEOUT_SEC` (3秒) 経過した場合、ENTRY_POINTへ遷移して再割当を待つ遷移を追加。
