### PR TITLE
fix(crane_robot_skills): ボールプレイスメント中のボール取りこぼし検知を改善

### DIFF
--- a/crane_msgs/msg/BallInfo.msg
+++ b/crane_msgs/msg/BallInfo.msg
@@ -5,6 +5,7 @@ geometry_msgs/Vector3 velocity
 float32 velocity_norm
 
 Vector3Stamped vision
+Vector3Stamped tracker
 
 bool detected
 

--- a/crane_robot_skills/include/crane_robot_skills/single_ball_placement.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/single_ball_placement.hpp
@@ -57,6 +57,31 @@ private:
     return p;
   }
 
+  /// ボールがドリブラーから確実に離れたかを判定する。
+  /// Vision/Tracker両方が検出かつ位置が一致かつデータが新鮮な場合のみ判定可能。
+  bool isBallTrulyLostFromDribbler(double distance_threshold = 0.2) const
+  {
+    const auto & ball_info = world_model()->getMsg().ball_info;
+    if (!ball_info.vision_detected || !ball_info.tracker_detected) {
+      return false;
+    }
+    auto now = rclcpp::Clock(RCL_ROS_TIME).now();
+    constexpr double FRESHNESS_SEC = 0.1;
+    rclcpp::Time vision_stamp(ball_info.vision.stamp, RCL_ROS_TIME);
+    rclcpp::Time tracker_stamp(ball_info.tracker.stamp, RCL_ROS_TIME);
+    if (
+      (now - vision_stamp).seconds() > FRESHNESS_SEC ||
+      (now - tracker_stamp).seconds() > FRESHNESS_SEC) {
+      return false;
+    }
+    Point vision_pos(ball_info.vision.pos.x, ball_info.vision.pos.y);
+    Point tracker_pos(ball_info.tracker.pos.x, ball_info.tracker.pos.y);
+    if ((vision_pos - tracker_pos).norm() > 0.15) {
+      return false;
+    }
+    return (tracker_pos - robot()->kicker_center()).norm() > distance_threshold;
+  }
+
 public:
   template <typename... Args>
   explicit SingleBallPlacement(Args &&... args)

--- a/crane_robot_skills/src/single_ball_placement.cpp
+++ b/crane_robot_skills/src/single_ball_placement.cpp
@@ -267,6 +267,12 @@ void SingleBallPlacement::initialize()
   //    SingleBallPlacementStates::PULL_BACK_FROM_EDGE_PREPARE,
   //    [this]() { return robot()->getDistance(world_model()->ball().pos) > 0.15; });
 
