### PR TITLE
feat: Attackerの転がりボール追跡を改善する

### DIFF
--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -117,13 +117,12 @@ void Attacker::initialize()
   addTransition(
     static_cast<int>(AttackerState::ENTRY_POINT), static_cast<int>(AttackerState::RECEIVE),
     [this]() -> bool {
-      // ボールが遠くにいる/動いている/ボール軌道の近く(<2.0m)にいる
+      // ボールが遠くにいて動いている場合にRECEIVEへ遷移する。
+      // 以前の「ボール軌道の2.0m以内」チェックは削除した。
+      // Attackerはボール取得が役割なので、転がるボールを積極的に追いかけるべきである。
       if (
         robot()->getDistance(world_model()->ball().pos) > BALL_CONTROL_DISTANCE &&
-        world_model()->ball().isMoving(MOVING_BALL_VELOCITY) && [&]() {
-          auto result = world_model()->ball().getClosestPointToTrajectory(robot()->pose.pos, 10.0);
-          return (result.closest_point - robot()->pose.pos).norm() < 2.0;
-        }()) {
+        world_model()->ball().isMoving(MOVING_BALL_VELOCITY)) {
         // GameAnalysisの既存slackデータで敵との競合チェック（追加計算コストなし）
         const auto & ga = world_model()->getMsg().game_analysis;
         double my_min_slack = -100.0;
@@ -232,7 +231,12 @@ void Attacker::initialize()
 
   addTransition(
     static_cast<int>(AttackerState::KICK), static_cast<int>(AttackerState::ENTRY_POINT),
-    [this]() -> bool { return world_model()->ball().isMoving(MOVING_BALL_VELOCITY); });
+    [this]() -> bool {
+      // ボールが動いていても、ロボットがボールに近い場合はKICKを継続する。
+      // ボールが動いているだけでKICKを抜けると、KICK→ENTRY_POINT→KICKの発振が起きるため。
+      return world_model()->ball().isMoving(MOVING_BALL_VELOCITY) &&
+             robot()->getDistance(world_model()->ball().pos) > BALL_CONTROL_DISTANCE;
+    });
 
   // KICK状態でボールに触れずKICK_TIMEOUT_SEC以上経過した場合、ENTRY_POINTへ戻って再割当を待つ
   addTransition(

--- a/crane_robot_skills/src/receive.cpp
+++ b/crane_robot_skills/src/receive.cpp
@@ -190,18 +190,26 @@ Point Receive::getInterceptionPoint() const
       slack_times.end());
 
     if (slack_times.empty()) {
-      std::string message = "WARN: [Receive] slack_timesが空のため、closest pointにフォールバック";
       RCLCPP_WARN(
-        rclcpp::get_logger("Receive"), "slack_times is empty, falling back to closest point");
-      command->addPlanningFactor("Receive", message);
+        rclcpp::get_logger("Receive"), "slack_times is empty, falling back to ball stop position");
+      // ボール停止予測位置へ先回りする（減速モデル対応フォールバック）
+      Point stop_pos =
+        world_model()->ball().getPredictedPosition(world_model()->ball().getStopTime());
+      if (isValidPoint(stop_pos) && world_model()->point_checker.isFieldInside(stop_pos)) {
+        command->addPlanningFactor(
+          "Receive", "WARN: [Receive] slack_timesが空のため、ボール停止予測位置にフォールバック");
+        return stop_pos;
+      }
+      // フィールド外またはNaN値の場合は従来の closest point フォールバック
+      command->addPlanningFactor(
+        "Receive", "WARN: [Receive] 停止予測位置が無効のため、closest pointにフォールバック");
       Point fallback_point = getClosestPointAndDistance(robot()->pose.pos, ball_line).closest_point;
       if (!isValidPoint(fallback_point)) {
-        // ball_lineもNaN値の場合、ロボット現在位置をフォールバック
-        std::string message = "WARN: [Receive] fallback_pointもNaN値のため、ロボット位置を使用";
+        command->addPlanningFactor(
+          "Receive", "WARN: [Receive] fallback_pointもNaN値のため、ロボット位置を使用");
         RCLCPP_WARN(
           rclcpp::get_logger("Receive"),
           "fallback_point is also NaN, falling back to robot position");
-        command->addPlanningFactor("Receive", message);
         return robot()->pose.pos;
       }
       return fallback_point;

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
@@ -252,6 +252,13 @@ struct WorldModelWrapper : public DelayMonitorMixin<WorldModelWrapper>
     const Point & ball_origin, const Vector2 & ball_velocity, double time, const RobotList & robots,
     const SlackTimeConfig & config) -> std::optional<SlackTimeResult>;
 
+  /// @brief 事前計算済みのインターセプト地点からスラックタイムを計算するオーバーロード
+  /// @details 減速モデルで生成したボールシーケンスと組み合わせて使用する。
+  ///          ボール位置の再計算を行わず、robot到達時間のみを計算する。
+  [[nodiscard]] auto getBallSlackTime(
+    const Point & intercept_point, double time, const RobotList & robots,
+    const SlackTimeConfig & config) -> std::optional<SlackTimeResult>;
+
   [[nodiscard]] auto getBallSlackTime(
     double time, const RobotList & robots, const SlackTimeConfig & config)
     -> std::optional<SlackTimeResult>;

--- a/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
@@ -379,6 +379,15 @@ auto WorldModelWrapper::getBallSlackTime(
   return getBallSlackTime(ball_.pos, ball_.vel, time, robots, config);
 }
 
+auto WorldModelWrapper::getBallSlackTime(
+  const Point & intercept_point, double time, const RobotList & robots,
+  const SlackTimeConfig & config) -> std::optional<SlackTimeResult>
+{
+  // 事前計算済みのインターセプト地点をそのまま渡す。
+  // Vector2::Zero() を速度に指定することで intercept_point + Zero * time = intercept_point となる。
+  return getBallSlackTime(intercept_point, Vector2::Zero(), time, robots, config);
+}
+
 auto WorldModelWrapper::getBallSequence(double t_horizon, double t_step)
   -> std::vector<std::pair<Point, double>>
 {
@@ -424,10 +433,10 @@ auto WorldModelWrapper::getSlackInterceptPointAndSlackTimeArray(
                return true;
              }
            })
