### PR TITLE
fix: crane_ball_calibration_uiの不正なrosdepキーを修正

### DIFF
--- a/crane_ball_calibration_ui/package.xml
+++ b/crane_ball_calibration_ui/package.xml
@@ -10,8 +10,6 @@
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
   <license>MIT</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclpy</exec_depend>


### PR DESCRIPTION
## 概要
`crane_ball_calibration_ui/package.xml` の不正な `buildtool_depend` を削除し、CI の `rosdep install` ステップのエラーを修正します。

## 背景・根本原因
`<buildtool_depend>ament_python</buildtool_depend>` という宣言が含まれていたが、`ament_python` は有効な rosdep キーではない。
そのため CI の rosdep install ステップで以下のエラーが発生していた:
```
crane_ball_calibration_ui: Cannot locate rosdep definition for [ament_python]
```

純粋な ament_python ビルドタイプのパッケージでは、export セクションの `<build_type>ament_python</build_type>` のみで十分であり、`buildtool_depend` としての宣言は不要。

## 変更内容
- `crane_ball_calibration_ui/package.xml` から `<buildtool_depend>ament_python</buildtool_depend>` を削除

## テスト方法
- [ ] CIの `rosdep install` ステップが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)