### PR TITLE
fix: crane_ball_calibration_ui のバージョンを 1.0.212 に修正

### DIFF
--- a/crane_ball_calibration_ui/package.xml
+++ b/crane_ball_calibration_ui/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>crane_ball_calibration_ui</name>
-  <version>1.0.211</version>
+  <version>1.0.212</version>
   <description>
     ボール物理モデルとキッカーモデルのパラメータをHuman-in-the-Loopで
     インタラクティブに最適化するためのWebインターフェース


### PR DESCRIPTION
## 概要
`crane_ball_calibration_ui/package.xml` のバージョンが `1.0.211` のままになっており、他パッケージの `1.0.212` と不一致になっていたため修正。

## 背景・根本原因
- #1213 で `crane_ball_calibration_ui` を新規追加した際、バージョンが `1.0.211` で作成された
- その後のリリースコミット（792b2b61）でバージョンバンプされなかった
- この不一致により CI の `catkin_prepare_release` ステップが失敗していた（[run #23177898702](https://github.com/ibis-ssl/crane/actions/runs/23177898702)）

## 変更内容
- `crane_ball_calibration_ui/package.xml`: version `1.0.211` → `1.0.212`

## テスト方法
- [ ] CI（Auto Version Bump and Release）が正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)