-         // ボール位置 -> スラックタイムを計算
+         // ボール位置 -> スラックタイムを計算（p_ballを直接渡して再計算を回避）
          | ranges::views::transform([&](const auto & ball_state) -> std::optional<SlackTimeResult> {
              auto [p_ball, t_ball] = ball_state;
-             auto slack = getBallSlackTime(ball_origin, ball_velocity, t_ball, robots, config);
+             auto slack = getBallSlackTime(p_ball, t_ball, robots, config);
              if (slack) {
                slack->slack_time += config.slack_time_offset;
              }
@@ -446,7 +455,46 @@ auto WorldModelWrapper::getSlackInterceptPointAndSlackTimeArray(
 auto WorldModelWrapper::getSlackInterceptPointAndSlackTimeArray(
   const RobotList & robots, const SlackTimeConfig & config) -> std::vector<SlackTimeResult>
 {
-  return getSlackInterceptPointAndSlackTimeArray(ball_.pos, ball_.vel, robots, config);
+  // 減速モデル（BallPhysicsModel）を使ってボールシーケンスを生成する。
+  // 等速直線モデルとは異なり、実際のボール減速（~0.7 m/s²）を考慮した
+  // インターセプト候補を計算できる。
+  std::vector<std::pair<Point, double>> ball_sequence;
+  if (ball_.isMoving(config.velocity_epsilon)) {
+    ball_sequence = ball_.getBallSequence(config.time_horizon, config.time_step);
+  } else {
+    ball_sequence.emplace_back(ball_.pos, 0.0);
+  }
+
+  auto their_robots = theirs_.robotsWhere().available().get();
+
+  return ball_sequence | ranges::views::filter([&](const auto & ball_state) {
+           return (ball_state.first - ball_.pos).norm() < config.distance_horizon;
+         }) |
+         ranges::views::filter([&](const auto & ball_state) {
+           return point_checker.isFieldInside(ball_state.first) &&
+                  not point_checker.isPenaltyArea(ball_state.first);
+         }) |
+         ranges::views::take_while([&](const auto & ball_state) {
+           auto nearest = getNearestRobotWithDistanceFromPoint(ball_state.first, their_robots);
+           if (nearest.has_value()) {
+             return nearest->distance > 0.2;
+           } else {
+             return true;
+           }
+         }) |
+         ranges::views::transform([&](const auto & ball_state) -> std::optional<SlackTimeResult> {
+           auto [p_ball, t_ball] = ball_state;
+           auto slack = getBallSlackTime(p_ball, t_ball, robots, config);
+           if (slack) {
+             slack->slack_time += config.slack_time_offset;
+           }
+           return slack;
+         }) |
+         ranges::views::filter([&](const auto & opt_slack) {
+           return opt_slack.has_value() && point_checker.isFieldInside(opt_slack->intercept_point);
+         }) |
+         ranges::views::transform([](const auto & opt_pair) { return opt_pair.value(); }) |
+         ranges::to<std::vector>();
 }
 
 auto WorldModelWrapper::getMinMaxSlackInterceptPointAndSlackTime(


### PR DESCRIPTION
## 概要
Attackerが転がるボールを追いかけてフィールド外に出てしまう問題を修正する。
原因となっていた3つの問題（RECEIVE遷移条件の制限、KICK状態の発振、Slack Time等速モデル）を解消する。

## 背景・根本原因
1. **RECEIVE遷移条件が厳しすぎた**: ボール軌道の2.0m以内にいないとRECEIVE状態にならず、遠くに転がるボールを追えなかった
2. **KICK→ENTRY_POINT発振**: ボールが動くと即座にKICKを抜けるため、ボール近くでKICK→ENTRY_POINT→KICKを繰り返していた
3. **Slack Time計算の精度不足**: 等速直線モデルのため実際のボール減速（~0.7 m/s²）を無視し、追いつけるはずのボールに「追いつけない」と判定していた

## 変更内容
- `world_model_wrapper`: `getBallSlackTime` に事前計算済みのインターセプト点を直接受け取る新オーバーロードを追加
- `world_model_wrapper`: `getSlackInterceptPointAndSlackTimeArray(robots)` を `ball_.getBallSequence()` を使う減速モデル対応に更新（旧等速オーバーロードは外部呼び出し用に保持）
- `attacker`: ENTRY_POINT→RECEIVE遷移の「軌道2.0m以内」チェックを削除し、転がるボールを積極的に追うようにした
- `attacker`: KICK→ENTRY_POINT遷移にボール距離チェックを追加して、ロボットがボールに近い場合の発振を防止
- `receive`: `slack_times` が空のフォールバックを `closest_point` から `ball.getPredictedPosition(getStopTime())` に変更してボール停止予測位置へ先回りする

## テスト方法
- [x] `colcon build --packages-select crane_msg_wrappers crane_robot_skills` でビルド確認
- [ ] grSim でボールをAttackerから離れる方向に蹴り、RECEIVE状態に遷移するか確認
- [ ] KICK状態での発振（KICK→ENTRY_POINT→KICK）が解消されているか確認
- [ ] ボール停止予測位置への先回りが機能しているか確認
- [ ] フィールド外に出る前にボールを確保できるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)