### PR TITLE
fix: ロボットが役割未割り当てで動かない問題を修正

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/skill_base.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/skill_base.hpp
@@ -105,6 +105,8 @@ public:
   : SkillInterface(std::forward<Args>(args)...)
   {
     this->name = name;
+    // commandはdelegating constructor内で空のnameで生成されるため、ここで正しいnameを設定する
+    this->command->name = name;
     if (visualizer->layer == "skill/") {
       visualizer->layer = "skill/" + name;
     }

--- a/crane_session_coordinator/src/global_robot_allocator.cpp
+++ b/crane_session_coordinator/src/global_robot_allocator.cpp
@@ -74,6 +74,21 @@ auto GlobalRobotAllocator::allocate(
                            << "ロボットを割り当て: " << assigned_robots);
   }
 
+  if (!remaining_robots.empty()) {
+    RCLCPP_WARN(
+      logger_,
+      "[GlobalRobotAllocator] %zu台のロボットがどのセッションにも割り当てられませんでした: %s",
+      remaining_robots.size(),
+      [&]() {
+        std::string ids;
+        for (auto id : remaining_robots) {
+          ids += std::to_string(id) + " ";
+        }
+        return ids;
+      }()
+        .c_str());
+  }
+
   return result;
 }
 

--- a/crane_sessions/include/crane_sessions/forward_session.hpp
+++ b/crane_sessions/include/crane_sessions/forward_session.hpp
@@ -52,8 +52,9 @@ public:
 
   int getDesiredRobotNumber(int max_robots) const override
   {
-    // Forwardは生成可能なライン数以上のロボットを扱えないため、動的に上限を調整する
-    return std::min<int>(static_cast<int>(createForwardLines().size()), max_robots);
+    // Forwardはcatch-allセッションとして余剰ロボットを全て受け入れる
+    // ライン数よりロボット数が多い場合はforward_session.cppで既存ラインを循環割当する
+    return max_robots;
   }
 
 protected:

--- a/crane_sessions/src/forward_session.cpp
+++ b/crane_sessions/src/forward_session.cpp
@@ -85,6 +85,12 @@ auto ForwardSession::calculatePositionCommand(const std::vector<RobotIdentifier>
     } else {
       if (forward_lines.size() > robots.size()) {
         forward_lines.resize(robots.size());
+      } else if (forward_lines.size() < robots.size()) {
+        // ロボット数がライン数を超える場合、既存ラインを循環的に複製して全ロボットに割当
+        size_t original_size = forward_lines.size();
+        while (forward_lines.size() < robots.size()) {
+          forward_lines.push_back(forward_lines[forward_lines.size() % original_size]);
+        }
       }
 
       std::vector<Point> robot_positions =

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
@@ -66,7 +66,7 @@ private:
   auto getID() const -> uint8_t { return latest_msg.robot_id; }
 
 public:
-  const std::string name;
+  std::string name;
 
   RobotCommandWrapper(
     std::string skill_name, uint8_t id, WorldModelWrapper::SharedPtr world_model_wrapper)


### PR DESCRIPTION
## 概要

rosbagのログ解析から発見した、INPLAYで特定のロボットが動かない問題を修正します。
根本原因はForwardSessionのcatch-all不具合とSkillInterfaceの初期化順序バグです。

## 背景・根本原因

rosbag `rosbag2_2026_03_21-19_06_02`（290秒、8台で稼働）の解析結果:
- ROBOT VELOCITY STATUSで10秒おきに1〜4台が速度ゼロ（t=170では4台同時停止）
- ROSOUT警告: `Session「forward」に割り当てるロボットが不足しています` 等

**原因1: ForwardSession がcatch-allとして機能していない（主因）**

`getDesiredRobotNumber()` がフォワードライン数（通常3〜5本）に自身を制限するため、
最後のセッションであるforwardに割り当てられなかったロボットがコマンドなしで放置されていた。

**原因2: GlobalRobotAllocatorに余剰ロボットのフォールバックがない**

全セッション処理後も `remaining_robots` が残った場合に警告もフォールバックもなかった。

**原因3: SkillInterface delegating constructorの初期化順序バグ（デバッグ阻害）**

`PositionCommandWrapper` がnameが確定する前に空文字列で生成されるため、
すべてのスキル由来の `stopHere()` で `CommandSource=""` となり停止原因の追跡が不可能だった。

## 変更内容

- **`forward_session.hpp`**: `getDesiredRobotNumber()` を `max_robots` を返すよう変更し、catch-allとして余剰ロボットを全て受け入れる
- **`forward_session.cpp`**: robots > lines の場合に既存ラインを循環複製して `getOptimalAssignments` のassert失敗を防ぐ
- **`global_robot_allocator.cpp`**: 割当後に余剰ロボットが残った場合のWARN出力を追加
- **`robot_command_wrapper.hpp`**: `name` フィールドの `const` を削除してSkillBaseからの更新を可能にする
- **`skill_base.hpp`**: delegating constructorの3引数版で `command->name` を正しいnameで上書きするよう修正

## テスト方法

- [x] `colcon build --packages-up-to crane_session_coordinator crane_sessions crane_robot_skills` でビルド成功確認済み
- [ ] シミュレーション実行でINPLAY中に全ロボットが動作し続けることを確認
- [ ] rosbagを再取得して `zero_v` ロボット数が減少すること、`CommandSource` が空でなくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)