### PR TITLE
feat: MarkerにペナルティエリアモードをするMarkerにpenalty_areaモードを追加

### DIFF
--- a/crane_robot_skills/src/marker.cpp
+++ b/crane_robot_skills/src/marker.cpp
@@ -20,10 +20,66 @@ void Marker::initialize()
 Status Marker::update()
 {
   auto marked_robot = world_model()->getTheirRobot(getParameter<int>("marking_robot_id"));
+  if (!marked_robot->available()) {
+    // マーク対象が存在しないためペナルティエリア正面中央（守備ライン上）で待機
+    constexpr double OFFSET_X = 0.2;
+    constexpr double OFFSET_Y = 0.2;
+    auto [p1, p2, p3, p4] = world_model()->getPenaltyAreaCorners(OFFSET_X, OFFSET_Y);
+    command->setTargetPosition((p2 + p3) / 2.0, 0.1).lookAtBall();
+    return Status::RUNNING;
+  }
   auto enemy_pos = marked_robot->pose.pos;
   std::string mode = getParameter<std::string>("mark_mode");
   double mark_distance = getParameter<double>("mark_distance");
   double max_mark_distance = getParameter<double>("max_mark_distance");
+
+  if (mode == "penalty_area") {
+    // 守備ライン（ペナルティエリア外周+オフセット）上の守備位置に配置
+    constexpr double OFFSET_X = 0.2;
+    constexpr double OFFSET_Y = 0.2;
+
+    Segment enemy_to_goal{enemy_pos, world_model()->getOurGoalCenter()};
+    auto [p1, p2, p3, p4] = world_model()->getPenaltyAreaCorners(OFFSET_X, OFFSET_Y);
+    Segment seg1{p1, p2}, seg2{p2, p3}, seg3{p3, p4};
+
+    // 敵→ゴール線と守備ラインの交点を求める
+    std::optional<Point> target_on_line_opt;
+    for (const auto & seg : {seg1, seg2, seg3}) {
+      auto intersections = getIntersections(seg, enemy_to_goal);
+      if (!intersections.empty()) {
+        target_on_line_opt = intersections[0];
+        break;
+      }
+    }
+
+    if (target_on_line_opt) {
+      Point target_on_line = *target_on_line_opt;
+
+      // 守備ラインの最近傍点を求める（3セグメント中で最短）
+      auto cp1 = getClosestPointAndDistance(robot()->pose.pos, seg1);
+      auto cp2 = getClosestPointAndDistance(robot()->pose.pos, seg2);
+      auto cp3 = getClosestPointAndDistance(robot()->pose.pos, seg3);
+
+      Point nearest_on_line = cp1.closest_point;
+      double min_dist = cp1.distance;
+      if (cp2.distance < min_dist) {
+        nearest_on_line = cp2.closest_point;
+        min_dist = cp2.distance;
+      }
+      if (cp3.distance < min_dist) {
+        nearest_on_line = cp3.closest_point;
+        min_dist = cp3.distance;
+      }
+
+      // ラインから離れているときは最近傍点優先、近いときはtarget_on_line優先
+      double pull_ratio = std::clamp(1.0 - min_dist * 2.0, 0.0, 1.0);
+      Point target = nearest_on_line * (1.0 - pull_ratio) + target_on_line * pull_ratio;
+      command->setTargetPosition(target, 0.1).lookAtBall();
+      return Status::RUNNING;
+    }
+    // 交点なし: save_goalモードにフォールバック
+    mode = "save_goal";
+  }
 
   // 基準点（ゴール中心 or ボール位置）
   Point reference;

--- a/crane_sessions/src/marker_functions.cpp
+++ b/crane_sessions/src/marker_functions.cpp
@@ -6,6 +6,7 @@
 
 #include <boost/math/constants/constants.hpp>
 #include <crane_geometry/geometry_operations.hpp>
+#include <crane_sessions/defense_functions.hpp>
 #include <crane_sessions/marker_functions.hpp>
 #include <range/v3/algorithm/find_if.hpp>
 #include <range/v3/algorithm/min.hpp>
@@ -83,6 +84,7 @@ auto assignMarkersToEnemies(
     ranges::to<std::vector>();
 
   const bool is_save_goal = (mark_mode == "save_goal");
+  const bool is_penalty_area = (mark_mode == "penalty_area");
   const Point reference = is_save_goal ? world_model->getOurGoalCenter() : world_model->ball().pos;
 
   for (const auto & [enemy_robot, score] : danger_enemies) {
@@ -93,19 +95,35 @@ auto assignMarkersToEnemies(
     // マーキングセグメントを事前計算（割当コストと可視化で共用）
     constexpr double mark_dist = 0.5;
     constexpr double max_mark_dist = 1.5;
-    auto dir = (reference - enemy_robot->pose.pos).normalized();
-    Point near_end = enemy_robot->pose.pos + dir * mark_dist;
-    Point far_end = enemy_robot->pose.pos + dir * max_mark_dist;
-    if (is_save_goal) {
-      constexpr double penalty_offset = 0.15;
+    Point near_end, far_end;
+    if (is_penalty_area) {
+      // 敵→ゴール線と守備ラインの交点をターゲットとする
       Segment enemy_to_goal{enemy_robot->pose.pos, world_model->getOurGoalCenter()};
-      auto intersection =
-        world_model->getIntersectionOurPenaltyArea(enemy_to_goal, penalty_offset, penalty_offset);
-      if (intersection) {
-        double dist_to_boundary = (intersection.value() - enemy_robot->pose.pos).norm();
-        double clamped_max = std::max(mark_dist, dist_to_boundary - 0.05);
-        far_end = enemy_robot->pose.pos + dir * std::min(max_mark_dist, clamped_max);
-        near_end = enemy_robot->pose.pos + dir * std::min(mark_dist, clamped_max);
+      auto param_opt = getDefenseLinePointParameter(enemy_to_goal, world_model);
+      if (param_opt) {
+        // near_end == far_endとすることで、コスト=ロボットから交点への直線距離として扱う
+        near_end = far_end = getDefenseLinePoint(param_opt.value(), world_model);
+      } else {
+        // フォールバック: save_goalと同じ方向計算
+        auto dir = (world_model->getOurGoalCenter() - enemy_robot->pose.pos).normalized();
+        near_end = enemy_robot->pose.pos + dir * mark_dist;
+        far_end = enemy_robot->pose.pos + dir * max_mark_dist;
+      }
+    } else {
+      auto dir = (reference - enemy_robot->pose.pos).normalized();
+      near_end = enemy_robot->pose.pos + dir * mark_dist;
+      far_end = enemy_robot->pose.pos + dir * max_mark_dist;
+      if (is_save_goal) {
+        constexpr double penalty_offset = 0.15;
+        Segment enemy_to_goal{enemy_robot->pose.pos, world_model->getOurGoalCenter()};
+        auto intersection =
+          world_model->getIntersectionOurPenaltyArea(enemy_to_goal, penalty_offset, penalty_offset);
+        if (intersection) {
+          double dist_to_boundary = (intersection.value() - enemy_robot->pose.pos).norm();
+          double clamped_max = std::max(mark_dist, dist_to_boundary - 0.05);
+          far_end = enemy_robot->pose.pos + dir * std::min(max_mark_dist, clamped_max);
+          near_end = enemy_robot->pose.pos + dir * std::min(mark_dist, clamped_max);
+        }
       }
     }
     Segment marking_segment{near_end, far_end};

--- a/crane_sessions/src/marker_session.cpp
+++ b/crane_sessions/src/marker_session.cpp
@@ -20,7 +20,8 @@ MarkerSession::calculatePositionCommand(const std::vector<RobotIdentifier> & rob
   auto lock = std::lock_guard(markers_mutex);
   visualizer->clearBuffer();
   // ボール停止中＋敵がボール近くにいる＝相手セットプレイ → save_goalモードでゴール前を守る
-  std::string mark_mode = "intercept_pass";
+  // それ以外は守備ライン上に配置するpenalty_areaモードを使用
+  std::string mark_mode = "penalty_area";
   if (!world_model->ball().isMoving(0.5)) {
     auto their_robots = world_model->theirs().robotsWhere().available().get();
     bool enemy_near_ball = std::any_of(


### PR DESCRIPTION
## 概要

Markerスキルに `penalty_area` モードを追加し、MarkerSessionのデフォルトモードを `intercept_pass` から `penalty_area` に変更する。これにより、マーカーが守備ライン（ペナルティエリア外周+オフセット）上のシュートライン交点に配置されるようになる。

## 背景・根本原因

rosbag分析でDefender 3台がball_line交点付近に密集し、ゴール前y>0側が無防備になって失点する問題が発生した。Defenderの間隔（`DEFENSE_LINE_INTERVAL=0.2m`）を広げると間を抜かれた過去の経緯があるため、間隔は維持しつつ、Markerが各敵ロボットのシュートラインを守備ライン上で塞ぐ役割を担うように変更した。

## 変更内容

- **`crane_robot_skills/src/marker.cpp`**: `penalty_area` モードを追加
  - 敵→ゴール線と守備ライン（ペナルティエリア外周+0.2mオフセット）の交点を目標位置に設定
  - 守備ラインから離れている間は最近傍点へ移動し、近づいたら交点位置にスライド（pull_ratio補間）
  - 交点なし時は `save_goal` モードにフォールバック
  - マーク対象ロボットが `available()==false` の場合、守備ライン正面中央で待機（`assign_remaining` ケースの潜在バグ修正）
- **`crane_sessions/src/marker_session.cpp`**: デフォルトモードを `intercept_pass` → `penalty_area` に変更
  - セットプレイ時（ボール停止+敵がボール1m以内）のみ `save_goal` を継続使用
- **`crane_sessions/src/marker_functions.cpp`**: `penalty_area` 時のロボット割り当てコスト計算を追加
  - `getDefenseLinePointParameter` / `getDefenseLinePoint` を使い守備ライン交点への距離でコスト計算
  - `crane_robot_skills` への循環依存を避けるため、`marker.cpp` では `defense_functions.hpp` をincludeせず `geometry_operations.hpp` の既存関数をインライン活用

## テスト方法

- [x] `colcon build --packages-select crane_robot_skills crane_sessions` でビルド確認
- [x] シミュレーションでINPLAY時にMarkerが守備ライン上（敵とゴール間の交点）に配置されることを確認
- [x] セットプレイ時（THEIR_FREE_KICK等）にsave_goalモードへ切り替わることを確認
- [x] マーク対象のいない余剰Markerが守備ライン正面中央で待機することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)