### PR TITLE
fix: ファール削減対策（ダブルタッチ防止・オーバードリブル共通化・ペナルティエリア速度制限）

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/attacker.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/attacker.hpp
@@ -69,15 +69,6 @@ public:
 
   Receive receive_skill;
 
-  struct OverDribbleInfo
-  {
-    bool detected = false;
-    Point previous_position;
-    double distance = 0.0;
-
-    auto update(const Point & current_position, const Point & ball_position) -> void;
-  } over_dribble;
-
 protected:
   void onPostUpdate() override;
 

--- a/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
@@ -34,6 +34,9 @@ public:
   Status update() override;
 
   Kick kick_skill;
+
+private:
+  bool kicked = false;
 };
 }  // namespace crane::skills
 #endif  // CRANE_ROBOT_SKILLS__SIMPLE_KICKOFF_HPP_

--- a/crane_robot_skills/include/crane_robot_skills/skill_base.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/skill_base.hpp
@@ -224,6 +224,31 @@ class SkillBaseWithState : public SkillInterface
 public:
   using StateFunctionType = std::function<Status()>;
 
+  static constexpr double OVER_DRIBBLE_DISTANCE_THRESHOLD = 0.5;
+
+  struct OverDribbleInfo
+  {
+    bool detected = false;
+    Point previous_position = Point::Zero();
+    double distance = 0.0;
+
+    auto update(const Point & current_position, const Point & ball_position) -> void
+    {
+      if ((current_position - ball_position).norm() < 0.12) {
+        if (!detected) {
+          distance = 0.0;
+        } else {
+          distance += (current_position - previous_position).norm();
+        }
+        detected = true;
+        previous_position = current_position;
+      } else {
+        detected = false;
+        distance = 0.0;
+      }
+    }
+  };
+
   template <typename... Args>
   explicit SkillBaseWithState(
     int init_state, std::function<std::string(int)> name_resolver, Args &&... args)
@@ -246,6 +271,11 @@ public:
     auto current_state = state_machine_.getCurrentState();
     auto it = state_functions_.find(current_state);
     Status status = (it != state_functions_.end()) ? it->second() : Status::RUNNING;
+
+    over_dribble.update(robot()->pose.pos, world_model()->ball().pos);
+    if (over_dribble.distance > OVER_DRIBBLE_DISTANCE_THRESHOLD) {
+      command->stopHere();
+    }
 
     onPostUpdate();
 
@@ -297,6 +327,7 @@ protected:
 
   StateMachine state_machine_;
   std::unordered_map<int, StateFunctionType> state_functions_;
+  OverDribbleInfo over_dribble;
 };
 }  // namespace crane::skills
 

