### PR TITLE
feat: ビジュアライザをSSL標準チーム色に統一

### DIFF
--- a/crane_debug_tools/web/svg_viewer.js
+++ b/crane_debug_tools/web/svg_viewer.js
@@ -300,7 +300,7 @@ class SvgViewer {
         svg.setAttribute('height', '100%');
         svg.setAttribute('viewBox', '-6000 -4500 12000 9000'); // SSL field dimensions in mm
         svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
-        svg.style.background = '#6c757d';
+        svg.style.background = 'green';
 
         // 座標グリッドを追加
         const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
@@ -313,7 +313,7 @@ class SvgViewer {
         const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
         path.setAttribute('d', 'M 1000 0 L 0 0 0 1000');
         path.setAttribute('fill', 'none');
-        path.setAttribute('stroke', '#adb5bd');
+        path.setAttribute('stroke', '#2d8a2d');
         path.setAttribute('stroke-width', '20');
 
         pattern.appendChild(path);
@@ -326,7 +326,7 @@ class SvgViewer {
         fieldBackground.setAttribute('y', '-4500');
         fieldBackground.setAttribute('width', '12000');
         fieldBackground.setAttribute('height', '9000');
-        fieldBackground.setAttribute('fill', '#6c757d');
+        fieldBackground.setAttribute('fill', 'green');
         svg.appendChild(fieldBackground);
 
         // グリッドの背景を追加

--- a/crane_world_model_publisher/include/crane_world_model_publisher/visualization_manager.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/visualization_manager.hpp
@@ -50,7 +50,7 @@ public:
   auto drawTrajectoryHistory(
     const std::array<std::deque<crane_msgs::msg::RobotInfo>, 20> & friend_history,
     const std::array<std::deque<crane_msgs::msg::RobotInfo>, 20> & enemy_history,
-    const std::deque<crane_msgs::msg::BallInfo> & ball_info_history) -> void;
+    const std::deque<crane_msgs::msg::BallInfo> & ball_info_history, bool is_yellow) -> void;
 
   // 各用途別の専用Builder
   crane::VisualizerMessageBuilder::SharedPtr geometry_builder;
@@ -63,8 +63,22 @@ public:
   crane::VisualizerMessageBuilder::SharedPtr pass_score_builder;
   crane::VisualizerMessageBuilder::SharedPtr kick_event_builder;
 
+  // drawFieldGeometry はコールバック経由で呼ばれるため world_model を受け取れない。
+  // ゴール色描画のためにチーム情報をキャッシュする。
+  void updateTeamInfo(bool is_yellow, bool on_positive_half)
+  {
+    is_yellow_ = is_yellow;
+    on_positive_half_ = on_positive_half;
+  }
+
 private:
   rclcpp::Node & node_;
+  bool is_yellow_ = false;         // drawFieldGeometry 用
+  bool on_positive_half_ = false;  // drawFieldGeometry 用
+
+  // drawFieldGeometry 専用ヘルパー
+  std::string getOurTeamColor() const { return is_yellow_ ? "yellow" : "blue"; }
+  std::string getTheirTeamColor() const { return is_yellow_ ? "blue" : "yellow"; }
 };
 
 }  // namespace crane

--- a/crane_world_model_publisher/src/visualization_manager.cpp
+++ b/crane_world_model_publisher/src/visualization_manager.cpp
@@ -72,9 +72,14 @@ auto VisualizationManager::drawFieldGeometry(
     double goal_width = field.goal_width() / 1000.0;
     double goal_depth = field.goal_depth() / 1000.0;
 
-    // ゴール描画（U字型構造）
-    geometry_builder->drawGoal(Point(-field_height / 2, 0), goal_width, -goal_depth);  // 左ゴール
-    geometry_builder->drawGoal(Point(field_height / 2, 0), goal_width, goal_depth);    // 右ゴール
+    // ゴール描画（U字型構造）: positive-half側が自チーム
+    const std::string left_goal_color = on_positive_half_ ? getTheirTeamColor() : getOurTeamColor();
+    const std::string right_goal_color =
+      on_positive_half_ ? getOurTeamColor() : getTheirTeamColor();
+    geometry_builder->drawGoal(
+      Point(-field_height / 2, 0), goal_width, -goal_depth, left_goal_color);  // 左ゴール
+    geometry_builder->drawGoal(
+      Point(field_height / 2, 0), goal_width, goal_depth, right_goal_color);  // 右ゴール
   }
 
   // ペナルティエリアの描画
