### PR TITLE
feat: Forwardポジショニングのスコアリングとライン生成を強化

### DIFF
--- a/crane_robot_skills/src/forward.cpp
+++ b/crane_robot_skills/src/forward.cpp
@@ -37,6 +37,11 @@ auto Forward::update() -> Status
   int num_points =
     std::clamp(static_cast<int>(std::ceil(line_length / 0.1)), 1, MAX_SAMPLING_POINTS);
 
+  // ループ外で定数を取得（サンプル点ごとの重複呼び出しを回避）
+  const auto their_goal_center = world_model()->getTheirGoalCenter();
+  const auto available_our_robots = world_model()->ours().robotsWhere().available().get();
+  const auto available_enemy_robots = world_model()->theirs().robotsWhere().available().get();
+
   std::vector<std::pair<Point, double>> points_with_score =
     ranges::views::iota(0, num_points) | ranges::views::transform([&](int i) -> Point {
       return front_point + (back_point - front_point) * static_cast<double>(i) / num_points;
@@ -46,8 +51,8 @@ auto Forward::update() -> Status
       // ボールの受取やすさ
       Segment segment{
         p, ball.pos + (p - ball.vel).normalized() * 1.5};  // ボール近くはチップで無視可能
-      auto nearest_enemy = world_model()->getNearestRobotWithDistanceFromSegment(
-        segment, world_model()->theirs().robotsWhere().available().get());
+      auto nearest_enemy =
+        world_model()->getNearestRobotWithDistanceFromSegment(segment, available_enemy_robots);
       if (nearest_enemy) {
         // 0.0~1.0 : 遠いほど高スコア
         score *= std::clamp(nearest_enemy->distance, 0.2, 2.0) / 2.0;
@@ -62,6 +67,22 @@ auto Forward::update() -> Status
       }
       // ボールとの距離評価（近すぎず遠すぎず）
       score *= (std::clamp(1.0 - distance / max_ball_distance, 0.0, 1.0) * 0.5 + 0.5);
+
+      // 1-A: ゴールシュート角度評価
+      auto [goal_angle, goal_width] = world_model()->getLargestGoalAngleRangeFromPoint(p);
+      score *= (std::clamp(goal_width / 0.6, 0.0, 1.0) * 0.5 + 0.5);
+
+      // 1-B: ボール後方回避（攻撃方向の後ろ側はスコアを下げる）
+      double dot = (their_goal_center - ball.pos).normalized().dot((p - ball.pos).normalized());
+      score *= std::max((dot + 0.5), 0.0);
+
+      // 1-C: 味方との分散（1.5m以内の味方ロボットがいる場合は減点）
+      constexpr double MIN_TEAM_SPACING = 1.5;
+      for (const auto & our_robot : available_our_robots) {
+        if (our_robot->id == robot()->id) continue;
+        double d = (p - our_robot->pose.pos).norm();
+        if (d < MIN_TEAM_SPACING) score *= d / MIN_TEAM_SPACING;
+      }
 
       if (planner_visualizer) {
         planner_visualizer->drawCircle(p, score * 0.25, "lime", 5, 0.5);

--- a/crane_sessions/include/crane_sessions/forward_session.hpp
+++ b/crane_sessions/include/crane_sessions/forward_session.hpp
@@ -57,10 +57,15 @@ public:
   }
 
 protected:
-  void onRobotsChanged() override { forward_skills.clear(); }
+  void onRobotsChanged() override
+  {
+    forward_skills.clear();
+    forward_line_assignments.clear();
+  }
 
 private:
   std::vector<std::shared_ptr<skills::Forward>> forward_skills;
+  std::vector<int> forward_line_assignments;
 };
 }  // namespace crane
 #endif  // CRANE_SESSIONS__FORWARD_SESSION_HPP_

