### PR TITLE
fix: BALL_PLACEMENT座標のmm→m単位変換バグを修正

### DIFF
--- a/docker/match-vs-tigers/scripts/match_controller_pb.py
+++ b/docker/match-vs-tigers/scripts/match_controller_pb.py
@@ -144,9 +144,10 @@ class MatchController:
             self.teleport_ball_to_position(PENALTY_SPOT_OFFSET, 0.0)
         elif command in ("BALL_PLACEMENT_YELLOW", "BALL_PLACEMENT_BLUE"):
             if referee_msg.HasField("designated_position"):
+                # SSL referee protobufはミリメートル単位、grSimはメートル単位
                 self.teleport_ball_to_position(
-                    referee_msg.designated_position.x,
-                    referee_msg.designated_position.y,
+                    referee_msg.designated_position.x / 1000.0,
+                    referee_msg.designated_position.y / 1000.0,
                 )
 
     def wait_for_gc_ready(self, timeout: int = 60) -> bool:


### PR DESCRIPTION
## 概要

TIGERs対戦CI（Run #23228648752）でBALL_PLACEMENTが常に失敗し、試合が0-0で終了していた問題を修正。

## 根本原因

SSL referee protobufの `designated_position.x/y` は**ミリメートル単位**（例: `-3200.00, 1748.59`）であるが、grSimの `grSim_BallReplacement` は**メートル単位**を期待する。変換なしでそのまま渡していたため、ボールが (-3200m, 1748m) という巨大な座標にテレポートしフィールド外に飛び出していた。

## 障害シーケンス

```
BOT_DRIBBLED_BALL_TOO_FAR → STOP → BALL_PLACEMENT_YELLOW
ボールをテレポート: (-3200.00, 1748.59)  ← mm値をm値として送信！
PLACEMENT_FAILED (Yellow) → BALL_PLACEMENT_BLUE
PLACEMENT_FAILED (Blue) → STOP
FORCE_START → NO_PROGRESS_IN_GAME → STOP（ループ）
試合終了: 180秒タイムアウト (0-0)
```

## 修正内容

```diff
- self.teleport_ball_to_position(
-     referee_msg.designated_position.x,
-     referee_msg.designated_position.y,
- )
+ # SSL referee protobufはミリメートル単位、grSimはメートル単位
+ self.teleport_ball_to_position(
+     referee_msg.designated_position.x / 1000.0,
+     referee_msg.designated_position.y / 1000.0,
+ )
```

## 確認ポイント

- [ ] ボールテレポート座標がメートル単位（例: `-3.20, 1.75`）でログに出力される
- [ ] BALL_PLACEMENTが成功（`PLACEMENT_SUCCEEDED`）する
- [ ] NO_PROGRESS_IN_GAMEループが発生しない
- [ ] ゴールやゲームイベントが正常に発生する