### PR TITLE
fix: ssl-log-recorderの停止処理をgraceful shutdownに改善

### DIFF
--- a/scripts/docker-dev.sh
+++ b/scripts/docker-dev.sh
@@ -165,17 +165,30 @@ start_ssl_log_recorder() {
 
 stop_ssl_log_recorder() {
     local container_state
-    container_state=$(docker inspect -f '{{.State.Status}}' "$SSL_LOG_RECORDER_CONTAINER_NAME" 2>/dev/null || true)
+    local stop_timeout=30
+    local wait_timeout=35
 
+    container_state=$(docker inspect -f '{{.State.Status}}' "$SSL_LOG_RECORDER_CONTAINER_NAME" 2>/dev/null || true)
     if [[ -z $container_state ]]; then
         return 0
     fi
 
     echo "=== ssl-log-recorder を停止中 (container: $SSL_LOG_RECORDER_CONTAINER_NAME) ==="
-    docker rm -f "$SSL_LOG_RECORDER_CONTAINER_NAME" >/dev/null 2>&1 || true
+
+    if [[ $container_state == "running" ]]; then
+        # ssl-log-recorder は SIGINT で正常終了処理に入る実装が多いため、先に SIGINT を試す
+        echo "SIGINT で graceful shutdown を試行します"
+        docker kill --signal=SIGINT "$SSL_LOG_RECORDER_CONTAINER_NAME" >/dev/null 2>&1 || true
+
+        if ! timeout "$wait_timeout" docker wait "$SSL_LOG_RECORDER_CONTAINER_NAME" >/dev/null 2>&1; then
+            echo "SIGINT で停止しなかったため docker stop へフォールバックします (timeout: ${stop_timeout}s)"
+            docker stop --time "$stop_timeout" "$SSL_LOG_RECORDER_CONTAINER_NAME" >/dev/null 2>&1 || true
+        fi
+    fi
+
+    docker rm "$SSL_LOG_RECORDER_CONTAINER_NAME" >/dev/null 2>&1 || true
     echo "ssl-log-recorder 停止完了"
 }
-
 COMPOSE_COMMAND="$(detect_compose_command)"
 
 # downコマンドの場合はdebug_toolsも停止


### PR DESCRIPTION
## 概要
`stop_ssl_log_recorder()` の停止処理を `docker rm -f`（強制削除）から、SIGINTによるgraceful shutdownへ変更しました。

## 背景・根本原因
従来の実装では `docker rm -f` でコンテナを強制削除していたため、ssl-log-recorderがログの書き込みを完了する前にプロセスが強制終了される恐れがありました。ssl-log-recorderはSIGINTで正常終了処理（ログのフラッシュ・クローズ等）を行う実装が多いため、graceful shutdownが必要でした。

## 変更内容
- `docker rm -f`（強制削除）を廃止
- SIGINT → タイムアウト待機(35s) → `docker stop`(30s) → `docker rm` の段階的停止フローを導入
- コンテナが `running` 状態のときのみSIGINTを送信するよう条件分岐を追加

## テスト方法
- [x] `./scripts/docker-dev.sh sim -d` でsim環境をバックグラウンド起動
- [x] `./scripts/docker-dev.sh down` でssl-log-recorderがSIGINTで正常停止することを確認
- [x] ログファイルが正常に書き込まれていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)