### PR TITLE
refactor: crane_debug_tools コード品質改善（バグ修正・重複削除・効率化）

### DIFF
--- a/crane_debug_tools/crane_debug_tools/bag_analysis/reader.py
+++ b/crane_debug_tools/crane_debug_tools/bag_analysis/reader.py
@@ -43,28 +43,22 @@ class BagReader:
         """Bagのメタデータのみを取得する."""
         mcap_file = self._resolve_mcap_path()
         reader = self._open_reader(mcap_file)
+        metadata = reader.get_metadata()
 
-        topic_types_list = reader.get_all_topics_and_types()
-        topic_types = {t.name: t.type for t in topic_types_list}
-
-        topic_counts: dict[str, int] = {}
-        start_ns = None
-        end_ns = None
-
-        while reader.has_next():
-            topic, _data, timestamp = reader.read_next()
-            topic_counts[topic] = topic_counts.get(topic, 0) + 1
-            if start_ns is None or timestamp < start_ns:
-                start_ns = timestamp
-            if end_ns is None or timestamp > end_ns:
-                end_ns = timestamp
-
-        start_ns = start_ns or 0
-        end_ns = end_ns or 0
+        start_ns = metadata.starting_time.nanoseconds
+        end_ns = start_ns + metadata.duration.nanoseconds
+        topic_counts = {
+            ti.topic_metadata.name: ti.message_count
+            for ti in metadata.topics_with_message_count
+        }
+        topic_types = {
+            ti.topic_metadata.name: ti.topic_metadata.type
+            for ti in metadata.topics_with_message_count
+        }
 
         return BagInfo(
             path=str(self.bag_path),
-            duration_sec=(end_ns - start_ns) / 1e9,
+            duration_sec=metadata.duration.nanoseconds / 1e9,
             start_time_ns=start_ns,
             end_time_ns=end_ns,
             topic_counts=topic_counts,
@@ -89,27 +83,18 @@ class BagReader:
         mcap_file = self._resolve_mcap_path()
         reader = self._open_reader(mcap_file)
 
-        topic_types_list = reader.get_all_topics_and_types()
-        topic_types = {t.name: t.type for t in topic_types_list}
-
-        # 最初にbag全体のstart/endを取得するため、1パスで処理
-        raw_messages: list[tuple[str, bytes, int]] = []
-        start_ns_all: int | None = None
-        end_ns_all: int | None = None
-        topic_counts_all: dict[str, int] = {}
-
-        while reader.has_next():
-            topic, data, timestamp = reader.read_next()
-            topic_counts_all[topic] = topic_counts_all.get(topic, 0) + 1
-            if start_ns_all is None or timestamp < start_ns_all:
-                start_ns_all = timestamp
-            if end_ns_all is None or timestamp > end_ns_all:
-                end_ns_all = timestamp
-            if topic in target_topics:
-                raw_messages.append((topic, data, timestamp))
-
-        start_ns = start_ns_all or 0
-        end_ns = end_ns_all or 0
+        # メタデータからbag全体のstart/end/topic情報を取得（メッセージ読み込み不要）
+        metadata = reader.get_metadata()
+        start_ns = metadata.starting_time.nanoseconds
+        end_ns = start_ns + metadata.duration.nanoseconds
+        topic_counts_all = {
+            ti.topic_metadata.name: ti.message_count
+            for ti in metadata.topics_with_message_count
+        }
+        topic_types = {
+            ti.topic_metadata.name: ti.topic_metadata.type
+            for ti in metadata.topics_with_message_count
+        }
 
         # 時間範囲フィルタ
         if time_range is not None:
@@ -119,10 +104,13 @@ class BagReader:
             range_start_ns = None
             range_end_ns = None
 
-        # デシリアライズ
+        # 1パスでフィルタ・デシリアライズ
         messages: dict[str, list[TimestampedMsg]] = {t: [] for t in target_topics}
 
-        for topic, data, timestamp in raw_messages:
+        while reader.has_next():
+            topic, data, timestamp = reader.read_next()
+            if topic not in target_topics:
+                continue
             if range_start_ns is not None and timestamp < range_start_ns:
                 continue
             if range_end_ns is not None and timestamp > range_end_ns:
@@ -139,7 +127,7 @@ class BagReader:
 
         bag_info = BagInfo(
             path=str(self.bag_path),
-            duration_sec=(end_ns - start_ns) / 1e9,
+            duration_sec=metadata.duration.nanoseconds / 1e9,
             start_time_ns=start_ns,
             end_time_ns=end_ns,
             topic_counts=topic_counts_all,

--- a/crane_debug_tools/crane_debug_tools/mcap_analysis/gemini_client.py
+++ b/crane_debug_tools/crane_debug_tools/mcap_analysis/gemini_client.py
@@ -308,7 +308,7 @@ class GeminiAnalysisClient:
         results: list[AnalysisResult] = []
         for i, item in enumerate(items):
             logger.info(f"Analyzing annotation {i + 1}/{total}...")
-            result = analyze_fn(*item) if isinstance(item, tuple) else analyze_fn(item)
+            result = analyze_fn(*item)
             results.append(result)
             if i < total - 1:
                 time.sleep(self.rate_limit_delay)

--- a/crane_debug_tools/crane_debug_tools/mcap_analysis/gemini_client.py
+++ b/crane_debug_tools/crane_debug_tools/mcap_analysis/gemini_client.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from .extractor import AnnotationContext
@@ -25,6 +26,18 @@ class AnalysisResult:
     confidence: str
     raw_response: str = ""
     error: str | None = None
+
+    @staticmethod
+    def error_result(error: str, raw_response: str = "") -> "AnalysisResult":
+        """エラー結果を生成するファクトリメソッド."""
+        return AnalysisResult(
+            root_cause="",
+            tactical_analysis="",
+            improvements=[],
+            confidence="UNKNOWN",
+            raw_response=raw_response,
+            error=error,
+        )
 
 
 class GeminiAnalysisClient:
@@ -110,24 +123,14 @@ class GeminiAnalysisClient:
 
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse Gemini response as JSON: {e}")
-            return AnalysisResult(
-                root_cause="",
-                tactical_analysis="",
-                improvements=[],
-                confidence="UNKNOWN",
-                raw_response=raw_response if "raw_response" in locals() else "",
-                error=f"JSON parse error: {e}",
+            return AnalysisResult.error_result(
+                f"JSON parse error: {e}",
+                raw_response if "raw_response" in locals() else "",
             )
 
         except Exception as e:
             logger.error(f"Gemini API error: {e}")
-            return AnalysisResult(
-                root_cause="",
-                tactical_analysis="",
-                improvements=[],
-                confidence="UNKNOWN",
-                error=str(e),
-            )
+            return AnalysisResult.error_result(str(e))
 
     def analyze_annotation_with_tools(
         self,
@@ -280,34 +283,36 @@ class GeminiAnalysisClient:
 
             # 最大呼び出し回数に達した
             logger.warning(f"Reached max tool calls ({max_tool_calls})")
-            return AnalysisResult(
-                root_cause="",
-                tactical_analysis="",
-                improvements=[],
-                confidence="UNKNOWN",
-                error=f"Reached max tool calls ({max_tool_calls})",
+            return AnalysisResult.error_result(
+                f"Reached max tool calls ({max_tool_calls})"
             )
 
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse Gemini response as JSON: {e}")
-            return AnalysisResult(
-                root_cause="",
-                tactical_analysis="",
-                improvements=[],
-                confidence="UNKNOWN",
-                raw_response=raw_response if "raw_response" in locals() else "",
-                error=f"JSON parse error: {e}",
+            return AnalysisResult.error_result(
+                f"JSON parse error: {e}",
+                raw_response if "raw_response" in locals() else "",
             )
 
         except Exception as e:
             logger.exception(f"Gemini API error: {e}")
-            return AnalysisResult(
-                root_cause="",
-                tactical_analysis="",
-                improvements=[],
-                confidence="UNKNOWN",
-                error=str(e),
-            )
+            return AnalysisResult.error_result(str(e))
+
+    def _run_batch(
+        self,
+        items: list,
+        analyze_fn: Callable[..., AnalysisResult],
+        total: int,
+    ) -> list[AnalysisResult]:
+        """バッチ処理の共通ループ（レート制限付き）."""
+        results: list[AnalysisResult] = []
+        for i, item in enumerate(items):
+            logger.info(f"Analyzing annotation {i + 1}/{total}...")
+            result = analyze_fn(*item) if isinstance(item, tuple) else analyze_fn(item)
+            results.append(result)
+            if i < total - 1:
+                time.sleep(self.rate_limit_delay)
+        return results
 
     def analyze_batch(self, prompts: list[tuple[str, str]]) -> list[AnalysisResult]:
         """
@@ -319,19 +324,7 @@ class GeminiAnalysisClient:
         Returns:
             解析結果のリスト
         """
-        results: list[AnalysisResult] = []
-
-        for i, (prompt, system_instruction) in enumerate(prompts):
-            logger.info(f"Analyzing annotation {i + 1}/{len(prompts)}...")
-
-            result = self.analyze_annotation(prompt, system_instruction)
-            results.append(result)
-
-            # レート制限対策
-            if i < len(prompts) - 1:
-                time.sleep(self.rate_limit_delay)
-
-        return results
+        return self._run_batch(prompts, self.analyze_annotation, len(prompts))
 
     def analyze_batch_with_tools(
         self,
@@ -350,20 +343,8 @@ class GeminiAnalysisClient:
         Returns:
             解析結果のリスト
         """
-        results: list[AnalysisResult] = []
-
-        for i, (annotation, (prompt, system_instruction)) in enumerate(
-            zip(annotations, prompts)
-        ):
-            logger.info(f"Analyzing annotation {i + 1}/{len(prompts)}...")
-
-            result = self.analyze_annotation_with_tools(
-                annotation, prompt, system_instruction, max_tool_calls
-            )
-            results.append(result)
-
-            # レート制限対策
-            if i < len(prompts) - 1:
-                time.sleep(self.rate_limit_delay)
-
-        return results
+        items = [
+            (annotation, prompt, system_instruction, max_tool_calls)
+            for annotation, (prompt, system_instruction) in zip(annotations, prompts)
+        ]
+        return self._run_batch(items, self.analyze_annotation_with_tools, len(items))

--- a/crane_debug_tools/crane_debug_tools/mcap_analysis/mcap_tools.py
+++ b/crane_debug_tools/crane_debug_tools/mcap_analysis/mcap_tools.py
@@ -132,7 +132,7 @@ class MCAPToolsHandler:
 
         return {
             "trajectory": trajectory,
-            "total_distance": self._calculate_ball_trajectory_distance(trajectory),
+            "total_distance": self._calculate_trajectory_distance(trajectory),
             "max_speed": max(
                 (
                     math.sqrt(v[0] ** 2 + v[1] ** 2 + v[2] ** 2)
@@ -283,7 +283,12 @@ class MCAPToolsHandler:
             # 自チーム内
             for i, r1 in enumerate(snapshot.our_robots):
                 for r2 in snapshot.our_robots[i + 1 :]:
-                    distance = self._distance_2d(r1["position"], r2["position"])
+                    distance = distance_2d(
+                        r1["position"][0],
+                        r1["position"][1],
+                        r2["position"][0],
+                        r2["position"][1],
+                    )
                     if distance < threshold:
                         collisions.append(
                             {
@@ -298,7 +303,12 @@ class MCAPToolsHandler:
             # 自チームと相手チーム
             for r1 in snapshot.our_robots:
                 for r2 in snapshot.their_robots:
-                    distance = self._distance_2d(r1["position"], r2["position"])
+                    distance = distance_2d(
+                        r1["position"][0],
+                        r1["position"][1],
+                        r2["position"][0],
+                        r2["position"][1],
+                    )
                     if distance < threshold:
                         collisions.append(
                             {
@@ -329,18 +339,6 @@ class MCAPToolsHandler:
 
     def _calculate_trajectory_distance(self, trajectory: list[dict]) -> float:
         """軌跡の総移動距離を計算."""
-        if len(trajectory) < 2:
-            return 0.0
-
-        total = 0.0
-        for i in range(len(trajectory) - 1):
-            p1 = trajectory[i]["position"]
-            p2 = trajectory[i + 1]["position"]
-            total += distance_2d(p1[0], p1[1], p2[0], p2[1])
-        return total
-
-    def _calculate_ball_trajectory_distance(self, trajectory: list[dict]) -> float:
-        """ボール軌跡の総移動距離を計算."""
         if len(trajectory) < 2:
             return 0.0
 


### PR DESCRIPTION
## 概要

`/simplify` レビューで検出した問題を修正。ランタイムバグ1件の修正、コードの重複解消、BagReaderのメモリ効率改善を行う。

## 背景・根本原因

- `mcap_tools.py` の `_check_robot_collision` が存在しない `self._distance_2d` メソッドを呼び出しており、Gemini が `check_robot_collision` ツールを使用すると `AttributeError` で落ちていた
- `_calculate_trajectory_distance` と `_calculate_ball_trajectory_distance` が完全同一のコードで2重実装されていた
- `AnalysisResult` のエラー生成パターンが5箇所で繰り返されていた
- `BagReader.info()` が全メッセージをスキャンしてメタデータを取得しており、C++版が `get_metadata()` を使うのと対照的だった
- `BagReader.read()` が全生データをメモリにバッファしてから2パス目でデシリアライズしていた

## 変更内容

- **fix**: `mcap_tools.py` の `_check_robot_collision` で `self._distance_2d`（未定義）→ モジュールレベルの `distance_2d` 関数を直接使用
- **refactor**: `_calculate_ball_trajectory_distance` を削除し `_calculate_trajectory_distance` を共用
- **refactor**: `AnalysisResult.error_result()` ファクトリメソッドを追加し、5箇所の重複パターンを置換
- **refactor**: `GeminiAnalysisClient._run_batch()` ヘルパーを抽出し、`analyze_batch` / `analyze_batch_with_tools` のバッチループを統合
- **perf**: `BagReader.info()` を全メッセージスキャン → `get_metadata()` 一発取得に変更
- **perf**: `BagReader.read()` を `raw_messages` バッファ+2パス → 1パスでフィルタ・デシリアライズ同時実行に変更

## テスト方法

- [x] `colcon build --packages-select crane_debug_tools` でビルド確認済み
- [x] `from crane_debug_tools.mcap_analysis.mcap_tools import MCAPToolsHandler` インポート確認済み
- [x] `AnalysisResult.error_result('test')` 動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)