### PR TITLE
feat: rosbag容量を4.9GiB→推定0.5〜1.0GiBに削減

### DIFF
--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -251,8 +251,12 @@ limitations under the License.
   </node>
 
   <!-- ROSバッグ記録（条件付き起動） -->
+  <!-- 記録対象トピックを選択的に指定し、zstd圧縮を有効化（容量削減: 4.9GiB → 推定0.5〜1.0GiB） -->
+  <!-- 除外: /diagnostics（/diagnostics_aggで代替）, **/process_time, /parameter_events, /events/write_split -->
   <group if="$(var record)">
-    <executable cmd="ros2 bag record -a -s mcap --log-level fatal"/>
+    <executable
+      cmd="ros2 bag record -s mcap --compression-mode file --compression-format zstd --log-level fatal /world_model /control_targets /robot_commands /game_analysis /robot_feedback /referee /play_situation /robot_select_results /game_event /rosout /aggregated_svgs /diagnostics_agg /ronar_events /ping /visualizer_svgs"
+    />
   </group>
 
   <!-- Foxglove Bridge（可視化ツール連携） -->

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_publisher.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_publisher.hpp
@@ -79,8 +79,6 @@ private:
 
   auto publishVisualization(WorldModelWrapperPtr world_model) -> void;
 
-  auto updateHistory(crane_msgs::msg::WorldModel & msg) -> void;
-
   auto postProcessWorldModel(WorldModelWrapperPtr) -> void;
 
   auto updateBallContact() -> void;
@@ -96,14 +94,6 @@ private:
   rclcpp::TimerBase::SharedPtr timer;
 
   std::unique_ptr<VisualizationManager> visualization_manager_;
-
-  std::array<std::deque<crane_msgs::msg::RobotInfo>, 20> friend_history;
-
-  std::array<std::deque<crane_msgs::msg::RobotInfo>, 20> enemy_history;
-
-  std::deque<crane_msgs::msg::BallInfo> ball_info_history;
-
-  int history_size{};
 
   WorldModelWrapperPtr wrapper_;
   rclcpp::Subscription<crane_msgs::msg::GameAnalysis>::SharedPtr sub_game_analysis_;

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -50,9 +50,6 @@ WorldModelPublisherComponent::WorldModelPublisherComponent(const rclcpp::NodeOpt
         msg, field_w, field_h, data_provider_->getLatestPlaySituation().command.name);
     });
 
-  declare_parameter("position_history_size", 200);
-  get_parameter<int>("position_history_size", history_size);
-
   declare_parameter("robot_id_mask", std::string("1, 2, 3"));
   std::string robot_id_mask_str;
   get_parameter("robot_id_mask", robot_id_mask_str);
@@ -125,32 +122,6 @@ WorldModelPublisherComponent::WorldModelPublisherComponent(const rclcpp::NodeOpt
 
 WorldModelPublisherComponent::~WorldModelPublisherComponent() = default;
 
-auto WorldModelPublisherComponent::updateHistory(crane_msgs::msg::WorldModel & msg) -> void
-{
-  if (ball_info_history.size() >= static_cast<size_t>(history_size)) {
-    ball_info_history.pop_front();
-  }
-  ball_info_history.emplace_back(msg.ball_info);
-
-  for (const auto & robot : msg.robot_info_ours) {
-    if (robot.available_vision || robot.available_feedback || robot.available_tracker) {
-      friend_history[robot.id].push_back(robot);
-    }
-    if (friend_history[robot.id].size() > static_cast<size_t>(history_size)) {
-      friend_history[robot.id].pop_front();
-    }
-  }
-
-  for (const auto & robot : msg.robot_info_theirs) {
-    if (robot.available_vision || robot.available_feedback || robot.available_tracker) {
-      enemy_history[robot.id].push_back(robot);
-    }
-    if (enemy_history[robot.id].size() > static_cast<size_t>(history_size)) {
-      enemy_history[robot.id].pop_front();
-    }
-  }
-}
-
 auto WorldModelPublisherComponent::publishWorldModel() -> void
 {
   // 遅延監視: データ取得開始
@@ -163,9 +134,6 @@ auto WorldModelPublisherComponent::publishWorldModel() -> void
   // ROS 2でのVisionパケット受信時刻を追加
   wrapper_->addDelayCheckpoint("vision_packet_received", "ros2_received");
   wrapper_->addDelayCheckpoint("data_provider_getMsg", "vision_processed");
-
-  updateHistory(msg);
-  wrapper_->addDelayCheckpoint("history_updated", "");
 
   wrapper_->update(msg);
   wrapper_->addDelayCheckpoint("wrapper_updated", "");
@@ -187,10 +155,6 @@ auto WorldModelPublisherComponent::publishVisualization(WorldModelWrapperPtr wor
 
   // VisualizationManagerによる統合可視化処理
   visualization_manager_->drawTrackedObjects(world_model);
-
-  // 軌跡履歴データをVisualizationManagerに渡す（コピーなし）
-  visualization_manager_->drawTrajectoryHistory(
-    friend_history, enemy_history, ball_info_history, world_model->isYellow());
 
   visualization_manager_->drawBallPlacement(world_model);
 


### PR DESCRIPTION
## 概要
1試合ハーフ（約17.6分）のrosbag2（MCAP形式）が4.9GiBに達していたため、zstd圧縮と選択的トピック記録により大幅な容量削減を実施。あわせてtrajectory history構築の不要なホットパス処理も除去した。

## 背景・根本原因
- `ros2 bag record -a`（全トピック・無圧縮）で記録していたため、`/world/trajectory`トピックが全データの約74%（推定1,872MB）を占めていた
- trajectory描画データはリアルタイムデバッグ以外では不要

## 変更内容
- **`crane_bringup/launch/crane.launch.xml`**: rosbag recordをzstd圧縮＋選択的トピック記録に変更
  - `--compression-mode file --compression-format zstd` を追加
  - `-a`（全トピック）から15トピックのホワイトリスト方式に変更
  - 除外: `/diagnostics`（`/diagnostics_agg`で代替）、`**/process_time`、`/parameter_events`、`/events/write_split`
- **`crane_world_model_publisher/src/world_model_publisher.cpp`**: `drawTrajectoryHistory`呼び出しと`updateHistory()`を完全削除
  - 毎フレーム60Hzで実行されていた不要なhistory構築処理（最大8,200オブジェクト管理）も除去
- **`crane_world_model_publisher/include/crane_world_model_publisher/world_model_publisher.hpp`**: 未使用メンバ変数・宣言を削除
  - `friend_history`, `enemy_history`, `ball_info_history`, `history_size`, `updateHistory()`を削除

## 推定削減効果

| 施策 | 削減量 |
|------|--------|
| trajectory無効化 | -1,872 MB (圧縮前) |
| 不要トピック除外 | -70 MB |
| zstd圧縮 | -1.5〜2.1 GiB |
| **合計** | **4.9 GiB → 推定 0.5〜1.0 GiB** |

## テスト方法
- [ ] `colcon build --packages-select crane_world_model_publisher crane_bringup` でビルド確認
- [ ] シミュレーションで短時間記録し、`mcap info` でサイズ・トピック・圧縮率を確認
- [ ] Web Debugger でtrajectory以外の可視化（ロボット・ボール描画等）が正常表示されることを確認
- [ ] `crane_bag` 解析ツールが正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)