### PR TITLE
feat: robot_receiverの統計と非同期受信対応

### DIFF
--- a/crane_msgs/msg/RobotFeedback.msg
+++ b/crane_msgs/msg/RobotFeedback.msg
@@ -1,6 +1,10 @@
 builtin_interfaces/Time received_stamp
 uint8 robot_id
 float32 packet_frequency_hz
+float32 receive_interval_mean_ms
+float32 receive_interval_min_ms
+float32 receive_interval_max_ms
+float32 receive_interval_stddev_ms
 
 uint8 counter
 

--- a/crane_robot_receiver/src/robot_receiver_node.cpp
+++ b/crane_robot_receiver/src/robot_receiver_node.cpp
@@ -6,6 +6,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/thread.hpp>
+#include <cmath>
 #include <crane_comm/unicast.hpp>
 #include <crane_msg_wrappers/crane_visualizer_wrapper.hpp>
 #include <crane_msgs/msg/robot_feedback.hpp>
@@ -13,144 +14,194 @@
 #include <crane_robot_receiver/robot_feedback_protocol.hpp>
 #include <deque>
 #include <format>
+#include <mutex>
+#include <optional>
 #include <rclcpp/rclcpp.hpp>
+#include <thread>
 #include <unordered_set>
 
-using boost::asio::ip::udp;
+namespace asio = boost::asio;
 using crane::robot_receiver::RobotFeedback;
 namespace protocol = crane::robot_receiver::protocol;
 
 class RobotFeedbackReceiver
 {
 public:
-  RobotFeedbackReceiver(const std::string & host, const int port)
+  RobotFeedbackReceiver(asio::io_context & io_ctx, const std::string & host, const int port)
   : robot_id(port - 50100),
-    receiver_(std::make_unique<crane::UdpReceiver>(host, port)),
-    buffer_(protocol::BUFFER_SIZE),
+    async_receiver_(
+      std::make_unique<crane::AsyncUdpReceiver>(io_ctx, host, port, protocol::BUFFER_SIZE)),
     clock(RCL_ROS_TIME)
   {
-    // 初回比較時のエラー回避
-    robot_feedback.received_stamp = rclcpp::Time(0, 0, RCL_ROS_TIME);
+    async_receiver_->startReceive(
+      [this](const std::vector<char> & buf, size_t size) { onReceive(buf, size); });
   }
 
-  auto receive() -> bool
+  // asioスレッドから呼ばれる
+  void onReceive(const std::vector<char> & buf, size_t /*size*/)
   {
-    if (receiver_->available()) {
-      receiver_->receive(buffer_);
-      // 受信タイムスタンプを記録
-      receive_timestamps_.push_back(clock.now());
-      return true;
-    }
-    return false;
+    auto stamp = clock.now();
+    RobotFeedback feedback = parseBuffer(buf, stamp);
+    std::lock_guard<std::mutex> lock(mutex_);
+    latest_feedback_ = feedback;
+    receive_timestamps_.push_back(stamp);
   }
 
-  auto updateFeedback() -> void
+  // ROS2タイマーから呼ばれる
+  auto getLatestFeedback() -> std::optional<RobotFeedback>
   {
-    RobotFeedback feedback;
-    // 受信タイムスタンプを更新
-    feedback.received_stamp = clock.now();
-
-    // 基本情報
-    feedback.counter = protocol::readByte(buffer_, protocol::offset::COUNTER);
-    feedback.yaw_angle = protocol::readFloat(buffer_, protocol::offset::YAW_ANGLE);
-    feedback.voltage[0] = protocol::readFloat(buffer_, protocol::offset::VOLTAGE_0);
-
-    // ボール検出
-    feedback.ball_detection[0] = protocol::readByte(buffer_, protocol::offset::BALL_DETECTION_0);
-    feedback.ball_detection[1] = protocol::readByte(buffer_, protocol::offset::BALL_DETECTION_1);
-    feedback.ball_detection[2] = protocol::readByte(buffer_, protocol::offset::BALL_DETECTION_2);
-    feedback.ball_detection[3] = protocol::readByte(buffer_, protocol::offset::BALL_DETECTION_3);
-    feedback.kick_state =
-      protocol::readByte(buffer_, protocol::offset::KICK_STATE) * protocol::KICK_STATE_SCALE;
-
-    // エラー情報
-    feedback.error_id = protocol::readUint16(buffer_, protocol::offset::ERROR_ID);
-    feedback.error_info = protocol::readUint16(buffer_, protocol::offset::ERROR_INFO);
-    feedback.error_value = protocol::readFloat(buffer_, protocol::offset::ERROR_VALUE);
-
-    // モーター電流
-    feedback.motor_current[0] = protocol::readByte(buffer_, protocol::offset::MOTOR_CURRENT_0) /
-                                protocol::MOTOR_CURRENT_SCALE;
-    feedback.motor_current[1] = protocol::readByte(buffer_, protocol::offset::MOTOR_CURRENT_1) /
-                                protocol::MOTOR_CURRENT_SCALE;
-    feedback.motor_current[2] = protocol::readByte(buffer_, protocol::offset::MOTOR_CURRENT_2) /
-                                protocol::MOTOR_CURRENT_SCALE;
-    feedback.motor_current[3] = protocol::readByte(buffer_, protocol::offset::MOTOR_CURRENT_3) /
-                                protocol::MOTOR_CURRENT_SCALE;
-
-    // 温度
-    feedback.temperature[0] = protocol::readByte(buffer_, protocol::offset::TEMPERATURE_0);
-    feedback.temperature[1] = protocol::readByte(buffer_, protocol::offset::TEMPERATURE_1);
-    feedback.temperature[2] = protocol::readByte(buffer_, protocol::offset::TEMPERATURE_2);
-    feedback.temperature[3] = protocol::readByte(buffer_, protocol::offset::TEMPERATURE_3);
-    feedback.temperature[4] = protocol::readByte(buffer_, protocol::offset::TEMPERATURE_4);
-    feedback.temperature[5] = protocol::readByte(buffer_, protocol::offset::TEMPERATURE_5);
-    feedback.temperature[6] = protocol::readByte(buffer_, protocol::offset::TEMPERATURE_6);
-
-    // 角度と電圧
-    feedback.diff_angle = protocol::readFloat(buffer_, protocol::offset::DIFF_ANGLE);
-    feedback.voltage[1] = protocol::readFloat(buffer_, protocol::offset::VOLTAGE_1);
-
-    // オドメトリ
-    feedback.odom[0] = protocol::readFloat(buffer_, protocol::offset::ODOM_X);
-    feedback.odom[1] = protocol::readFloat(buffer_, protocol::offset::ODOM_Y);
-    feedback.odom_speed[0] = protocol::readFloat(buffer_, protocol::offset::ODOM_SPEED_X);
-    feedback.odom_speed[1] = protocol::readFloat(buffer_, protocol::offset::ODOM_SPEED_Y);
-
-    feedback.check_ver = protocol::readByte(buffer_, protocol::offset::CHECK_VER);
-
-    // マウスセンサー
-    feedback.mouse_odom[0] = protocol::readFloat(buffer_, protocol::offset::MOUSE_ODOM_X);
-    feedback.mouse_odom[1] = protocol::readFloat(buffer_, protocol::offset::MOUSE_ODOM_Y);
-    feedback.mouse_vel[0] = protocol::readFloat(buffer_, protocol::offset::MOUSE_VEL_X);
-    feedback.mouse_vel[1] = protocol::readFloat(buffer_, protocol::offset::MOUSE_VEL_Y);
-
-    // デバッグ値
-    feedback.values.clear();
-    for (size_t i = protocol::offset::DEBUG_VALUES_START;
-         i < protocol::DEBUG_VALUES_END - protocol::FLOAT_SIZE; i += protocol::FLOAT_SIZE) {
-      feedback.values.push_back(protocol::readFloat(buffer_, static_cast<int>(i)));
-    }
-
-    robot_feedback = feedback;
+    std::lock_guard<std::mutex> lock(mutex_);
+    return latest_feedback_;
   }
 
-  auto getFeedback() const -> RobotFeedback { return robot_feedback; }
+  struct IntervalStats
+  {
+    float mean_ms = 0.f;
+    float min_ms = 0.f;
+    float max_ms = 0.f;
+    float stddev_ms = 0.f;
+  };
 
   auto getPacketFrequency() -> float
   {
-    using std::chrono::operator""ms;
-    auto now = clock.now();
+    std::lock_guard<std::mutex> lock(mutex_);
+    pruneTimestampsLocked();
+    return static_cast<float>(receive_timestamps_.size());
+  }
 
-    // 1秒より古いタイムスタンプを削除
-    while (!receive_timestamps_.empty() && (now - receive_timestamps_.front()) > 1000ms) {
-      receive_timestamps_.pop_front();
+  auto getReceiveIntervalStats() -> IntervalStats
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    pruneTimestampsLocked();
+    if (receive_timestamps_.size() < 2) {
+      return {};
     }
 
-    // 最近1秒間の受信回数を返す
-    return static_cast<float>(receive_timestamps_.size());
+    std::vector<float> intervals;
+    intervals.reserve(receive_timestamps_.size() - 1);
+    for (size_t i = 1; i < receive_timestamps_.size(); ++i) {
+      float dt = static_cast<float>(
+        (receive_timestamps_[i] - receive_timestamps_[i - 1]).nanoseconds() * 1e-6);
+      intervals.push_back(dt);
+    }
+
+    float sum = 0.f;
+    float min_val = intervals[0];
+    float max_val = intervals[0];
+    for (float v : intervals) {
+      sum += v;
+      if (v < min_val) min_val = v;
+      if (v > max_val) max_val = v;
+    }
+    float mean = sum / static_cast<float>(intervals.size());
+
+    float var = 0.f;
+    for (float v : intervals) {
+      float d = v - mean;
+      var += d * d;
+    }
+    float stddev = std::sqrt(var / static_cast<float>(intervals.size()));
+
+    return {mean, min_val, max_val, stddev};
   }
 
   const int robot_id;
 
 private:
-  std::unique_ptr<crane::UdpReceiver> receiver_;
+  auto parseBuffer(const std::vector<char> & buf, rclcpp::Time stamp) -> RobotFeedback
+  {
+    RobotFeedback feedback;
+    feedback.received_stamp = stamp;
 
-  std::vector<char> buffer_;
+    // 基本情報
+    feedback.counter = protocol::readByte(buf, protocol::offset::COUNTER);
+    feedback.yaw_angle = protocol::readFloat(buf, protocol::offset::YAW_ANGLE);
+    feedback.voltage[0] = protocol::readFloat(buf, protocol::offset::VOLTAGE_0);
 
-  RobotFeedback robot_feedback;
+    // ボール検出
+    feedback.ball_detection[0] = protocol::readByte(buf, protocol::offset::BALL_DETECTION_0);
+    feedback.ball_detection[1] = protocol::readByte(buf, protocol::offset::BALL_DETECTION_1);
+    feedback.ball_detection[2] = protocol::readByte(buf, protocol::offset::BALL_DETECTION_2);
+    feedback.ball_detection[3] = protocol::readByte(buf, protocol::offset::BALL_DETECTION_3);
+    feedback.kick_state =
+      protocol::readByte(buf, protocol::offset::KICK_STATE) * protocol::KICK_STATE_SCALE;
 
-  rclcpp::Clock clock;
+    // エラー情報
+    feedback.error_id = protocol::readUint16(buf, protocol::offset::ERROR_ID);
+    feedback.error_info = protocol::readUint16(buf, protocol::offset::ERROR_INFO);
+    feedback.error_value = protocol::readFloat(buf, protocol::offset::ERROR_VALUE);
 
-  // パケット受信頻度計算用のタイムスタンプキュー
+    // モーター電流
+    feedback.motor_current[0] =
+      protocol::readByte(buf, protocol::offset::MOTOR_CURRENT_0) / protocol::MOTOR_CURRENT_SCALE;
+    feedback.motor_current[1] =
+      protocol::readByte(buf, protocol::offset::MOTOR_CURRENT_1) / protocol::MOTOR_CURRENT_SCALE;
+    feedback.motor_current[2] =
+      protocol::readByte(buf, protocol::offset::MOTOR_CURRENT_2) / protocol::MOTOR_CURRENT_SCALE;
+    feedback.motor_current[3] =
+      protocol::readByte(buf, protocol::offset::MOTOR_CURRENT_3) / protocol::MOTOR_CURRENT_SCALE;
+
+    // 温度
+    feedback.temperature[0] = protocol::readByte(buf, protocol::offset::TEMPERATURE_0);
+    feedback.temperature[1] = protocol::readByte(buf, protocol::offset::TEMPERATURE_1);
+    feedback.temperature[2] = protocol::readByte(buf, protocol::offset::TEMPERATURE_2);
+    feedback.temperature[3] = protocol::readByte(buf, protocol::offset::TEMPERATURE_3);
+    feedback.temperature[4] = protocol::readByte(buf, protocol::offset::TEMPERATURE_4);
+    feedback.temperature[5] = protocol::readByte(buf, protocol::offset::TEMPERATURE_5);
+    feedback.temperature[6] = protocol::readByte(buf, protocol::offset::TEMPERATURE_6);
+
+    // 角度と電圧
+    feedback.diff_angle = protocol::readFloat(buf, protocol::offset::DIFF_ANGLE);
+    feedback.voltage[1] = protocol::readFloat(buf, protocol::offset::VOLTAGE_1);
+
+    // オドメトリ
+    feedback.odom[0] = protocol::readFloat(buf, protocol::offset::ODOM_X);
+    feedback.odom[1] = protocol::readFloat(buf, protocol::offset::ODOM_Y);
+    feedback.odom_speed[0] = protocol::readFloat(buf, protocol::offset::ODOM_SPEED_X);
+    feedback.odom_speed[1] = protocol::readFloat(buf, protocol::offset::ODOM_SPEED_Y);
+
+    feedback.check_ver = protocol::readByte(buf, protocol::offset::CHECK_VER);
+
+    // マウスセンサー
+    feedback.mouse_odom[0] = protocol::readFloat(buf, protocol::offset::MOUSE_ODOM_X);
+    feedback.mouse_odom[1] = protocol::readFloat(buf, protocol::offset::MOUSE_ODOM_Y);
+    feedback.mouse_vel[0] = protocol::readFloat(buf, protocol::offset::MOUSE_VEL_X);
+    feedback.mouse_vel[1] = protocol::readFloat(buf, protocol::offset::MOUSE_VEL_Y);
+
+    // デバッグ値
+    feedback.values.clear();
+    for (size_t i = protocol::offset::DEBUG_VALUES_START;
+         i < protocol::DEBUG_VALUES_END - protocol::FLOAT_SIZE; i += protocol::FLOAT_SIZE) {
+      feedback.values.push_back(protocol::readFloat(buf, static_cast<int>(i)));
+    }
+
+    return feedback;
+  }
+
+  // mutex_ を保持した状態で呼ぶこと
+  void pruneTimestampsLocked()
+  {
+    using std::chrono::operator""ms;
+    auto now = clock.now();
+    while (!receive_timestamps_.empty() && (now - receive_timestamps_.front()) > 1000ms) {
+      receive_timestamps_.pop_front();
+    }
+  }
+
+  std::unique_ptr<crane::AsyncUdpReceiver> async_receiver_;
+  std::mutex mutex_;
+  std::optional<RobotFeedback> latest_feedback_;
   std::deque<rclcpp::Time> receive_timestamps_;
+  rclcpp::Clock clock;
 };
 
 class RobotReceiverNode : public rclcpp::Node
 {
 public:
   explicit RobotReceiverNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
-  : rclcpp::Node("robot_receiver_node", options), clock(RCL_ROS_TIME)
+  : rclcpp::Node("robot_receiver_node", options),
+    work_guard_(asio::make_work_guard(io_context_)),
+    clock(RCL_ROS_TIME)
   {
     crane::CraneVisualizerBuffer::activate(*this);
     publisher = create_publisher<crane_msgs::msg::RobotFeedbackArray>("/robot_feedback", 10);
@@ -169,63 +220,82 @@ public:
     for (int i = 0; i <= max_robot_id; i++) {
       std::string ip;
       if (sim_mode) {
-        // シミュレータモード: 127.0.0.1 (固定)
         ip = "127.0.0.1";
       } else {
-        // 実機モード: 224.5.20.{100+robot_id}
         ip = std::format("{}.{}", ip_base, i + ip_offset);
       }
       int port = port_base + i;
-      receivers.push_back(std::make_shared<RobotFeedbackReceiver>(ip, port));
+      receivers.push_back(std::make_shared<RobotFeedbackReceiver>(io_context_, ip, port));
     }
 
+    // asioイベントループを専用スレッドで開始
+    io_thread_ = std::thread([this]() { io_context_.run(); });
+
     using std::chrono::operator""ms;
+    using std::chrono::operator""s;
+    log_timer = rclcpp::create_timer(this, get_clock(), 5s, [&]() {
+      for (auto & receiver : receivers) {
+        float freq = receiver->getPacketFrequency();
+        if (freq <= 0.f) continue;
+        auto stats = receiver->getReceiveIntervalStats();
+        RCLCPP_INFO(
+          get_logger(),
+          "[Robot %d] interval: mean=%.1fms, min=%.1fms, max=%.1fms, stddev=%.1fms, freq=%.1fHz",
+          receiver->robot_id, stats.mean_ms, stats.min_ms, stats.max_ms, stats.stddev_ms, freq);
+      }
+    });
+
     timer = rclcpp::create_timer(this, get_clock(), 10ms, [&]() {
       crane_msgs::msg::RobotFeedbackArray msg;
 
       auto now = clock.now();
       for (auto & receiver : receivers) {
-        while (receiver->receive()) {
-          receiver->updateFeedback();
-        }
+        auto robot_feedback = receiver->getLatestFeedback();
+        if (!robot_feedback) continue;
 
         // 古いデータは入れない(100msより古いデータはVisionより価値が薄い可能性が高い)
-        if (
-          auto robot_feedback = receiver->getFeedback();
-          (now - robot_feedback.received_stamp) < 100ms) {
-          crane_msgs::msg::RobotFeedback robot_feedback_msg;
-          robot_feedback_msg.received_stamp = robot_feedback.received_stamp;
-          robot_feedback_msg.robot_id = receiver->robot_id;
-          robot_feedback_msg.packet_frequency_hz = receiver->getPacketFrequency();
-          robot_feedback_msg.counter = robot_feedback.counter;
-          robot_feedback_msg.kick_state = robot_feedback.kick_state;
-          robot_feedback_msg.temperatures.assign(
-            std::begin(robot_feedback.temperature), std::end(robot_feedback.temperature));
+        using std::chrono::operator""ms;
+        if ((now - robot_feedback->received_stamp) >= 100ms) continue;
 
-          robot_feedback_msg.error_id = robot_feedback.error_id;
-          robot_feedback_msg.error_info = robot_feedback.error_info;
-          robot_feedback_msg.error_value = robot_feedback.error_value;
-
-          robot_feedback_msg.motor_current.assign(
-            std::begin(robot_feedback.motor_current), std::end(robot_feedback.motor_current));
-          robot_feedback_msg.ball_detection.assign(
-            std::begin(robot_feedback.ball_detection), std::end(robot_feedback.ball_detection));
-          robot_feedback_msg.ball_sensor = (robot_feedback_msg.ball_detection[0] == 1);
-          robot_feedback_msg.yaw_angle = robot_feedback.yaw_angle;
-          robot_feedback_msg.diff_angle = robot_feedback.diff_angle;
-          robot_feedback_msg.odom.assign(robot_feedback.odom.begin(), robot_feedback.odom.end());
-          robot_feedback_msg.odom_speed.assign(
-            robot_feedback.odom_speed.begin(), robot_feedback.odom_speed.end());
-          robot_feedback_msg.mouse_odom.assign(
-            robot_feedback.mouse_odom.begin(), robot_feedback.mouse_odom.end());
-          robot_feedback_msg.mouse_vel.assign(
-            robot_feedback.mouse_vel.begin(), robot_feedback.mouse_vel.end());
-          robot_feedback_msg.voltage.assign(
-            robot_feedback.voltage.begin(), robot_feedback.voltage.end());
-          robot_feedback_msg.check_ver = robot_feedback.check_ver;
-          robot_feedback_msg.values = robot_feedback.values;
-          msg.feedback.push_back(robot_feedback_msg);
+        crane_msgs::msg::RobotFeedback robot_feedback_msg;
+        robot_feedback_msg.received_stamp = robot_feedback->received_stamp;
+        robot_feedback_msg.robot_id = receiver->robot_id;
+        robot_feedback_msg.packet_frequency_hz = receiver->getPacketFrequency();
+        {
+          auto stats = receiver->getReceiveIntervalStats();
+          robot_feedback_msg.receive_interval_mean_ms = stats.mean_ms;
+          robot_feedback_msg.receive_interval_min_ms = stats.min_ms;
+          robot_feedback_msg.receive_interval_max_ms = stats.max_ms;
+          robot_feedback_msg.receive_interval_stddev_ms = stats.stddev_ms;
         }
+        robot_feedback_msg.counter = robot_feedback->counter;
+        robot_feedback_msg.kick_state = robot_feedback->kick_state;
+        robot_feedback_msg.temperatures.assign(
+          std::begin(robot_feedback->temperature), std::end(robot_feedback->temperature));
+
+        robot_feedback_msg.error_id = robot_feedback->error_id;
+        robot_feedback_msg.error_info = robot_feedback->error_info;
+        robot_feedback_msg.error_value = robot_feedback->error_value;
+
+        robot_feedback_msg.motor_current.assign(
+          std::begin(robot_feedback->motor_current), std::end(robot_feedback->motor_current));
+        robot_feedback_msg.ball_detection.assign(
+          std::begin(robot_feedback->ball_detection), std::end(robot_feedback->ball_detection));
+        robot_feedback_msg.ball_sensor = (robot_feedback_msg.ball_detection[0] == 1);
+        robot_feedback_msg.yaw_angle = robot_feedback->yaw_angle;
+        robot_feedback_msg.diff_angle = robot_feedback->diff_angle;
+        robot_feedback_msg.odom.assign(robot_feedback->odom.begin(), robot_feedback->odom.end());
+        robot_feedback_msg.odom_speed.assign(
+          robot_feedback->odom_speed.begin(), robot_feedback->odom_speed.end());
+        robot_feedback_msg.mouse_odom.assign(
+          robot_feedback->mouse_odom.begin(), robot_feedback->mouse_odom.end());
+        robot_feedback_msg.mouse_vel.assign(
+          robot_feedback->mouse_vel.begin(), robot_feedback->mouse_vel.end());
+        robot_feedback_msg.voltage.assign(
+          robot_feedback->voltage.begin(), robot_feedback->voltage.end());
+        robot_feedback_msg.check_ver = robot_feedback->check_ver;
+        robot_feedback_msg.values = robot_feedback->values;
+        msg.feedback.push_back(robot_feedback_msg);
       }
       publisher->publish(msg);
       visualizer->flush();
@@ -233,7 +303,19 @@ public:
     });
   }
 
+  ~RobotReceiverNode()
+  {
+    work_guard_.reset();
+    io_context_.stop();
+    if (io_thread_.joinable()) io_thread_.join();
+  }
+
+  asio::io_context io_context_;
+  asio::executor_work_guard<asio::io_context::executor_type> work_guard_;
+  std::thread io_thread_;
+
   rclcpp::TimerBase::SharedPtr timer;
+  rclcpp::TimerBase::SharedPtr log_timer;
 
   std::vector<std::shared_ptr<RobotFeedbackReceiver>> receivers;
 

--- a/crane_robot_receiver/src/robot_receiver_node.cpp
+++ b/crane_robot_receiver/src/robot_receiver_node.cpp
@@ -14,6 +14,7 @@
 #include <crane_robot_receiver/robot_feedback_protocol.hpp>
 #include <deque>
 #include <format>
+#include <limits>
 #include <mutex>
 #include <optional>
 #include <rclcpp/rclcpp.hpp>
@@ -62,47 +63,23 @@ public:
     float stddev_ms = 0.f;
   };
 
-  auto getPacketFrequency() -> float
+  struct ReceiverStats
+  {
+    float packet_frequency_hz = 0.f;
+    IntervalStats interval;
+  };
+
+  // 周波数と受信間隔統計を1回のロックでまとめて取得する
+  auto getStats() -> ReceiverStats
   {
     std::lock_guard<std::mutex> lock(mutex_);
     pruneTimestampsLocked();
-    return static_cast<float>(receive_timestamps_.size());
-  }
-
-  auto getReceiveIntervalStats() -> IntervalStats
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    pruneTimestampsLocked();
-    if (receive_timestamps_.size() < 2) {
-      return {};
+    ReceiverStats result;
+    result.packet_frequency_hz = static_cast<float>(receive_timestamps_.size());
+    if (receive_timestamps_.size() >= 2) {
+      result.interval = computeIntervalStatsLocked();
     }
-
-    std::vector<float> intervals;
-    intervals.reserve(receive_timestamps_.size() - 1);
-    for (size_t i = 1; i < receive_timestamps_.size(); ++i) {
-      float dt = static_cast<float>(
-        (receive_timestamps_[i] - receive_timestamps_[i - 1]).nanoseconds() * 1e-6);
-      intervals.push_back(dt);
-    }
-
-    float sum = 0.f;
-    float min_val = intervals[0];
-    float max_val = intervals[0];
-    for (float v : intervals) {
-      sum += v;
-      if (v < min_val) min_val = v;
-      if (v > max_val) max_val = v;
-    }
-    float mean = sum / static_cast<float>(intervals.size());
-
-    float var = 0.f;
-    for (float v : intervals) {
-      float d = v - mean;
-      var += d * d;
-    }
-    float stddev = std::sqrt(var / static_cast<float>(intervals.size()));
-
-    return {mean, min_val, max_val, stddev};
+    return result;
   }
 
   const int robot_id;
@@ -188,6 +165,31 @@ private:
     }
   }
 
