### PR TITLE
fix: シナリオテストのPython仮想環境キャッシュ戦略を修正

### DIFF
--- a/.github/workflows/scenario_test.yaml
+++ b/.github/workflows/scenario_test.yaml
@@ -64,23 +64,19 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Setup virtual environment
-        run: |
-          python -m venv env
-          source env/bin/activate
-
       - name: Cache virtual environment
+        id: cache-venv
         uses: actions/cache@v4
         with:
           path: |
-            env
             ~/.cache/pip
-          key: ${{ runner.os }}-venv-${{ env.PYTHON_VERSION }}-${{ hashFiles('scenario_test/**/*.py') }}-robocup-scenario
+          key: ${{ runner.os }}-pip-${{ env.PYTHON_VERSION }}-${{ hashFiles('scenario_test/**/*.py') }}-robocup-scenario
           restore-keys: |
-            ${{ runner.os }}-venv-${{ env.PYTHON_VERSION }}-
+            ${{ runner.os }}-pip-${{ env.PYTHON_VERSION }}-
 
       - name: Install robocup_scenario_test library
         run: |
+          python -m venv env
           source env/bin/activate
           python -m pip install --upgrade pip
           sudo apt update
@@ -115,15 +111,14 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Cache virtual environment
+      - name: Cache pip packages
         uses: actions/cache@v4
         with:
           path: |
-            env
             ~/.cache/pip
-          key: ${{ runner.os }}-venv-${{ env.PYTHON_VERSION }}-${{ hashFiles('scenario_test/**/*.py') }}-robocup-scenario
+          key: ${{ runner.os }}-pip-${{ env.PYTHON_VERSION }}-${{ hashFiles('scenario_test/**/*.py') }}-robocup-scenario
           restore-keys: |
-            ${{ runner.os }}-venv-${{ env.PYTHON_VERSION }}-
+            ${{ runner.os }}-pip-${{ env.PYTHON_VERSION }}-
 
       - name: Setup virtual environment
         run: |


### PR DESCRIPTION
## 概要
GitHub Actionsのシナリオテストジョブで発生していた `env/bin/pip: cannot execute: required file not found`（exit code 127）を修正します。

## 背景・根本原因
`env/`（Python仮想環境ディレクトリ）をキャッシュすると、内部のシンボリックリンクが古いランナーのPythonパスを指したまま復元されます。
別のランナーVMでは異なるPythonパスになるため、`pip` が実行不能になっていました。

また、ステップの順序にも問題がありました：
1. `Setup virtual environment` で `env/` を作成
2. `Cache virtual environment` でキャッシュを復元（キャッシュヒット時、壊れた `env/` で上書き）
3. `Install` で壊れた `pip` を使おうとして失敗

## 変更内容
- キャッシュ対象を `env/` ディレクトリから `~/.cache/pip` のみに変更
- `python -m venv env` は毎回クリーンに実行するよう修正（venv自体はキャッシュしない）
- キャッシュキーを `venv-` から `pip-` に変更し、両ジョブ（`setup_scenario_test_library` / `scenario_test`）で統一

## テスト方法
- [x] GitHub Actions の scenario test ワークフローが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)