### PR TITLE
refactor: sessionのmin_robotsを廃止

### DIFF
--- a/crane_msgs/msg/RobotSelectResult.msg
+++ b/crane_msgs/msg/RobotSelectResult.msg
@@ -1,6 +1,5 @@
 string name
 
-uint8 min_robots_num
 uint8 max_robots_num
 uint8 selectable_robots_num
 uint8[] selectable_robots

--- a/crane_session_coordinator/config/unified_session_config.yaml
+++ b/crane_session_coordinator/config/unified_session_config.yaml
@@ -14,8 +14,9 @@ situations:
       - name: attacker_skill
         max_robots: 1
       - name: defender
-        min_robots: 2
         max_robots: 3
+        params:
+          reduced_robots: 2
       - name: pass_receive
         max_robots: 1
       - name: second_threat_defender

--- a/crane_session_coordinator/include/crane_session_coordinator/configuration_manager.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/configuration_manager.hpp
@@ -22,7 +22,6 @@ using SessionParameterType = std::variant<double, bool, int, std::string>;
 struct SessionSlot
 {
   std::string session_name;
-  int min_robots = 0;
   int max_robots;
   std::unordered_map<std::string, SessionParameterType> params;
 };

--- a/crane_session_coordinator/include/crane_session_coordinator/global_robot_allocator.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/global_robot_allocator.hpp
@@ -32,9 +32,6 @@ struct SessionRequirement
   // 優先度（数値が小さいほど優先度が高い、0が最高優先度）
   int priority;
 
-  // 必要最小ロボット数
-  int min_robots;
-
   // 必要最大ロボット数
   int max_robots;
 
@@ -42,13 +39,8 @@ struct SessionRequirement
   std::function<double(const std::shared_ptr<RobotInfo> &)> suitability_func;
 
   SessionRequirement(
-    std::string n, int p, int min_r, int max_r,
-    std::function<double(const std::shared_ptr<RobotInfo> &)> func)
-  : name(std::move(n)),
-    priority(p),
-    min_robots(min_r),
-    max_robots(max_r),
-    suitability_func(std::move(func))
+    std::string n, int p, int max_r, std::function<double(const std::shared_ptr<RobotInfo> &)> func)
+  : name(std::move(n)), priority(p), max_robots(max_r), suitability_func(std::move(func))
   {
   }
 };