+  // mutex_ を保持した状態で呼ぶこと。サイズが2以上であることを確認してから呼ぶ
+  auto computeIntervalStatsLocked() -> IntervalStats
+  {
+    const size_t n = receive_timestamps_.size() - 1;
+    float sum = 0.f;
+    float min_val = std::numeric_limits<float>::max();
+    float max_val = std::numeric_limits<float>::lowest();
+    for (size_t i = 1; i <= n; ++i) {
+      float dt = static_cast<float>(
+        (receive_timestamps_[i] - receive_timestamps_[i - 1]).nanoseconds() * 1e-6);
+      sum += dt;
+      if (dt < min_val) min_val = dt;
+      if (dt > max_val) max_val = dt;
+    }
+    float mean = sum / static_cast<float>(n);
+    float var = 0.f;
+    for (size_t i = 1; i <= n; ++i) {
+      float dt = static_cast<float>(
+        (receive_timestamps_[i] - receive_timestamps_[i - 1]).nanoseconds() * 1e-6);
+      float d = dt - mean;
+      var += d * d;
+    }
+    return {mean, min_val, max_val, std::sqrt(var / static_cast<float>(n))};
+  }
+
   std::unique_ptr<crane::AsyncUdpReceiver> async_receiver_;
   std::mutex mutex_;
   std::optional<RobotFeedback> latest_feedback_;
