### PR TITLE
fix: setTargetPositionのデフォルトtoleranceを0.01mに変更しDEFAULT_1CM_TOLERANCEフォールバックを削除

### DIFF
--- a/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
@@ -26,7 +26,6 @@ namespace crane
 enum class ZeroVelocityReason {
   NONE,
   POSITION_TOLERANCE,
-  DEFAULT_1CM_TOLERANCE,
   RVO_COLLISION_OR_CONSTRAINT,
   PREF_VELOCITY_ZERO,
 };
@@ -36,8 +35,6 @@ inline auto toString(ZeroVelocityReason reason) -> std::string
   switch (reason) {
     case ZeroVelocityReason::POSITION_TOLERANCE:
       return "POSITION_TOLERANCE";
-    case ZeroVelocityReason::DEFAULT_1CM_TOLERANCE:
-      return "DEFAULT_1CM_TOLERANCE";
     case ZeroVelocityReason::RVO_COLLISION_OR_CONSTRAINT:
       return "RVO_COLLISION_OR_CONSTRAINT";
     case ZeroVelocityReason::PREF_VELOCITY_ZERO:

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -447,12 +447,6 @@ auto RVO2Planner::extractVelocityCommandsFromRVOSim(
     if (distance < original_pos_mode.position_tolerance) {
       vel = Velocity::Zero();
       zero_velocity_reason = ZeroVelocityReason::POSITION_TOLERANCE;
-    } else if (
-      original_command.local_planner_config.terminal_velocity == 0. &&
-      original_pos_mode.position_tolerance == 0. && distance < 0.01) {
-      // terminal_velocityが0のときはデフォルトで1cmのトレランス
-      vel = Velocity::Zero();
-      zero_velocity_reason = ZeroVelocityReason::DEFAULT_1CM_TOLERANCE;
     }
     if (zero_velocity_reason == ZeroVelocityReason::NONE && vel.norm() < 1e-4) {
       zero_velocity_reason = (pref_vel.norm() > 1e-3)

--- a/crane_robot_skills/src/single_ball_placement.cpp
+++ b/crane_robot_skills/src/single_ball_placement.cpp
@@ -284,7 +284,7 @@ void SingleBallPlacement::initialize()
     approach.x() = std::clamp(approach.x(), -max_x, max_x);
     approach.y() = std::clamp(approach.y(), -max_y, max_y);
 
-    command->setTargetPosition(approach);
+    command->setTargetPosition(approach, 0.0);
     command->lookAtFrom(placement_target, ball_pos);
     command->disablePlacementAvoidance();
     command->disableGoalAreaAvoidance();

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
@@ -425,7 +425,7 @@ public:
 
   // ===== PositionTargetMode固有の関数 =====
 
-  auto setTargetPosition(double x, double y, double tolerance = 0.0) -> RobotCommandWrapper &
+  auto setTargetPosition(double x, double y, double tolerance = 0.01) -> RobotCommandWrapper &
   {
     // 必要に応じてモードを切り替え
     if (current_mode != crane_msgs::msg::RobotCommand::POSITION_TARGET_MODE) {
@@ -439,12 +439,12 @@ public:
     return *this;
   }
 
-  auto setTargetPosition(Point position, double tolerance = 0.0) -> RobotCommandWrapper &
+  auto setTargetPosition(Point position, double tolerance = 0.01) -> RobotCommandWrapper &
   {
     return setTargetPosition(position.x(), position.y(), tolerance);
   }
 
-  auto setDribblerTargetPosition(Point position, double tolerance = 0.0) -> RobotCommandWrapper &
+  auto setDribblerTargetPosition(Point position, double tolerance = 0.01) -> RobotCommandWrapper &
   {
     double theta = latest_msg.target_theta;
     return setTargetPosition(


### PR DESCRIPTION
## 概要
`setTargetPosition` のデフォルトtolerance値を0.0から0.01m（1cm）に変更し、rvo2_plannerのDEFAULT_1CM_TOLERANCEフォールバックロジックを削除する。

## 背景・根本原因
これまで `position_tolerance=0.0` かつ `terminal_velocity=0` のとき、rvo2_plannerが暗黙的に1cmトレランスを適用するフォールバックが存在していた。そのため `setTargetPosition(pos, 0.0)` と明示的に指定しても0.0として機能せず、意図した動作が実現できなかった。

## 変更内容
- `setTargetPosition(x, y)` / `setTargetPosition(Point)` / `setDribblerTargetPosition(Point)` のデフォルトtolerance値を `0.0` → `0.01` に変更
- `rvo2_planner.cpp` の `DEFAULT_1CM_TOLERANCE` フォールバックロジックを削除
- `ZeroVelocityReason::DEFAULT_1CM_TOLERANCE` enum値と `toString` ケースを削除
- `single_ball_placement.cpp` の `GO_OVER_BALL` ステートで `tolerance=0.0` を明示指定（真に0を意図）

## テスト方法
- [x] `colcon build --packages-select crane_msg_wrappers crane_robot_skills crane_local_planner` でビルド確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)