### PR TITLE
feat: Kick スキルにピボットターン機能を追加

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/kick.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/kick.hpp
@@ -7,15 +7,19 @@
 #ifndef CRANE_ROBOT_SKILLS__KICK_HPP_
 #define CRANE_ROBOT_SKILLS__KICK_HPP_
 
+#include <chrono>
 #include <crane_geometry/vector2d_adapter.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
+#include <optional>
 
 namespace crane::skills
 {
 enum class KickState {
   ENTRY_POINT,
   AROUND_BALL_AND_KICK,
+  PIVOT_CAPTURE,
+  PIVOT_TURN,
 };
 
 class Kick : public SkillBaseWithState
@@ -51,6 +55,15 @@ private:
   void kickWithChip();
 
   void kickStraight();
+
+  /// @brief ターゲット方向のキックベクトルを計算（フォールバック付き）
+  Vector2 computeKickVec() const;
+
+  /// @brief キック方向の矢印と角度しきい値の扇を描画
+  void drawKickDirectionVisualization(const Point & ball_pos, const Vector2 & kick_vec);
+
+  /// @brief PIVOT_TURN に入った時刻（タイムアウト検出用）
+  std::optional<std::chrono::steady_clock::time_point> pivot_turn_entry_time_;
 };
 }  // namespace crane::skills
 #endif  // CRANE_ROBOT_SKILLS__KICK_HPP_

--- a/crane_robot_skills/src/kick.cpp
+++ b/crane_robot_skills/src/kick.cpp
@@ -32,65 +32,47 @@ void Kick::initialize()
   setParameter("around_interval", 0.15f);
   setParameter("go_around_ball", true);
   setParameter("kicked_speed_threshold", 1.5);
+  setParameter("enable_pivot_turn", true);
+  setParameter("pivot_dribble_power", 0.6);
+  setParameter("pivot_omega_limit", 3.0);
+  setParameter("pivot_max_velocity", 1.0);
+  setParameter("pivot_ball_lost_distance", 0.20);
+  setParameter("pivot_exit_angle_deg", 5.0f);
+  setParameter("pivot_turn_timeout", 3.0);
 
   addStateFunction(static_cast<int>(KickState::ENTRY_POINT), [this]() {
     visualizer->drawDebugLabel(robot()->pose.pos, "Kick::ENTRY_POINT");
     return Status::RUNNING;
   });
 