@@ -235,13 +237,13 @@ public:
     using std::chrono::operator""s;
     log_timer = rclcpp::create_timer(this, get_clock(), 5s, [&]() {
       for (auto & receiver : receivers) {
-        float freq = receiver->getPacketFrequency();
-        if (freq <= 0.f) continue;
-        auto stats = receiver->getReceiveIntervalStats();
+        auto s = receiver->getStats();
+        if (s.packet_frequency_hz <= 0.f) continue;
         RCLCPP_INFO(
           get_logger(),
           "[Robot %d] interval: mean=%.1fms, min=%.1fms, max=%.1fms, stddev=%.1fms, freq=%.1fHz",
-          receiver->robot_id, stats.mean_ms, stats.min_ms, stats.max_ms, stats.stddev_ms, freq);
+          receiver->robot_id, s.interval.mean_ms, s.interval.min_ms, s.interval.max_ms,
+          s.interval.stddev_ms, s.packet_frequency_hz);
       }
     });
 
@@ -260,13 +262,13 @@ public:
         crane_msgs::msg::RobotFeedback robot_feedback_msg;
         robot_feedback_msg.received_stamp = robot_feedback->received_stamp;
         robot_feedback_msg.robot_id = receiver->robot_id;
-        robot_feedback_msg.packet_frequency_hz = receiver->getPacketFrequency();
         {
-          auto stats = receiver->getReceiveIntervalStats();
-          robot_feedback_msg.receive_interval_mean_ms = stats.mean_ms;
-          robot_feedback_msg.receive_interval_min_ms = stats.min_ms;
-          robot_feedback_msg.receive_interval_max_ms = stats.max_ms;
-          robot_feedback_msg.receive_interval_stddev_ms = stats.stddev_ms;
+          auto s = receiver->getStats();
+          robot_feedback_msg.packet_frequency_hz = s.packet_frequency_hz;
+          robot_feedback_msg.receive_interval_mean_ms = s.interval.mean_ms;
+          robot_feedback_msg.receive_interval_min_ms = s.interval.min_ms;
+          robot_feedback_msg.receive_interval_max_ms = s.interval.max_ms;
+          robot_feedback_msg.receive_interval_stddev_ms = s.interval.stddev_ms;
         }
         robot_feedback_msg.counter = robot_feedback->counter;
         robot_feedback_msg.kick_state = robot_feedback->kick_state;