+  // Vision/Tracker両方が一致してボールがドリブラーから離れている場合はやり直し
+  addTransition(
+    static_cast<int>(SingleBallPlacementStates::PULL_BACK_FROM_EDGE_PULL),
+    static_cast<int>(SingleBallPlacementStates::ENTRY_POINT),
+    [this]() { return isBallTrulyLostFromDribbler(0.2); });
+
   addStateFunction(static_cast<int>(SingleBallPlacementStates::GO_OVER_BALL), [this]() {
     command->setMaxVelocity("SingleBallPlacementStates::GO_OVER_BALL", 1.5);
     auto placement_target = getPlacementTarget();
@@ -380,11 +386,14 @@ void SingleBallPlacement::initialize()
   addTransition(
     static_cast<int>(SingleBallPlacementStates::CONTACT_BALL),
     static_cast<int>(SingleBallPlacementStates::ENTRY_POINT), [this]() {
-      // ロボットの向きがボールの方を向いていなかったらやり直し
       using boost::math::constants::degree;
-      return std::abs(getAngleDiff(
-               getAngle(world_model()->ball().pos - robot()->pose.pos), robot()->pose.theta)) >
-             45 * degree<double>();
+      if (
+        std::abs(getAngleDiff(
+          getAngle(world_model()->ball().pos - robot()->pose.pos), robot()->pose.theta)) >
+        45 * degree<double>()) {
+        return true;
+      }
+      return isBallTrulyLostFromDribbler(0.3);
     });
 
   addStateFunction(static_cast<int>(SingleBallPlacementStates::MOVE_TO_TARGET), [this]() {
@@ -402,8 +411,8 @@ void SingleBallPlacement::initialize()
     double dist = (placement_target - robot()->pose.pos).norm();
     double acc = 0.5;
     double max_vel = std::min({std::sqrt(2. * dist * acc), 1.0, robot()->vel.linear.norm() + 0.1});
-    command->setTargetPosition(placement_target);
     command->lookAt(placement_target);
+    command->setDribblerTargetPosition(placement_target);
     command->disableAnyAreaAvoidance();
     command->setMaxVelocity("SingleBallPlacementStates::MOVE_TO_TARGET", max_vel);
     command->setMaxAcceleration("SingleBallPlacementStates::MOVE_TO_TARGET", 1.0);
@@ -453,19 +462,24 @@ void SingleBallPlacement::initialize()
     static_cast<int>(SingleBallPlacementStates::MOVE_TO_TARGET),
     static_cast<int>(SingleBallPlacementStates::ENTRY_POINT), [this]() {
       auto now = rclcpp::Clock(RCL_ROS_TIME).now();
-      bool flag = robot()->ball_sensor_stamp.has_value() &&
-                  now.get_clock_type() == robot()->ball_sensor_stamp->get_clock_type() &&
-                  (now - *(robot()->ball_sensor_stamp)).seconds() >= 1.0;
-
-      if (flag && !robot()->ball_sensor) {
+      bool feedback_timeout =
+        robot()->ball_sensor_stamp.has_value() &&
+        now.get_clock_type() == robot()->ball_sensor_stamp->get_clock_type() &&
+        (now - *(robot()->ball_sensor_stamp)).seconds() >= 1.0;
+      if (feedback_timeout && !robot()->ball_sensor) {
         RCLCPP_INFO(
           rclcpp::get_logger("SingleBallPlacement"),
           "Ball sensor is not working, so return to ENTRY_POINT: %fs",
           std::abs((now - *(robot()->ball_sensor_stamp)).seconds()));
         return true;
-      } else {
-        return false;
       }
+      if (isBallTrulyLostFromDribbler(0.2)) {
+        RCLCPP_INFO(
+          rclcpp::get_logger("SingleBallPlacement"),
+          "Ball truly lost during MOVE_TO_TARGET (vision+tracker agree, ball far from dribbler)");
+        return true;
+      }
+      return false;
     });
   // ボールが離れたら始めに戻る
   // addTransition(

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -814,6 +814,14 @@ auto WorldModelDataProvider::integrateBallInfo() -> void
     ball_info_.vision.pos = vision_ball_state_.raw_position;
   }
 
+  // Tracker情報の更新（常にTrackerの生データを保持）
+  if (tracker_ball_state_.detected) {
+    ball_info_.tracker.stamp = tracker_ball_state_.last_detect_time;
+    ball_info_.tracker.pos.x = tracker_ball_state_.position.x();
+    ball_info_.tracker.pos.y = tracker_ball_state_.position.y();
+    ball_info_.tracker.pos.z = tracker_ball_state_.position.z();
+  }
+
   // ボール状態の決定
   if (ball_info_.velocity_norm < 0.1) {
     ball_info_.state = crane_msgs::msg::BallInfo::STOPPED;


### PR DESCRIPTION
## Summary

- `BallInfo.msg` に Tracker 生データ用の `tracker` (Vector3Stamped) フィールドを追加し、Vision と同様にタイムスタンプ付きの生位置データを保持できるようにした
- Vision/Tracker 両方が検出かつ位置一致かつデータが新鮮な場合のみボール喪失と判定する `isBallTrulyLostFromDribbler()` ヘルパー関数を `SingleBallPlacement` に追加
- `MOVE_TO_TARGET`・`CONTACT_BALL`・`PULL_BACK_FROM_EDGE_PULL` の各状態の中止判断に、上記ヘルパーを使ったボール落下検知を追加
- `MOVE_TO_TARGET` のターゲット設定を `setTargetPosition` から `setDribblerTargetPosition` に変更し、ドリブラー位置が正確に配置ターゲットに合うようにした

### 背景

rosbag（2026-03-21 試合）の解析で、OUR_BALL_PLACEMENT 13回中7回がタイムアウト（31秒）で失敗していることを確認。原因は `MOVE_TO_TARGET` 中のボール落下検知が実質機能していなかったこと。

従来の `MOVE_TO_TARGET → ENTRY_POINT` 遷移条件は「`ball_sensor_stamp` が1秒以上古い」のみで、これは通信断のみを検知する（feedback は 100Hz で届くため、ボールが物理的に離れても発火しない）。

### 判定ロジックの設計

ボール保持中はドリブラーの影にボールが隠れて Vision から見えなくなることがある。Tracker はその間、最後に見えた位置から外挿するため、実際とは異なる位置を報告する（ターゲット方向に向かっていた場合、既に到着したと誤認する）。

このため、ボール位置を信頼できる条件として以下を全て満たす必要がある:
1. Vision/Tracker 両方が検出している
2. 各データが 100ms 以内に更新されている（鮮度チェック）
3. Vision 位置と Tracker 位置が 15cm 以内で一致している

これらを満たした上でボールがドリブラーから一定距離以上離れている場合のみ「落下確定」と判定する。

## Test plan

- [ ] `colcon build --packages-select crane_msgs crane_world_model_publisher crane_robot_skills` でビルドが通ること
- [ ] シナリオテスト `scenario_test/BALL_PLACEMENT_NEAR_WALL.py` が通ること
- [ ] シミュレータでボールを途中で落とした場合に ENTRY_POINT に素早く戻ることを確認
- [ ] `ros2 topic echo /rosout | grep SingleBallPlacement` で「Ball truly lost」ログが出ることを確認
- [ ] `/world_model` トピックで `ball_info.tracker` フィールドに Tracker 生位置が入っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)