### PR TITLE
fix: Goalieの壁バウンスシュート対応と待ち受け振動抑制

### DIFF
--- a/crane_robot_skills/src/goalie.cpp
+++ b/crane_robot_skills/src/goalie.cpp
@@ -96,22 +96,42 @@ void Goalie::inplay(bool enable_emit)
   auto goals = world_model()->getOurGoalPosts();
   const auto goal_center = world_model()->getOurGoalCenter();
   const auto & ball = world_model()->ball();
+  const double ball_vel_norm = ball.vel.norm();
+  const double goal_min_y = std::min(goals.first.y(), goals.second.y());
+  const double goal_max_y = std::max(goals.first.y(), goals.second.y());
   // シュートチェック
   Segment goal_line(goals.first, goals.second);
   Segment ball_line = ball.getTrajectorySegmentByDistance(10.0);
   auto intersections = getIntersections(ball_line, Segment{goals.first, goals.second});
   command->setTerminalVelocity(0.0).disableGoalAreaAvoidance().disableBallAvoidance();
 
-  if (not intersections.empty() && world_model()->ball().vel.norm() > 0.3f) {
+  // 改善1: ニアミス判定（ボール軌道がゴールラインと交差しなくても近い場合はブロック）
+  // intersections.empty()を先頭にして短絡評価でbg::distance計算を省略
+  bool near_miss_shot =
+    intersections.empty() && bg::distance(ball_line, goal_line) < 1.0 && ball_vel_norm > 0.5;
+
+  if ((not intersections.empty() || near_miss_shot) && ball_vel_norm > 0.3) {
     // シュートブロック
     phase = "シュートブロック";
     prev_wait_point = std::nullopt;
     auto result = ball.getClosestPointToTrajectory(command->getRobot()->pose.pos);
     auto target = [&]() -> Point {
-      if (not world_model()->point_checker.isFieldInside(result.closest_point)) {
-        return clampXToGoalLine(intersections.front(), 0.15);
+      if (not intersections.empty()) {
+        if (not world_model()->point_checker.isFieldInside(result.closest_point)) {
+          return clampXToGoalLine(intersections.front(), 0.15);
+        } else {
+          return result.closest_point;
+        }
       } else {
-        return result.closest_point;
+        // ニアミス: ボール速度ベクトルからゴールラインのX位置でのy座標を予測
+        double clamped_y;
+        if (std::abs(ball.vel.x()) > 0.01f) {
+          double t = (goal_center.x() - ball.pos.x()) / ball.vel.x();
+          clamped_y = std::clamp(ball.pos.y() + t * ball.vel.y(), goal_min_y, goal_max_y);
+        } else {
+          clamped_y = std::clamp(static_cast<double>(ball.pos.y()), goal_min_y, goal_max_y);
+        }
+        return clampXToGoalLine(Point(goal_center.x(), clamped_y), 0.15);
       }
     }();
 
@@ -140,6 +160,14 @@ void Goalie::inplay(bool enable_emit)
       // ボールが止まっていて，味方ペナルティエリア内にあり，敵が近くにいないときは排出
       phase = "ボール排出";
       emitBallFromPenaltyArea();
+    } else if (  // 改善2: 緊急接近ブロック（シュートブロック条件を満たさないゴール接近ボール）
+      ball.isMovingTowards(goal_center, 60.0) && ball_vel_norm > 1.0 &&
+      std::abs(goal_center.x() - ball.pos.x()) < 2.0) {
+      phase = "緊急接近ブロック";
+      prev_wait_point = std::nullopt;
+      double target_y = std::clamp(static_cast<double>(ball.pos.y()), goal_min_y, goal_max_y);
+      Point target = clampXToGoalLine(Point(goal_center.x(), target_y), 0.15);
+      command->setTargetPosition(target).lookAtBallFrom(target);
     } else {
       const double BLOCK_DIST = getParameter<double>("block_distance");
       if (phase.empty()) {
@@ -274,14 +302,15 @@ void Goalie::inplay(bool enable_emit)
           Point wait_point = weak_point + (threat_point - weak_point).normalized() * dist;
 
           // 改善D: wait_pointのY座標をゴールポスト幅内にクランプ
-          double min_y = std::min(goals.first.y(), goals.second.y());
-          double max_y = std::max(goals.first.y(), goals.second.y());
-          wait_point.y() = std::clamp(wait_point.y(), min_y, max_y);
+          wait_point.y() = std::clamp(wait_point.y(), goal_min_y, goal_max_y);
 
-          // 改善B: ローパスフィルタでターゲット振動を抑制
-          constexpr double SMOOTHING_ALPHA = 0.7;
+          // 改善3: 適応的ローパスフィルタ（通常は強平滑化、ボール接近時は高応答）
+          double smoothing_alpha = 0.9;  // デフォルト: 振動抑制優先
+          if (ball.isMovingTowards(goal_center) && ball_vel_norm > 1.0) {
+            smoothing_alpha = 0.3;  // ボール接近中: 応答性優先
+          }
           if (prev_wait_point) {
-            wait_point = *prev_wait_point * SMOOTHING_ALPHA + wait_point * (1.0 - SMOOTHING_ALPHA);
+            wait_point = *prev_wait_point * smoothing_alpha + wait_point * (1.0 - smoothing_alpha);
           }
           prev_wait_point = wait_point;
 


### PR DESCRIPTION
## 背景

rosbag分析（t=753〜756秒）で、ボールが壁でバウンドしてゴールに入る間接的シュートに対し
Goalieのシュートブロックが発動せず失点するケースを確認。

バウンド後の軌道がゴールラインと交差しないため `intersections` が空になり、
シュートブロック条件を満たさないことが根本原因。
さらに待ち受けモードのターゲットが±0.8mで振動し続けていたことも重なって失点。

## 変更内容

### 改善1: ニアミス検出によるシュートブロック拡張 (`goalie.cpp`)
- ボール軌道がゴールラインと交差しなくても距離1.0m以内かつ速度0.5m/s超の場合にシュートブロックを発動
- ニアミス時のブロック位置はボール速度ベクトルからゴールラインX位置でのy座標を予測して計算
- `bg::distance` 計算は `intersections.empty()` の短絡評価で交差あり時はスキップ

### 改善2: 緊急接近ブロックモードの追加 (`goalie.cpp`)
- 改善1でもカバーできないゴール接近ボール（ゴールに向かって移動中、速度1.0m/s超、X距離2.0m以内）に対応
- フォールバックとしてボール現在位置y座標をゴールポスト幅内にクランプして守備

### 改善3: 待ち受けモードの適応的ローパスフィルタ (`goalie.cpp`)
- 通常時: `alpha=0.9`（強平滑化で振動抑制）
- ボール接近中（ゴールに向かって速度1.0m/s超）: `alpha=0.3`（高応答性）
- 従来固定値 `0.7` から変更し、振動抑制と応答性を状況に応じて切り替え

## テスト計画

- [ ] `colcon build --packages-select crane_robot_skills` が通ること ✅
- [ ] 直接シュート → 既存シュートブロックが正常動作すること
- [ ] 壁バウンスシュート → 改善1または改善2が発動すること
- [ ] 待ち受け時 → visualizerでターゲット振動が抑制されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)