@@ -110,12 +115,11 @@ auto VisualizationManager::drawVisionDetections(
     Point pos(robot.x() / 1000.0, robot.y() / 1000.0);
     double theta = robot.orientation();
 
-    // ロボット本体とID
     if (robot.has_robot_id()) {
       vision_builder->drawRobotWithID(
-        pos, theta, robot.robot_id(), "white", 0.0, "white", 1.0, 20, 50, "white", 0.0, 0.15);
+        pos, theta, robot.robot_id(), "blue", 0.0, "blue", 1.0, 20, 50, "white", 0.0, 0.15);
     } else {
-      vision_builder->drawRobot(pos, theta, "white", 0.0, "white", 1.0, 20);
+      vision_builder->drawRobot(pos, theta, "blue", 0.0, "blue", 1.0, 20);
     }
   }
 
@@ -124,12 +128,11 @@ auto VisualizationManager::drawVisionDetections(
     Point pos(robot.x() / 1000.0, robot.y() / 1000.0);
     double theta = robot.orientation();
 
-    // ロボット本体とID
     if (robot.has_robot_id()) {
       vision_builder->drawRobotWithID(
-        pos, theta, robot.robot_id(), "white", 0.0, "white", 1.0, 20, 50, "white", 0.0, 0.15);
+        pos, theta, robot.robot_id(), "yellow", 0.0, "yellow", 1.0, 20, 50, "black", 0.0, 0.15);
     } else {
-      vision_builder->drawRobot(pos, theta, "white", 0.0, "white", 1.0, 20);
+      vision_builder->drawRobot(pos, theta, "yellow", 0.0, "yellow", 1.0, 20);
     }
   }
 
@@ -208,7 +211,9 @@ auto VisualizationManager::drawTrackedObjects(const WorldModelWrapper::SharedPtr
     }
   };
 
