### PR TITLE
feat: crane_web_debuggerにロボット管理画面を追加

### DIFF
--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -194,6 +194,9 @@ limitations under the License.
     <param name="sim_mode" value="$(var sim)"/>
   </node>
 
+  <!-- Webデバッガー（ブラウザ http://localhost:8090 でアクセス可能） -->
+  <node pkg="crane_web_debugger" exec="crane_websocket_server" output="screen"/>
+
   <!-- 可視化情報の集約 -->
   <node pkg="crane_visualization_aggregator" exec="crane_visualization_aggregator_node" output="screen"/>
 

--- a/crane_web_debugger/package.xml
+++ b/crane_web_debugger/package.xml
@@ -12,6 +12,7 @@
   <depend>ament_index_cpp</depend>
   <depend>crane_msgs</depend>
   <depend>crane_visualization_interfaces</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>libboost-system-dev</depend>
   <depend>libssl-dev</depend>
   <depend>nlohmann-json-dev</depend>

--- a/crane_web_debugger/src/websocket_server.cpp
+++ b/crane_web_debugger/src/websocket_server.cpp
@@ -8,6 +8,8 @@
 #include <openssl/buffer.h>
 #include <openssl/evp.h>
 #include <openssl/sha.h>
+#include <sys/socket.h>
+#include <sys/time.h>
 
 #include <algorithm>
 #include <ament_index_cpp/get_package_share_directory.hpp>
@@ -15,13 +17,17 @@
 #include <cctype>
 #include <chrono>
 #include <crane_msgs/msg/human_annotation.hpp>
+#include <crane_msgs/msg/ping_status_array.hpp>
 #include <crane_msgs/msg/play_situation.hpp>
 #include <crane_msgs/msg/robot_commands.hpp>
+#include <crane_msgs/msg/robot_feedback_array.hpp>
 #include <crane_msgs/msg/world_model.hpp>
 #include <crane_visualization_interfaces/msg/svg_snapshot.hpp>
 #include <crane_visualization_interfaces/msg/svg_updates.hpp>
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <nlohmann/json.hpp>
@@ -288,6 +294,39 @@ public:
     annotation_pub_ =
       this->create_publisher<crane_msgs::msg::HumanAnnotation>("/human_annotations", 10);
 
+    // Robot feedback subscription (cached, broadcast at 10Hz via timer)
+    robot_feedback_sub_ = this->create_subscription<crane_msgs::msg::RobotFeedbackArray>(
+      "/robot_feedback", 10, [this](const crane_msgs::msg::RobotFeedbackArray::SharedPtr msg) {
+        std::lock_guard<std::mutex> lock(robot_feedback_mutex_);
+        latest_robot_feedback_ = msg;
+        robot_feedback_updated_ = true;
+      });
+
+    ping_sub_ = this->create_subscription<crane_msgs::msg::PingStatusArray>(
+      "/ping", 10,
+      [this](const crane_msgs::msg::PingStatusArray::SharedPtr msg) { broadcastPingStatus(msg); });
+
+    diagnostics_sub_ = this->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+      "/diagnostics_agg", 10, [this](const diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg) {
+        broadcastDiagnostics(msg);
+      });
+
+    // 100ms timer for robot_feedback broadcast (10Hz throttle)
+    robot_feedback_timer_ = this->create_wall_timer(std::chrono::milliseconds(100), [this]() {
+      crane_msgs::msg::RobotFeedbackArray::SharedPtr msg;
+      {
+        std::lock_guard<std::mutex> lock(robot_feedback_mutex_);
+        if (!robot_feedback_updated_ || !latest_robot_feedback_) return;
+        msg = latest_robot_feedback_;
+        robot_feedback_updated_ = false;
+      }
+      broadcastRobotFeedback(msg);
+    });
+
+    // 5s timer for Pi status polling
+    pi_status_timer_ =
+      this->create_wall_timer(std::chrono::seconds(5), [this]() { pollAllPiStatus(); });
+
     // Start servers
     startServers();
 
@@ -385,6 +424,21 @@ private:
       }
     }
 
