### PR TITLE
fix: rosbag解析でチームカラー（味方/敵）が判別できない問題を修正

### DIFF
--- a/.claude/commands/analyze-rosbag.md
+++ b/.claude/commands/analyze-rosbag.md
@@ -42,6 +42,8 @@ ros2 run crane_bag crane_bag survey <rosbag_path>
 
 出力される7セクション（PLAY SITUATIONS / ROLE ASSIGNMENTS / WORLD MODEL / CONTROL_TARGETS / ROBOT VELOCITY STATUS / GAME ANALYSIS / ROSOUT WARN/ERROR）を確認し、異常箇所を特定する。
 
+**重要**: WORLD MODEL セクションのヘッダーに `[OUR_TEAM=YELLOW]` または `[OUR_TEAM=BLUE]` が表示される。これを確認し、以降の分析レポートでは必ず「味方=○色」「敵=○色」を明記すること。`our[ID]` ラベルは crane（自チーム）のロボット、`theirs` は相手チームを指す。
+
 ### Step 3: 深掘り分析
 
 Step 2の結果とユーザーの質問に合わせて追加調査を行う。

--- a/crane_bag/src/bag/bag_survey.cpp
+++ b/crane_bag/src/bag/bag_survey.cpp
@@ -80,7 +80,10 @@ std::string section_world_model(const BagData & data, double interval)
 {
   std::ostringstream oss;
   char buf[128];
-  std::snprintf(buf, sizeof(buf), "=== WORLD MODEL (every %.0fs) ===\n", interval);
+  const char * team_color =
+    (!data.world_models.empty() && data.world_models.front().msg.is_yellow) ? "YELLOW" : "BLUE";
+  std::snprintf(
+    buf, sizeof(buf), "=== WORLD MODEL (every %.0fs) [OUR_TEAM=%s] ===\n", interval, team_color);
   oss << buf;
 
   for (const auto * tm : BagData::sample(data.world_models, interval)) {


### PR DESCRIPTION
## 概要

`analyze-rosbag` コマンドでrosbagを解析した際、Claudeが毎回敵味方を逆に解釈してしまう問題を修正。

## 背景・根本原因

`crane_bag survey` の出力に `is_yellow` フラグが含まれていなかったため、Claudeが `our[ID]` ラベルがyellowチームなのかblueチームなのか判断できなかった。

参照: WorldModelメッセージには `is_yellow` フィールドが存在するが、survey出力には含まれていなかった。

## 変更内容

- `crane_bag/src/bag/bag_survey.cpp`: WORLD MODEL セクションのヘッダーに `[OUR_TEAM=YELLOW]` / `[OUR_TEAM=BLUE]` を追加
  ```
  === WORLD MODEL (every 10s) [OUR_TEAM=YELLOW] ===
  ```
- `.claude/commands/analyze-rosbag.md`: Step 2後にチームカラーを確認して明記するよう指示を追加

## テスト方法

- [x] `colcon build --packages-select crane_bag` でビルド確認
- [ ] 既存rosbagに対して `ros2 run crane_bag crane_bag survey <path>` を実行し、`[OUR_TEAM=YELLOW]` or `[OUR_TEAM=BLUE]` が表示されることを確認
- [ ] `analyze-rosbag` スキルで解析し、敵味方が正しく判定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)