-  addTransition(
-    static_cast<int>(KickState::ENTRY_POINT), static_cast<int>(KickState::AROUND_BALL_AND_KICK),
-    [this]() { return true; });
+  addTransitions(
+    static_cast<int>(KickState::ENTRY_POINT),
+    {
+      {static_cast<int>(KickState::PIVOT_CAPTURE),
+       [this]() {
+         if (!getParameter<bool>("enable_pivot_turn")) return false;
+         return (world_model()->ball().pos - robot()->pose.pos).norm() < 0.20;
+       }},
+      {static_cast<int>(KickState::AROUND_BALL_AND_KICK), [this]() { return true; }},
+    });
 
   addStateFunction(static_cast<int>(KickState::AROUND_BALL_AND_KICK), [this]() {
-    auto target = getParameter<Point>("target");
+    pivot_turn_entry_time_.reset();
     Point ball_pos = world_model()->ball().pos;
     const double interval = std::max(getParameter<double>("around_interval"), 0.01);
     const bool go_around_ball = getParameter<bool>("go_around_ball");
-    const auto kick_vec = [&]() -> Vector2 {
-      auto target_vec = target - ball_pos;
-      if (target_vec.norm() > 1e-6) {
-        return target_vec.normalized();
-      }
-      auto fallback = robot()->pose.pos - ball_pos;
-      if (fallback.norm() > 1e-6) {
-        return fallback.normalized();
-      }
-      return Vector2(1.0, 0.0);
-    }();
+    const Vector2 kick_vec = computeKickVec();
     Point safe_target = ball_pos + kick_vec;
 
     // 視認性の高いキック方向の可視化: 太い矢印 + 角度しきい値の扇
-    {
-      Vector2 dir = kick_vec;
-      // 長めの矢印（フィールド半分+余裕）
-      double arrow_len = world_model()->fieldSize().x() * 0.5 + 0.5;
-
-      // メインの矢印シャフト + アローヘッド
-      visualizer->arrow(ball_pos, dir, arrow_len, "lime", 20, 0.35, 0.20);
-
-      // 角度しきい値の扇（境界線 + アーク）
-      using boost::math::constants::degree;
-      double half_angle = getParameter<double>("angle_threshold_deg") * degree<double>();
-      double base_theta = getAngle(dir);
-      double arc_radius = 0.9;
-      // 境界線
-      auto dir_left = Vector2(std::cos(base_theta + half_angle), std::sin(base_theta + half_angle));
-      auto dir_right =
-        Vector2(std::cos(base_theta - half_angle), std::sin(base_theta - half_angle));
-      visualizer->drawLine(ball_pos, ball_pos + dir_left * arc_radius, "white", 10, 0.6);
-      visualizer->drawLine(ball_pos, ball_pos + dir_right * arc_radius, "white", 10, 0.6);
-      // アーク（扇の円弧）
-      visualizer->arc(
-        ball_pos, arc_radius, base_theta - half_angle, base_theta + half_angle, "white", 10, 16);
-    }
+    drawKickDirectionVisualization(ball_pos, kick_vec);
     visualizer->drawDebugLabel(robot()->pose.pos, "Kick::AROUND_BALL");
     Point approach = [&]() -> Point {
       if (!go_around_ball) {
         return ball_pos - kick_vec * interval;
       }
       // 改良回り込み: ロボット->目標線分に対するボール最近傍方向へ回り込み
-      double max_interval = std::max(interval, interval * 2.0);
+      double max_interval = interval * 2.0;
       return computeAroundBallApproachTargetDynamic(
         ball_pos, safe_target, robot()->pose.pos, interval, max_interval);
     }();
@@ -146,6 +128,94 @@ void Kick::initialize()
       return world_model()->ball().isMoving(getParameter<double>("kicked_speed_threshold")) &&
              world_model()->ball().isMovingAwayFrom(robot()->pose.pos, 30.);
     });
