### PR TITLE
chore: Docker開発環境のシミュレーション設定を更新

### DIFF
--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - sim
 
   ssl-game-controller:
-    image: robocupssl/ssl-game-controller:3.11.2
+    image: robocupssl/ssl-game-controller:latest
     command:
       - -visionAddress
       - 224.5.23.2:${VISION_PORT:-10020}

--- a/docker/ssl-vision-client-config.json
+++ b/docker/ssl-vision-client-config.json
@@ -1,5 +1,9 @@
 {
   "visionPort": 10020,
   "trackedPort": 11010,
-  "refereePort": 11003
+  "refereePort": 11003,
+  "grSimAddress": "127.0.0.1",
+  "grSimPort": 20011,
+  "autoBallPlacementEnabled": true,
+  "autoCenterAfterGoalEnabled": true
 }


### PR DESCRIPTION
## 概要
ssl-game-controllerのイメージバージョンを最新に更新し、ssl-vision-clientのgrSim連携設定を追加します。

## 背景・根本原因
- ssl-game-controllerが固定バージョン（3.11.2）だったため、最新版に追従できていなかった
- ssl-vision-client-config.jsonにgrSim連携（ボール配置・センタリング自動化）の設定が不足していた

## 変更内容
- `docker/dev/docker-compose.yaml`: ssl-game-controllerイメージを `3.11.2` → `latest` に更新
- `docker/ssl-vision-client-config.json`: 以下の設定を追加
  - `grSimAddress`: `127.0.0.1`
  - `grSimPort`: `20011`
  - `autoBallPlacementEnabled`: `true`
  - `autoCenterAfterGoalEnabled`: `true`

## テスト方法
- [ ] `docker compose --profile sim up` でシミュレーション環境が起動することを確認
- [ ] ssl-vision-clientでボール自動配置・センタリングが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)