-  auto draw_robot = [this](const std::shared_ptr<RobotInfo> & robot, bool is_friend) {
+  const bool team_is_yellow = world_model->isYellow();
+  auto draw_robot = [this, team_is_yellow](
+                      const std::shared_ptr<RobotInfo> & robot, bool is_friend) {
     // 味方のみ直近検出チェック（エラーでも表示はOK）
     if (is_friend) {
       const auto now = node_.now();
@@ -221,9 +226,13 @@ auto VisualizationManager::drawTrackedObjects(const WorldModelWrapper::SharedPtr
     const Point & pos = robot->pose.pos;
     const double theta = std::isfinite(robot->pose.theta) ? robot->pose.theta : 0.0;
 
-    // ロボット本体とID
+    // ロボット本体とID（world_modelから直接取得したチーム色を使用）
+    const std::string fill_color =
+      is_friend ? (team_is_yellow ? "yellow" : "blue") : (team_is_yellow ? "blue" : "yellow");
+    const std::string id_color =
+      is_friend ? (team_is_yellow ? "black" : "white") : (team_is_yellow ? "white" : "black");
     tracked_builder->drawRobotWithID(
-      pos, theta, robot->id, is_friend ? "green" : "red", 1.0, "black", 1.0, 10);
+      pos, theta, robot->id, fill_color, 1.0, "black", 1.0, 10, 150, id_color);
   };
 
   // トラッキング済みロボット（味方）: エラー有無に関わらず、直近検出があれば描画
@@ -264,18 +273,19 @@ auto VisualizationManager::drawBallPlacement(const WorldModelWrapper::SharedPtr 
 {
   if (auto target = world_model->getBallPlacementTarget(); target) {
     const auto & ball = world_model->ball();
-    placement_builder->drawCircle(target.value(), 0.5, "white", 5);
+    const std::string placement_color = world_model->isYellow() ? "yellow" : "blue";
+    placement_builder->drawCircle(target.value(), 0.5, placement_color, 5);
     Vector2 vertical = getVerticalVec((ball.pos - target.value()).normalized()) * 0.5;
     placement_builder->line()
       .start(ball.pos + vertical)
       .end(target.value() + vertical)
-      .stroke("white")
+      .stroke(placement_color)
       .strokeWidth(5)
       .build();
     placement_builder->line()
       .start(ball.pos - vertical)
       .end(target.value() - vertical)
-      .stroke("white")
+      .stroke(placement_color)
       .strokeWidth(5)
       .build();
     placement_builder->flush();
@@ -288,7 +298,7 @@ auto VisualizationManager::drawBallPlacement(const WorldModelWrapper::SharedPtr 
 auto VisualizationManager::drawTrajectoryHistory(
   const std::array<std::deque<crane_msgs::msg::RobotInfo>, 20> & friend_history,
   const std::array<std::deque<crane_msgs::msg::RobotInfo>, 20> & enemy_history,
-  const std::deque<crane_msgs::msg::BallInfo> & ball_info_history) -> void
+  const std::deque<crane_msgs::msg::BallInfo> & ball_info_history, bool is_yellow) -> void
 {
   static constexpr int SAMPLING_NUM = 4;
 
@@ -317,8 +327,8 @@ auto VisualizationManager::drawTrajectoryHistory(
   };
 
   // 味方・敵の履歴描画（共通処理）
-  draw_team_history(friend_history, "green");
-  draw_team_history(enemy_history, "red");
+  draw_team_history(friend_history, is_yellow ? "yellow" : "blue");
+  draw_team_history(enemy_history, is_yellow ? "blue" : "yellow");
 
   // ボール軌跡描画
   if (ball_info_history.size() > SAMPLING_NUM + 1) {

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -182,11 +182,15 @@ auto WorldModelPublisherComponent::publishWorldModel() -> void
 
 auto WorldModelPublisherComponent::publishVisualization(WorldModelWrapperPtr world_model) -> void
 {
+  // チーム色情報を更新
+  visualization_manager_->updateTeamInfo(world_model->isYellow(), world_model->onPositiveHalf());
+
   // VisualizationManagerによる統合可視化処理
   visualization_manager_->drawTrackedObjects(world_model);
 
   // 軌跡履歴データをVisualizationManagerに渡す（コピーなし）
-  visualization_manager_->drawTrajectoryHistory(friend_history, enemy_history, ball_info_history);
+  visualization_manager_->drawTrajectoryHistory(
+    friend_history, enemy_history, ball_info_history, world_model->isYellow());
 
   visualization_manager_->drawBallPlacement(world_model);
 


### PR DESCRIPTION
## 概要

crane ビジュアライザの配色を ssl-vision-client に準拠した SSL 標準チーム色（青/黄）に統一する。
これまでの味方=緑/敵=赤という独自配色を廃止し、フィールド背景も緑色に変更する。

## 背景・根本原因

ssl-vision-client のフィールド描画スタイルが見やすいため、crane のビジュアライザを同スタイルに合わせる方針となった。

## 変更内容

- **svg_viewer.js**: フィールド背景 `#6c757d`(グレー) → `green`、グリッド線を暗緑(`#2d8a2d`)に変更
- **visualization_manager**: チーム色管理を追加
  - `is_yellow_` / `on_positive_half_` を `drawFieldGeometry` 専用にキャッシュ（コールバック経由のため world_model が渡せない）
  - `drawTrackedObjects` / `drawBallPlacement`: `world_model->isYellow()` から直接チーム色を取得
  - `drawTrajectoryHistory`: `bool is_yellow` 引数を追加し、呼び出し側から渡す
  - `drawFieldGeometry`: ゴールをチーム色で描画（positive-half 側が自チーム色）
  - `drawVisionDetections`: 青チームは青 outline/白 ID、黄チームは黄 outline/黒 ID

## テスト方法

- [x] `colcon build --packages-select crane_world_model_publisher crane_debug_tools` でビルド確認（警告ゼロ）
- [ ] シミュレーション起動後 `http://localhost:8090/svg_viewer.html` で確認
  - フィールド背景が緑色であること
  - ゴールがチーム色で描画されること
  - ロボットが青/黄チーム色で描画されること
  - ロボット ID 文字色が適切（黄ロボ→黒、青ロボ→白）であること
  - 軌跡がチーム色で描画されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)