### PR TITLE
fix: 敵ペナルティキック時の非GKロボットのエリア侵入ファールを修正

### DIFF
--- a/crane_sessions/src/their_penalty_kick_session.cpp
+++ b/crane_sessions/src/their_penalty_kick_session.cpp
@@ -20,7 +20,6 @@ TheirPenaltyKickSession::calculatePositionCommand(
     target << (world_model->getTheirGoalCenter().x() + world_model->ball().pos.x()) / 2,
       command->getRobot()->pose.pos.y();
     command->setTargetPosition(target);
-    command->disableAnyAreaAvoidance();
     command->enableBallAvoidance();
     command->setMaxVelocity("TheirPenaltyKickSession for non goalie", 1.5);
     robot_commands.push_back(command->getMsg());


### PR DESCRIPTION
## 概要
敵ペナルティキック時、GK以外のロボットが敵ペナルティエリアに侵入して `ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA` ファールを連発していた問題を修正。

## 背景・根本原因
`their_penalty_kick_session.cpp` の非GKロボットループで `disableAnyAreaAvoidance()` が呼ばれており、ローカルプランナーのペナルティエリア回避が無効化されていた。目標位置（ボールと敵ゴールの中間点）が敵ペナルティエリア内に位置する場合、そのまま侵入してしまっていた。

SSLルール5.3.5.3では非参加ロボットはボールから1m以上後方にいる必要があり、目標X座標の計算自体はルール準拠だったが、エリア回避が無効なため侵入を防げていなかった。

## 変更内容
- 非GKロボットのループから `command->disableAnyAreaAvoidance()` を削除
- ペナルティエリア回避をデフォルト有効のまま維持 → `adjustForPenaltyAreaAvoidance()` が敵ペナルティエリア侵入を自動防止
- GKの `disableAnyAreaAvoidance()`（自ペナルティエリア内移動に必要）は維持

## テスト方法
- [x] `colcon build --packages-select crane_sessions` でビルド確認（警告のみ、エラーなし）
- [x] シミュレーションで敵PKシナリオを実行し、非GKロボットがペナルティエリア外に留まることを確認
- [x] `ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA` ファールが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)