### PR TITLE
fix: TIGERs対戦CIでcraneイメージのタグ参照を環境変数化

### DIFF
--- a/docker/match-vs-tigers/docker-compose.yaml
+++ b/docker/match-vs-tigers/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
     restart: "no"
 
   crane:
-    image: ghcr.io/ibis-ssl/crane:match-local
+    image: ghcr.io/ibis-ssl/crane:${CRANE_TAG:-match-local}
     container_name: match_crane
     network_mode: host
     command: |


### PR DESCRIPTION
## 概要
TIGERs対戦CIで `crane` Dockerイメージの pull 時に `manifest unknown` エラーが発生していた問題を修正します。

## 背景・根本原因
CIワークフロー (`match-vs-tigers.yaml`) はビルドしたcraneイメージを `ghcr.io/ibis-ssl/crane:match-<SHA>` タグでpushし、`CRANE_TAG=match-<SHA>` を環境変数として渡しています。しかし `docker/match-vs-tigers/docker-compose.yaml` のcraneサービスのイメージタグが `match-local` にハードコードされており、`CRANE_TAG` 環境変数が参照されていませんでした。

## 変更内容
- `docker/match-vs-tigers/docker-compose.yaml`: craneイメージタグを変数展開に変更
  - Before: `ghcr.io/ibis-ssl/crane:match-local`
  - After: `ghcr.io/ibis-ssl/crane:${CRANE_TAG:-match-local}`

## テスト方法
- [ ] TIGERs対戦CIワークフローを手動実行して `Start Docker Compose services` ステップが成功することを確認
- [ ] ローカルでは `CRANE_TAG` 未設定時に `match-local` フォールバックが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)