### PR TITLE
refactor: ロボット割当をハンガリアン法からSession単位の貪欲法に移行

### DIFF
--- a/crane_session_coordinator/include/crane_session_coordinator/global_robot_allocator.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/global_robot_allocator.hpp
@@ -9,7 +9,6 @@
 
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 #include <crane_physics/allocation_cost.hpp>
-#include <crane_physics/position_assignments.hpp>
 #include <crane_physics/robot_info.hpp>
 #include <crane_session_coordinator/allocation_state.hpp>
 #include <functional>
@@ -59,9 +58,9 @@ struct SessionRequirement
 };
 
 /**
- * @brief 全体最適化ロボット割当クラス
+ * @brief グリーディ方式ロボット割当クラス
  *
- * 複数のSessionからの要求を統一的に処理し、ハンガリアン法で全体最適な割当を行う。
+ * 複数のSessionからの要求を優先度順に処理し、グリーディ方式で割当を行う。
  */
 class GlobalRobotAllocator
 {
@@ -69,12 +68,12 @@ public:
   explicit GlobalRobotAllocator(rclcpp::Logger logger) : logger_(logger) {}
 
   /**
-   * @brief 全体最適化によるロボット割当
+   * @brief グリーディ方式によるロボット割当
    *
    * @param requirements Sessionごとの要求リスト
    * @param available_robots 利用可能なロボットIDリスト
    * @param world_model ワールドモデル
-   * @param prev_state 前フレームの割当状態
+   * @param prev_state 前フレームの割当状態（ヒステリシス用）
    * @param config コスト計算設定
    * @return Session名→割り当てられたロボットIDリストのマップ
    */
@@ -88,42 +87,15 @@ private:
   rclcpp::Logger logger_;
 
   /**
-   * @brief ハード制約Sessionを先に処理
+   * @brief グリーディ方式でSessionにロボットを割り当てる（ハード/ソフト共通実装）
+   * @param label ログ用ラベル
    */
-  auto allocateHardConstraints(
-    const std::vector<SessionRequirement> & hard_requirements,
-    std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
-    const AllocationState & prev_state, const AllocationCostConfig & config,
-    std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void;
-
-  /**
-   * @brief ソフト制約Sessionをハンガリアン法で処理
-   */
-  auto allocateSoftConstraints(
-    const std::vector<SessionRequirement> & soft_requirements,
-    const std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
-    const AllocationState & prev_state, const AllocationCostConfig & config,
-    std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void;
-
-  /**
-   * @brief 仮想ターゲット（Session-Robot ペア）を生成
-   */
-  struct VirtualTarget
-  {
-    std::string session_name;
-    int session_priority;
-    size_t robot_index;
-    std::shared_ptr<std::function<double(const std::shared_ptr<RobotInfo> &)>> suitability_func;
-  };
-
-  /**
-   * @brief コスト行列を構築
-   */
-  auto buildCostMatrix(
-    const std::vector<uint8_t> & robots, const std::vector<VirtualTarget> & targets,
+  auto allocateGreedy(
+    const std::vector<SessionRequirement> & requirements, std::vector<uint8_t> & remaining_robots,
     WorldModelWrapper::SharedPtr & world_model, const AllocationState & prev_state,
-    const AllocationCostConfig & config)
-    -> std::function<double(size_t robot_idx, size_t target_idx)>;
+    const AllocationCostConfig & config,
+    std::unordered_map<std::string, std::vector<uint8_t>> & result, const std::string & label)
+    -> void;
 };
 
 }  // namespace crane

--- a/crane_session_coordinator/src/global_robot_allocator.cpp
+++ b/crane_session_coordinator/src/global_robot_allocator.cpp
@@ -7,10 +7,7 @@
 #include "crane_session_coordinator/global_robot_allocator.hpp"
 
 #include <algorithm>
-#include <crane_physics/position_assignments.hpp>
 #include <crane_utils/stream.hpp>
-#include <limits>
-#include <sstream>
 
 namespace crane
 {
@@ -51,30 +48,31 @@ auto GlobalRobotAllocator::allocate(
   auto remaining_robots = available_robots;
 
   // Phase 1: ハード制約Sessionを先に処理
-  allocateHardConstraints(
-    hard_requirements, remaining_robots, world_model, prev_state, config, result);
+  allocateGreedy(
+    hard_requirements, remaining_robots, world_model, prev_state, config, result, "ハード制約");
 
-  // Phase 2: 残りのロボットでソフト制約Sessionをハンガリアン法で処理
-  allocateSoftConstraints(
-    soft_requirements, remaining_robots, world_model, prev_state, config, result);
+  // Phase 2: 残りのロボットでソフト制約Sessionをグリーディに処理
+  allocateGreedy(
+    soft_requirements, remaining_robots, world_model, prev_state, config, result, "ソフト制約");
 
   return result;
 }
 
-auto GlobalRobotAllocator::allocateHardConstraints(
-  const std::vector<SessionRequirement> & hard_requirements,
-  std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
-  const AllocationState & prev_state, const AllocationCostConfig & config,
-  std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void
+auto GlobalRobotAllocator::allocateGreedy(
+  const std::vector<SessionRequirement> & requirements, std::vector<uint8_t> & remaining_robots,
+  WorldModelWrapper::SharedPtr & world_model, const AllocationState & prev_state,
+  const AllocationCostConfig & config,
+  std::unordered_map<std::string, std::vector<uint8_t>> & result, const std::string & label) -> void
 {
-  for (const auto & req : hard_requirements) {
+  for (const auto & req : requirements) {
     if (remaining_robots.empty()) {
       RCLCPP_WARN(
-        logger_, "ハード制約Session「%s」に割り当てるロボットが不足しています", req.name.c_str());
-      break;
+        logger_, "%sSession「%s」に割り当てるロボットが不足しています", label.c_str(),
+        req.name.c_str());
+      continue;
     }
 
-    // 適性評価でロボットをソート（ヒステリシスボーナスを適用して安定化）
+    // 適性評価でロボットをスコアリング（ヒステリシスボーナスを適用して安定化）
     std::vector<std::pair<uint8_t, double>> robot_scores;
     for (const auto & robot_id : remaining_robots) {
       auto robot = world_model->getOurRobot(robot_id);
@@ -91,259 +89,29 @@ auto GlobalRobotAllocator::allocateHardConstraints(
 
     // 必要数だけロボットを割り当て
     int num_to_allocate = std::min(req.max_robots, static_cast<int>(remaining_robots.size()));
-    num_to_allocate = std::max(req.min_robots, num_to_allocate);
 
     std::vector<uint8_t> assigned_robots;
-    for (int i = 0; i < num_to_allocate && i < robot_scores.size(); ++i) {
+    for (int i = 0; i < num_to_allocate; ++i) {
       assigned_robots.push_back(robot_scores[i].first);
+    }
+
+    if (static_cast<int>(assigned_robots.size()) < req.min_robots) {
+      RCLCPP_WARN(
+        logger_, "%sSession「%s」の最小ロボット数(%d)を満たせませんでした（実際: %lu）",
+        label.c_str(), req.name.c_str(), req.min_robots, assigned_robots.size());
     }
 
     result[req.name] = assigned_robots;
 
     // 割り当てたロボットをremaining_robotsから削除
-    for (const auto & robot_id : assigned_robots) {
-      auto it = std::find(remaining_robots.begin(), remaining_robots.end(), robot_id);
-      if (it != remaining_robots.end()) {
-        remaining_robots.erase(it);
-      }
-    }
+    std::erase_if(remaining_robots, [&assigned_robots](uint8_t id) {
+      return std::find(assigned_robots.begin(), assigned_robots.end(), id) != assigned_robots.end();
+    });
 
     RCLCPP_DEBUG_STREAM(
-      logger_, "ハード制約Session「" << req.name << "」に" << assigned_robots.size()
-                                     << "ロボットを割り当て: " << assigned_robots);
+      logger_, label << "Session「" << req.name << "」に" << assigned_robots.size()
+                     << "ロボットを割り当て: " << assigned_robots);
   }
-}
-
-auto GlobalRobotAllocator::allocateSoftConstraints(
-  const std::vector<SessionRequirement> & soft_requirements,
-  const std::vector<uint8_t> & remaining_robots, WorldModelWrapper::SharedPtr & world_model,
-  const AllocationState & prev_state, const AllocationCostConfig & config,
-  std::unordered_map<std::string, std::vector<uint8_t>> & result) -> void
-{
-  if (remaining_robots.empty() || soft_requirements.empty()) {
-    return;
-  }
-
-  // 仮想ターゲットを生成（各Sessionが必要とするロボット数分）
-  std::vector<VirtualTarget> virtual_targets;
-  for (const auto & req : soft_requirements) {
-    int num_targets = std::min(req.max_robots, static_cast<int>(remaining_robots.size()));
-    // 適性関数をshared_ptrでラップ（コピーコストを削減しライフタイムを管理）
-    auto func_ptr = std::make_shared<std::function<double(const std::shared_ptr<RobotInfo> &)>>(
-      req.suitability_func);
-    for (int i = 0; i < num_targets; ++i) {
-      virtual_targets.push_back({req.name, req.priority, static_cast<size_t>(i), func_ptr});
-    }
-  }
-
-  if (virtual_targets.empty()) {
-    return;
-  }
-
-  // ロボット数 ≤ ターゲット数 を保証
-  if (remaining_robots.size() > virtual_targets.size()) {
-    RCLCPP_WARN(
-      logger_, "[allocateSoftConstraints] ロボット数(%lu)がターゲット数(%lu)を超えています",
-      remaining_robots.size(), virtual_targets.size());
-    // ハンガリアン法は robots <= targets を要求するため、
-    // ダミーターゲットを追加する必要があるが、ここでは単純に警告を出す
-  }
-
-  // コスト関数を構築
-  auto cost_func =
-    buildCostMatrix(remaining_robots, virtual_targets, world_model, prev_state, config);
-
-  // Hungarian実装は U >= V を要求するため、robots < targets の場合は転置する
-  bool needs_transpose = remaining_robots.size() < virtual_targets.size();
-  size_t matrix_rows = needs_transpose ? virtual_targets.size() : remaining_robots.size();
-  size_t matrix_cols = needs_transpose ? remaining_robots.size() : virtual_targets.size();
-
-  std::vector<std::vector<double>> cost_matrix(matrix_rows, std::vector<double>(matrix_cols));
-
-  if (needs_transpose) {
-    // 転置: cost_matrix[target][robot] = cost(robot, target)
-    for (size_t i = 0; i < remaining_robots.size(); ++i) {
-      for (size_t j = 0; j < virtual_targets.size(); ++j) {
-        cost_matrix[j][i] = cost_func(i, j);
-      }
-    }
-  } else {
-    // 通常: cost_matrix[robot][target] = cost(robot, target)
-    for (size_t i = 0; i < remaining_robots.size(); ++i) {
-      for (size_t j = 0; j < virtual_targets.size(); ++j) {
-        cost_matrix[i][j] = cost_func(i, j);
-      }
-    }
-  }
-
-  // コスト行列の検証と正規化
-  double min_cost = std::numeric_limits<double>::max();
-  double max_cost = std::numeric_limits<double>::lowest();
-  bool has_invalid = false;
-
-  for (size_t i = 0; i < matrix_rows; ++i) {
-    for (size_t j = 0; j < matrix_cols; ++j) {
-      if (std::isnan(cost_matrix[i][j]) || std::isinf(cost_matrix[i][j])) {
-        RCLCPP_ERROR(
-          logger_, "[allocateSoftConstraints] 不正なコスト値: cost[%lu][%lu]=%f", i, j,
-          cost_matrix[i][j]);
-        has_invalid = true;
-      } else {
-        min_cost = std::min(min_cost, cost_matrix[i][j]);
-        max_cost = std::max(max_cost, cost_matrix[i][j]);
-      }
-    }
-  }
-
-  if (has_invalid) {
-    RCLCPP_ERROR(logger_, "[allocateSoftConstraints] コスト行列に不正な値が含まれています");
-    return;
-  }
-
-  // Hungarian法は非負のコスト行列を要求するため、負の値がある場合はオフセットを追加
-  if (min_cost < 0.0) {
-    // 最小値がちょうど0になるように平行移動し、相対的なコスト差を保つ
-    double offset = -min_cost;
-    for (size_t i = 0; i < matrix_rows; ++i) {
-      for (size_t j = 0; j < matrix_cols; ++j) {
-        cost_matrix[i][j] += offset;
-      }
-    }
-  }
-
-  // ハンガリアン法で最適割当を計算
-  std::vector<int> assignment;
-
-  try {
-    math::Hungarian<double> hungarian_solver(cost_matrix);
-    auto [cost, solution_index] = hungarian_solver.solve();
-    assignment = std::move(solution_index);
-  } catch (const std::exception & e) {
-    RCLCPP_ERROR(logger_, "[allocateSoftConstraints] ハンガリアン法で例外発生: %s", e.what());
-    return;
-  }
-
-  // 割当結果を集計
-  std::unordered_map<std::string, std::vector<uint8_t>> session_assignments;
-
-  if (needs_transpose) {
-    // 転置モード: assignment[target_idx] = robot_idx
-    for (size_t target_idx = 0; target_idx < assignment.size(); ++target_idx) {
-      int robot_idx = assignment[target_idx];
-      if (robot_idx < 0 || robot_idx >= remaining_robots.size()) {
-        continue;
-      }
-
-      const auto & target = virtual_targets[target_idx];
-      uint8_t robot_id = remaining_robots[robot_idx];
-      session_assignments[target.session_name].push_back(robot_id);
-    }
-  } else {
-    // 通常モード: assignment[robot_idx] = target_idx
-    for (size_t robot_idx = 0; robot_idx < assignment.size(); ++robot_idx) {
-      int target_idx = assignment[robot_idx];
-      if (target_idx < 0 || target_idx >= virtual_targets.size()) {
-        continue;
-      }
-
-      const auto & target = virtual_targets[target_idx];
-      uint8_t robot_id = remaining_robots[robot_idx];
-      session_assignments[target.session_name].push_back(robot_id);
-    }
-  }
-
-  // min_robotsの制約を満たしているか確認
-  for (const auto & req : soft_requirements) {
-    auto it = session_assignments.find(req.name);
-    if (it != session_assignments.end()) {
-      if (it->second.size() < req.min_robots) {
-        RCLCPP_WARN(
-          logger_, "Session「%s」の最小ロボット数(%d)を満たせませんでした（実際: %lu）",
-          req.name.c_str(), req.min_robots, it->second.size());
-      }
-    } else if (req.min_robots > 0) {
-      RCLCPP_WARN(
-        logger_, "Session「%s」にロボットを割り当てられませんでした（最小要求: %d）",
-        req.name.c_str(), req.min_robots);
-    }
-  }
-
-  // 結果をマージ
-  for (const auto & [session_name, robots] : session_assignments) {
-    result[session_name] = robots;
-    RCLCPP_DEBUG_STREAM(
-      logger_, "ソフト制約Session「" << session_name << "」に" << robots.size()
-                                     << "ロボットを割り当て: " << robots);
-  }
-}
-
-auto GlobalRobotAllocator::buildCostMatrix(
-  const std::vector<uint8_t> & robots, const std::vector<VirtualTarget> & targets,
-  WorldModelWrapper::SharedPtr & world_model, const AllocationState & prev_state,
-  const AllocationCostConfig & config) -> std::function<double(size_t, size_t)>
-{
-  // 必要な情報を値キャプチャしてライフタイムを保証
-  // ただし、VirtualTargetは軽量なので直接コピー
-  auto robots_copy = robots;
-  auto targets_copy = targets;
-  auto wm = world_model;
-  auto state_copy = prev_state;
-  auto config_copy = config;
-
-  return [robots_copy, targets_copy, wm, state_copy, config_copy](
-           size_t robot_idx, size_t target_idx) -> double {
-    if (robot_idx >= robots_copy.size() || target_idx >= targets_copy.size()) {
-      return std::numeric_limits<double>::max();
-    }
-
-    uint8_t robot_id = robots_copy[robot_idx];
-    const auto & target = targets_copy[target_idx];
-    auto robot = wm->getOurRobot(robot_id);
-
-    // 基本コスト: shared_ptr経由で適性関数を呼び出す
-    double base_cost = 0.0;
-    if (target.suitability_func) {
-      base_cost = (*target.suitability_func)(robot);
-    }
-
-    // ヒステリシスコンテキストを構築
-    AssignmentContext context;
-    context.was_assigned_to_same_session = state_copy.wasAssignedTo(robot_id, target.session_name);
-    context.session_priority = target.session_priority;
-
-    // 総コスト計算
-    double priority_cost = context.session_priority * config_copy.priority_cost_multiplier;
-    double hysteresis_bonus =
-      context.was_assigned_to_same_session ? config_copy.hysteresis_bonus : 0.0;
-    double velocity_hysteresis = 0.0;
-    if (!context.was_assigned_to_same_session) {
-      constexpr double DIRECTION_SPEED_THRESHOLD = 0.3;    // 方向ボーナス適用の最低速度 [m/s]
-      constexpr double DIRECTION_DIST_THRESHOLD = 0.1;     // ターゲット距離の最小値 [m]
-      constexpr double DIRECTION_HYSTERESIS_WEIGHT = 0.3;  // 方向一致度への重み係数
-
-      double robot_speed = robot->vel.linear.norm();
-      // 基本ペナルティ: 速度が大きいほど再割り当てコスト増
-      velocity_hysteresis = robot_speed * config_copy.velocity_hysteresis_factor;
-
-      // 方向ボーナス: 前フレームのターゲット方向に移動中なら追加ペナルティ
-      // (Sumatra DesiredDefendersCalcUtil 参考)
-      auto prev_target = state_copy.getPrevTarget(robot_id);
-      if (prev_target && robot_speed > DIRECTION_SPEED_THRESHOLD) {
-        Vector2 to_prev_target = prev_target.value() - robot->pose.pos;
-        double dist_to_target = to_prev_target.norm();
-        if (dist_to_target > DIRECTION_DIST_THRESHOLD) {
-          // norm()の再計算を避けるため、既計算値で除算してunit vectorを作成
-          Vector2 vel_unit = robot->vel.linear / robot_speed;
-          Vector2 dir_unit = to_prev_target / dist_to_target;
-          double direction_alignment = std::max(0.0, vel_unit.dot(dir_unit));
-          // 方向一致度 * 速度 * 係数 を追加ペナルティとして加算
-          velocity_hysteresis += direction_alignment * robot_speed * DIRECTION_HYSTERESIS_WEIGHT;
-        }
-      }
-    }
-
-    return base_cost + priority_cost - hysteresis_bonus + velocity_hysteresis;
-  };
 }
 
 }  // namespace crane


### PR DESCRIPTION
## 概要

PR #1043 で導入したハンガリアン法による全体最適化を廃止し、Session単位の貪欲法（優先度順グリーディ）に移行する。

## 背景・根本原因

全体最適化は理論的には最適解を返すが、実際の試合環境では想定外の非効率な割当（例: 遠くのロボットが割り当てられてしまう等）が発生し制御が困難だった。貪欲法は予測可能で直感的な動作をするため、現場での調整が容易。

## 変更内容

- `allocateSoftConstraints`（ハンガリアン法実装）を削除
- `allocateHardConstraints` と `allocateSoftConstraints` を統合し、共通の `allocateGreedy` として実装
- 優先度順にSessionをイテレートし、`suitability_func` + ヒステリシスボーナスでスコアリングして上位N台をグリーディに選択
- `VirtualTarget` 構造体・`buildCostMatrix`・`position_assignments.hpp` への依存を削除（約260行削減）
- ロボット不足時は `break` → `continue` に変更し、全未割当Sessionに警告を出力
- `min_robots` 未達時の警告を明示的に追加
- ロボット除去を `std::erase_if` に統一

## テスト方法

- [x] `colcon build --packages-select crane_session_coordinator` でビルド確認済み
- [x] シミュレーション上でロボット割当が優先度順に安定して行われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)