### PR TITLE
feat: docker composeからaivis-speechサービスを削除

### DIFF
--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -81,7 +81,6 @@ docker compose -f docker/dev/docker-compose.yaml down
 - **ssl-status-board**: ステータスボード(simのみ)
 - **autoref-tigers**: Tigers Mannheimのオートレフェリー
 - **voicevox**: 音声合成エンジン
-- **aivis-speech**: AIVIS音声エンジン
 - **debug_tools**: WebSocketベースのデバッグツール(docker-dev.shで自動起動)
 
 ## 設定ファイル

--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -72,8 +72,3 @@ services:
     # image: voicevox/voicevox_engine:nvidia-latest
     ports:
       - 127.0.0.1:50021:50021
-
-  aivis-speech:
-    image: ghcr.io/aivis-project/aivisspeech-engine:cpu-latest
-    ports:
-      - 127.0.0.1:10101:10101


### PR DESCRIPTION
## 概要
docker compose設定からaivis-speechサービスを削除する。

## 背景・根本原因
aivis-speechサービスが現在は不要になったため、設定ファイルから削除する。

## 変更内容
- `docker/dev/docker-compose.yaml`: aivis-speechサービス定義を削除
- `docker/dev/README.md`: aivis-speechの説明行を削除

## テスト方法
- [x] `docker compose -f docker/dev/docker-compose.yaml config` でYAML構文確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)