### PR TITLE
refactor: crane_sender パッケージのコード簡素化

### DIFF
--- a/crane_sender/include/crane_sender/sender_base.hpp
+++ b/crane_sender/include/crane_sender/sender_base.hpp
@@ -34,6 +34,8 @@ protected:
 
   virtual void sendCommands(const VelocityCommandsMsg & msg) = 0;
 
+  double calculateAccelerationLimit(double current_speed, double target_speed) const;
+
   double delay_s{};
 
   std::shared_ptr<WorldModelWrapper> world_model;
@@ -41,6 +43,11 @@ protected:
   rclcpp::Clock clock;
 
   bool no_movement{false};
+
+  double robot_acceleration_acceleration_{2.5};
+  double robot_acceleration_deceleration_high_{3.0};
+  double robot_acceleration_deceleration_low_{2.0};
+  double robot_acceleration_velocity_threshold_{1.5};
 
 private:
   void callback(const VelocityCommandsMsg & msg);

--- a/crane_sender/include/crane_sender/sim_sender.hpp
+++ b/crane_sender/include/crane_sender/sim_sender.hpp
@@ -56,88 +56,36 @@ public:
       }
     };
 
-    declare_parameter("i_saturation", I_SATURATION);
-    I_SATURATION = get_parameter("i_saturation").as_double();
+    declare_parameter("i_saturation", i_saturation_);
+    i_saturation_ = get_parameter("i_saturation").as_double();
 
     // 全ロボットの状態を初期化
     for (auto & state : robot_states_) {
       state.vx_controller.setGain(
-        p_gain.getValue(), i_gain.getValue(), d_gain.getValue(), I_SATURATION);
+        p_gain.getValue(), i_gain.getValue(), d_gain.getValue(), i_saturation_);
       state.vy_controller.setGain(
-        p_gain.getValue(), i_gain.getValue(), d_gain.getValue(), I_SATURATION);
+        p_gain.getValue(), i_gain.getValue(), d_gain.getValue(), i_saturation_);
       state.theta_controller.setGain(
         theta_p_gain.getValue(), theta_i_gain.getValue(), theta_d_gain.getValue());
       state.previous_velocity = Velocity::Zero();
     }
 
     // the parameters of the PID controller
-    theta_p_gain.callback = [this](double) {
+    auto update_theta_gains = [this](double) {
       for (auto & state : robot_states_) {
         state.theta_controller.setGain(
           theta_p_gain.getValue(), theta_i_gain.getValue(), theta_d_gain.getValue());
       }
     };
-
-    theta_i_gain.callback = [this](double) {
-      for (auto & state : robot_states_) {
-        state.theta_controller.setGain(
-          theta_p_gain.getValue(), theta_i_gain.getValue(), theta_d_gain.getValue());
-      }
-    };
-
-    theta_d_gain.callback = [this](double) {
-      for (auto & state : robot_states_) {
-        state.theta_controller.setGain(
-          theta_p_gain.getValue(), theta_i_gain.getValue(), theta_d_gain.getValue());
-      }
-    };
-
-    // ロボット送信用の加速度パラメータを読み込み
-    declare_parameter("robot_acceleration.acceleration", 2.5);
-    get_parameter("robot_acceleration.acceleration", robot_acceleration_acceleration_);
-
-    declare_parameter("robot_acceleration.deceleration_high", 3.0);
-    get_parameter("robot_acceleration.deceleration_high", robot_acceleration_deceleration_high_);
-
-    declare_parameter("robot_acceleration.deceleration_low", 2.0);
-    get_parameter("robot_acceleration.deceleration_low", robot_acceleration_deceleration_low_);
-
-    declare_parameter("robot_acceleration.velocity_threshold", 1.5);
-    get_parameter("robot_acceleration.velocity_threshold", robot_acceleration_velocity_threshold_);
+    theta_p_gain.callback = update_theta_gains;
+    theta_i_gain.callback = update_theta_gains;
+    theta_d_gain.callback = update_theta_gains;
 
     declare_parameter("chip_angle_deg", chip_angle_deg);
     chip_angle_deg = get_parameter("chip_angle_deg").as_double();
   }
 
   void sendCommands(const crane_msgs::msg::RobotCommands & msg) override;
