### PR TITLE
fix: ForwardSessionのATTACKER_TOO_CLOSE_TO_DEFENSE_AREAファウルを修正

### DIFF
--- a/crane_sessions/src/forward_session.cpp
+++ b/crane_sessions/src/forward_session.cpp
@@ -18,7 +18,9 @@ auto ForwardSession::createForwardLines() const -> std::vector<Segment>
 
   const double goal_line_x = world_model->fieldSize().x() * 0.5;
   const double field_half_width = world_model->fieldSize().y() * 0.5;
-  const double penalty_front_x = goal_line_x - world_model->penaltyAreaSize().y() * 0.5;
+  constexpr double PENALTY_AREA_MARGIN = 0.3;  // SSL rule: 0.2m minimum + 0.1m safety buffer
+  const double penalty_front_x =
+    goal_line_x - world_model->penaltyAreaSize().x() - PENALTY_AREA_MARGIN;
   const double penalty_side_y = world_model->penaltyAreaSize().y() * 0.5;
   const double side_center_y = std::midpoint(field_half_width, penalty_side_y);
   const double ball_x_abs = world_model->ball().pos.x() * (-world_model->getOurSideSign());


### PR DESCRIPTION
## 概要

ForwardSession のフォワードライン生成において、ペナルティエリア前面へのマージンがゼロだったため、ロボットがエリア境界上に停滞し ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA ファウルが繰り返し発生していた問題を修正。

## 背景・根本原因

`forward_session.cpp` の `penalty_front_x` 計算がペナルティエリア前面境界と完全に一致しており、マージンがゼロだった。
また `penaltyAreaSize().y() * 0.5` を奥行きとして誤用していたバグも同時に修正。

rosbag `rosbag2_2026_03_20-01_23_05` の解析にて、bot=1 (-4.07, -1.66) および bot=4 (-4.07, 1.67) がフォワードライン端点上に停滞し、ファウルが繰り返し発生していることを確認。

## 変更内容

- `penalty_front_x` に 0.3m マージンを追加（SSL規則 0.2m + 安全余裕 0.1m）
- `penaltyAreaSize().y() * 0.5`（誤用）を `penaltyAreaSize().x()`（奥行き、正しいAPI）に修正

## テスト方法

- [x] `colcon build --packages-select crane_sessions` でビルド確認（エラーなし）
- [x] rosbag `rosbag2_2026_03_20-03_27_24` にて ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA ファウル 0 件を確認（修正前は多数発生）

🤖 Generated with [Claude Code](https://claude.com/claude-code)