+    // 接続確立時に最新のロボットフィードバックを送信
+    {
+      crane_msgs::msg::RobotFeedbackArray::SharedPtr fb_msg;
+      {
+        std::lock_guard<std::mutex> lock(robot_feedback_mutex_);
+        fb_msg = latest_robot_feedback_;
+      }
+      if (fb_msg) {
+        broadcastRobotFeedback(fb_msg);
+      }
+    }
+
+    // 接続確立時にPiステータスを取得・送信
+    pollAllPiStatus();
+
     // Message processing loop
     while (connection->isConnected() && running_) {
       std::string message = connection->receiveMessage();
@@ -416,6 +470,10 @@ private:
         handleTimeSyncRequest(connection, request);
       } else if (type == "annotation") {
         handleAnnotation(connection, request);
+      } else if (type == "robot_control") {
+        handleRobotControl(connection, request);
+      } else if (type == "poll_pi_status") {
+        pollAllPiStatus();
       } else if (type == "get_world_model") {
         // World model is automatically broadcasted, but we can send current state if needed
       } else {
@@ -727,6 +785,209 @@ private:
     broadcastToAll(createGameInfoMessage(msg));
   }
 
+  static std::string getRobotIp(int robot_id)
+  {
+    return "192.168.20." + std::to_string(100 + robot_id);
+  }
+
+  // レスポンスボディから "status" フィールドを抽出する。失敗時は default_failure を返す
+  static std::string parseStatusFromBody(
+    bool success, const std::string & body, const std::string & default_ok = "OK",
+    const std::string & default_failure = "Offline")
+  {
+    if (!success) return default_failure;
+    if (!body.empty()) {
+      try {
+        auto body_json = json::parse(body);
+        if (body_json.contains("status")) {
+          return body_json["status"].get<std::string>();
+        }
+      } catch (...) {
+      }
+    }
+    return default_ok;
+  }
+
+  void broadcastRobotFeedback(const crane_msgs::msg::RobotFeedbackArray::SharedPtr msg)
+  {
+    json data = {{"type", "robot_feedback"}, {"robots", json::array()}};
+    for (const auto & robot : msg->feedback) {
+      json robot_json = {
+        {"robot_id", robot.robot_id},           {"voltage", robot.voltage},
+        {"temperatures", robot.temperatures},   {"error_id", robot.error_id},
+        {"error_info", robot.error_info},       {"error_value", robot.error_value},
+        {"motor_current", robot.motor_current}, {"ball_sensor", robot.ball_sensor},
+        {"kick_state", robot.kick_state},       {"packet_frequency_hz", robot.packet_frequency_hz},
+        {"yaw_angle", robot.yaw_angle},         {"odom_speed", robot.odom_speed}};
+      data["robots"].push_back(robot_json);
+    }
+    broadcastToAll(data.dump());
+  }
+
+  void broadcastPingStatus(const crane_msgs::msg::PingStatusArray::SharedPtr msg)
+  {
+    json data = {{"type", "ping_status"}, {"robots", json::array()}};
+    for (const auto & ping : msg->ping) {
+      data["robots"].push_back({{"robot_id", ping.robot_id}, {"ping_ms", ping.ping_ms}});
+    }
+    broadcastToAll(data.dump());
+  }
+
+  void broadcastDiagnostics(const diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg)
+  {
+    json data = {{"type", "diagnostics"}, {"statuses", json::array()}};
+    for (const auto & status : msg->status) {
+      json values = json::array();
+      for (const auto & kv : status.values) {
+        values.push_back({{"key", kv.key}, {"value", kv.value}});
+      }
+      data["statuses"].push_back(
+        {{"name", status.name},
+         {"level", status.level},
+         {"message", status.message},
+         {"values", values}});
+    }
+    broadcastToAll(data.dump());
+  }
+
+  // Simple blocking HTTP client with connect/read/write timeouts
+  static std::pair<bool, std::string> sendHttpRequest(
+    const std::string & host, int port, const std::string & method, const std::string & path,
+    int timeout_ms = 500)
+  {
+    try {
+      boost::asio::io_context io_context;
+      boost::asio::ip::tcp::resolver resolver(io_context);
+      boost::asio::ip::tcp::socket socket(io_context);
+      boost::asio::steady_timer timer(io_context);
+
+      boost::system::error_code ec;
+      auto endpoints = resolver.resolve(host, std::to_string(port), ec);
+      if (ec) return {false, ""};
+
+      // Async connect with timeout
+      bool connected = false;
+      timer.expires_after(std::chrono::milliseconds(timeout_ms));
+      timer.async_wait([&socket](const boost::system::error_code & timer_ec) {
+        if (!timer_ec) socket.cancel();
+      });
+      boost::asio::async_connect(
+        socket, endpoints,
+        [&](const boost::system::error_code & conn_ec, const boost::asio::ip::tcp::endpoint &) {
+          if (!conn_ec) connected = true;
+          timer.cancel();
+        });
+      io_context.run();
+      if (!connected) return {false, ""};
+
+      // Set socket read/write timeouts
+      timeval tv;
+      tv.tv_sec = 0;
+      tv.tv_usec = static_cast<suseconds_t>(timeout_ms) * 1000;
+      setsockopt(socket.native_handle(), SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+      setsockopt(socket.native_handle(), SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+      // Send HTTP request
+      std::string req = method + " " + path + " HTTP/1.0\r\n" + "Host: " + host + ":" +
+                        std::to_string(port) + "\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+      boost::asio::write(socket, boost::asio::buffer(req), ec);
+      if (ec) return {false, ""};
+
+      // Read full response
+      boost::asio::streambuf resp_buf;
+      boost::asio::read(socket, resp_buf, boost::asio::transfer_all(), ec);
+      // ec == eof is expected
+
+      std::istream stream(&resp_buf);
+      std::string http_ver;
+      int status_code = 0;
+      stream >> http_ver >> status_code;
+      std::string status_line_rest;
+      std::getline(stream, status_line_rest);
+
+      // Skip headers
+      std::string line;
+      while (std::getline(stream, line) && line != "\r" && !line.empty()) {
+      }
+
+      std::ostringstream body_stream;
+      body_stream << stream.rdbuf();
+      return {status_code >= 200 && status_code < 300, body_stream.str()};
+    } catch (const std::exception &) {
+      return {false, ""};
+    }
+  }
+
+  void handleRobotControl(std::shared_ptr<WebSocketConnection> connection, const json & request)
+  {
+    int robot_id = request.value("robot_id", -1);
+    std::string command = request.value("command", "");
+
+    if (robot_id < 0 || robot_id > 15 || command.empty()) {
+      json error = {
+        {"type", "robot_control_result"},
+        {"robot_id", robot_id},
+        {"command", command},
+        {"success", false},
+        {"status", "Invalid request"}};
+      connection->sendMessage(error.dump());
+      return;
+    }
+
+    static const std::map<std::string, std::pair<std::string, std::string>> kCommandMap = {
+      {"start", {"POST", "/start"}}, {"stop", {"POST", "/stop"}}, {"status", {"GET", "/status"}}};
+
+    auto it = kCommandMap.find(command);
+    if (it == kCommandMap.end()) {
+      json error = {
+        {"type", "robot_control_result"},
+        {"robot_id", robot_id},
+        {"command", command},
+        {"success", false},
+        {"status", "Unknown command"}};
+      connection->sendMessage(error.dump());
+      return;
+    }
+    const auto & [method, path] = it->second;
+
+    std::thread([connection, robot_id, command, method, path]() {
+      constexpr int kPiPort = 8000;
+      auto [success, body] = sendHttpRequest(getRobotIp(robot_id), kPiPort, method, path);
+      json result = {
+        {"type", "robot_control_result"},
+        {"robot_id", robot_id},
+        {"command", command},
+        {"success", success},
+        {"status", parseStatusFromBody(success, body)}};
+      connection->sendMessage(result.dump());
+    }).detach();
+  }
+
+  void pollAllPiStatus()
+  {
+    std::thread([this]() {
+      constexpr int kNumRobots = 13;
+      constexpr int kPiPort = 8000;
+
+      std::vector<std::future<std::pair<int, std::string>>> futures;
+      futures.reserve(kNumRobots);
+
+      for (int id = 0; id < kNumRobots; id++) {
+        futures.push_back(std::async(std::launch::async, [id]() {
+          auto [success, body] = sendHttpRequest(getRobotIp(id), kPiPort, "GET", "/status");
+          return std::make_pair(id, parseStatusFromBody(success, body, "Running", "Offline"));
+        }));
+      }
+
+      json pi_status = {{"type", "pi_status"}, {"robots", json::array()}};
+      for (auto & future : futures) {
+        auto [id, status] = future.get();
+        pi_status["robots"].push_back({{"robot_id", id}, {"status", status}});
+      }
+      broadcastToAll(pi_status.dump());
+    }).detach();
+  }
+
   void broadcastToAll(const std::string & message)
   {
     std::lock_guard<std::mutex> lock(connections_mutex_);
@@ -746,6 +1007,16 @@ private:
   rclcpp::Subscription<crane_visualization_interfaces::msg::SvgUpdates>::SharedPtr
     visualizer_svgs_sub_;
   rclcpp::Publisher<crane_msgs::msg::HumanAnnotation>::SharedPtr annotation_pub_;
+
+  // Robot monitoring
+  rclcpp::Subscription<crane_msgs::msg::RobotFeedbackArray>::SharedPtr robot_feedback_sub_;
+  rclcpp::Subscription<crane_msgs::msg::PingStatusArray>::SharedPtr ping_sub_;
+  rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_sub_;
+  rclcpp::TimerBase::SharedPtr robot_feedback_timer_;
+  rclcpp::TimerBase::SharedPtr pi_status_timer_;
+  crane_msgs::msg::RobotFeedbackArray::SharedPtr latest_robot_feedback_;
+  bool robot_feedback_updated_{false};
+  std::mutex robot_feedback_mutex_;
 
   // Server components
   std::thread http_thread_;

--- a/crane_web_debugger/web/index.html
+++ b/crane_web_debugger/web/index.html
@@ -191,6 +191,25 @@
                     </ul>
                 </a>
             </div>
+
+            <!-- ロボット管理 -->
+            <div class="col-md-6">
+                <a href="/robot_manager.html" class="tool-card">
+                    <div class="tool-icon">
+                        <i class="fas fa-microchip"></i>
+                    </div>
+                    <div class="tool-title">ロボット管理</div>
+                    <div class="tool-description">
+                        ロボットのハードウェア状態監視と起動制御（電圧・温度・エラー・Ping）
+                    </div>
+                    <ul class="tool-features">
+                        <li><i class="fas fa-check text-success"></i> バッテリー電圧・温度のリアルタイム監視</li>
+                        <li><i class="fas fa-check text-success"></i> エラー状態の詳細表示</li>
+                        <li><i class="fas fa-check text-success"></i> Pi起動・停止制御</li>
+                        <li><i class="fas fa-check text-success"></i> Ping・通信品質の確認</li>
+                    </ul>
+                </a>
+            </div>
         </div>
 
         <!-- SSL Infrastructure -->

--- a/crane_web_debugger/web/robot_manager.html
+++ b/crane_web_debugger/web/robot_manager.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ロボット管理 - Crane Debug Tools</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <style>
+        body { background-color: #f8f9fa; }
+        .status-dot {
+            display: inline-block;
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            margin-right: 6px;
+        }
+        .status-dot.connected { background-color: #28a745; }
+        .status-dot.disconnected { background-color: #dc3545; }
+
+        .robot-card {
+            transition: border-color 0.3s ease;
+        }
+        .robot-card.has-error { border-color: #dc3545; border-width: 2px; }
+        .robot-card.has-warning { border-color: #ffc107; border-width: 2px; }
+        .robot-card.offline { opacity: 0.65; }
+
+        .card-header { padding: 0.5rem 0.75rem; }
+        .card-body { padding: 0.5rem 0.75rem; }
+        .card-footer { padding: 0.4rem 0.75rem; }
+
+        .voltage-bar { height: 6px; }
+        .info-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.3rem;
+            font-size: 0.82rem;
+        }
+        .info-label { color: #6c757d; }
+        .info-value { font-weight: 500; }
+
+        .error-text {
+            font-size: 0.78rem;
+            word-break: break-word;
+        }
+    </style>
+</head>
+<body>
+    <!-- Navbar -->
+    <nav class="navbar navbar-dark bg-dark py-2">
+        <div class="container-fluid">
+            <div class="d-flex align-items-center gap-3">
+                <a href="/" class="text-white text-decoration-none">
+                    <i class="fas fa-arrow-left"></i>
+                </a>
+                <span class="navbar-brand mb-0">
+                    <i class="fas fa-microchip me-2"></i>ロボット管理
+                </span>
+            </div>
+            <div class="text-white d-flex align-items-center">
+                <span class="status-dot disconnected" id="ws-dot"></span>
+                <small id="ws-status-text">未接続</small>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container-fluid py-3">
+        <!-- Summary Bar -->
+        <div class="row mb-3">
+            <div class="col">
+                <div class="card shadow-sm">
+                    <div class="card-body py-2">
+                        <div class="d-flex flex-wrap align-items-center gap-3">
+                            <span>
+                                <i class="fas fa-robot text-success me-1"></i>
+                                稼働中: <strong id="active-count">0</strong>
+                            </span>
+                            <span>
+                                <i class="fas fa-exclamation-triangle text-danger me-1"></i>
+                                エラー: <strong id="error-count">0</strong>
+                            </span>
+                            <span>
+                                <i class="fas fa-signal text-info me-1"></i>
+                                フィードバック受信: <strong id="feedback-count">0</strong>
+                            </span>
+                            <div class="ms-auto d-flex gap-2">
+                                <button class="btn btn-sm btn-success" onclick="startAll()">
+                                    <i class="fas fa-play me-1"></i>全台起動
+                                </button>
+                                <button class="btn btn-sm btn-danger" onclick="stopAll()">
+                                    <i class="fas fa-stop me-1"></i>全台停止
+                                </button>
+                                <button class="btn btn-sm btn-outline-secondary" onclick="refreshPiStatus()">
+                                    <i class="fas fa-sync-alt me-1"></i>状態更新
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Robot Cards Grid -->
+        <div class="row g-3" id="robot-grid"></div>
+    </div>
+
+    <script src="robot_manager.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/crane_web_debugger/web/robot_manager.js
+++ b/crane_web_debugger/web/robot_manager.js
@@ -1,0 +1,442 @@
+// ロボット管理画面 JavaScript
+'use strict';
+
+const NUM_ROBOTS = 13;
+const WS_PORT = 8091;
+const VOLTAGE_MIN = 22.0;
+const VOLTAGE_MAX = 25.2;
+const TEMP_WARN = 60;
+const PING_WARN = 10;
+const PING_CRIT = 50;
+
+// ---- State ----------------------------------------------------------------
+
+const robotState = {};
+for (let i = 0; i < NUM_ROBOTS; i++) {
+    robotState[i] = {
+        feedback: null,   // latest robot_feedback entry
+        ping_ms: null,
+        pi_status: 'Unknown',
+        last_feedback_ms: 0,
+    };
+}
+
+let ws = null;
+let wsConnected = false;
+let pendingUpdate = false;
+
+// ---- WebSocket ------------------------------------------------------------
+
+function connectWebSocket() {
+    const host = window.location.hostname;
+    ws = new WebSocket(`ws://${host}:${WS_PORT}`);
+
+    ws.onopen = () => {
+        wsConnected = true;
+        setWsStatus(true);
+        // サーバー側が接続確立時に自動でpollAllPiStatus()を呼ぶため追加送信不要
+    };
+
+    ws.onclose = () => {
+        wsConnected = false;
+        setWsStatus(false);
+        setTimeout(connectWebSocket, 3000);
+    };
+
+    ws.onerror = () => {
+        setWsStatus(false);
+    };
+
+    ws.onmessage = (event) => {
+        try {
+            const msg = JSON.parse(event.data);
+            handleMessage(msg);
+        } catch (e) {
+            // ignore parse errors
+        }
+    };
+}
+
+function setWsStatus(connected) {
+    const dot = document.getElementById('ws-dot');
+    const text = document.getElementById('ws-status-text');
+    if (connected) {
+        dot.className = 'status-dot connected';
+        text.textContent = '接続済み';
+    } else {
+        dot.className = 'status-dot disconnected';
+        text.textContent = '未接続';
+    }
+}
+
+// ---- Message Handlers -----------------------------------------------------
+
+function handleMessage(msg) {
+    switch (msg.type) {
+        case 'robot_feedback':
+            onRobotFeedback(msg);
+            break;
+        case 'ping_status':
+            onPingStatus(msg);
+            break;
+        case 'pi_status':
+            onPiStatus(msg);
+            break;
+        case 'robot_control_result':
+            onRobotControlResult(msg);
+            break;
+        // diagnostics は将来の拡張用
+        default:
+            break;
+    }
+}
+
+function onRobotFeedback(msg) {
+    const now = Date.now();
+    for (const robot of msg.robots) {
+        const id = robot.robot_id;
+        if (id >= 0 && id < NUM_ROBOTS) {
+            robotState[id].feedback = robot;
+            robotState[id].last_feedback_ms = now;
+        }
+    }
+    pendingUpdate = true;
+}
+
+function onPingStatus(msg) {
+    for (const entry of msg.robots) {
+        const id = entry.robot_id;
+        if (id >= 0 && id < NUM_ROBOTS) {
+            robotState[id].ping_ms = entry.ping_ms;
+        }
+    }
+    pendingUpdate = true;
+}
+
+function onPiStatus(msg) {
+    for (const entry of msg.robots) {
+        const id = entry.robot_id;
+        if (id >= 0 && id < NUM_ROBOTS) {
+            robotState[id].pi_status = entry.status;
+        }
+    }
+    pendingUpdate = true;
+}
+
+function onRobotControlResult(msg) {
+    const id = msg.robot_id;
+    const success = msg.success;
+    const status = msg.status || '';
+    const command = msg.command || '';
+
+    if (id >= 0 && id < NUM_ROBOTS && success) {
+        robotState[id].pi_status = status;
+        pendingUpdate = true;
+    }
+
+    const icon = success ? '✅' : '❌';
+    console.log(`${icon} Robot#${id} ${command}: ${status}`);
+}
+
+// ---- Error String Conversion ----------------------------------------------
+
+function getErrorString(error_id, error_info) {
+    if (!error_info) return 'OK';
+
+    if (error_id === 100) {
+        // POWERエラー
+        const bits = [
+            [0x0001, '低電圧'],
+            [0x0002, '過電圧'],
+            [0x0004, '過電流'],
+            [0x0008, '短絡'],
+            [0x0010, '充電タイムアウト'],
+            [0x0020, '充電電力異常'],
+            [0x0040, '放電異常'],
+            [0x0080, 'パラメータ異常'],
+            [0x0100, 'コマンド異常'],
+            [0x0200, 'キャパシタ未接続'],
+            [0x0400, '放電失敗'],
+            [0x0800, 'GD電源異常'],
+            [0x1000, 'コイル過熱'],
+            [0x2000, 'FET過熱'],
+        ];
+        const errors = bits.filter(([bit]) => error_info & bit).map(([, name]) => name);
+        return 'POWER: ' + (errors.length ? errors.join(', ') : '不明');
+    }
+
+    if (error_id <= 3) {
+        // BLDCモーターエラー
+        const motorNames = ['RF', 'RB', 'LB', 'LF'];
+        const motorName = motorNames[error_id] ?? `M${error_id}`;
+        const bits = [
+            [0x0001, '低電圧'],
+            [0x0002, '過電流'],
+            [0x0004, 'モーター過熱'],
+            [0x0008, '過負荷'],
+            [0x0010, 'エンコーダエラー'],
+            [0x0020, '過電圧'],
+            [0x0040, 'FET過熱'],
+        ];
+        const errors = bits.filter(([bit]) => error_info & bit).map(([, name]) => name);
+        return `BLDC[${motorName}]: ` + (errors.length ? errors.join(', ') : '不明');
+    }
+
+    return `ERR(id=${error_id}, info=0x${error_info.toString(16)})`;
+}
+
+// ---- Rendering ------------------------------------------------------------
+
+function getOverallStatus(id) {
+    const state = robotState[id];
+    const fb = state.feedback;
+    const pi = state.pi_status;
+
+    if (fb && fb.error_info) return 'Error';
+    if (pi === 'Running') return 'Running';
+    if (pi === 'Stopped') return 'Stopped';
+    if (pi === 'Offline' || pi === 'Unknown') return 'Offline';
+    return pi;
+}
+
+const STATUS_CONFIG = {
+    'Running': { badge: 'bg-success',          label: '稼働中' },
+    'Stopped': { badge: 'bg-warning text-dark', label: '停止中' },
+    'Error':   { badge: 'bg-danger',            label: 'エラー' },
+    'Offline': { badge: 'bg-secondary',         label: 'オフライン' },
+};
+
+function statusBadgeClass(status) {
+    return STATUS_CONFIG[status]?.badge ?? 'bg-secondary';
+}
+
+function statusLabel(status) {
+    return STATUS_CONFIG[status]?.label ?? (status || '不明');
+}
+
+function voltageBarClass(v) {
+    if (v < 22.0) return 'bg-danger';
+    if (v < 23.0) return 'bg-warning';
+    return 'bg-success';
+}
+
+function pingClass(ms) {
+    if (ms === null) return 'text-secondary';
+    if (ms > PING_CRIT) return 'text-danger';
+    if (ms > PING_WARN) return 'text-warning';
+    return 'text-success';
+}
+
+function renderRobotCard(id) {
+    const state = robotState[id];
+    const fb = state.feedback;
+    const overallStatus = getOverallStatus(id);
+
+    const card = document.getElementById(`robot-card-${id}`);
+    if (!card) return;
+
+    // Card border style
+    card.className = 'card robot-card h-100';
+    if (overallStatus === 'Error') card.classList.add('has-error');
+    else if (overallStatus === 'Offline') card.classList.add('offline');
+
+    // Status badge
+    const badge = document.getElementById(`badge-${id}`);
+    badge.className = `badge ${statusBadgeClass(overallStatus)}`;
+    badge.textContent = statusLabel(overallStatus);
+
+    // Voltage
+    const voltageEl = document.getElementById(`voltage-${id}`);
+    const voltageBarEl = document.getElementById(`voltage-bar-${id}`);
+    if (fb && fb.voltage && fb.voltage.length > 0) {
+        const v = fb.voltage[0];
+        const pct = Math.max(0, Math.min(100, (v - VOLTAGE_MIN) / (VOLTAGE_MAX - VOLTAGE_MIN) * 100));
+        voltageEl.textContent = `${v.toFixed(2)} V`;
+        voltageEl.className = `info-value ${v < 22.0 ? 'text-danger' : v < 23.0 ? 'text-warning' : 'text-success'}`;
+        voltageBarEl.style.width = `${pct}%`;
+        voltageBarEl.className = `progress-bar ${voltageBarClass(v)}`;
+    } else {
+        voltageEl.textContent = '--';
+        voltageEl.className = 'info-value text-secondary';
+        voltageBarEl.style.width = '0%';
+        voltageBarEl.className = 'progress-bar bg-secondary';
+    }
+
+    // Temperature
+    const tempEl = document.getElementById(`temp-${id}`);
+    if (fb && fb.temperatures && fb.temperatures.length > 0) {
+        const maxTemp = Math.max(...fb.temperatures);
+        tempEl.textContent = `${maxTemp} °C`;
+        tempEl.className = `info-value ${maxTemp >= TEMP_WARN ? 'text-danger' : ''}`;
+    } else {
+        tempEl.textContent = '--';
+        tempEl.className = 'info-value text-secondary';
+    }
+
+    // Ping
+    const pingEl = document.getElementById(`ping-${id}`);
+    if (state.ping_ms !== null) {
+        pingEl.textContent = `${state.ping_ms.toFixed(1)} ms`;
+        pingEl.className = `info-value ${pingClass(state.ping_ms)}`;
+    } else {
+        pingEl.textContent = '--';
+        pingEl.className = 'info-value text-secondary';
+    }
+
+    // Packet frequency
+    const freqEl = document.getElementById(`freq-${id}`);
+    if (fb) {
+        freqEl.textContent = `${fb.packet_frequency_hz.toFixed(1)} Hz`;
+        freqEl.className = `info-value ${fb.packet_frequency_hz < 50 ? 'text-warning' : 'text-success'}`;
+    } else {
+        freqEl.textContent = '--';
+        freqEl.className = 'info-value text-secondary';
+    }
+
+    // Error
+    const errorEl = document.getElementById(`error-${id}`);
+    if (fb && fb.error_info) {
+        errorEl.textContent = getErrorString(fb.error_id, fb.error_info);
+        errorEl.className = 'error-text text-danger';
+    } else {
+        errorEl.textContent = 'OK';
+        errorEl.className = 'error-text text-success';
+    }
+}
+
+function renderSummary() {
+    let activeCount = 0;
+    let errorCount = 0;
+    let feedbackCount = 0;
+    const staleThreshold = 2000; // 2秒以上古いフィードバックは無視
+    const now = Date.now();
+
+    for (let i = 0; i < NUM_ROBOTS; i++) {
+        const state = robotState[i];
+        const status = getOverallStatus(i);
+        if (status === 'Running') activeCount++;
+        if (status === 'Error') errorCount++;
+        if (state.feedback && (now - state.last_feedback_ms) < staleThreshold) feedbackCount++;
+    }
+
+    document.getElementById('active-count').textContent = activeCount;
+    document.getElementById('error-count').textContent = errorCount;
+    document.getElementById('feedback-count').textContent = feedbackCount;
+}
+
+function renderAll() {
+    for (let i = 0; i < NUM_ROBOTS; i++) {
+        renderRobotCard(i);
+    }
+    renderSummary();
+}
+
+// ---- Card Generation ------------------------------------------------------
+
+function createRobotCard(id) {
+    return `
+<div class="col-xl-3 col-lg-4 col-md-6">
+    <div class="card robot-card h-100" id="robot-card-${id}">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <strong><i class="fas fa-robot me-1"></i>Robot #${id}</strong>
+            <span class="badge bg-secondary" id="badge-${id}">不明</span>
+        </div>
+        <div class="card-body">
+            <!-- 電圧 -->
+            <div class="info-row">
+                <span class="info-label"><i class="fas fa-battery-half me-1"></i>電圧</span>
+                <span class="info-value text-secondary" id="voltage-${id}">--</span>
+            </div>
+            <div class="progress voltage-bar mb-2">
+                <div class="progress-bar bg-secondary" id="voltage-bar-${id}" style="width:0%"></div>
+            </div>
+            <!-- 温度 -->
+            <div class="info-row">
+                <span class="info-label"><i class="fas fa-thermometer-half me-1"></i>最高温度</span>
+                <span class="info-value text-secondary" id="temp-${id}">--</span>
+            </div>
+            <!-- Ping -->
+            <div class="info-row">
+                <span class="info-label"><i class="fas fa-wifi me-1"></i>Ping</span>
+                <span class="info-value text-secondary" id="ping-${id}">--</span>
+            </div>
+            <!-- 通信頻度 -->
+            <div class="info-row">
+                <span class="info-label"><i class="fas fa-signal me-1"></i>通信</span>
+                <span class="info-value text-secondary" id="freq-${id}">--</span>
+            </div>
+            <!-- エラー -->
+            <div class="info-row align-items-start">
+                <span class="info-label"><i class="fas fa-exclamation-circle me-1"></i>エラー</span>
+                <span class="error-text text-success" id="error-${id}">OK</span>
+            </div>
+        </div>
+        <div class="card-footer p-2">
+            <div class="btn-group w-100" role="group">
+                <button class="btn btn-sm btn-outline-success"
+                        onclick="sendRobotControl(${id}, 'start')">
+                    <i class="fas fa-play me-1"></i>Start
+                </button>
+                <button class="btn btn-sm btn-outline-danger"
+                        onclick="sendRobotControl(${id}, 'stop')">
+                    <i class="fas fa-stop me-1"></i>Stop
+                </button>
+            </div>
+        </div>
+    </div>
+</div>`;
+}
+
+function initGrid() {
+    const grid = document.getElementById('robot-grid');
+    let html = '';
+    for (let i = 0; i < NUM_ROBOTS; i++) {
+        html += createRobotCard(i);
+    }
+    grid.innerHTML = html;
+}
+
+// ---- Control Commands -----------------------------------------------------
+
+function sendRobotControl(robotId, command) {
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+        alert('WebSocketに接続されていません');
+        return;
+    }
+    ws.send(JSON.stringify({ type: 'robot_control', robot_id: robotId, command: command }));
+}
+
+function startAll() {
+    for (let i = 0; i < NUM_ROBOTS; i++) {
+        sendRobotControl(i, 'start');
+    }
+}
+
+function stopAll() {
+    if (!confirm('全ロボットを停止しますか？')) return;
+    for (let i = 0; i < NUM_ROBOTS; i++) {
+        sendRobotControl(i, 'stop');
+    }
+}
+
+function refreshPiStatus() {
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+        alert('WebSocketに接続されていません');
+        return;
+    }
+    ws.send(JSON.stringify({ type: 'poll_pi_status' }));
+}
+
+// ---- Main -----------------------------------------------------------------
+
+initGrid();
+renderAll();
+connectWebSocket();
+
+// 500ms ごとに DOM 更新
+setInterval(() => {
+    if (pendingUpdate) {
+        renderAll();
+        pendingUpdate = false;
+    }
+}, 500);


### PR DESCRIPTION
## 概要
crane_web_debugger に新しいロボット管理画面（`robot_manager.html`）を追加。
電圧・温度・Ping・エラー状態のリアルタイム監視と、Pi の起動/停止制御をブラウザから行えるようにした。

## 背景・根本原因
ロボットのハードウェア状態確認が Foxglove Studio / rqt / tkinter（host_launcher.py）に分散しており、
試合中・デバッグ中に一元管理できなかった。

## 変更内容
### バックエンド (`websocket_server.cpp`)
- `/robot_feedback`（RobotFeedbackArray）購読 → 100msスロットルでブロードキャスト
- `/ping`（PingStatusArray）購読 → 受信時即ブロードキャスト
- `/diagnostics_agg`（DiagnosticArray）購読 → 受信時即ブロードキャスト
- Pi制御プロキシ: `robot_control` WebSocketメッセージ → `192.168.20.{100+id}:8000` へHTTP POST/GET
  - boost::asio製簡易HTTPクライアント（接続500msタイムアウト）
  - 13台並列ポーリング（std::async使用）
- 接続確立時に最新フィードバックとPiステータスを自動送信
- `package.xml` に `diagnostic_msgs` 依存を追加

### フロントエンド (`robot_manager.html` / `robot_manager.js`)
- ロボット13台（ID 0–12）のカードグリッド（Bootstrap 5）
- 電圧プログレスバー（<23V 黄・<22V 赤）
- 温度・Ping・通信頻度の色分け表示
- `error_id`/`error_info` → POWER/BLDCエラーの日本語変換
- Start/Stop ボタン、全台一括操作、状態更新ボタン
- 500ms スロットル DOM 更新

### その他
- `index.html`: ポータルにロボット管理カード追加
- `crane.launch.xml`: `crane_websocket_server` を常時起動ノードとして追加

## テスト方法
- [x] `colcon build --packages-select crane_web_debugger` でビルド確認
- [ ] `ros2 launch crane_bringup crane.launch.xml` で起動後、`http://localhost:8090/robot_manager.html` にアクセス
- [ ] ロボットフィードバック受信時にカードがリアルタイム更新されることを確認
- [ ] Start/Stop ボタンで Pi の起動・停止が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)