@@ -310,19 +312,20 @@ public:
     if (io_thread_.joinable()) io_thread_.join();
   }
 
-  asio::io_context io_context_;
-  asio::executor_work_guard<asio::io_context::executor_type> work_guard_;
-  std::thread io_thread_;
-
-  rclcpp::TimerBase::SharedPtr timer;
-  rclcpp::TimerBase::SharedPtr log_timer;
-
   std::vector<std::shared_ptr<RobotFeedbackReceiver>> receivers;
 
   rclcpp::Publisher<crane_msgs::msg::RobotFeedbackArray>::SharedPtr publisher;
 
   crane::VisualizerMessageBuilder::SharedPtr visualizer =
     std::make_shared<crane::VisualizerMessageBuilder>("robot_receiver");
+
+private:
+  asio::io_context io_context_;
+  asio::executor_work_guard<asio::io_context::executor_type> work_guard_;
+  std::thread io_thread_;
+
+  rclcpp::TimerBase::SharedPtr timer;
+  rclcpp::TimerBase::SharedPtr log_timer;
 
   rclcpp::Clock clock;
 };

--- a/utility/crane_comm/include/crane_comm/unicast.hpp
+++ b/utility/crane_comm/include/crane_comm/unicast.hpp
@@ -21,6 +21,7 @@
 
 #include <boost/asio.hpp>
 #include <exception>