+
+  addStateFunction(static_cast<int>(KickState::PIVOT_CAPTURE), [this]() {
+    pivot_turn_entry_time_.reset();
+    Point ball_pos = world_model()->ball().pos;
+    const Vector2 kick_vec = computeKickVec();
+    Point safe_target = ball_pos + kick_vec;
+
+    visualizer->drawDebugLabel(robot()->pose.pos, "Kick::PIVOT_CAPTURE");
+
+    // ドリブラーをボールに当てながら、最終的なキック方向を向く
+    command->disableBallAvoidance();
+    command->disableCollisionAvoidance();
+    command->setMaxVelocity("Kick::PIVOT_CAPTURE", getParameter<double>("pivot_max_velocity"));
+    command->lookAtFrom(safe_target, ball_pos).setDribblerTargetPosition(ball_pos);
+    command->withDribble(getParameter<double>("pivot_dribble_power"));
+    command->kickStraight(0.0);
+
+    return Status::RUNNING;
+  });
+
+  // ボールセンサー反応 → PIVOT_TURNへ
+  addTransition(
+    static_cast<int>(KickState::PIVOT_CAPTURE), static_cast<int>(KickState::PIVOT_TURN),
+    [this]() { return robot()->ball_contact.findPastContact(0.05); });
+
+  // ボールが遠ざかった（捕捉失敗）→ AROUND_BALL_AND_KICKにフォールバック
+  addTransition(
+    static_cast<int>(KickState::PIVOT_CAPTURE), static_cast<int>(KickState::AROUND_BALL_AND_KICK),
+    [this]() {
+      return (world_model()->ball().pos - robot()->pose.pos).norm() >
+               getParameter<double>("pivot_ball_lost_distance") &&
+             !world_model()->ball().isMoving(getParameter<double>("kicked_speed_threshold"));
+    });
+
+  addStateFunction(static_cast<int>(KickState::PIVOT_TURN), [this]() {
+    if (!pivot_turn_entry_time_) {
+      pivot_turn_entry_time_ = std::chrono::steady_clock::now();
+    }
+    Point ball_pos = world_model()->ball().pos;
+    const Vector2 kick_vec = computeKickVec();
+    Point safe_target = ball_pos + kick_vec;
+
+    drawKickDirectionVisualization(ball_pos, kick_vec);
+    visualizer->drawDebugLabel(robot()->pose.pos, "Kick::PIVOT_TURN");
+
+    command->disableBallAvoidance();
+    command->disableCollisionAvoidance();
+    command->setOmegaLimit(getParameter<double>("pivot_omega_limit"));
+    command->setMaxVelocity("Kick::PIVOT_TURN", getParameter<double>("pivot_max_velocity"));
+
+    // lookAtFromが先（target_thetaを設定）、setDribblerTargetPositionが後（theta依存）
+    command->lookAtFrom(safe_target, ball_pos).setDribblerTargetPosition(ball_pos);
+    command->withDribble(getParameter<double>("pivot_dribble_power"));
+    command->kickStraight(0.0);
+
+    return Status::RUNNING;
+  });
+
+  // 角度が揃ったら AROUND_BALL_AND_KICK へ渡してキックを担当させる
+  // ボールセンサー反応状態（PIVOT_CAPTURE確認済み）ではボールはキッカー前にあるため、
+  // 幾何学的角度より robot()->pose.theta を使う方が位置誤差の影響を受けにくい
+  addTransition(
+    static_cast<int>(KickState::PIVOT_TURN), static_cast<int>(KickState::AROUND_BALL_AND_KICK),
+    [this]() {
+      const Vector2 kick_vec = computeKickVec();
+      using boost::math::constants::degree;
+      const double threshold = getParameter<double>("pivot_exit_angle_deg") * degree<double>();
+      return std::abs(getAngleDiff(getAngle(kick_vec), robot()->pose.theta)) < threshold;
+    });
+
+  // ボール保持失敗（ボールが低速で離脱）→ AROUND_BALL_AND_KICKにフォールバック
+  addTransition(
+    static_cast<int>(KickState::PIVOT_TURN), static_cast<int>(KickState::AROUND_BALL_AND_KICK),
+    [this]() {
+      double ball_dist = (world_model()->ball().pos - robot()->kicker_center()).norm();
+      return ball_dist > getParameter<double>("pivot_ball_lost_distance") &&
+             !world_model()->ball().isMoving(getParameter<double>("kicked_speed_threshold"));
+    });
+
+  // タイムアウト → AROUND_BALL_AND_KICKにフォールバック（デッドロック防止）
+  addTransition(
+    static_cast<int>(KickState::PIVOT_TURN), static_cast<int>(KickState::AROUND_BALL_AND_KICK),
+    [this]() {
+      if (!pivot_turn_entry_time_) return false;
+      auto elapsed = std::chrono::steady_clock::now() - *pivot_turn_entry_time_;
+      return std::chrono::duration<double>(elapsed).count() >
+             getParameter<double>("pivot_turn_timeout");
+    });
 }
 
 auto Kick::getBallExitPointFromField(const double offset) -> Point
@@ -187,5 +257,32 @@ auto Kick::kickStraight() -> void
   } else {
     command->kickStraight(getParameter<double>("kick_power"));
   }
