### PR TITLE
fix: 相手セットプレイ時のマーカーをsave_goalモードに切り替えて失点防止

### DIFF
--- a/crane_sessions/include/crane_sessions/marker_functions.hpp
+++ b/crane_sessions/include/crane_sessions/marker_functions.hpp
@@ -36,12 +36,13 @@ struct MarkingResult
 /// @param visualizer ビジュアライザー
 /// @param command_name コマンド名（デバッグ用）
 /// @param assign_remaining ターゲットがいない残余ロボットにもMarkerを生成するか
+/// @param mark_mode マーキングモード ("intercept_pass": ボール基準, "save_goal": ゴール基準)
 /// @return マーキング結果（生成したMarkerリストと選択されたロボットIDリスト）
 auto assignMarkersToEnemies(
   const std::vector<uint8_t> & available_robot_ids,
   const WorldModelWrapper::SharedPtr & world_model,
   const VisualizerMessageBuilder::SharedPtr & visualizer, const std::string & command_name,
-  bool assign_remaining = false) -> MarkingResult;
+  bool assign_remaining = false, const std::string & mark_mode = "intercept_pass") -> MarkingResult;
 
 }  // namespace crane
 #endif  // CRANE_SESSIONS__MARKER_FUNCTIONS_HPP_

--- a/crane_sessions/src/marker_functions.cpp
+++ b/crane_sessions/src/marker_functions.cpp
@@ -61,7 +61,7 @@ auto assignMarkersToEnemies(
   const std::vector<uint8_t> & available_robot_ids,
   const WorldModelWrapper::SharedPtr & world_model,
   const VisualizerMessageBuilder::SharedPtr & visualizer, const std::string & command_name,
-  bool assign_remaining) -> MarkingResult
+  bool assign_remaining, const std::string & mark_mode) -> MarkingResult
 {
   MarkingResult result;
 
@@ -81,19 +81,36 @@ auto assignMarkersToEnemies(
     ranges::views::transform([&](const auto & id) { return world_model->getOurRobot(id); }) |
     ranges::to<std::vector>();
 
+  const bool is_save_goal = (mark_mode == "save_goal");
+  const Point reference = is_save_goal ? world_model->getOurGoalCenter() : world_model->ball().pos;
+
   for (const auto & [enemy_robot, score] : danger_enemies) {
     if (remaining_robots.empty()) {
       break;
     }
+
+    // マーキングセグメントを事前計算（割当コストと可視化で共用）
+    constexpr double mark_dist = 0.5;
+    constexpr double max_mark_dist = 1.5;
+    auto dir = (reference - enemy_robot->pose.pos).normalized();
+    Point near_end = enemy_robot->pose.pos + dir * mark_dist;
+    Point far_end = enemy_robot->pose.pos + dir * max_mark_dist;
+    if (is_save_goal) {
+      constexpr double penalty_offset = 0.15;
+      Segment enemy_to_goal{enemy_robot->pose.pos, world_model->getOurGoalCenter()};
+      auto intersection =
+        world_model->getIntersectionOurPenaltyArea(enemy_to_goal, penalty_offset, penalty_offset);
+      if (intersection) {
+        double dist_to_boundary = (intersection.value() - enemy_robot->pose.pos).norm();
+        double clamped_max = std::max(mark_dist, dist_to_boundary - 0.05);
+        far_end = enemy_robot->pose.pos + dir * std::min(max_mark_dist, clamped_max);
+        near_end = enemy_robot->pose.pos + dir * std::min(mark_dist, clamped_max);
+      }
+    }
+    Segment marking_segment{near_end, far_end};
+
     auto best_robot = ranges::min(remaining_robots, ranges::less{}, [&](const auto & robot) {
       // 割当コスト: 敵に対するマーキングセグメントへの距離（固定点ではなく線分ベース）
-      Point reference = world_model->ball().pos;
-      constexpr double mark_dist = 0.5;
-      constexpr double max_mark_dist = 1.5;
-      auto dir = (reference - enemy_robot->pose.pos).normalized();
-      Point near_end = enemy_robot->pose.pos + dir * mark_dist;
-      Point far_end = enemy_robot->pose.pos + dir * max_mark_dist;
-      Segment marking_segment{near_end, far_end};
       return getClosestPointAndDistance(robot->pose.pos, marking_segment).distance;
     });
 
@@ -105,17 +122,13 @@ auto assignMarkersToEnemies(
     auto marker = std::make_shared<skills::Marker>(
       command_name, static_cast<uint8_t>(best_robot->id), world_model);
     marker->setParameter("marking_robot_id", enemy_robot->id);
-    marker->setParameter("mark_mode", std::string("intercept_pass"));
+    marker->setParameter("mark_mode", mark_mode);
     marker->setParameter("mark_distance", 0.5);
     result.markers.push_back(marker);
 
     visualizer->drawCircle(enemy_robot->pose.pos, 0.3, "black", 10);
-    // マーキングセグメントを可視化
-    {
-      auto dir = (world_model->ball().pos - enemy_robot->pose.pos).normalized();
-      visualizer->drawLine(
-        enemy_robot->pose.pos + dir * 0.5, enemy_robot->pose.pos + dir * 1.5, "green", 10);
-    }
+    // マーキングセグメントを可視化（コスト計算と同一セグメント）
+    visualizer->drawLine(near_end, far_end, "green", 10);
     visualizer->drawLine(best_robot->pose.pos, enemy_robot->pose.pos, "black", 20);
   }
 

--- a/crane_sessions/src/marker_session.cpp
+++ b/crane_sessions/src/marker_session.cpp
@@ -19,7 +19,19 @@ MarkerSession::calculatePositionCommand(const std::vector<RobotIdentifier> & rob
     ranges::to<std::vector>();
   auto lock = std::lock_guard(markers_mutex);
   visualizer->clearBuffer();
-  auto result = assignMarkersToEnemies(robot_ids, world_model, visualizer, "marker_planner", true);
+  // ボール停止中＋敵がボール近くにいる＝相手セットプレイ → save_goalモードでゴール前を守る
+  std::string mark_mode = "intercept_pass";
+  if (!world_model->ball().isMoving(0.5)) {
+    auto their_robots = world_model->theirs().robotsWhere().available().get();
+    bool enemy_near_ball = std::any_of(
+      their_robots.begin(), their_robots.end(),
+      [&](const auto & r) { return r->getDistance(world_model->ball().pos) < 1.0; });
+    if (enemy_near_ball) {
+      mark_mode = "save_goal";
+    }
+  }
+  auto result =
+    assignMarkersToEnemies(robot_ids, world_model, visualizer, "marker_planner", true, mark_mode);
   markers = std::move(result.markers);
 
   std::vector<crane_msgs::msg::RobotCommand> robot_commands;

--- a/crane_sessions/src/total_defense_session.cpp
+++ b/crane_sessions/src/total_defense_session.cpp
@@ -180,7 +180,7 @@ auto TotalDefenseSession::assignMarkingTargets(const std::vector<uint8_t> & avai
 {
   auto lock = std::lock_guard(markers_mutex);
   auto result = assignMarkersToEnemies(
-    available_robots, world_model, visualizer, "total_defense_planner/marker");
+    available_robots, world_model, visualizer, "total_defense_planner/marker", false, "save_goal");
   markers = std::move(result.markers);
   return result.selected_robot_ids;
 }


### PR DESCRIPTION
## 概要

相手フリーキック/コーナーキック時にマーカーが`save_goal`モードを使用するよう変更し、ゴール正面の無防備状態を解消します。

## 背景・根本原因

`rosbag2_2026_03_14-21_08_24`の後半（t=459〜470）で相手ダイレクトフリーキックにより失点。
マーカー5台が`intercept_pass`モード（ボール基準）で位置取りしていたため、ボール位置(3.1, 4.3)方向に引き寄せられ、ゴール正面(x=4〜6, y=0付近)が無防備になり4.12m/sのシュートを許した。

`save_goal`モードであれば、referenceがゴール中心になるため、敵ロボットとゴールの間に位置取りできる。

## 変更内容

- `assignMarkersToEnemies()`に`mark_mode`パラメータを追加（デフォルト: `"intercept_pass"`）
- **save_goalモード**: referenceをゴール中心に切り替え
- **save_goalモード**: ペナルティエリアクランプ処理でマーカーがPA内に侵入しないよう制御（0.15mマージン）
- **marker_session**: ボール停止中 & 敵がボール1m以内 → `save_goal`モードを自動選択（INPLAY中はボールが動くため自動的に`intercept_pass`に戻る）
- **total_defense_session**: 守備特化セッションは常に`save_goal`モード
- セグメント計算の事前化によりラムダ内の文字列比較・重複計算を除去、可視化とコスト計算で同一セグメントを使用