+#include <functional>
 #include <rclcpp/logging.hpp>
 #include <stdexcept>
 #include <string>
@@ -146,6 +147,108 @@ private:
   asio::io_context io_context;
 
   asio::ip::udp::socket socket;
+};
+
+class AsyncUdpReceiver
+{
+public:
+  AsyncUdpReceiver(
+    asio::io_context & io_ctx, const std::string & host, const int port, size_t buffer_size = 2048)
+  : socket_(io_ctx, asio::ip::udp::v4()), recv_buffer_(buffer_size)
+  {
+    asio::ip::address addr = asio::ip::address::from_string(host);
+    boost::system::error_code ec;
+
+    socket_.set_option(asio::socket_base::reuse_address(true), ec);
+    socket_.set_option(reuse_port(true), ec);
+
+    if (addr.is_multicast()) {
+      socket_.bind(asio::ip::udp::endpoint(asio::ip::udp::v4(), port), ec);
+      if (ec) {
+        RCLCPP_ERROR(
+          rclcpp::get_logger("crane_comm"), "[ERROR] bind失敗: %s", ec.message().c_str());
+        throw std::runtime_error("bind failed: " + ec.message());
+      }
+
+      try {
+        struct ifaddrs * interfaces = nullptr;
+        if (getifaddrs(&interfaces) == -1) {
+          throw std::runtime_error("Error: getifaddrs failed.");
+        }
+
+        std::unordered_set<std::string> joined_interfaces;
+        for (struct ifaddrs * ifa = interfaces; ifa != nullptr; ifa = ifa->ifa_next) {
+          if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET) continue;
+
+          char ip[INET_ADDRSTRLEN];
+          auto * addr_in = reinterpret_cast<struct sockaddr_in *>(ifa->ifa_addr);
+          inet_ntop(AF_INET, &(addr_in->sin_addr), ip, INET_ADDRSTRLEN);
+
+          std::string if_name(ifa->ifa_name);
+          if (joined_interfaces.count(if_name) > 0) continue;
+
+          boost::asio::ip::detail::socket_option::multicast_request<
+            IPPROTO_IP, IP_ADD_MEMBERSHIP, IPPROTO_IPV6, IPV6_JOIN_GROUP>
+            join_device(addr.to_v4(), asio::ip::address::from_string(ip).to_v4());
+
+          boost::system::error_code join_ec;
+          socket_.set_option(join_device, join_ec);
+          if (!join_ec) {
+            joined_interfaces.insert(if_name);
+          }
+        }
+        freeifaddrs(interfaces);
+      } catch (std::exception & e) {
+        RCLCPP_ERROR(rclcpp::get_logger("crane_comm"), "%s", e.what());
+      }
+    } else {
+      socket_.bind(asio::ip::udp::endpoint(addr, port), ec);
+      if (ec) {
+        RCLCPP_ERROR(
+          rclcpp::get_logger("crane_comm"), "[ERROR] bind失敗: %s", ec.message().c_str());
+        throw std::runtime_error("bind failed: " + ec.message());
+      }
+    }
+  }
+
+  void startReceive(std::function<void(const std::vector<char> &, size_t)> callback)
+  {
+    callback_ = std::move(callback);
+    running_ = true;
+    doReceive();
+  }
+
+  void stop()
+  {
+    running_ = false;
+    boost::system::error_code ec;
+    socket_.cancel(ec);
+  }
+
+private:
+  void doReceive()
+  {
+    socket_.async_receive_from(
+      asio::buffer(recv_buffer_), sender_endpoint_,
+      [this](const boost::system::error_code & ec, size_t bytes_transferred) {
+        if (!ec) {
+          try {
+            callback_(recv_buffer_, bytes_transferred);
+          } catch (const std::exception & e) {
+            RCLCPP_ERROR(rclcpp::get_logger("crane_comm"), "受信コールバックエラー: %s", e.what());
+          }
+        } else if (ec != asio::error::operation_aborted) {
+          RCLCPP_ERROR(rclcpp::get_logger("crane_comm"), "UDP受信エラー: %s", ec.message().c_str());
+        }
+        if (running_) doReceive();
+      });
+  }
+
+  asio::ip::udp::socket socket_;
+  asio::ip::udp::endpoint sender_endpoint_;
+  std::vector<char> recv_buffer_;
+  std::function<void(const std::vector<char> &, size_t)> callback_;
+  bool running_ = false;
 };
 
 }  // namespace crane


### PR DESCRIPTION
## 概要
robot_receiverノードに統計情報の収集と非同期受信機能を追加する。

## 背景・根本原因
ロボットからの受信パフォーマンスを計測・可視化するための統計機能と、受信処理の効率化のための非同期対応が必要だった。

## 変更内容
- `crane_msgs/msg/RobotFeedback.msg`: 統計情報フィールドを追加
- `crane_robot_receiver/src/robot_receiver_node.cpp`: 統計収集ロジックと非同期受信処理を実装
- `utility/crane_comm/include/crane_comm/unicast.hpp`: ユニキャスト通信のヘッダに非同期受信サポートを追加