+}
+
+Vector2 Kick::computeKickVec() const
+{
+  auto target = getParameter<Point>("target");
+  Point ball_pos = world_model()->ball().pos;
+  Vector2 v = target - ball_pos;
+  if (v.norm() > 1e-6) return v.normalized();
+  v = robot()->pose.pos - ball_pos;
+  if (v.norm() > 1e-6) return v.normalized();
+  return Vector2(1.0, 0.0);
+}
+
+void Kick::drawKickDirectionVisualization(const Point & ball_pos, const Vector2 & kick_vec)
+{
+  double arrow_len = world_model()->fieldSize().x() * 0.5 + 0.5;
+  visualizer->arrow(ball_pos, kick_vec, arrow_len, "lime", 20, 0.35, 0.20);
+  using boost::math::constants::degree;
+  double half_angle = getParameter<double>("angle_threshold_deg") * degree<double>();
+  double base_theta = getAngle(kick_vec);
+  constexpr double arc_radius = 0.9;
+  auto dir_left = Vector2(std::cos(base_theta + half_angle), std::sin(base_theta + half_angle));
+  auto dir_right = Vector2(std::cos(base_theta - half_angle), std::sin(base_theta - half_angle));
+  visualizer->drawLine(ball_pos, ball_pos + dir_left * arc_radius, "white", 10, 0.6);
+  visualizer->drawLine(ball_pos, ball_pos + dir_right * arc_radius, "white", 10, 0.6);
+  visualizer->arc(
+    ball_pos, arc_radius, base_theta - half_angle, base_theta + half_angle, "white", 10, 16);
 }
 }  // namespace crane::skills

--- a/crane_robot_skills/src/receive.cpp
+++ b/crane_robot_skills/src/receive.cpp
@@ -135,7 +135,9 @@ Point Receive::getInterceptionPoint() const
   std::string policy = getParameter<std::string>("policy");
   command->addPlanningFactor("Receive::policy", policy);
 
-  if (policy.ends_with("slack")) {
+  if (
+    policy.ends_with("slack") &&
+    world_model()->ball().vel.norm() > world_model()->getSlackConfig().velocity_epsilon) {
     auto slack_times = world_model()->getSlackInterceptPointAndSlackTimeArray({robot()});
     // Slack color mapper: [-0.5, 0, +0.5] -> red, yellow, green
     auto slackColor = [](double s) -> std::string {


### PR DESCRIPTION
## 概要

パス受信後のキック方向転換を高速化するため、ドリブラーでボールを保持しながらその場回転（ピボットターン）する機能を追加した。また、PIVOT_TURN のデッドロック問題を修正し、`receive.cpp` の NaN 警告も解消した。

## 背景・根本原因

パス受信後にロボットがキック方向と反対側にいると、`AROUND_BALL_AND_KICK` の `computeAroundBallApproachTargetDynamic` による大回り迂回に最大7秒かかり、敵の接近を許す問題があった（rosbag `rosbag2_2026_03_15-02_55_53` で確認）。

またデッドロック問題（rosbag `rosbag2_2026_03_15-12_20_42`）として、PIVOT_TURN が5.5秒間フリーズする現象が確認された。原因は遷移条件で `getAngle(ball_pos - robot_pos)` を使っており、ドリブラーとボールの位置ズレにより幾何学的角度が収束しないことだった。

## 変更内容

### kick.hpp / kick.cpp
- `KickState` に `PIVOT_CAPTURE`・`PIVOT_TURN` を追加
- **PIVOT_CAPTURE**: ボールセンサー反応を確認してからターンに入る捕捉フェーズ
- **PIVOT_TURN**: `lookAtFrom` + `setDribblerTargetPosition(ball_pos)` でボールを中心に回転
  - 遷移条件を `robot()->pose.theta` ベースに変更（幾何学的角度の不正確さを回避）
  - タイムアウト機構（デフォルト3秒）でデッドロックを防止
- 新パラメータ: `enable_pivot_turn`, `pivot_dribble_power`, `pivot_omega_limit`, `pivot_max_velocity`, `pivot_ball_lost_distance`, `pivot_exit_angle_deg`, `pivot_turn_timeout`
- `computeKickVec()` / `drawKickDirectionVisualization()` を抽出して4箇所の重複を解消

### receive.cpp
- `min_slack` ポリシーをボール停止時（`vel < velocity_epsilon`）に適用しないよう修正

## テスト方法
- [x] `colcon build --packages-select crane_robot_skills` でビルド確認
- [x] grSim でパス受信後のキック方向転換速度を確認（ピボット有効 vs 無効）
- [x] PIVOT_TURN が3秒以内に完了することを確認
- [x] ボール離脱時の `AROUND_BALL_AND_KICK` フォールバックを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)