-
-  //  bool checkNan(const crane_msgs::msg::RobotCommands & msg)
-  //  {
-  //    bool is_nan = false;
-  //    for (const auto & command : msg.robot_commands) {
-  //      if (std::isnan(command.target_velocity.x)) {
-  //        std::cout << "id: " << command.robot_id << " target_velocity.x is nan" << std::endl;
-  //        is_nan = true;
-  //      }
-  //      if (std::isnan(command.target_velocity.y)) {
-  //        std::cout << "id: " << command.robot_id << "target_velocity.y is nan" << std::endl;
-  //        is_nan = true;
-  //      }
-  //      if (std::isnan(command.target_velocity.theta)) {
-  //        std::cout << "id: " << command.robot_id << "target_velocity.theta is nan" << std::endl;
-  //        is_nan = true;
-  //      }
-  //      if (std::isnan(command.kick_power)) {
-  //        std::cout << "id: " << command.robot_id << "kick_power is nan" << std::endl;
-  //        is_nan = true;
-  //      }
-  //      if (std::isnan(command.dribble_power)) {
-  //        std::cout << "id: " << command.robot_id << "dribble_power is nan" << std::endl;
-  //        is_nan = true;
-  //      }
-  //    }
-  //    return is_nan;
-  //  }
 
   std::unique_ptr<UDPSender> yellow_sender;
   std::unique_ptr<UDPSender> blue_sender;
@@ -150,7 +98,7 @@ public:
   ParameterWithEvent<double> theta_i_gain;
   ParameterWithEvent<double> theta_d_gain;
 
-  double I_SATURATION = 0.0;
+  double i_saturation_ = 0.0;
 
   double chip_angle_deg = 30.0;
 
@@ -166,18 +114,6 @@ private:
 
   // 全ロボットの状態
   std::array<PerRobotState, 20> robot_states_;
-
-  // ロボット送信用の加速度パラメータ
-  double robot_acceleration_acceleration_;
-  double robot_acceleration_deceleration_high_;
-  double robot_acceleration_deceleration_low_;
-  double robot_acceleration_velocity_threshold_;
-
-  // 加速度制限を計算
-  double calculateAccelerationLimit(
-    double current_velocity, double target_velocity, double robot_acceleration_acceleration,
-    double robot_acceleration_deceleration_high, double robot_acceleration_deceleration_low,
-    double robot_acceleration_velocity_threshold);
 };
 }  // namespace crane
 #endif  // CRANE_SENDER__SIM_SENDER_HPP_

--- a/crane_sender/src/broadcast_command_sender.cpp
+++ b/crane_sender/src/broadcast_command_sender.cpp
@@ -61,7 +61,6 @@ void BroadcastCommandSender::sendBroadcastPackets(
   }
 
   // パケット送信
