### PR TITLE
fix: ペナルティエリア内でstopHere状態のとき脱出できないバグを修正

### DIFF
--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -676,10 +676,14 @@ auto RVO2Planner::adjustForPenaltyAreaAvoidance(
         if (std::abs(current_pos.x()) > world_model->fieldSize().x() / 2.0) {
           target_pos.x() = std::copysign(world_model->fieldSize().x() / 2.0, target_pos.x());
         }
+        // stopHere()等でtarget_pos == current_posの場合（ペナルティエリア内で停止指示）、
+        // ゴールから離れる方向に初期目標を設定することで脱出ループを有効化する
+        if ((target_pos - current_pos).norm() < 1e-6) {
+          target_pos = current_pos + (current_pos - goal_pos).normalized() * 0.05;
+        }
         // 目標点をペナルティエリアの外に出るようにする (反復上限で無限ループ防止)
         for (int iter = 0;
-             iter < MAX_ITERATIONS && isInBox(penalty_area, target_pos, PENALTY_AREA_OFFSET) &&
-             target_pos != current_pos;
+             iter < MAX_ITERATIONS && isInBox(penalty_area, target_pos, PENALTY_AREA_OFFSET);
              ++iter) {
           target_pos += (target_pos - current_pos).normalized() * 0.05;  // 5cmずつ離れていく
         }


### PR DESCRIPTION
## 概要
ペナルティエリア内でロボットに`stopHere()`が指示された際、ペナルティエリア脱出処理が
機能せずそのまま停止し続けるバグを修正。

## 背景・根本原因
`avoidPenaltyArea`内のループ条件に`target_pos != current_pos`があった。
`stopHere()`は`target_pos = current_pos`（現在位置）を設定するため、ロボットが
ペナルティエリア内にいてもループが1回も実行されず、脱出目標が計算されないまま
ペナルティエリア内に停止し続けた。

rosbag（KIKS 2nd half penalty, t=331付近）で確認された事例：
- 9番ロボットがReceiverとしてペナルティエリア付近に向かった際に内部に入り込んだ
- ボールが静止したためpass_receiver_sessionがstopHere()を呼び出した
- **約1.8秒間ペナルティエリア内で停止**し、その後角を大きく迂回して脱出

## 変更内容
- `rvo2_planner.cpp`のavoidPenaltyAreaラムダ:
  - `target_pos ≈ current_pos`（stopHere状態等）のとき、ゴールから離れる方向に
    初期目標を5cmオフセットして設定
  - ループ条件から`target_pos != current_pos`を削除（初期化で保証されるため不要）

## テスト方法
- [x] `colcon build --packages-select crane_local_planner` でビルド確認
- [x] HALTは`overrideTargetPosition`自体がスキップされるため影響なし（コード確認済み）
- [x] ペナルティエリア内でstopHere状態になるシナリオで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)