### PR TITLE
refactor: /aggregated_svgs レイヤー名を整理・統一する

### DIFF
--- a/crane_ball_calibration_ui/package.xml
+++ b/crane_ball_calibration_ui/package.xml
@@ -10,7 +10,9 @@
   <maintainer email="ibis.ssl.team@gmail.com">ibis-ssl</maintainer>
   <license>MIT</license>
 
+  <exec_depend>python3-fastapi</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-pydantic</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclpy</exec_depend>
 

--- a/crane_game_analyzer/include/crane_game_analyzer/kick_event_detector.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/kick_event_detector.hpp
@@ -38,7 +38,8 @@ class KickEventDetector
 {
 public:
   KickEventDetector()
-  : ros_clock(RCL_ROS_TIME), visualizer(std::make_shared<VisualizerMessageBuilder>("kick_event"))
+  : ros_clock(RCL_ROS_TIME),
+    visualizer(std::make_shared<VisualizerMessageBuilder>("analyzer/kick_event"))
   {
   }
 

--- a/crane_game_analyzer/src/crane_game_analyzer.cpp
+++ b/crane_game_analyzer/src/crane_game_analyzer.cpp
@@ -26,7 +26,7 @@ namespace crane
 
 GameAnalyzerComponent::GameAnalyzerComponent(const rclcpp::NodeOptions & options)
 : Node("crane_game_analyzer", options),
-  visualizer(std::make_shared<VisualizerMessageBuilder>("game_analyzer"))
+  visualizer(std::make_shared<VisualizerMessageBuilder>("analyzer"))
 {
   RCLCPP_INFO(get_logger(), "GameAnalyzer is constructed.");
 

--- a/crane_local_planner/include/crane_local_planner/planner_base.hpp
+++ b/crane_local_planner/include/crane_local_planner/planner_base.hpp
@@ -19,7 +19,7 @@ class LocalPlannerBase
 {
 public:
   LocalPlannerBase(const std::string & name, rclcpp::Node & node)
-  : visualizer(std::make_shared<VisualizerMessageBuilder>("local_planner/" + name))
+  : visualizer(std::make_shared<VisualizerMessageBuilder>("planner/" + name))
   {
     world_model = std::make_shared<WorldModelWrapper>(node);
 

--- a/crane_robot_receiver/src/diagnostic_publisher.cpp
+++ b/crane_robot_receiver/src/diagnostic_publisher.cpp
@@ -273,7 +273,7 @@ DiagnosticPublisherNode::DiagnosticPublisherNode() : Node("diagnostic_publisher_
 
   // 可視化用のCraneVisualizerBufferを初期化
   CraneVisualizerBuffer::activate(*this);
-  visualizer_error = std::make_shared<VisualizerMessageBuilder>("diagnostic_errors");
+  visualizer_error = std::make_shared<VisualizerMessageBuilder>("receiver/diagnostic");
 
   // WorldModelの設定（ロボットデータ初期化より先に必要）
   world_model = std::make_unique<WorldModelWrapper>(*this);

--- a/crane_robot_receiver/src/robot_receiver_node.cpp
+++ b/crane_robot_receiver/src/robot_receiver_node.cpp
@@ -317,7 +317,7 @@ public:
   rclcpp::Publisher<crane_msgs::msg::RobotFeedbackArray>::SharedPtr publisher;
 
   crane::VisualizerMessageBuilder::SharedPtr visualizer =
-    std::make_shared<crane::VisualizerMessageBuilder>("robot_receiver");
+    std::make_shared<crane::VisualizerMessageBuilder>("receiver/feedback");
 
 private:
   asio::io_context io_context_;

--- a/crane_robot_skills/include/crane_robot_skills/attacker.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/attacker.hpp
@@ -36,7 +36,7 @@ public:
   template <typename... Args>
   explicit Attacker(Args &&... args)
   : SkillBaseWithState(
-      static_cast<int>(AttackerState::ENTRY_POINT), &Attacker::getStateName, "Attacker",
+      static_cast<int>(AttackerState::ENTRY_POINT), &Attacker::getStateName, "attacker",
       std::forward<Args>(args)...),
     kick_skill(command),
     goal_kick_skill(command),

--- a/crane_robot_skills/include/crane_robot_skills/ball_nearby_positioner.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/ball_nearby_positioner.hpp
@@ -18,7 +18,7 @@ class BallNearByPositioner : public SkillBase
 public:
   template <typename... Args>
   explicit BallNearByPositioner(Args &&... args)
-  : SkillBase("BallNearByPositioner", std::forward<Args>(args)...)
+  : SkillBase("ball_positioner", std::forward<Args>(args)...)
   {
     // このロボットのインデックス
     setParameter("current_robot_index", 0);

--- a/crane_robot_skills/include/crane_robot_skills/emplace_robot.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/emplace_robot.hpp
@@ -16,7 +16,7 @@ class EmplaceRobot : public SkillBase
 {
 public:
   template <typename... Args>
-  explicit EmplaceRobot(Args &&... args) : SkillBase("EmplaceRobot", std::forward<Args>(args)...)
+  explicit EmplaceRobot(Args &&... args) : SkillBase("emplace_robot", std::forward<Args>(args)...)
   {
     // このロボットのインデックス
     setParameter("current_robot_index", 0);

--- a/crane_robot_skills/include/crane_robot_skills/forward.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/forward.hpp
@@ -17,7 +17,7 @@ class Forward : public SkillBase
 {
 public:
   template <typename... Args>
-  explicit Forward(Args &&... args) : SkillBase("Forward", std::forward<Args>(args)...)
+  explicit Forward(Args &&... args) : SkillBase("forward", std::forward<Args>(args)...)
   {
     // 敵陣側
     setParameter("front_point", Point(0, 0));

--- a/crane_robot_skills/include/crane_robot_skills/goal_kick.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/goal_kick.hpp
@@ -19,7 +19,7 @@ class GoalKick : public SkillBase
 public:
   template <typename... Args>
   explicit GoalKick(Args &&... args)
-  : SkillBase("GoalKick", std::forward<Args>(args)...), kick_skill(command)
+  : SkillBase("goal_kick", std::forward<Args>(args)...), kick_skill(command)
   {
     initialize();
   }

--- a/crane_robot_skills/include/crane_robot_skills/goalie.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/goalie.hpp
@@ -22,7 +22,7 @@ class Goalie : public SkillBase
 public:
   template <typename... Args>
   explicit Goalie(Args &&... args)
-  : SkillBase("Goalie", std::forward<Args>(args)...), kick_skill(command)
+  : SkillBase("goalie", std::forward<Args>(args)...), kick_skill(command)
   {
     initialize();
   }

--- a/crane_robot_skills/include/crane_robot_skills/idle.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/idle.hpp
@@ -17,7 +17,7 @@ class Idle : public SkillBase
 {
 public:
   template <typename... Args>
-  explicit Idle(Args &&... args) : SkillBase("Idle", std::forward<Args>(args)...)
+  explicit Idle(Args &&... args) : SkillBase("idle", std::forward<Args>(args)...)
   {
   }
 

--- a/crane_robot_skills/include/crane_robot_skills/kick.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/kick.hpp
@@ -31,7 +31,7 @@ public:
   template <typename... Args>
   explicit Kick(Args &&... args)
   : SkillBaseWithState(
-      static_cast<int>(KickState::ENTRY_POINT), &Kick::getStateName, "Kick",
+      static_cast<int>(KickState::ENTRY_POINT), &Kick::getStateName, "kick",
       std::forward<Args>(args)...)
   {
     initialize();

--- a/crane_robot_skills/include/crane_robot_skills/marker.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/marker.hpp
@@ -22,7 +22,7 @@ class Marker : public SkillBase
 {
 public:
   template <typename... Args>
-  explicit Marker(Args &&... args) : SkillBase("Marker", std::forward<Args>(args)...)
+  explicit Marker(Args &&... args) : SkillBase("marker", std::forward<Args>(args)...)
   {
     initialize();
   }

--- a/crane_robot_skills/include/crane_robot_skills/receive.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/receive.hpp
@@ -18,7 +18,7 @@ class Receive : public SkillBase
 {
 public:
   template <typename... Args>
-  explicit Receive(Args &&... args) : SkillBase("Receive", std::forward<Args>(args)...)
+  explicit Receive(Args &&... args) : SkillBase("receive", std::forward<Args>(args)...)
   {
     setParameter("dribble_power", 0.3);
     setParameter("enable_software_bumper", true);

--- a/crane_robot_skills/include/crane_robot_skills/second_threat_defender.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/second_threat_defender.hpp
@@ -18,7 +18,7 @@ class SecondThreatDefender : public SkillBase
 public:
   template <typename... Args>
   explicit SecondThreatDefender(Args &&... args)
-  : SkillBase("SecondThreatDefender", std::forward<Args>(args)...)
+  : SkillBase("second_threat_defender", std::forward<Args>(args)...)
   {
     initialize();
   }

--- a/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
@@ -24,7 +24,7 @@ class SimpleKickOff : public SkillBase
 public:
   template <typename... Args>
   explicit SimpleKickOff(Args &&... args)
-  : SkillBase("SimpleKickOff", std::forward<Args>(args)...), kick_skill(command)
+  : SkillBase("simple_kickoff", std::forward<Args>(args)...), kick_skill(command)
   {
     initializeParameters();
   }

--- a/crane_robot_skills/include/crane_robot_skills/sleep.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/sleep.hpp
@@ -17,7 +17,7 @@ class Sleep : public SkillBase
 {
 public:
   template <typename... Args>
-  explicit Sleep(Args &&... args) : SkillBase("Sleep", std::forward<Args>(args)...)
+  explicit Sleep(Args &&... args) : SkillBase("sleep", std::forward<Args>(args)...)
   {
     setParameter("duration", 0.0);
   }

--- a/crane_robot_skills/include/crane_robot_skills/sub_attacker.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/sub_attacker.hpp
@@ -21,7 +21,7 @@ class SubAttacker : public SkillBase
 {
 public:
   template <typename... Args>
-  explicit SubAttacker(Args &&... args) : SkillBase("SubAttacker", std::forward<Args>(args)...)
+  explicit SubAttacker(Args &&... args) : SkillBase("sub_attacker", std::forward<Args>(args)...)
   {
     initialize();
   }

--- a/crane_robot_skills/include/crane_robot_skills/teleop.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/teleop.hpp
@@ -19,7 +19,7 @@ class Teleop : public SkillBase, public rclcpp::Node
 public:
   template <typename... Args>
   explicit Teleop(Args &&... args)
-  : SkillBase("Teleop", std::forward<Args>(args)...), Node("teleop_skill")
+  : SkillBase("teleop", std::forward<Args>(args)...), Node("teleop_skill")
   {
     setParameter("rotation_deg", 0.);
     setParameter("use_local_coordinate", false);

--- a/crane_session_coordinator/include/crane_session_coordinator/session_coordinator.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/session_coordinator.hpp
@@ -94,7 +94,7 @@ private:
   std::shared_ptr<std::unordered_map<uint8_t, RobotRole>> robot_roles;
 
   VisualizerMessageBuilder::SharedPtr visualizer =
-    std::make_shared<VisualizerMessageBuilder>("session_controller");
+    std::make_shared<VisualizerMessageBuilder>("coordinator");
 
   diagnostic_updater::Updater diagnostic_updater_;
 

--- a/crane_sessions/include/crane_sessions/attacker_skill_session.hpp
+++ b/crane_sessions/include/crane_sessions/attacker_skill_session.hpp
@@ -50,7 +50,8 @@ public:
       return {SessionBase::Status::RUNNING, {}};
     }
     if (not skill) {
-      skill = std::make_shared<skills::Attacker>("attacker", robots.front().id, world_model);
+      skill = std::make_shared<skills::Attacker>(robots.front().id, world_model);
+      visualizer->layer = "skill/" + skill->name;
     }
 
     std::string state_name(magic_enum::enum_name(skill->getCurrentState()));

--- a/crane_sessions/include/crane_sessions/formation_session.hpp
+++ b/crane_sessions/include/crane_sessions/formation_session.hpp
@@ -61,7 +61,7 @@ class IbisFormationSession final : public FormationSession
 public:
   COMPOSITION_PUBLIC
   explicit IbisFormationSession(WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node)
-  : FormationSession(world_model, node, FormationType::IBIS, "ibis_formation")
+  : FormationSession(world_model, node, FormationType::IBIS, "formation")
   {
   }
 };

--- a/crane_sessions/include/crane_sessions/goalie_skill_session.hpp
+++ b/crane_sessions/include/crane_sessions/goalie_skill_session.hpp
@@ -44,7 +44,7 @@ public:
 protected:
   auto createSkill(uint8_t robot_id) -> std::shared_ptr<skills::Goalie> override
   {
-    return std::make_shared<skills::Goalie>("goalie", robot_id, world_model);
+    return std::make_shared<skills::Goalie>(robot_id, world_model);
   }
 };
 }  // namespace crane

--- a/crane_sessions/include/crane_sessions/marker_functions.hpp
+++ b/crane_sessions/include/crane_sessions/marker_functions.hpp
@@ -37,15 +37,14 @@ struct MarkingResult
 /// @param available_robot_ids 割り当て可能なロボットIDのリスト
 /// @param world_model ワールドモデル
 /// @param visualizer ビジュアライザー
-/// @param command_name コマンド名（デバッグ用）
 /// @param assign_remaining ターゲットがいない残余ロボットにもMarkerを生成するか
 /// @param mark_mode マーキングモード ("intercept_pass": ボール基準, "save_goal": ゴール基準)
 /// @return マーキング結果（生成したMarkerリストと選択されたロボットIDリスト）
 auto assignMarkersToEnemies(
   const std::vector<uint8_t> & available_robot_ids,
   const WorldModelWrapper::SharedPtr & world_model,
-  const VisualizerMessageBuilder::SharedPtr & visualizer, const std::string & command_name,
-  bool assign_remaining = false, const std::string & mark_mode = "intercept_pass",
+  const VisualizerMessageBuilder::SharedPtr & visualizer, bool assign_remaining = false,
+  const std::string & mark_mode = "intercept_pass",
   const std::unordered_map<uint8_t, uint8_t> & prev_assignments = {}) -> MarkingResult;
 
 }  // namespace crane

--- a/crane_sessions/include/crane_sessions/pass_receiver_session.hpp
+++ b/crane_sessions/include/crane_sessions/pass_receiver_session.hpp
@@ -49,9 +49,9 @@ public:
       return {SessionBase::Status::RUNNING, {}};
     }
     if (!receive_skill) {
-      receive_skill =
-        std::make_shared<skills::Receive>("pass_receiver", robots.front().id, world_model);
+      receive_skill = std::make_shared<skills::Receive>("receiver", robots.front().id, world_model);
       receive_skill->setParameter("policy", std::string("closest"));
+      visualizer->layer = "skill/" + receive_skill->name;
     }
 
     // If a kick is ongoing by our team or ball is moving sufficiently, actively receive

--- a/crane_sessions/include/crane_sessions/placement_avoidance_session.hpp
+++ b/crane_sessions/include/crane_sessions/placement_avoidance_session.hpp
@@ -29,7 +29,7 @@ class BallPlacementAvoidanceSession : public SessionBase
 public:
   COMPOSITION_PUBLIC explicit BallPlacementAvoidanceSession(
     WorldModelWrapper::SharedPtr & world_model, rclcpp::Node &)
-  : SessionBase("ball_placement_avoidance", world_model)
+  : SessionBase("placement_avoidance", world_model)
   {
   }
 

--- a/crane_sessions/include/crane_sessions/session_base.hpp
+++ b/crane_sessions/include/crane_sessions/session_base.hpp
@@ -62,7 +62,7 @@ public:
   explicit SessionBase(const std::string & name, WorldModelWrapper::SharedPtr & world_model)
   : name(name),
     world_model(world_model),
-    visualizer(std::make_shared<VisualizerMessageBuilder>("session_coordinator/" + name))
+    visualizer(std::make_shared<VisualizerMessageBuilder>("session/" + name))
   {
     // セッション用ビジュアライザのデフォルトduration: 0.5秒
     visualizer->withDuration(0.5);

--- a/crane_sessions/include/crane_sessions/single_skill_session.hpp
+++ b/crane_sessions/include/crane_sessions/single_skill_session.hpp
@@ -33,6 +33,7 @@ public:
     }
     if (not skill) {
       skill = createSkill(robots.front().id);
+      visualizer->layer = "skill/" + skill->name;
     }
     auto status = skill->run();
     return {static_cast<SessionBase::Status>(status), {skill->getRobotCommand()}};

--- a/crane_sessions/include/crane_sessions/sub_attacker_skill_session.hpp
+++ b/crane_sessions/include/crane_sessions/sub_attacker_skill_session.hpp
@@ -48,8 +48,7 @@ public:
 protected:
   auto createSkill(uint8_t robot_id) -> std::shared_ptr<skills::SubAttacker> override
   {
-    return std::make_shared<skills::SubAttacker>(
-      "sub_attacker_skill_planner", robot_id, world_model);
+    return std::make_shared<skills::SubAttacker>(robot_id, world_model);
   }
 };
 }  // namespace crane

--- a/crane_sessions/src/ball_near_by_positioner_skill_session.cpp
+++ b/crane_sessions/src/ball_near_by_positioner_skill_session.cpp
@@ -24,12 +24,11 @@ auto BallNearByPositionerSkillSession::calculatePositionCommand(
   };
   if (ids_changed()) {
     skills.clear();
+    visualizer->layer = "skill/ball_positioner";
 
     int index = 0;
     for (const auto & robot_id : robots) {
-      skills.emplace_back(
-        std::make_shared<skills::BallNearByPositioner>(
-          "ball_near_by_positioner_skill_planner", robot_id.id, world_model));
+      skills.emplace_back(std::make_shared<skills::BallNearByPositioner>(robot_id.id, world_model));
       skills.back()->setParameter("total_robot_number", static_cast<int>(robots.size()));
       skills.back()->setParameter("current_robot_index", index++);
       skills.back()->setParameter("line_policy", std::string("arc"));

--- a/crane_sessions/src/emplace_robot_session.cpp
+++ b/crane_sessions/src/emplace_robot_session.cpp
@@ -16,7 +16,7 @@ void EmplaceRobotSession::onRobotsChanged() { m_skill_map.clear(); }
 
 EmplaceRobotSession::EmplaceRobotSession(
   WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node)
-: SessionBase("emplace_robot", world_model), topics_interface_(node.get_node_topics_interface())
+: SessionBase("emplace", world_model), topics_interface_(node.get_node_topics_interface())
 {
   // パラメータを取得（既に宣言されている場合はその値を使用、未宣言ならデフォルト値を使用）
   if (!node.has_parameter("emplace_robot.use_voice_announcement")) {

--- a/crane_sessions/src/forward_session.cpp
+++ b/crane_sessions/src/forward_session.cpp
@@ -64,6 +64,7 @@ auto ForwardSession::calculatePositionCommand(const std::vector<RobotIdentifier>
   // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
   if (forward_skills.size() != robots.size()) {
     forward_skills.clear();
+    visualizer->layer = "skill/forward";
 
     auto forward_lines = createForwardLines();
 

--- a/crane_sessions/src/marker_functions.cpp
+++ b/crane_sessions/src/marker_functions.cpp
@@ -61,9 +61,9 @@ auto getDangerEnemies(const WorldModelWrapper::SharedPtr & world_model)
 auto assignMarkersToEnemies(
   const std::vector<uint8_t> & available_robot_ids,
   const WorldModelWrapper::SharedPtr & world_model,
-  const VisualizerMessageBuilder::SharedPtr & visualizer, const std::string & command_name,
-  bool assign_remaining, const std::string & mark_mode,
-  const std::unordered_map<uint8_t, uint8_t> & prev_assignments) -> MarkingResult
+  const VisualizerMessageBuilder::SharedPtr & visualizer, bool assign_remaining,
+  const std::string & mark_mode, const std::unordered_map<uint8_t, uint8_t> & prev_assignments)
+  -> MarkingResult
 {
   MarkingResult result;
 
@@ -147,8 +147,8 @@ auto assignMarkersToEnemies(
       return robot->id == best_robot->id;
     }));
 
-    auto marker = std::make_shared<skills::Marker>(
-      command_name, static_cast<uint8_t>(best_robot->id), world_model);
+    auto marker =
+      std::make_shared<skills::Marker>(static_cast<uint8_t>(best_robot->id), world_model);
     marker->setParameter("marking_robot_id", enemy_robot->id);
     marker->setParameter("mark_mode", mark_mode);
     marker->setParameter("mark_distance", 0.5);
@@ -164,8 +164,7 @@ auto assignMarkersToEnemies(
   if (assign_remaining) {
     for (const auto & robot : remaining_robots) {
       result.markers.push_back(
-        std::make_shared<skills::Marker>(
-          command_name, static_cast<uint8_t>(robot->id), world_model));
+        std::make_shared<skills::Marker>(static_cast<uint8_t>(robot->id), world_model));
       result.selected_robot_ids.push_back(robot->id);
     }
   }

--- a/crane_sessions/src/marker_session.cpp
+++ b/crane_sessions/src/marker_session.cpp
@@ -31,8 +31,9 @@ MarkerSession::calculatePositionCommand(const std::vector<RobotIdentifier> & rob
       mark_mode = "save_goal";
     }
   }
-  auto result = assignMarkersToEnemies(
-    robot_ids, world_model, visualizer, "marker_planner", true, mark_mode, prev_assignments_);
+  visualizer->layer = "skill/marker";
+  auto result =
+    assignMarkersToEnemies(robot_ids, world_model, visualizer, true, mark_mode, prev_assignments_);
   prev_assignments_ = std::move(result.enemy_to_marker);
   markers = std::move(result.markers);
 

--- a/crane_sessions/src/total_defense_session.cpp
+++ b/crane_sessions/src/total_defense_session.cpp
@@ -179,8 +179,8 @@ auto TotalDefenseSession::assignMarkingTargets(const std::vector<uint8_t> & avai
   -> std::vector<uint8_t>
 {
   auto lock = std::lock_guard(markers_mutex);
-  auto result = assignMarkersToEnemies(
-    available_robots, world_model, visualizer, "total_defense_planner/marker", false, "save_goal");
+  auto result =
+    assignMarkersToEnemies(available_robots, world_model, visualizer, false, "save_goal");
   markers = std::move(result.markers);
   return result.selected_robot_ids;
 }

--- a/crane_world_model_publisher/include/crane_world_model_publisher/visualization_manager.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/visualization_manager.hpp
@@ -59,9 +59,6 @@ public:
   crane::VisualizerMessageBuilder::SharedPtr referee_builder;
   crane::VisualizerMessageBuilder::SharedPtr placement_builder;
   crane::VisualizerMessageBuilder::SharedPtr trajectory_builder;
-  crane::VisualizerMessageBuilder::SharedPtr slack_builder;
-  crane::VisualizerMessageBuilder::SharedPtr pass_score_builder;
-  crane::VisualizerMessageBuilder::SharedPtr kick_event_builder;
 
   // drawFieldGeometry はコールバック経由で呼ばれるため world_model を受け取れない。
   // ゴール色描画のためにチーム情報をキャッシュする。

--- a/crane_world_model_publisher/src/visualization_manager.cpp
+++ b/crane_world_model_publisher/src/visualization_manager.cpp
@@ -29,15 +29,12 @@ namespace crane
 
 VisualizationManager::VisualizationManager(rclcpp::Node & node) : node_(node)
 {
-  geometry_builder = std::make_shared<crane::VisualizerMessageBuilder>("world_model/geometry");
-  vision_builder = std::make_shared<crane::VisualizerMessageBuilder>("world_model/vision");
-  tracked_builder = std::make_shared<crane::VisualizerMessageBuilder>("world_model/tracked");
-  referee_builder = std::make_shared<crane::VisualizerMessageBuilder>("world_model/referee");
-  trajectory_builder = std::make_shared<crane::VisualizerMessageBuilder>("world_model/trajectory");
-  placement_builder = std::make_shared<crane::VisualizerMessageBuilder>("world_model/placement");
-  slack_builder = std::make_shared<crane::VisualizerMessageBuilder>("world_model/slack");
-  pass_score_builder = std::make_shared<crane::VisualizerMessageBuilder>("world_model/pass_score");
-  kick_event_builder = std::make_shared<crane::VisualizerMessageBuilder>("world_model/kick_event");
+  geometry_builder = std::make_shared<crane::VisualizerMessageBuilder>("world/geometry");
+  vision_builder = std::make_shared<crane::VisualizerMessageBuilder>("world/vision");
+  tracked_builder = std::make_shared<crane::VisualizerMessageBuilder>("world/tracked");
+  referee_builder = std::make_shared<crane::VisualizerMessageBuilder>("world/referee");
+  trajectory_builder = std::make_shared<crane::VisualizerMessageBuilder>("world/trajectory");
+  placement_builder = std::make_shared<crane::VisualizerMessageBuilder>("world/placement");
 
   crane::CraneVisualizerBuffer::activate(node_);
 


### PR DESCRIPTION
## 概要

`/aggregated_svgs` トピックに34個のレイヤー名が乱立していた問題を解消し、約25レイヤーに削減して一貫した命名規則を確立する。

## 背景・根本原因

- `session_coordinator/<X>` と `skill/<X>` の二重レイヤーが多数存在していた
- スキルのデフォルト名が PascalCase（`"Goalie"`, `"SubAttacker"` 等）で統一されていなかった
- 未使用のレイヤー（`world/slack`, `world/pass_score`, `world/kick_event`）が残っていた
- プレフィックスが冗長だった（`world_model/` → `world/`、`local_planner/` → `planner/` 等）

## 変更内容

- **未使用レイヤー削除**: `slack_builder`, `pass_score_builder`, `kick_event_builder` を `VisualizationManager` から削除
- **world_model/ → world/** に短縮（6レイヤー）
- **スキル名 snake_case 化**: 15スキルのデフォルト名を統一（`"Forward"` → `"forward"` 等）
- **二重レイヤー統合**: `SingleSkillSession` でスキル生成後に `visualizer->layer` をスキルの layer に同期
- **session_coordinator/ → session/** にプレフィックスを短縮（`session_base.hpp`）
- **カスタムスキル名整理**: 不要な重複カスタム名を削除（goalie, attacker, sub_attacker 等）
- **`assignMarkersToEnemies()` の `command_name` パラメータ削除**
- **トップレベルレイヤー整理**:
  - `session_controller` → `coordinator`
  - `game_analyzer` → `analyzer`
  - `kick_event` → `analyzer/kick_event`
  - `diagnostic_errors` → `receiver/diagnostic`
  - `robot_receiver` → `receiver/feedback`
- **local_planner/ → planner/** に短縮

## テスト方法

- [x] `colcon build` でビルド確認（全38パッケージ成功）
- [ ] シミュレーション起動後、`ros2 topic echo /aggregated_svgs --once | grep "layer:"` でレイヤー名確認
- [ ] SVGビューアでレイヤー表示・トグルが正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)