-  size_t total_size = sizeof(broadcast_buf);
   try {
     socket.send_to(boost::asio::buffer(broadcast_buf), endpoint);
   } catch (boost::system::system_error & e) {

--- a/crane_sender/src/ibis_sender_node.cpp
+++ b/crane_sender/src/ibis_sender_node.cpp
@@ -4,22 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#include <arpa/inet.h>
-#include <ifaddrs.h>
-#include <math.h>
-#include <net/if.h>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <netinet/udp.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <unistd.h>
-
 #include <array>
-#include <boost/asio.hpp>
 #include <class_loader/visibility_control.hpp>
 #include <cmath>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
@@ -28,7 +13,6 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
-#include <optional>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
 #include <vector>
@@ -51,11 +35,8 @@ private:
 
   std::shared_ptr<BroadcastCommandSender> broadcast_sender;
 
-  // ロボット送信用の加速度パラメータ
-  double robot_acceleration_acceleration;
-  double robot_acceleration_deceleration_high;
-  double robot_acceleration_deceleration_low;
-  double robot_acceleration_velocity_threshold;
+  int counter_{0};
+  int call_count_{0};
 
 public:
   CLASS_LOADER_PUBLIC
@@ -63,19 +44,6 @@ public:
   {
     declare_parameter("debug_id", -1);
     get_parameter("debug_id", debug_id);
-
-    // ロボット送信用の加速度パラメータを読み込み
-    declare_parameter("robot_acceleration.acceleration", 2.5);
-    get_parameter("robot_acceleration.acceleration", robot_acceleration_acceleration);
-
-    declare_parameter("robot_acceleration.deceleration_high", 3.0);
-    get_parameter("robot_acceleration.deceleration_high", robot_acceleration_deceleration_high);
-
-    declare_parameter("robot_acceleration.deceleration_low", 2.0);
-    get_parameter("robot_acceleration.deceleration_low", robot_acceleration_deceleration_low);
-
-    declare_parameter("robot_acceleration.velocity_threshold", 1.5);
-    get_parameter("robot_acceleration.velocity_threshold", robot_acceleration_velocity_threshold);
 
     parameter_subscriber = std::make_shared<rclcpp::ParameterEventHandler>(this);
     parameter_callback_handle =
@@ -93,7 +61,9 @@ public:
   }
 
 private:
-  RobotCommandV2 createRobotPacket(const crane_msgs::msg::RobotCommand & command, int counter)
+  RobotCommandV2 createRobotPacket(
+    const crane_msgs::msg::RobotCommand & command, int counter,
+    const std::vector<uint8_t> & available_ids)
   {
     RobotCommandV2 packet;
     const float resolved_max_velocity =
@@ -113,10 +83,8 @@ private:
     packet.vision_global_pos[0] = command.current_pose.x;
     packet.vision_global_pos[1] = command.current_pose.y;
     packet.vision_global_theta = command.current_pose.theta;
-    packet.is_vision_available = [&]() -> bool {
-      std::vector<uint8_t> available_ids = world_model->ours().robotsWhere().available().getIds();
-      return std::count(available_ids.begin(), available_ids.end(), command.robot_id) == 1;
-    }();
+    packet.is_vision_available =
+      std::count(available_ids.begin(), available_ids.end(), command.robot_id) == 1;
     packet.target_global_theta = command.target_theta;
     packet.kick_power = command.kick_power;
     packet.dribble_power = std::clamp(command.dribble_power, 0.f, 1.f);
@@ -126,21 +94,7 @@ private:
     // 現在の速度から加速度を選択
     double current_speed = std::hypot(command.current_velocity.x, command.current_velocity.y);
     double target_speed = resolved_max_velocity;
-
-    double selected_acceleration;
-    if (current_speed < target_speed) {
-      // 加速時
-      selected_acceleration = robot_acceleration_acceleration;
-    } else {
-      // 減速時：速度に応じて選択
-      if (current_speed >= robot_acceleration_velocity_threshold) {
-        // 高速域
-        selected_acceleration = robot_acceleration_deceleration_high;
-      } else {
-        // 低速域
-        selected_acceleration = robot_acceleration_deceleration_low;
-      }
-    }
+    double selected_acceleration = calculateAccelerationLimit(current_speed, target_speed);
 
     packet.acceleration_limit =
       resolved_max_acceleration > 0.0f
@@ -162,32 +116,33 @@ private:
 public:
   void sendCommands(const crane_msgs::msg::RobotCommands & msg) override
   {
-    static int counter = 0;
-    static int call_count = 0;
-    call_count++;
+    call_count_++;
 
-    if (++counter > 200) {
-      counter = 0;
+    if (++counter_ > 200) {
+      counter_ = 0;
     }
 
     RCLCPP_DEBUG(
-      get_logger(), "🚀 sendCommands method called #%d (counter=%d)", call_count, counter);
+      get_logger(), "🚀 sendCommands method called #%d (counter=%d)", call_count_, counter_);
     RCLCPP_DEBUG(get_logger(), "  Received robot command count: %ld", msg.robot_commands.size());
 
-    // ブロードキャストモード：全ロボットのパケットを作成して一括送信
-    std::vector<std::pair<uint8_t, RobotCommandSerializedV2>> robot_packets;
+    const auto available_ids = world_model->ours().robotsWhere().available().getIds();
 
-    // 全11スロット分の配列を初期化（ロボットIDでインデックス指定）
-    std::array<std::optional<RobotCommandSerializedV2>, CommConfig::AI_CMD_V2_ROBOT_NUM>
-      packet_slots;
+    // ブロードキャストモード：全ロボットのパケットを作成して一括送信
+    // 11スロット分を空パケットで初期化
+    std::vector<std::pair<uint8_t, RobotCommandSerializedV2>> robot_packets(
+      CommConfig::AI_CMD_V2_ROBOT_NUM);
+    for (int i = 0; i < CommConfig::AI_CMD_V2_ROBOT_NUM; i++) {
+      robot_packets[i] = {static_cast<uint8_t>(i), RobotCommandSerializedV2{}};
+    }
 
     int processed_commands = 0;
-    for (auto command : msg.robot_commands) {
+    for (const auto & command : msg.robot_commands) {
       if (command.robot_id < CommConfig::AI_CMD_V2_ROBOT_NUM) {
-        RobotCommandV2 packet = createRobotPacket(command, counter);
+        RobotCommandV2 packet = createRobotPacket(command, counter_, available_ids);
         RobotCommandSerializedV2 serialized_packet;
         RobotCommandSerializedV2_serialize(&serialized_packet, &packet);
-        packet_slots[command.robot_id] = serialized_packet;
+        robot_packets[command.robot_id] = {command.robot_id, serialized_packet};
         processed_commands++;
       }
     }
@@ -196,31 +151,18 @@ public:
       get_logger(), "  Processed command count: %d/%ld", processed_commands,
       msg.robot_commands.size());
 
-    // 全スロットを順番にパケットリストに追加（空のスロットは空パケット）
-    int filled_slots = 0;
-    for (int i = 0; i < CommConfig::AI_CMD_V2_ROBOT_NUM; i++) {
-      if (packet_slots[i]) {
-        robot_packets.push_back(std::make_pair(i, packet_slots[i].value()));
-        filled_slots++;
-      } else {
-        // 空パケットを作成
-        RobotCommandSerializedV2 empty_packet = {};
-        robot_packets.push_back(std::make_pair(i, empty_packet));
-      }
-    }
-
     RCLCPP_DEBUG(
-      get_logger(), "  Packet slot usage: %d/%d slots used", filled_slots,
+      get_logger(), "  Packet slot usage: %d/%d slots used", processed_commands,
       CommConfig::AI_CMD_V2_ROBOT_NUM);
     RCLCPP_DEBUG(get_logger(), "  Broadcast preparation complete -> Start sending packet");
 
-    broadcast_sender->sendBroadcastPackets(robot_packets, counter);
+    broadcast_sender->sendBroadcastPackets(robot_packets, counter_);
 
     // 定期的な詳細ログ（100回に1回）
-    if (call_count % 100 == 0) {
+    if (call_count_ % 100 == 0) {
       RCLCPP_INFO(
         get_logger(), "📈 Statistics (every 100 calls): Total calls=%d Avg cmd count=%ld",
-        call_count, msg.robot_commands.size());
+        call_count_, msg.robot_commands.size());
     }
   }
 };

--- a/crane_sender/src/sender_base.cpp
+++ b/crane_sender/src/sender_base.cpp
@@ -36,6 +36,19 @@ SenderBase::SenderBase(const std::string & name, const rclcpp::NodeOptions & opt
   declare_parameter<double>("latency_ms", current_latency_ms);
   get_parameter("latency_ms", current_latency_ms);
 
+  declare_parameter("robot_acceleration.acceleration", robot_acceleration_acceleration_);
+  get_parameter("robot_acceleration.acceleration", robot_acceleration_acceleration_);
+
+  declare_parameter("robot_acceleration.deceleration_high", robot_acceleration_deceleration_high_);
+  get_parameter("robot_acceleration.deceleration_high", robot_acceleration_deceleration_high_);
+
+  declare_parameter("robot_acceleration.deceleration_low", robot_acceleration_deceleration_low_);
+  get_parameter("robot_acceleration.deceleration_low", robot_acceleration_deceleration_low_);
+
+  declare_parameter(
+    "robot_acceleration.velocity_threshold", robot_acceleration_velocity_threshold_);
+  get_parameter("robot_acceleration.velocity_threshold", robot_acceleration_velocity_threshold_);
+
   world_model = std::make_shared<WorldModelWrapper>(*this);
 }
 
@@ -57,9 +70,9 @@ void SenderBase::callback(const VelocityCommandsMsg & msg)
     }
 
     command.latency_ms = current_latency_ms;
