### PR TITLE
feat: Sumatraの技術を活用したパスカット安定性改善（修正1〜5）

### DIFF
--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/attacker_metrics.hpp
@@ -34,9 +34,9 @@ public:
 private:
   // ヒステリシス管理
   SelectionHysteresis<int> attacker_hysteresis_{SelectionHysteresis<int>::Config{
-    .min_hold_duration_sec = 0.2,
-    .min_improvement_ratio = 0.01,
-    .emergency_switch_ratio = 1.03,
+    .min_hold_duration_sec = 0.5,   // 200ms → 500ms: パスカットウィンドウ内の振動抑制
+    .min_improvement_ratio = 0.15,  // 1% → 15%: 僅差での無意味な切替を防止
+    .emergency_switch_ratio = 1.5,  // 3% → 50%: 明らかに優位な場合のみ即切替
     .force_switch_timeout = 3.0,
     .absolute_threshold = 2.0}};
 
@@ -44,7 +44,7 @@ private:
   std::unordered_map<uint8_t, double> ema_scores_;
 
   // EMAスムージング係数
-  static constexpr double EMA_ALPHA = 0.7;  // 新スコア70%、古いスコア30%
+  static constexpr double EMA_ALPHA = 0.3;  // 新スコア30%、旧70%でスコア安定化
 };
 
 }  // namespace crane::metrics

--- a/crane_robot_skills/include/crane_robot_skills/receive.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/receive.hpp
@@ -10,6 +10,7 @@
 #include <crane_geometry/vector2d_adapter.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
+#include <optional>
 
 namespace crane::skills
 {
@@ -44,6 +45,10 @@ public:
   // 敵割り込み検出・回避関数
   bool isEnemyBlockingPassLine(const Point & interception_point) const;
   Point getInterceptionPointWithEnemyAvoidance() const;
+
+private:
+  // 前フレームのインターセプト位置（ジッター抑制用、Sumatra BallInterceptor参考）
+  mutable std::optional<Point> prev_interception_point_;
 };
 
 }  // namespace crane::skills

--- a/crane_robot_skills/src/forward.cpp
+++ b/crane_robot_skills/src/forward.cpp
@@ -24,7 +24,9 @@ auto Forward::update() -> Status
 
   const double line_length = (back_point - front_point).norm();
   if (!std::isfinite(line_length)) {
-    command->stopHere();
+    // stopHereの代わりに現在位置を維持してボールを注視
+    // (ForwardSessionのライン生成が一時的に不安定な場合のフォールバック)
+    command->setTargetPosition(robot()->pose.pos).lookAtBall();
     return Status::RUNNING;
   }
 
