### PR TITLE
fix: crane_ball_calibration_uiのrosdepキーをament_pytestからpython3-pytestに修正

### DIFF
--- a/crane_ball_calibration_ui/package.xml
+++ b/crane_ball_calibration_ui/package.xml
@@ -17,8 +17,8 @@
   <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_pytest</test_depend>
   <test_depend>crane_lint_common</test_depend>
+  <test_depend>python3-pytest</test_depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
## 概要

`crane_ball_calibration_ui` パッケージの `package.xml` に記載されていた無効な rosdep キー `ament_pytest` を `python3-pytest` に修正します。

## 背景・根本原因

GitHub Actions の `develop full build test` ワークフローで `rosdep install` が以下のエラーで失敗していました:

```
ERROR: the following packages/stacks could not have their rosdep keys resolved to system dependencies:
crane_ball_calibration_ui: Cannot locate rosdep definition for [ament_pytest]
```

`ament_pytest` は rosdep データベースに登録された有効なキーではないため、ROS 2 Jazzy 環境でのビルドが通らなかった。

## 変更内容

- `crane_ball_calibration_ui/package.xml`: `<test_depend>ament_pytest</test_depend>` → `<test_depend>python3-pytest</test_depend>`

## テスト方法

- [ ] GitHub Actions の CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)