### PR TITLE
fix: BallNearByPositioner の NaN target_pos バグを修正

### DIFF
--- a/crane_robot_skills/src/ball_nearby_positioner.cpp
+++ b/crane_robot_skills/src/ball_nearby_positioner.cpp
@@ -48,11 +48,13 @@ auto BallNearByPositioner::update() -> Status
           std::erase_if(theirs, [&](const auto & r) { return r->id == nearest_robot->robot->id; });
           auto second_nearest_robot =
             world_model()->getNearestRobotWithDistanceFromPoint(target, theirs);
-          return (second_nearest_robot->robot->pose.pos - target).normalized();
-        } else {
-          // 敵ロボットが2台未満の場合：ゴール方向をフォールバック
-          return (world_model()->getOurGoalCenter() - target).normalized();
+          Vector2 dir = second_nearest_robot->robot->pose.pos - target;
+          if (dir.squaredNorm() > 1e-6) {
+            return dir.normalized();
+          }
         }
+        // 敵ロボットが2台未満、または方向ベクトルが無効な場合：ゴール方向をフォールバック
+        return (world_model()->getOurGoalCenter() - target).normalized();
       } else {
         throw std::runtime_error(
           "[BallNearByPositioner] "

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -12,6 +12,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <cmath>
 #include <crane_msg_wrappers/crane_visualizer_wrapper.hpp>
 #include <crane_msg_wrappers/delay_monitor_wrapper.hpp>
 #include <crane_msgs/msg/robot_info.hpp>
@@ -831,9 +832,11 @@ auto WorldModelDataProvider::convertTrackedRobot(
   robot_info.vision.pose.theta = tracked_robot.orientation;
 
   // 検出フラグ（TrackerはVisionを統合しているため、両方trueに設定）
-  robot_info.available_vision = true;
+  // NaN位置のロボットは利用不可として扱う
+  const bool valid_position = !std::isnan(tracked_robot.pos.x) && !std::isnan(tracked_robot.pos.y);
+  robot_info.available_vision = valid_position;
   robot_info.available_feedback = false;
-  robot_info.available_tracker = true;
+  robot_info.available_tracker = valid_position;
 
   // タイムスタンプ設定
   robot_info.last_tracker_detection_stamp = now;


### PR DESCRIPTION
## 概要

`BallNearByPositioner` の "pass" ポリシーにおいて、NaN 位置を持つ敵ロボットが選出され `target_pos(nan, nan)` が発生するバグを修正。

## 背景・根本原因

rosbag2_2026_03_20-01_04_23 の解析で robot 9 が t=43.38〜46.42 の間 NaN target_pos で移動し、t=47.25 にイエローカードを受領。

**発生経路:**
1. Tracker が NaN 位置を持つ敵ロボットを送信
2. `convertTrackedRobot()` が位置の有効性に関わらず `available_vision / available_tracker = true` を設定
3. "pass" ポリシーで当該ロボットが選出され `(NaN_pos - target).normalized()` → NaN 伝播

## 変更内容

- **`crane_world_model_publisher/src/world_model_data_provider.cpp`**  
  `convertTrackedRobot()` で `pos.x/y` の NaN チェックを追加。NaN の場合は `available_vision / available_tracker = false` にする（ingestion 段階での遮断）

- **`crane_robot_skills/src/ball_nearby_positioner.cpp`**  
  "pass" ポリシーで `.normalized()` を呼ぶ前に `squaredNorm() > 1e-6` チェックを追加。NaN・ゼロベクトルの場合はゴール方向にフォールバック（多層防御）

## テスト方法

- [x] `colcon build --packages-up-to crane_robot_skills crane_world_model_publisher` でビルド確認
- [ ] rosbag2_2026_03_20-01_04_23 で再現テスト（NaN 警告が出なくなることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)