### PR TITLE
refactor: ペナルティエリア迂回の角選択ロジックをshortest total pathに統一

### DIFF
--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -679,55 +679,22 @@ auto RVO2Planner::adjustForPenaltyAreaAvoidance(
           target_pos += (target_pos - goal_pos).normalized() * 0.05;
         }
       }
-      // ペナルティエリアを通り抜ける場合は、一旦角に
+      // ペナルティエリアを通り抜ける場合は、総移動距離が短い方の角を経由
+      // estimatePenaltyAwareDistance と同じ選択ロジックで一貫性を保つ
       Segment move_line(current_pos, target_pos);
       if (bg::intersects(move_line, penalty_area)) {
         const auto penalty_area_size = world_model->penaltyAreaSize();
-        Point corner_1 = goal_pos + Point(
-                                      std::copysign(penalty_area_size.x(), -goal_pos.x()),
-                                      world_model->penaltyAreaSize().y() * 0.5);
-        Point around_corner_1 =
-          goal_pos + Point(
-                       std::copysign(penalty_area_size.x() + SURROUNDING_OFFSET, -goal_pos.x()),
-                       world_model->penaltyAreaSize().y() * 0.5 + SURROUNDING_OFFSET);
+        const double x_offset =
+          std::copysign(penalty_area_size.x() + SURROUNDING_OFFSET, -goal_pos.x());
+        const double half_height = penalty_area_size.y() * 0.5 + SURROUNDING_OFFSET;
+        const Point around_corner_1 = goal_pos + Point(x_offset, half_height);
+        const Point around_corner_2 = goal_pos + Point(x_offset, -half_height);
 
-        Point corner_2 = goal_pos + Point(
-                                      std::copysign(penalty_area_size.x(), -goal_pos.x()),
-                                      -world_model->penaltyAreaSize().y() * 0.5);
-        Point around_corner_2 =
-          goal_pos + Point(
-                       std::copysign(penalty_area_size.x() + SURROUNDING_OFFSET, -goal_pos.x()),
-                       -world_model->penaltyAreaSize().y() * 0.5 - SURROUNDING_OFFSET);
-
-        auto [distance_1, closest_point_1] = getClosestPointAndDistance(corner_1, move_line);
-        auto [distance_2, closest_point_2] = getClosestPointAndDistance(corner_2, move_line);
-
-        const double penalty_area_min_x = world_model->fieldSize().x() * 0.5 -
-                                          world_model->penaltyAreaSize().x() - PENALTY_AREA_OFFSET;
-        if (
-          std::abs(closest_point_1.x()) > penalty_area_min_x &&
-          std::abs(closest_point_2.x()) > penalty_area_min_x) {
-          // 横切る場合は、近い方の角に向かう
-          if (bg::distance(corner_1, current_pos) < bg::distance(corner_2, current_pos)) {
-            target_pos = around_corner_1;
-          } else {
-            target_pos = around_corner_2;
-          }
-        } else if (isInBox(penalty_area, closest_point_1, PENALTY_AREA_OFFSET)) {
-          target_pos = around_corner_1;
-        } else if (isInBox(penalty_area, closest_point_2, PENALTY_AREA_OFFSET)) {
-          target_pos = around_corner_2;
-        } else {
-          static rclcpp::Clock steady_clock(RCL_STEADY_TIME);
-          RCLCPP_WARN_THROTTLE(
-            rclcpp::get_logger("rvo2_local_planner"), steady_clock, 1000,
-            "Failed to find a target position outside the penalty area. Fallback to current "
-            "position. current_pos:(%.3f, %.3f) target_pos:(%.3f, %.3f) "
-            "closest_point_1:(%.3f, %.3f) closest_point_2:(%.3f, %.3f)",
-            current_pos.x(), current_pos.y(), target_pos.x(), target_pos.y(), closest_point_1.x(),
-            closest_point_1.y(), closest_point_2.x(), closest_point_2.y());
-          target_pos = current_pos;
-        }
+        const double dist_via_1 =
+          (around_corner_1 - current_pos).norm() + (target_pos - around_corner_1).norm();
+        const double dist_via_2 =
+          (around_corner_2 - current_pos).norm() + (target_pos - around_corner_2).norm();
+        target_pos = (dist_via_1 <= dist_via_2) ? around_corner_1 : around_corner_2;
       }
     };
 


### PR DESCRIPTION
## 概要
`adjustForPenaltyAreaAvoidance` の交差時ロジックを `estimatePenaltyAwareDistance` と同じ「総移動距離が短い方の角を選択」に統一し、コードを大幅に簡素化。

## 背景・根本原因
- 旧実装は4分岐の条件判定で角を選択していたが、`estimatePenaltyAwareDistance`（距離推定側）はシンプルに shortest total path を使っており、選択基準が不一致だった
- フォールバックケース（どの条件にも合致しない場合）で `target_pos = current_pos`（その場に停止）という不適切な動作が残っていた

## 変更内容
- ペナルティエリア交差時の4分岐条件を廃止し、`estimatePenaltyAwareDistance` と同じ「総移動距離が短い方の角を選択」に統一
- 不要な中間変数（`corner_1/2`, `closest_point_1/2`, `distance_1/2`, `penalty_area_min_x`）を削除
- 停止フォールバック（`target_pos = current_pos`）と WARN ログを除去
- `x_offset` / `half_height` を変数に抽出し、`penalty_aware_distance.hpp` と同スタイルに統一

## テスト方法
- [x] `colcon build --packages-select crane_local_planner` でビルド確認（警告・エラーなし）
- [ ] シミュレーションでペナルティエリア迂回動作の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)