--- a/crane_sessions/src/forward_session.cpp
+++ b/crane_sessions/src/forward_session.cpp
@@ -21,7 +21,8 @@ auto ForwardSession::createForwardLines() const -> std::vector<Segment>
   const double penalty_front_x = goal_line_x - world_model->penaltyAreaSize().y() * 0.5;
   const double penalty_side_y = world_model->penaltyAreaSize().y() * 0.5;
   const double side_center_y = std::midpoint(field_half_width, penalty_side_y);
-  const double back_x = -1.;
+  const double ball_x_abs = world_model->ball().pos.x() * (-world_model->getOurSideSign());
+  const double back_x = std::clamp(ball_x_abs - 1.0, -goal_line_x + 1.0, goal_line_x - 3.0);
 
   auto push_line = [&](Point p1, Point p2) {
     Segment line{p1, p2};
@@ -91,6 +92,7 @@ auto ForwardSession::calculatePositionCommand(const std::vector<RobotIdentifier>
 
       auto solution = getOptimalAssignments(robot_positions, forward_lines);
 
+      forward_line_assignments.clear();
       for (const auto & [index, robot_id] : robots | ranges::views::enumerate) {
         auto skill = std::make_shared<skills::Forward>(robot_id.id, world_model);
 
@@ -109,6 +111,22 @@ auto ForwardSession::calculatePositionCommand(const std::vector<RobotIdentifier>
         skill->setParameter("max_vel", 1.5);
         skill->planner_visualizer = visualizer;
         forward_skills.emplace_back(skill);
+        forward_line_assignments.emplace_back(line_index);
+      }
+    }
+  }
+
+  // 毎フレームback_xを更新してラインパラメータを再設定
+  if (!forward_skills.empty() && forward_line_assignments.size() == forward_skills.size()) {
+    auto current_lines = createForwardLines();
+    if (!current_lines.empty()) {
+      for (size_t i = 0; i < forward_skills.size(); ++i) {
+        const int line_index = forward_line_assignments[i];
+        if (static_cast<size_t>(line_index) < current_lines.size()) {
+          const auto & line = current_lines[line_index];
+          forward_skills[i]->setParameter("front_point", line.second);
+          forward_skills[i]->setParameter("back_point", line.first);
+        }
       }
     }
   }


### PR DESCRIPTION
## 概要

Forwardロボットの配置判断に、ゴールシュート角度・ボール後方回避・味方分散の3つのスコア基準を追加し、ラインのback_xをボール位置に連動して動的に更新するよう改善。

## 背景・根本原因

従来のForwardスコアリングは「敵遮蔽」「ボール距離」のみを考慮しており、以下の問題があった:
- ゴールが見えない位置（敵DFに遮蔽された位置）でも高スコアが付くことがあった
- ボールの後方（攻撃方向と逆側）に位置取りしてしまうケースがあった
- 複数Forwardが同じ位置付近に集中することがあった
- back_xが固定値（-1.0m）のため、ボールが前進してもラインが更新されなかった

## 変更内容

### フェーズ1: スコアラムダの強化（forward.cpp）
- **ゴールシュート角度評価**: `getLargestGoalAngleRangeFromPoint()` でゴールへの角度幅が広い位置を優先
- **ボール後方回避**: 攻撃方向の後ろ側にいるForwardのスコアを大幅減点
- **味方との分散**: 1.5m以内に味方ロボットがいる場合に減点し、密集を防止
- **効率化**: ループ内定数（敵ゴール座標・ロボットリスト）をループ外で一度だけ取得

### フェーズ2: ライン生成の動的化（forward_session.cpp/hpp）
- **back_x動的化**: ボールのx位置に連動し、フィールドサイズ内でクランプ
- **毎フレーム更新**: ライン割当をキャッシュし、毎フレームfront/back pointを再設定

## テスト方法

- [x] `colcon build --packages-select crane_robot_skills crane_sessions` でビルド確認
- [x] シミュレーションでINPLAY時のForwardの配置を可視化（drawCircleスコア表示で確認）
- [x] ゴール前のフリースペースにForwardが集まるか確認
- [x] ボール位置変化時にフォワードラインが追従するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)