--- a/crane_session_coordinator/src/configuration_manager.cpp
+++ b/crane_session_coordinator/src/configuration_manager.cpp
@@ -78,29 +78,14 @@ auto ConfigurationManager::loadUnifiedConfig(const std::filesystem::path & confi
         SessionSlot session_capacity;
         session_capacity.session_name = session_node["name"].as<std::string>();
 
-        // min_robotsの読み込みとデフォルト値設定
-        if (session_node["min_robots"]) {
-          session_capacity.min_robots = session_node["min_robots"].as<int>();
-        } else {
-          session_capacity.min_robots = 0;  // デフォルト: 0
-        }
-
         // max_robotsの読み込みとデフォルト値設定
         if (session_node["max_robots"]) {
           session_capacity.max_robots = session_node["max_robots"].as<int>();
         } else {
-          session_capacity.max_robots =
-            session_capacity.min_robots;  // デフォルト: min_robotsと同じ
+          session_capacity.max_robots = 1;  // デフォルト: 1
         }
 
         // バリデーション
-        if (session_capacity.min_robots < 0) {
-          RCLCPP_ERROR(
-            logger_, "Invalid min_robots (%d) for session '%s': must be >= 0. Using 0.",
-            session_capacity.min_robots, session_capacity.session_name.c_str());
-          session_capacity.min_robots = 0;
-        }
-
         if (session_capacity.max_robots <= 0) {
           RCLCPP_WARN(
             logger_, "Invalid max_robots (%d) for session '%s': must be > 0. Using 1.",
@@ -108,18 +93,7 @@ auto ConfigurationManager::loadUnifiedConfig(const std::filesystem::path & confi
           session_capacity.max_robots = 1;
         }
 
-        if (session_capacity.min_robots > session_capacity.max_robots) {
-          RCLCPP_WARN(
-            logger_,
-            "Invalid range for session '%s': min_robots (%d) > max_robots (%d). Adjusting "
-            "min_robots to match max_robots.",
-            session_capacity.session_name.c_str(), session_capacity.min_robots,
-            session_capacity.max_robots);
-          session_capacity.min_robots = session_capacity.max_robots;
-        }
-
         ss << "\tNAME       : " << session_capacity.session_name << "\n";
-        ss << "\tMIN_ROBOTS : " << session_capacity.min_robots << "\n";
         ss << "\tMAX_ROBOTS : " << session_capacity.max_robots << "\n";
 
         // params の読み込み（存在する場合のみ）

--- a/crane_session_coordinator/src/global_robot_allocator.cpp
+++ b/crane_session_coordinator/src/global_robot_allocator.cpp
@@ -62,12 +62,6 @@ auto GlobalRobotAllocator::allocate(
       assigned_robots.push_back(robot_scores[i].first);
     }
 
-    if (static_cast<int>(assigned_robots.size()) < req.min_robots) {
-      RCLCPP_WARN(
-        logger_, "Session「%s」の最小ロボット数(%d)を満たせませんでした（実際: %lu）",
-        req.name.c_str(), req.min_robots, assigned_robots.size());
-    }
-
     result[req.name] = assigned_robots;
 
     // 割り当てたロボットをremaining_robotsから削除

--- a/crane_session_coordinator/src/robot_allocator.cpp
+++ b/crane_session_coordinator/src/robot_allocator.cpp
@@ -65,15 +65,12 @@ auto RobotAllocator::allocate(
     auto suitability_func = session->getRobotSuitabilityFunc();
 
     // 動的ロボット数を取得してクランプ
-    int desired =
-      session->getDesiredRobotNumber(session_capacity.min_robots, session_capacity.max_robots);
-    int effective_max =
-      std::clamp(desired, session_capacity.min_robots, session_capacity.max_robots);
+    int desired = session->getDesiredRobotNumber(session_capacity.max_robots);
+    int effective_max = std::min(desired, session_capacity.max_robots);
 
     requirements.emplace_back(
       session_capacity.session_name, priority++,
-      session_capacity.min_robots,  // min_robots
-      effective_max,                // max_robots（動的に調整）
+      effective_max,  // max_robots（動的に調整）
       suitability_func);
   }
 
@@ -125,7 +122,6 @@ auto RobotAllocator::allocate(
       result.name = allocated_name;
 
       if (capacity_it != session_capacities.end()) {
-        result.min_robots_num = static_cast<uint8_t>(capacity_it->min_robots);
         result.max_robots_num = static_cast<uint8_t>(capacity_it->max_robots);
       }
 

--- a/crane_sessions/include/crane_sessions/defender_session.hpp
+++ b/crane_sessions/include/crane_sessions/defender_session.hpp
@@ -38,12 +38,12 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::RobotCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
 
-  int getDesiredRobotNumber(int min_robots, int max_robots) const override
+  int getDesiredRobotNumber(int max_robots) const override
   {
     if (world_model->point_checker.isInOurHalf(world_model->ball().pos)) {
       return max_robots;
     }
-    return min_robots;
+    return getSessionParameter<int>("reduced_robots", max_robots);
   }
 
   auto getRobotSuitabilityFunc() const

--- a/crane_sessions/include/crane_sessions/emplace_robot_session.hpp
+++ b/crane_sessions/include/crane_sessions/emplace_robot_session.hpp
@@ -43,7 +43,7 @@ public:
   std::pair<Status, std::vector<crane_msgs::msg::RobotCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) override;
 
-  int getDesiredRobotNumber(int /* min_robots */, int /* max_robots */) const override
+  int getDesiredRobotNumber(int /* max_robots */) const override
   {
     int available_count =
       static_cast<int>(world_model->ours().robotsWhere().available().getIds().size());

--- a/crane_sessions/include/crane_sessions/forward_session.hpp
+++ b/crane_sessions/include/crane_sessions/forward_session.hpp
@@ -50,7 +50,7 @@ public:
     };
   }
 
-  int getDesiredRobotNumber(int /* min_robots */, int max_robots) const override
+  int getDesiredRobotNumber(int max_robots) const override
   {
     // Forwardは生成可能なライン数以上のロボットを扱えないため、動的に上限を調整する
     return std::min<int>(static_cast<int>(createForwardLines().size()), max_robots);

--- a/crane_sessions/include/crane_sessions/marker_session.hpp
+++ b/crane_sessions/include/crane_sessions/marker_session.hpp
@@ -60,7 +60,7 @@ public:
     };
   }
 
-  int getDesiredRobotNumber(int /* min_robots */, int /* max_robots */) const override
+  int getDesiredRobotNumber(int /* max_robots */) const override
   {
     // 危険な敵の数に基づいてロボット数を決定
     auto danger_enemies = getDangerEnemies(world_model);

--- a/crane_sessions/include/crane_sessions/session_base.hpp
+++ b/crane_sessions/include/crane_sessions/session_base.hpp
@@ -191,13 +191,12 @@ public:
    * @brief 現在の状況に基づく推奨ロボット数を返す（動的ロボット割当用）
    *
    * Sessionが状況に応じて必要なロボット数を動的に決定するためのメソッド。
-   * 返される値は呼び出し側でmin_robots〜max_robotsの範囲にクランプされる。
+   * 返される値は呼び出し側で0〜max_robotsの範囲にクランプされる。
    *
-   * @param min_robots YAML設定の最小ロボット数
    * @param max_robots YAML設定の最大ロボット数
    * @return 推奨ロボット数。デフォルトはmax_robots
    */
-  virtual int getDesiredRobotNumber(int min_robots, int max_robots) const { return max_robots; }
+  virtual int getDesiredRobotNumber(int max_robots) const { return max_robots; }
 
   /**
    * @brief GameAnalysisメッセージを設定する


### PR DESCRIPTION
## 概要
sessionの `min_robots` 概念を廃止し、`getDesiredRobotNumber` のシグネチャを `(int max_robots)` に簡略化します。

## 背景・根本原因
`min_robots` は実質的に DefenderSession でのみ使用されており（ボール位置に応じて2〜3台を切り替え）、他のセッションではデフォルト0か無視されていました。GlobalRobotAllocator でのチェックも警告ログのみのソフト制約であり、複雑さに見合わない概念でした。

## 変更内容
- `SessionSlot::min_robots` / `SessionRequirement::min_robots` を削除
- `getDesiredRobotNumber(int min, int max)` → `getDesiredRobotNumber(int max)` に変更（全実装クラス対応）
- `ConfigurationManager` の min_robots 読み込み・バリデーションロジックを削除
- `GlobalRobotAllocator` の min_robots 不足時警告ログを削除
- `RobotSelectResult.msg` の `min_robots_num` フィールドを削除
- DefenderSession の削減台数を YAML `params: { reduced_robots: 2 }` 経由で指定する方式に移行

## テスト方法
- [x] `colcon build --packages-up-to crane_session_coordinator crane_sessions crane_msgs` でビルド確認済み
- [ ] INPLAY 時にボールが敵陣にいるときディフェンダーが2台に削減されることを動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)