-    command.kick_power = std::clamp(command.kick_power, 0.f, [this, command]() -> float {
-      return command.chip_enable ? kick_power_limit_chip : kick_power_limit_straight;
-    }());
+    command.kick_power = std::clamp(
+      command.kick_power, 0.f,
+      static_cast<float>(command.chip_enable ? kick_power_limit_chip : kick_power_limit_straight));
     command.dribble_power = std::clamp(command.dribble_power, 0.f, 1.f);
 
     try {
@@ -99,6 +112,17 @@ void SenderBase::callback(const VelocityCommandsMsg & msg)
 
   previous_commands = preprocessed_msg;
   sendCommands(preprocessed_msg);
+}
+
+double SenderBase::calculateAccelerationLimit(double current_speed, double target_speed) const
+{
+  if (current_speed < target_speed) {
+    return robot_acceleration_acceleration_;
+  } else if (current_speed >= robot_acceleration_velocity_threshold_) {
+    return robot_acceleration_deceleration_high_;
+  } else {
+    return robot_acceleration_deceleration_low_;
+  }
 }
 
 }  // namespace crane

--- a/crane_sender/src/sim_sender.cpp
+++ b/crane_sender/src/sim_sender.cpp
@@ -64,10 +64,7 @@ void SimSenderComponent::sendCommands(const crane_msgs::msg::RobotCommands & msg
     // Step 3: 加速度制限を選択（速度の大きさで加速/減速を判定）
     double current_speed = current_vel_local.norm();
     double target_speed = target_vel_local.norm();
-    double acceleration_limit = calculateAccelerationLimit(
-      current_speed, target_speed, robot_acceleration_acceleration_,
-      robot_acceleration_deceleration_high_, robot_acceleration_deceleration_low_,
-      robot_acceleration_velocity_threshold_);
+    double acceleration_limit = calculateAccelerationLimit(current_speed, target_speed);
 
     // Step 4: ローカル座標系で速度変化ベクトルの大きさを制限（方向は維持）
     Eigen::Vector2d delta_vel = target_vel_local - current_vel_local;
@@ -108,7 +105,7 @@ void SimSenderComponent::sendCommands(const crane_msgs::msg::RobotCommands & msg
       cmd->set_kick_speed(kick_speed * 0.5);
     } else {
       cmd->set_kick_angle(0.);
-      cmd->set_kick_speed(kick_speed * 1.0);
+      cmd->set_kick_speed(kick_speed);
     }
 
     // ドリブル(単位：rpm)
@@ -120,28 +117,6 @@ void SimSenderComponent::sendCommands(const crane_msgs::msg::RobotCommands & msg
   sender->send(output);
 }
 
-double SimSenderComponent::calculateAccelerationLimit(
-  double current_velocity, double target_velocity, double robot_acceleration_acceleration,
-  double robot_acceleration_deceleration_high, double robot_acceleration_deceleration_low,
-  double robot_acceleration_velocity_threshold)
-{
-  // ibis_sender_node.cppの行114-133と同じロジック
-  double selected_acceleration;
-  if (current_velocity < target_velocity) {
-    // 加速時
-    selected_acceleration = robot_acceleration_acceleration;
-  } else {
-    // 減速時：速度に応じて選択
-    if (current_velocity >= robot_acceleration_velocity_threshold) {
-      // 高速域
-      selected_acceleration = robot_acceleration_deceleration_high;
-    } else {
-      // 低速域
-      selected_acceleration = robot_acceleration_deceleration_low;
-    }
-  }
-  return selected_acceleration;
-}
 }  // namespace crane
 #include <rclcpp_components/register_node_macro.hpp>
 


