### PR TITLE
fix(crane_bag): analyze-rosbagコマンドにzstd圧縮rosbag対応の前処理を追加

### DIFF
--- a/.claude/commands/analyze-rosbag.md
+++ b/.claude/commands/analyze-rosbag.md
@@ -26,6 +26,34 @@ $ARGUMENTS
 
 ## 実行手順
 
+### Step 0: Rosbag前処理（zstd圧縮対応）
+
+`crane_bag` を実行する前に、rosbagディレクトリを正常な状態にする。
+rosbag2ライブラリが `.mcap.zstd` を直接 mcap プラグインで開こうとしてエラーになるため、必ず以下のbashを実行すること。
+
+```bash
+BAG_DIR="<rosbag_path>"
+
+# .mcap.zstd があるが .mcap がない場合、展開する
+for zst in "$BAG_DIR"/*.mcap.zstd; do
+  [ -f "$zst" ] || continue
+  mcap="${zst%.zstd}"
+  if [ ! -f "$mcap" ]; then
+    echo "zstd展開中: $(basename "$zst")"
+    zstd -d "$zst" -o "$mcap"
+  fi
+done
+
+# metadata.yaml の compression 設定を修正（.mcap.zstd を指したままだと読めない）
+META="$BAG_DIR/metadata.yaml"
+if [ -f "$META" ] && grep -q 'compression_format: zstd' "$META"; then
+  sed -i 's/compression_format: zstd/compression_format: ""/' "$META"
+  sed -i 's/compression_mode: FILE/compression_mode: NONE/' "$META"
+  sed -i 's/\.mcap\.zstd/.mcap/g' "$META"
+  echo "metadata.yaml を更新しました（圧縮設定を解除）"
+fi
+```
+
 ### Step 1: Bag情報の確認
 
 ```bash


### PR DESCRIPTION
## 概要

`/analyze-rosbag` コマンド実行時に、zstd圧縮されたrosbagを正しく読み込めるよう前処理ステップを追加した。

## 背景・根本原因

rosbagをzstd圧縮で保存すると、`metadata.yaml` の `relative_file_paths` に `.mcap.zstd` が記録される。rosbag2ライブラリはこれをmcapプラグインで直接開こうとするが、zstdヘッダーを持つファイルのmagic bytesがmcap形式と異なるためエラーになる。

```
[ERROR] Could not open '...mcap.zstd' with 'mcap'. Error: invalid magic bytes in Header: 0x28B52FFD005834EB
```

## 変更内容

- `analyze-rosbag.md` に **Step 0（Rosbag前処理）** を追加
  - `.mcap.zstd` が存在するが `.mcap` がない場合: `zstd -d` で展開
  - `.mcap.zstd` と `.mcap` が両方ある場合: 展開スキップ
  - `metadata.yaml` に `compression_format: zstd` が含まれる場合: 圧縮設定を解除（`relative_file_paths` の `.mcap.zstd` → `.mcap`、`compression_mode: FILE` → `NONE`）

## テスト方法

- [x] zstd圧縮rosbag（`.mcap.zstd`のみ）でStep 0前処理後に `crane_bag info` が正常動作することを確認
- [x] `.mcap` と `.mcap.zstd` 両方存在するケースで前処理後に `crane_bag info` が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)