--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -73,15 +73,14 @@ void Attacker::initialize()
         (game_command == crane_msgs::msg::PlaySituation::OUR_DIRECT_FREE ||
          game_command == crane_msgs::msg::PlaySituation::OUR_KICKOFF_START) &&
         world_model()->ball().isStopped()) {
-        // 上位層のパス先が未選択なら強制パスに入らない
-        if (world_model()->getMsg().game_analysis.pass_target_id < 0) {
-          return false;
+        // pass_target_id が有効な場合のみパス先を設定（無い場合は FORCED_PASS で敵ゴールへキック）
+        if (world_model()->getMsg().game_analysis.pass_target_id >= 0) {
+          forced_pass_receiver_id =
+            static_cast<int>(world_model()->getMsg().game_analysis.pass_target_id);
+          pass_receiver_id = forced_pass_receiver_id;
+          auto receiver = world_model()->getOurRobot(pass_receiver_id.value());
+          kick_skill.setParameter("target", receiver->pose.pos);
         }
-        forced_pass_receiver_id =
-          static_cast<int>(world_model()->getMsg().game_analysis.pass_target_id);
-        pass_receiver_id = forced_pass_receiver_id;
-        auto receiver = world_model()->getOurRobot(pass_receiver_id.value());
-        kick_skill.setParameter("target", receiver->pose.pos);
         return true;
       } else {
         return false;
@@ -260,6 +259,12 @@ void Attacker::initialize()
       kick_state_entry_time = std::chrono::steady_clock::now();
       in_kick_state = true;
     }
+
+    // 相手ペナルティエリア近辺での速度制限（ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA防止）
+    if (world_model()->point_checker.isEnemyPenaltyArea(robot()->pose.pos, 0.5)) {
+      command->setMaxVelocity("near_their_penalty_area", 1.5);
+    }
+
     double goal_angle_width = evaluateGoalAngle(world_model()->ball().pos);
 
     // パスは pass_target_id がある場合のみ検討
@@ -338,29 +343,10 @@ void Attacker::initialize()
 
 void Attacker::onPostUpdate()
 {
-  over_dribble.update(robot()->pose.pos, world_model()->ball().pos);
-  if (over_dribble.distance > 0.5) {
+  if (over_dribble.distance > OVER_DRIBBLE_DISTANCE_THRESHOLD) {
     RCLCPP_INFO(rclcpp::get_logger("Attacker"), "オーバードリブル[m]: %f", over_dribble.distance);
-    command->stopHere();
   } else {
     command->setOmegaLimit(10.0);
-  }
-}
-
-auto Attacker::OverDribbleInfo::update(const Point & current_position, const Point & ball_position)
-  -> void
-{
-  if ((current_position - ball_position).norm() < 0.12) {
-    if (not detected) {
-      distance = 0.0;
-    } else {
-      distance += (current_position - previous_position).norm();
-    }
-    detected = true;
-    previous_position = current_position;
-  } else {
-    detected = false;
-    distance = 0.0;
   }
 }
 

--- a/crane_robot_skills/src/simple_kickoff.cpp
+++ b/crane_robot_skills/src/simple_kickoff.cpp
@@ -17,6 +17,15 @@ void SimpleKickOff::initializeParameters()
 
 Status SimpleKickOff::update()
 {
+  if (!kicked && world_model()->ball().isMoving(0.5)) {
+    kicked = true;
+  }
+
+  if (kicked) {
+    command->stopHere();
+    return Status::RUNNING;
+  }
+
   kick_skill.setParameter("target", world_model()->getTheirGoalCenter());
   return kick_skill.run();
 }


### PR DESCRIPTION
## 概要

rosbag2_2026_03_17-12_33_58（約20分の試合）で記録された大量のファール（ATTACKER_DOUBLE_TOUCHED_BALL: 143件、BOT_DRIBBLED_BALL_TOO_FAR: 130件等）への対策を実装。

## 背景・根本原因

- `Attacker`: セットプレイ時 `pass_target_id < 0` の場合 FORCED_PASS に遷移せず KICK → ENTRY_POINT のループでダブルタッチが発生
- `SimpleKickOff`: キック後もボールを追い続けダブルタッチの可能性
- `OverDribbleInfo`: Attacker 固有実装のため他スキルでオーバードリブルが検知されない
- ペナルティエリア近辺で Attacker の速度が高く相手ロボットに接触

## 変更内容

- **Attacker ダブルタッチ防止**: `pass_target_id < 0` でも FORCED_PASS へ遷移するよう修正（FORCED_PASS → ENTRY_POINT 遷移なし）
- **SimpleKickOff ダブルタッチ防止**: `isMoving(0.5)` 検出後 `stopHere()` で停止（既存 API を活用し状態変数を削減）
- **OverDribbleInfo の共通化**: `SkillBaseWithState` に移動し全スキルで自動適用、`OVER_DRIBBLE_DISTANCE_THRESHOLD` 定数で閾値統一
- **ペナルティエリア近辺速度制限**: KICK state で 0.5m 以内なら最大 1.5m/s に制限、`point_checker.isEnemyPenaltyArea()` で統一

## テスト方法

- [x] `colcon build --packages-up-to crane_robot_skills` でビルド確認
- [ ] シミュレーション試合を実施し `crane_bag survey` でファール数を比較
- [ ] THEIR_DIRECT_FREE の発生回数が減少していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)