@@ -77,7 +79,9 @@ auto Forward::update() -> Status
       .lookAtBall()
       .setMaxVelocity("Forward::max_vel", max_vel);
   } else {
-    command->stopHere();
+    // stopHereの代わりにfront/back中点にフォールバック
+    Point midpoint = (front_point + back_point) * 0.5;
+    command->setTargetPosition(midpoint).lookAtBall().setMaxVelocity("Forward::fallback", max_vel);
   }
 
   if (planner_visualizer) {

--- a/crane_robot_skills/src/receive.cpp
+++ b/crane_robot_skills/src/receive.cpp
@@ -17,6 +17,23 @@ namespace crane::skills
 {
 Status Receive::update()
 {
+  // ボール方向が90度以上変わったら前フレームインターセプト位置をリセット
+  // (Sumatra BallInterceptor参考: 大きな方向変化は新規インターセプト位置を採用)
+  if (prev_interception_point_) {
+    constexpr double BALL_SPEED_RESET_THRESHOLD = 0.5;  // リセット判定の最低ボール速度 [m/s]
+    constexpr double PREV_DIST_RESET_THRESHOLD = 0.1;   // リセット判定の最低距離 [m]
+    auto ball_vel = world_model()->ball().vel;
+    double ball_speed = ball_vel.norm();
+    Vector2 to_prev = prev_interception_point_.value() - world_model()->ball().pos;
+    double prev_dist = to_prev.norm();
+    if (ball_speed > BALL_SPEED_RESET_THRESHOLD && prev_dist > PREV_DIST_RESET_THRESHOLD) {
+      double cos_angle = (ball_vel / ball_speed).dot(to_prev / prev_dist);
+      if (cos_angle < 0.0) {  // 90度以上の方向変化
+        prev_interception_point_ = std::nullopt;
+      }
+    }
+  }
+
   auto offset = [&]() -> Point {
     Point offset(0, 0);
     if (getParameter<bool>("enable_software_bumper")) {
@@ -221,6 +238,16 @@ Point Receive::getInterceptionPoint() const
       command->addPlanningFactor("Receive", message);
       return robot()->pose.pos;
     }
+
+    // 前フレーム位置の安定化ボーナス（Sumatra BallInterceptor参考）
+    if (prev_interception_point_) {
+      double dist_to_prev = (selected_point - prev_interception_point_.value()).norm();
+      constexpr double STABILITY_DISTANCE_THRESHOLD = 0.5;  // 0.5m以内なら前回位置を優先
+      if (dist_to_prev < STABILITY_DISTANCE_THRESHOLD) {
+        selected_point = prev_interception_point_.value();
+      }
+    }
+    prev_interception_point_ = selected_point;
 
     // Emphasize selected point with double circle and small label
     if (getParameter<bool>("viz_candidates")) {

--- a/crane_session_coordinator/src/global_robot_allocator.cpp
+++ b/crane_session_coordinator/src/global_robot_allocator.cpp
@@ -317,7 +317,29 @@ auto GlobalRobotAllocator::buildCostMatrix(
       context.was_assigned_to_same_session ? config_copy.hysteresis_bonus : 0.0;
     double velocity_hysteresis = 0.0;
     if (!context.was_assigned_to_same_session) {
-      velocity_hysteresis = robot->vel.linear.norm() * config_copy.velocity_hysteresis_factor;
+      constexpr double DIRECTION_SPEED_THRESHOLD = 0.3;    // 方向ボーナス適用の最低速度 [m/s]
+      constexpr double DIRECTION_DIST_THRESHOLD = 0.1;     // ターゲット距離の最小値 [m]
+      constexpr double DIRECTION_HYSTERESIS_WEIGHT = 0.3;  // 方向一致度への重み係数
+
+      double robot_speed = robot->vel.linear.norm();
+      // 基本ペナルティ: 速度が大きいほど再割り当てコスト増
+      velocity_hysteresis = robot_speed * config_copy.velocity_hysteresis_factor;
+
+      // 方向ボーナス: 前フレームのターゲット方向に移動中なら追加ペナルティ
+      // (Sumatra DesiredDefendersCalcUtil 参考)
+      auto prev_target = state_copy.getPrevTarget(robot_id);
+      if (prev_target && robot_speed > DIRECTION_SPEED_THRESHOLD) {
+        Vector2 to_prev_target = prev_target.value() - robot->pose.pos;
+        double dist_to_target = to_prev_target.norm();
+        if (dist_to_target > DIRECTION_DIST_THRESHOLD) {
+          // norm()の再計算を避けるため、既計算値で除算してunit vectorを作成
+          Vector2 vel_unit = robot->vel.linear / robot_speed;
+          Vector2 dir_unit = to_prev_target / dist_to_target;
+          double direction_alignment = std::max(0.0, vel_unit.dot(dir_unit));
+          // 方向一致度 * 速度 * 係数 を追加ペナルティとして加算
+          velocity_hysteresis += direction_alignment * robot_speed * DIRECTION_HYSTERESIS_WEIGHT;
+        }
+      }
     }
 
     return base_cost + priority_cost - hysteresis_bonus + velocity_hysteresis;

--- a/crane_sessions/include/crane_sessions/marker_functions.hpp
+++ b/crane_sessions/include/crane_sessions/marker_functions.hpp
@@ -13,6 +13,7 @@
 #include <crane_robot_skills/marker.hpp>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -28,6 +29,8 @@ struct MarkingResult
 {
   std::vector<std::shared_ptr<skills::Marker>> markers;
   std::vector<uint8_t> selected_robot_ids;
+  // 割り当て結果マップ（ヒステリシス引き継ぎ用: enemy_id -> our_robot_id）
+  std::unordered_map<uint8_t, uint8_t> enemy_to_marker;
 };
 
 /// 危険な敵ロボットに対してマーカーを割り当てる共通関数
@@ -42,7 +45,8 @@ auto assignMarkersToEnemies(
   const std::vector<uint8_t> & available_robot_ids,
   const WorldModelWrapper::SharedPtr & world_model,
   const VisualizerMessageBuilder::SharedPtr & visualizer, const std::string & command_name,
-  bool assign_remaining = false, const std::string & mark_mode = "intercept_pass") -> MarkingResult;
+  bool assign_remaining = false, const std::string & mark_mode = "intercept_pass",
+  const std::unordered_map<uint8_t, uint8_t> & prev_assignments = {}) -> MarkingResult;
 
 }  // namespace crane
 #endif  // CRANE_SESSIONS__MARKER_FUNCTIONS_HPP_

--- a/crane_sessions/include/crane_sessions/marker_session.hpp
+++ b/crane_sessions/include/crane_sessions/marker_session.hpp
@@ -76,6 +76,9 @@ private:
   std::vector<std::shared_ptr<skills::Marker>> markers;
 
   std::mutex markers_mutex;
+
+  // 前フレームのマーカー割り当て（ヒステリシス用: enemy_id -> our_robot_id）
+  std::unordered_map<uint8_t, uint8_t> prev_assignments_;
 };
 
 }  // namespace crane

--- a/crane_sessions/src/marker_functions.cpp
+++ b/crane_sessions/src/marker_functions.cpp
@@ -61,7 +61,8 @@ auto assignMarkersToEnemies(
   const std::vector<uint8_t> & available_robot_ids,
   const WorldModelWrapper::SharedPtr & world_model,
   const VisualizerMessageBuilder::SharedPtr & visualizer, const std::string & command_name,
-  bool assign_remaining, const std::string & mark_mode) -> MarkingResult
+  bool assign_remaining, const std::string & mark_mode,
+  const std::unordered_map<uint8_t, uint8_t> & prev_assignments) -> MarkingResult
 {
   MarkingResult result;
 
@@ -111,9 +112,18 @@ auto assignMarkersToEnemies(
 
     auto best_robot = ranges::min(remaining_robots, ranges::less{}, [&](const auto & robot) {
       // 割当コスト: 敵に対するマーキングセグメントへの距離（固定点ではなく線分ベース）
-      return getClosestPointAndDistance(robot->pose.pos, marking_segment).distance;
+      double dist = getClosestPointAndDistance(robot->pose.pos, marking_segment).distance;
+      // ヒステリシス: 前フレームで同じ敵をマークしていたロボットにボーナス
+      // (Sumatra DesiredDefendersCalcUtil 参考)
+      constexpr double MARKER_HYSTERESIS_BONUS = 0.5;  // 前フレーム割り当て継続ボーナス [m]
+      auto it = prev_assignments.find(enemy_robot->id);
+      if (it != prev_assignments.end() && it->second == robot->id) {
+        dist -= MARKER_HYSTERESIS_BONUS;
+      }
+      return dist;
     });
 
+    result.enemy_to_marker[enemy_robot->id] = best_robot->id;
     result.selected_robot_ids.push_back(best_robot->id);
     remaining_robots.erase(ranges::find_if(remaining_robots, [&](const auto & robot) {
       return robot->id == best_robot->id;

--- a/crane_sessions/src/marker_session.cpp
+++ b/crane_sessions/src/marker_session.cpp
@@ -30,8 +30,9 @@ MarkerSession::calculatePositionCommand(const std::vector<RobotIdentifier> & rob
       mark_mode = "save_goal";
     }
   }
-  auto result =
-    assignMarkersToEnemies(robot_ids, world_model, visualizer, "marker_planner", true, mark_mode);
+  auto result = assignMarkersToEnemies(
+    robot_ids, world_model, visualizer, "marker_planner", true, mark_mode, prev_assignments_);
+  prev_assignments_ = std::move(result.enemy_to_marker);
   markers = std::move(result.markers);
 
   std::vector<crane_msgs::msg::RobotCommand> robot_commands;


### PR DESCRIPTION
## 概要

rosbag分析で判明した「ロール振動によるパスカット失敗」問題を解消するため、Sumatraコードベースの安定化手法をcraneに移植・適用する。修正1〜5の5つの改善を一括適用する。

## 背景・根本原因

t=109〜112秒のrosbagで確認されたパスカット失敗の原因：
- **ロール振動**: ロボット再割り当てのヒステリシスが不足し、役割が高頻度で切り替わる
- **インターセプト位置ジッター**: ボール観測ノイズでReceiveの目標位置が毎フレーム微小変動
- **マーカー入れ替わり**: 敵位置の僅かな変化でマーカーロボットが頻繁に交代

## 変更内容

### 修正1: AttackerMetricsヒステリシスパラメータ調整（`attacker_metrics.hpp`）
- `min_hold_duration_sec`: 200ms → 500ms（パスカットウィンドウ内の振動抑制）
- `min_improvement_ratio`: 1% → 15%（僅差での無意味な切替防止）
- `emergency_switch_ratio`: 3% → 50%（明らかに優位な場合のみ即切替）
- `EMA_ALPHA`: 0.7 → 0.3（過去値への重みを増加してスコアを安定化）

### 修正2: ForwardスキルSTOP_HEREフォールバック改善（`forward.cpp`）
- ライン長NaN時: `stopHere` → 現在位置維持＋`lookAtBall`でロール振動を防止
- ライン終端以外の位置エラー時: `stopHere` → `front/back`中点へのフォールバック

### 修正3: GlobalRobotAllocatorに速度方向依存ヒステリシスを追加（`global_robot_allocator.cpp`）
- 前フレームターゲット方向へ移動中のロボットに追加再割り当てペナルティを付与
- Sumatra `DesiredDefendersCalcUtil`参考: 方向一致度(0〜1) × 速度 × 0.3 の追加コスト
- `norm()`/`normalized()`の二重計算を除去してコスト行列構築のホットパスを最適化

### 修正4: Receiveスキルにインターセプト位置安定化を追加（`receive.hpp`, `receive.cpp`）
- `mutable std::optional<Point> prev_interception_point_`で前フレーム位置をキャッシュ
- 0.5m以内の変動は前回位置を維持してジッター抑制
- ボール方向が90度以上変化した場合はキャッシュリセット（古い位置への固執を防止）
- Sumatra `BallInterceptor`参考

### 修正5: MarkerSessionにマーカー割り当てヒステリシスを追加（`marker_functions.*`, `marker_session.*`）
- `assignMarkersToEnemies()`に`prev_assignments`引数を追加（デフォルト空マップ、後方互換）
- 前フレームで同じ敵をマークしていたロボットに0.5mのコスト削減ボーナス
- `MarkerSession`がフレーム間で`enemy_to_marker`マップを保持・引き継ぎ
- Sumatra `DesiredDefendersCalcUtil`参考

## テスト方法

- [x] `colcon build --packages-select crane_game_analyzer crane_robot_skills crane_session_coordinator crane_sessions` でビルド確認
- [ ] `rosbag2_2026_03_15-14_32_58` の t=109〜112秒でロボット再割り当て頻度の減少を確認
- [ ] Receiveのインターセプト位置ジッターが軽減されているか確認
- [ ] grSimで敵パスシナリオを再現し、各修正の効果を個別確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)