### PR TITLE
fix: crane_mcap_toolsの無効なrosdep依存キーを削除してCIを修正

### DIFF
--- a/crane_mcap_tools/package.xml
+++ b/crane_mcap_tools/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <exec_depend>python3-cairosvg</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclpy</exec_depend>


### PR DESCRIPTION
## Summary

- `crane_mcap_tools/package.xml` から無効なrosdepキー `<buildtool_depend>ament_python</buildtool_depend>` を削除
- これが原因でCIの `rosdep install` ステップが失敗していた (#23299719397)
- 純粋なPythonパッケージでは `<export><build_type>ament_python</build_type></export>` の記述のみで十分（他のPythonパッケージと同様）

## Root Cause

PR #1232 で `crane_debug_tools` を3パッケージに分割した際に、`crane_mcap_tools` の `package.xml` に誤った依存が追加された。

## Test plan

- [ ] CI (rosdep install) が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)