### PR DESCRIPTION
## 概要

`crane_sender` パッケージのコードレビューで特定した、コード重複・パフォーマンス・品質上の問題12件を修正。

## 背景・根本原因

- 加速度選択ロジックが `ibis_sender_node.cpp` と `sim_sender.cpp` の2箇所に完全重複していた
- `createRobotPacket` が毎フレーム最大11回 `available_ids` クエリを実行していた（結果は同一）
- `static` ローカル変数・コメントアウトコード・不要ヘッダなど、保守性を下げる要素が残存していた

## 変更内容

### Critical（パフォーマンス影響あり）
- `available_ids` クエリをループ外に移動（最大11回/フレーム → 1回/フレーム）
- `for (auto command :` → `for (const auto & command :` でコピーコストを排除

### Important（コード品質・簡素化）
- `calculateAccelerationLimit` を `SenderBase` に統合し、加速度パラメータ4つも `SenderBase` に集約
- theta系 PIDゲインコールバック3つをラムダ共有で統合
- コメントアウトされた `checkNan` メソッド（27行）を削除
- 未使用変数 `total_size` を削除
- 未使用Cヘッダ12個・`<boost/asio.hpp>`・`<optional>` を削除
- `static int counter/call_count` をメンバ変数 `counter_`/`call_count_` に変更
- `I_SATURATION` を命名規約に合わせ `i_saturation_` にリネーム
- `optional` 配列の2パス処理を1パス化
- IIFE ラムダを三項演算子に簡素化（`sender_base.cpp`）
- `kick_speed * 1.0` の無意味な乗算を削除

## テスト方法

- [x] `colcon build --packages-select crane_sender` でビルド確認（ビルド成功済み）
- [ ] シミュレーション環境で sim_sender の動作確認
- [ ] 実機環境で ibis_sender の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)