### PR TITLE
fix: cppcheck stlFindInsert 警告を修正

### DIFF
--- a/crane_debug_tools/src/bag/bag_survey.cpp
+++ b/crane_debug_tools/src/bag/bag_survey.cpp
@@ -210,8 +210,7 @@ std::string section_rosout(const BagData & data)
     if (tm.msg.level < WARN_LEVEL) continue;
     std::string key_msg = tm.msg.msg.substr(0, 80);
     auto key = std::make_pair(tm.msg.name, key_msg);
-    if (seen.find(key) == seen.end()) {
-      seen.insert(key);
+    if (seen.insert(key).second) {
       double t = tm.t(data.info.start_time_ns);
       std::string truncated = tm.msg.msg.size() > 200 ? tm.msg.msg.substr(0, 200) : tm.msg.msg;
       char buf[64];


### PR DESCRIPTION
## 概要

`crane_debug_tools/src/bag/bag_survey.cpp` の cppcheck `stlFindInsert` 警告を修正します。

## 背景・根本原因

PR #1210 のCI (`cppcheck` ジョブ) が以下の警告で失敗していました:

```
crane_debug_tools/src/bag/bag_survey.cpp:214:19: performance: Searching before insertion is not necessary. [stlFindInsert]
```

`std::set` に対して `find` で存在確認してから `insert` する冗長なパターンが原因です。

## 変更内容

- `seen.find(key) == seen.end()` + `seen.insert(key)` の2ステップを `seen.insert(key).second` の1ステップに統合
  - `std::set::insert` は `pair<iterator, bool>` を返し、`.second == true` が新規挿入を示す
  - ロジックの変更なし

## テスト方法

- [x] cppcheck で警告が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)