### PR TITLE
fix: EmplaceRobotSessionが不要なときにロボットを退場させる問題を修正

### DIFF
--- a/crane_sessions/include/crane_sessions/emplace_robot_session.hpp
+++ b/crane_sessions/include/crane_sessions/emplace_robot_session.hpp
@@ -43,6 +43,18 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::RobotCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
 
+  int getDesiredRobotNumber(int /* min_robots */, int /* max_robots */) const override
+  {
+    int available_count =
+      static_cast<int>(world_model->ours().robotsWhere().available().getIds().size());
+    int max_allowed = static_cast<int>(world_model->getOurMaxAllowedBots());
+    // max_allowed_botsが0(未受信)の場合は退場不要と判断
+    if (max_allowed == 0) {
+      return 0;
+    }
+    return std::max(0, available_count - max_allowed);
+  }
+
   auto getRobotSuitabilityFunc() const
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override;
 


### PR DESCRIPTION
## 概要

EmplaceRobotSessionが、退場不要な場合（イエローカードなし）でも常に1台のロボットをサイドラインへ退場させていた問題を修正。

## 背景・根本原因

`EmplaceRobotSession`が`getDesiredRobotNumber`をオーバーライドしていなかったため、デフォルト実装の`max_robots`(=1)を常に返していた。  
INPLAY/STOP状況でのYAML設定が`max_robots: 1`なので、通常時でも1台が退場対象として割り当てられていた。

## 変更内容

- `EmplaceRobotSession`に`getDesiredRobotNumber`をオーバーライド追加
- 退場必要数 = `利用可能ロボット数 - max_allowed_bots`（0以上にクランプ）で動的に計算
- `max_allowed_bots=0`（レフェリー未受信）時は安全側として0を返す

## テスト方法

- [x] `colcon build --packages-select crane_sessions` でビルド確認
- [x] シミュレータで通常試合(6v6)を開始し、ロボットが退場しないことを確認
- [x] SSL Game Controllerからイエローカードを出し、1台退場を確認
- [x] カードのペナルティ終了後、退場が停止することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)