### PR TITLE
feat(crane_sessions): ロボット台数不足時に追加可能音声案内を追加

### DIFF
--- a/crane_sessions/src/emplace_robot_session.cpp
+++ b/crane_sessions/src/emplace_robot_session.cpp
@@ -102,6 +102,21 @@ EmplaceRobotSession::calculatePositionCommand(const std::vector<RobotIdentifier>
       }
       last_announce_time_ = now;
     }
+  } else {
+    // ロボット不足時のアナウンス
+    int available_count =
+      static_cast<int>(world_model->ours().robotsWhere().available().getIds().size());
+    int max_allowed = static_cast<int>(world_model->getOurMaxAllowedBots());
+    if (max_allowed > 0 && available_count < max_allowed) {
+      auto now = std::chrono::steady_clock::now();
+      if (now - last_announce_time_ >= ANNOUNCE_INTERVAL) {
+        if (use_voice_announcement_) {
+          sendSpeakGoal(
+            "ロボット上限は" + std::to_string(max_allowed) + "台です。ロボットを追加できます");
+        }
+        last_announce_time_ = now;
+      }
+    }
   }
 
   // GlobalRobotAllocator対応: robotsが変更されたらスキルマップを再生成


### PR DESCRIPTION
## 概要

emplace plannerでロボット台数がゲームコントローラーの上限より少ない場合に、「ロボット上限はN台です。ロボットを追加できます」と音声案内するよう実装しました。

## 背景・根本原因

ロボット退場（過剰）時は音声案内がある一方、ロボット追加が可能（不足）な状況ではオペレータへの通知がなく、気づけない問題がありました。

## 変更内容

- `calculatePositionCommand()` のロボットなし時に不足チェックを追加
- `available_count < max_allowed`（かつ `max_allowed > 0`）の場合、5秒間隔で音声アナウンス
- テキスト: 「ロボット上限は{N}台です。ロボットを追加できます」
- ビープ音は対象外（音声アナウンスのみ）

## テスト方法

- [ ] `colcon build --packages-select crane_sessions` でビルド確認
- [ ] ssl-game-controllerで `max_allowed_bots` を設定し、それより少ない台数で起動 → 音声案内が出ることを確認
- [ ] ロボットを追加して上限に達したら案内が止まることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)