### PR TITLE
fix: crane_web_debugger の CMake CMP0167 ポリシーエラーを修正

### DIFF
--- a/crane_web_debugger/CMakeLists.txt
+++ b/crane_web_debugger/CMakeLists.txt
@@ -16,7 +16,9 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-cmake_policy(SET CMP0167 NEW)
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
 
 # WebSocket Debug Server
 ament_auto_add_executable(crane_websocket_server


### PR DESCRIPTION
## 概要
`crane_web_debugger` の CMakeLists.txt で CMake 3.30 未満の環境で未知のポリシー `CMP0167` を無条件に設定していたため CI ビルドが失敗していた問題を修正。

## 背景・根本原因
- Docker イメージ（`ros:jazzy` / Ubuntu 24.04）の CMake バージョンは **3.28.3**
- `CMP0167`（Boost の FindBoost モジュール非推奨化に関するポリシー）は **CMake 3.30** で導入
- `cmake_policy(SET CMP0167 NEW)` を無条件に呼び出すと CMake 3.28 では「Policy CMP0167 is not known」エラーとなりビルド失敗
- 参照: https://github.com/ibis-ssl/crane/actions/runs/23310938766

## 変更内容
- `cmake_policy(SET CMP0167 NEW)` を `if(POLICY CMP0167)` ガードで囲む標準イディオムに変更
- CMake 3.28（CI/Docker）: ガードがfalseになり何もしない
- CMake 3.30+（ローカル環境）: CMP0167 NEW を適用

## テスト方法
- [ ] `colcon build --packages-select crane_web_debugger` でビルド確認
- [ ] CI の docker build が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)