### PR TITLE
feat(crane_web_debugger): ロボット管理UIをテーブル型に変更し詳細サイドパネルを追加

### DIFF
--- a/crane_web_debugger/web/robot_manager.html
+++ b/crane_web_debugger/web/robot_manager.html
@@ -18,31 +18,73 @@
         .status-dot.connected { background-color: #28a745; }
         .status-dot.disconnected { background-color: #dc3545; }
 
-        .robot-card {
-            transition: border-color 0.3s ease;
-        }
-        .robot-card.has-error { border-color: #dc3545; border-width: 2px; }
-        .robot-card.has-warning { border-color: #ffc107; border-width: 2px; }
-        .robot-card.offline { opacity: 0.65; }
+        .robot-row.has-error { background-color: rgba(220, 53, 69, 0.1); }
+        .robot-row.offline { opacity: 0.65; }
 
-        .card-header { padding: 0.5rem 0.75rem; }
-        .card-body { padding: 0.5rem 0.75rem; }
-        .card-footer { padding: 0.4rem 0.75rem; }
-
-        .voltage-bar { height: 6px; }
-        .info-row {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 0.3rem;
-            font-size: 0.82rem;
-        }
-        .info-label { color: #6c757d; }
-        .info-value { font-weight: 500; }
+        .voltage-bar { height: 5px; margin-top: 3px; }
 
         .error-text {
-            font-size: 0.78rem;
+            font-size: 0.82rem;
             word-break: break-word;
+        }
+
+        /* Side Panel */
+        #detail-panel {
+            position: fixed;
+            top: 0;
+            right: -380px;
+            width: 360px;
+            height: 100%;
+            background: #212529;
+            color: #dee2e6;
+            z-index: 1050;
+            transition: right 0.25s ease;
+            display: flex;
+            flex-direction: column;
+            box-shadow: -4px 0 12px rgba(0,0,0,0.4);
+        }
+        #detail-panel.open { right: 0; }
+        #detail-panel .panel-header {
+            padding: 0.75rem 1rem;
+            background: #343a40;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            flex-shrink: 0;
+        }
+        #detail-panel .panel-body {
+            flex: 1;
+            overflow-y: auto;
+            padding: 0.75rem 1rem;
+        }
+        #detail-panel .section-title {
+            font-size: 0.72rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: #6c757d;
+            margin: 0.75rem 0 0.3rem;
+        }
+        #detail-panel table td:first-child {
+            color: #6c757d;
+            white-space: nowrap;
+            padding-right: 0.75rem;
+            font-size: 0.82rem;
+        }
+        #detail-panel table td:last-child {
+            font-size: 0.85rem;
+            font-weight: 500;
+        }
+        #detail-panel .factor-bar {
+            height: 4px;
+            background: #495057;
+            border-radius: 2px;
+            margin-top: 2px;
+        }
+        #detail-panel .factor-bar-fill {
+            height: 100%;
+            background: #0d6efd;
+            border-radius: 2px;
+            transition: width 0.3s;
         }
     </style>
 </head>
@@ -101,8 +143,62 @@
             </div>
         </div>
 
-        <!-- Robot Cards Grid -->
-        <div class="row g-3" id="robot-grid"></div>
+        <!-- Detail Side Panel -->
+        <div id="detail-panel">
+            <div class="panel-header">
+                <span><i class="fas fa-robot me-2"></i><strong id="panel-title">Robot #--</strong></span>
+                <button class="btn btn-sm btn-outline-secondary" onclick="closeDetailPanel()">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+            <div class="panel-body">
+                <!-- 位置・速度 -->
+                <div class="section-title"><i class="fas fa-map-marker-alt me-1"></i>位置・速度</div>
+                <div id="panel-pose"></div>
+                <!-- 目標値 -->
+                <div class="section-title"><i class="fas fa-crosshairs me-1"></i>目標値</div>
+                <div id="panel-target"></div>
+                <!-- Session / スキル -->
+                <div class="section-title"><i class="fas fa-layer-group me-1"></i>Session / スキル</div>
+                <table class="table table-sm table-borderless table-dark mb-0">
+                    <tbody id="panel-session"></tbody>
+                </table>
+                <!-- プランニング要素 -->
+                <div class="section-title"><i class="fas fa-sliders-h me-1"></i>プランニング要素</div>
+                <div id="panel-factors"></div>
+                <!-- ハードウェア -->
+                <div class="section-title"><i class="fas fa-microchip me-1"></i>ハードウェア</div>
+                <table class="table table-sm table-borderless table-dark mb-0">
+                    <tbody id="panel-hw"></tbody>
+                </table>
+                <div class="mt-3">
+                    <a id="panel-telemetry-link" href="#" class="btn btn-sm btn-primary w-100">
+                        <i class="fas fa-chart-line me-1"></i>テレメトリを開く
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div id="panel-backdrop" onclick="closeDetailPanel()"
+             style="display:none; position:fixed; inset:0; z-index:1040; background:rgba(0,0,0,0.3)"></div>
+
+        <!-- Robot Table -->
+        <div class="table-responsive">
+            <table class="table table-sm table-hover align-middle">
+                <thead class="table-dark">
+                    <tr>
+                        <th>ID</th>
+                        <th>ステータス / 操作</th>
+                        <th style="min-width:110px">電圧</th>
+                        <th>最高温度</th>
+                        <th>Ping</th>
+                        <th>通信</th>
+                        <th>エラー</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody id="robot-table-body"></tbody>
+            </table>
+        </div>
     </div>
 
     <script src="robot_manager.js"></script>

--- a/crane_web_debugger/web/robot_manager.js
+++ b/crane_web_debugger/web/robot_manager.js
@@ -9,6 +9,8 @@ const TEMP_WARN = 60;
 const PING_WARN = 10;
 const PING_CRIT = 50;
 
+const CONTROL_MODE_LONG = { 0: 'LOCAL_CAMERA', 1: 'POSITION_TARGET', 2: 'SIMPLE_VELOCITY', 3: 'POLAR_VELOCITY' };
+
 // ---- State ----------------------------------------------------------------
 
 const robotState = {};
@@ -20,6 +22,12 @@ for (let i = 0; i < NUM_ROBOTS; i++) {
         last_feedback_ms: 0,
     };
 }
+
+// world_model / control_targets per robot
+const robotPose = {};     // { x, y, theta, vx, vy, omega, vision_x, vision_y, vision_theta }
+const robotCommand = {};  // control_targets commands keyed by robot_id
+
+let detailOpenId = null;
 
 let ws = null;
 let wsConnected = false;
@@ -73,21 +81,14 @@ function setWsStatus(connected) {
 
 function handleMessage(msg) {
     switch (msg.type) {
-        case 'robot_feedback':
-            onRobotFeedback(msg);
-            break;
-        case 'ping_status':
-            onPingStatus(msg);
-            break;
-        case 'pi_status':
-            onPiStatus(msg);
-            break;
-        case 'robot_control_result':
-            onRobotControlResult(msg);
-            break;
-        // diagnostics は将来の拡張用
-        default:
-            break;
+        case 'robot_feedback':      onRobotFeedback(msg); break;
+        case 'ping_status':         onPingStatus(msg); break;
+        case 'pi_status':           onPiStatus(msg); break;
+        case 'robot_control_result': onRobotControlResult(msg); break;
+        case 'world_model':         onWorldModel(msg); break;
+        case 'control_targets':     onControlTargets(msg); break;
+        case 'robot_commands':      onRobotCommands(msg); break;
+        default: break;
     }
 }
 
@@ -121,6 +122,34 @@ function onPiStatus(msg) {
         }
     }
     pendingUpdate = true;
+}
+
+function onWorldModel(msg) {
+    if (msg.robots_ours) {
+        for (const r of msg.robots_ours) {
+            robotPose[r.id] = r;
+        }
+    }
+    if (detailOpenId !== null) refreshDetailPanel(detailOpenId);
+}
+
+function onControlTargets(msg) {
+    if (msg.commands) {
+        for (const cmd of msg.commands) {
+            robotCommand[cmd.robot_id] = cmd;
+        }
+    }
+    if (detailOpenId !== null) refreshDetailPanel(detailOpenId);
+}
+
+function onRobotCommands(msg) {
+    // control_targets がない場合のフォールバック
+    if (msg.commands && Object.keys(robotCommand).length === 0) {
+        for (const cmd of msg.commands) {
+            robotCommand[cmd.robot_id] = cmd;
+        }
+        if (detailOpenId !== null) refreshDetailPanel(detailOpenId);
+    }
 }
 
 function onRobotControlResult(msg) {
@@ -227,18 +256,18 @@ function pingClass(ms) {
     return 'text-success';
 }
 
-function renderRobotCard(id) {
+function renderRobotRow(id) {
     const state = robotState[id];
     const fb = state.feedback;
     const overallStatus = getOverallStatus(id);
 
-    const card = document.getElementById(`robot-card-${id}`);
-    if (!card) return;
+    const row = document.getElementById(`robot-row-${id}`);
+    if (!row) return;
 
-    // Card border style
-    card.className = 'card robot-card h-100';
-    if (overallStatus === 'Error') card.classList.add('has-error');
-    else if (overallStatus === 'Offline') card.classList.add('offline');
+    // Row style
+    row.className = 'robot-row';
+    if (overallStatus === 'Error') row.classList.add('has-error');
+    else if (overallStatus === 'Offline') row.classList.add('offline');
 
     // Status badge
     const badge = document.getElementById(`badge-${id}`);
@@ -252,12 +281,12 @@ function renderRobotCard(id) {
         const v = fb.voltage[0];
         const pct = Math.max(0, Math.min(100, (v - VOLTAGE_MIN) / (VOLTAGE_MAX - VOLTAGE_MIN) * 100));
         voltageEl.textContent = `${v.toFixed(2)} V`;
-        voltageEl.className = `info-value ${v < 22.0 ? 'text-danger' : v < 23.0 ? 'text-warning' : 'text-success'}`;
+        voltageEl.className = `fw-medium ${v < 22.0 ? 'text-danger' : v < 23.0 ? 'text-warning' : 'text-success'}`;
         voltageBarEl.style.width = `${pct}%`;
         voltageBarEl.className = `progress-bar ${voltageBarClass(v)}`;
     } else {
         voltageEl.textContent = '--';
-        voltageEl.className = 'info-value text-secondary';
+        voltageEl.className = 'fw-medium text-secondary';
         voltageBarEl.style.width = '0%';
         voltageBarEl.className = 'progress-bar bg-secondary';
     }
@@ -267,30 +296,30 @@ function renderRobotCard(id) {
     if (fb && fb.temperatures && fb.temperatures.length > 0) {
         const maxTemp = Math.max(...fb.temperatures);
         tempEl.textContent = `${maxTemp} °C`;
-        tempEl.className = `info-value ${maxTemp >= TEMP_WARN ? 'text-danger' : ''}`;
+        tempEl.className = `fw-medium ${maxTemp >= TEMP_WARN ? 'text-danger' : ''}`;
     } else {
         tempEl.textContent = '--';
-        tempEl.className = 'info-value text-secondary';
+        tempEl.className = 'fw-medium text-secondary';
     }
 
     // Ping
     const pingEl = document.getElementById(`ping-${id}`);
     if (state.ping_ms !== null) {
         pingEl.textContent = `${state.ping_ms.toFixed(1)} ms`;
-        pingEl.className = `info-value ${pingClass(state.ping_ms)}`;
+        pingEl.className = `fw-medium ${pingClass(state.ping_ms)}`;
     } else {
         pingEl.textContent = '--';
-        pingEl.className = 'info-value text-secondary';
+        pingEl.className = 'fw-medium text-secondary';
     }
 
     // Packet frequency
     const freqEl = document.getElementById(`freq-${id}`);
     if (fb) {
         freqEl.textContent = `${fb.packet_frequency_hz.toFixed(1)} Hz`;
-        freqEl.className = `info-value ${fb.packet_frequency_hz < 50 ? 'text-warning' : 'text-success'}`;
+        freqEl.className = `fw-medium ${fb.packet_frequency_hz < 50 ? 'text-warning' : 'text-success'}`;
     } else {
         freqEl.textContent = '--';
-        freqEl.className = 'info-value text-secondary';
+        freqEl.className = 'fw-medium text-secondary';
     }
 
     // Error
@@ -326,74 +355,207 @@ function renderSummary() {
 
 function renderAll() {
     for (let i = 0; i < NUM_ROBOTS; i++) {
-        renderRobotCard(i);
+        renderRobotRow(i);
     }
     renderSummary();
 }
 
-// ---- Card Generation ------------------------------------------------------
+// ---- Table Row Generation -------------------------------------------------
 
-function createRobotCard(id) {
+function createRobotRow(id) {
     return `
-<div class="col-xl-3 col-lg-4 col-md-6">
-    <div class="card robot-card h-100" id="robot-card-${id}">
-        <div class="card-header d-flex justify-content-between align-items-center">
-            <strong><i class="fas fa-robot me-1"></i>Robot #${id}</strong>
-            <span class="badge bg-secondary" id="badge-${id}">不明</span>
-        </div>
-        <div class="card-body">
-            <!-- 電圧 -->
-            <div class="info-row">
-                <span class="info-label"><i class="fas fa-battery-half me-1"></i>電圧</span>
-                <span class="info-value text-secondary" id="voltage-${id}">--</span>
-            </div>
-            <div class="progress voltage-bar mb-2">
-                <div class="progress-bar bg-secondary" id="voltage-bar-${id}" style="width:0%"></div>
-            </div>
-            <!-- 温度 -->
-            <div class="info-row">
-                <span class="info-label"><i class="fas fa-thermometer-half me-1"></i>最高温度</span>
-                <span class="info-value text-secondary" id="temp-${id}">--</span>
-            </div>
-            <!-- Ping -->
-            <div class="info-row">
-                <span class="info-label"><i class="fas fa-wifi me-1"></i>Ping</span>
-                <span class="info-value text-secondary" id="ping-${id}">--</span>
-            </div>
-            <!-- 通信頻度 -->
-            <div class="info-row">
-                <span class="info-label"><i class="fas fa-signal me-1"></i>通信</span>
-                <span class="info-value text-secondary" id="freq-${id}">--</span>
-            </div>
-            <!-- エラー -->
-            <div class="info-row align-items-start">
-                <span class="info-label"><i class="fas fa-exclamation-circle me-1"></i>エラー</span>
-                <span class="error-text text-success" id="error-${id}">OK</span>
-            </div>
-        </div>
-        <div class="card-footer p-2">
-            <div class="btn-group w-100" role="group">
-                <button class="btn btn-sm btn-outline-success"
-                        onclick="sendRobotControl(${id}, 'start')">
-                    <i class="fas fa-play me-1"></i>Start
+<tr class="robot-row" id="robot-row-${id}">
+    <td><i class="fas fa-robot me-1 text-secondary"></i><strong>#${id}</strong></td>
+    <td>
+        <div class="d-flex align-items-center gap-2">
+            <span class="badge bg-secondary" id="badge-${id}" style="min-width:60px">不明</span>
+            <div class="btn-group btn-group-sm" role="group">
+                <button class="btn btn-outline-success" onclick="sendRobotControl(${id}, 'start')" title="Start">
+                    <i class="fas fa-play"></i>
                 </button>
-                <button class="btn btn-sm btn-outline-danger"
-                        onclick="sendRobotControl(${id}, 'stop')">
-                    <i class="fas fa-stop me-1"></i>Stop
+                <button class="btn btn-outline-danger" onclick="sendRobotControl(${id}, 'stop')" title="Stop">
+                    <i class="fas fa-stop"></i>
                 </button>
             </div>
         </div>
-    </div>
-</div>`;
+    </td>
+    <td>
+        <span class="fw-medium text-secondary" id="voltage-${id}">--</span>
+        <div class="progress voltage-bar">
+            <div class="progress-bar bg-secondary" id="voltage-bar-${id}" style="width:0%"></div>
+        </div>
+    </td>
+    <td><span class="fw-medium text-secondary" id="temp-${id}">--</span></td>
+    <td><span class="fw-medium text-secondary" id="ping-${id}">--</span></td>
+    <td><span class="fw-medium text-secondary" id="freq-${id}">--</span></td>
+    <td><span class="error-text text-success" id="error-${id}">OK</span></td>
+    <td>
+        <button class="btn btn-sm btn-outline-info" onclick="openDetailPanel(${id})" title="詳細">
+            <i class="fas fa-info-circle"></i>
+        </button>
+    </td>
+</tr>`;
 }
 
-function initGrid() {
-    const grid = document.getElementById('robot-grid');
+function initTable() {
+    const tbody = document.getElementById('robot-table-body');
     let html = '';
     for (let i = 0; i < NUM_ROBOTS; i++) {
-        html += createRobotCard(i);
+        html += createRobotRow(i);
     }
-    grid.innerHTML = html;
+    tbody.innerHTML = html;
+}
+
+// ---- Detail Side Panel ----------------------------------------------------
+
+function openDetailPanel(id) {
+    detailOpenId = id;
+    refreshDetailPanel(id);
+    document.getElementById('detail-panel').classList.add('open');
+    document.getElementById('panel-backdrop').style.display = 'block';
+}
+
+function closeDetailPanel() {
+    detailOpenId = null;
+    document.getElementById('detail-panel').classList.remove('open');
+    document.getElementById('panel-backdrop').style.display = 'none';
+}
+
+function row(label, value) {
+    return `<tr><td>${label}</td><td>${value}</td></tr>`;
+}
+
+function refreshDetailPanel(id) {
+    const pose = robotPose[id];
+    const cmd = robotCommand[id];
+    const state = robotState[id];
+
+    document.getElementById('panel-title').textContent = `Robot #${id}`;
+    document.getElementById('panel-telemetry-link').href = `/robot_telemetry.html?id=${id}`;
+
+    // --- 位置・速度 ---
+    let poseHtml = '';
+    if (pose) {
+        const fp = (v, d) => { const n = parseFloat(v); return isNaN(n) ? '--' : n.toFixed(d); };
+        const deg = (v) => { const n = parseFloat(v); return isNaN(n) ? '--' : (n * 180 / Math.PI).toFixed(1); };
+        const cell = (label, val) =>
+            `<td style="padding:1px 6px 1px 0;font-size:0.78rem"><span style="color:#6c757d">${label}</span> ${val}</td>`;
+        poseHtml = `
+<table style="width:100%;border-collapse:collapse">
+  <tr>
+    ${cell('X', fp(pose.x, 3))}
+    ${cell('Y', fp(pose.y, 3))}
+    ${cell('θ', deg(pose.theta) + '°')}
+  </tr>
+  <tr>
+    ${cell('Vx', fp(pose.vx, 3))}
+    ${cell('Vy', fp(pose.vy, 3))}
+    ${cell('ω', deg(pose.omega) + '°/s')}
+  </tr>`;
+        if (pose.available_vision != null) {
+            const flag = (ok, label) =>
+                ok ? `<span class="text-success">${label}</span>` : `<span class="text-secondary">${label}</span>`;
+            poseHtml += `<tr><td colspan="3" style="padding-top:4px;font-size:0.78rem">
+                ${flag(pose.available_vision, 'Vision')}
+                ${flag(pose.available_feedback, 'FB')}
+                ${flag(pose.available_tracker, 'Tracker')}
+            </td></tr>`;
+        }
+        poseHtml += '</table>';
+    } else {
+        poseHtml = '<span class="text-secondary" style="font-size:0.82rem">データなし</span>';
+    }
+    document.getElementById('panel-pose').innerHTML = poseHtml;
+
+    // --- Session / スキル ---
+    let sessionHtml = '';
+    if (cmd) {
+        const fc = (v, d) => { const n = parseFloat(v); return isNaN(n) ? '--' : n.toFixed(d); };
+        const modeName = CONTROL_MODE_LONG[cmd.control_mode] ?? `MODE_${cmd.control_mode}`;
+        sessionHtml += row('プランナー', cmd.planner_name || '--');
+        sessionHtml += row('制御モード', modeName);
+        const kick = parseFloat(cmd.kick_power);
+        sessionHtml += row('キック', kick > 0 ? `<span class="text-warning">${fc(cmd.kick_power, 2)}</span>` : '0');
+        const drib = parseFloat(cmd.dribble_power);
+        sessionHtml += row('ドリブル', drib > 0 ? `<span class="text-info">${fc(cmd.dribble_power, 2)}</span>` : '0');
+        sessionHtml += row('チップ', cmd.chip_enable ? '<span class="text-warning">ON</span>' : 'OFF');
+    } else {
+        sessionHtml = row('--', '<span class="text-secondary">データなし</span>');
+    }
+    document.getElementById('panel-session').innerHTML = sessionHtml;
+
+    // --- 目標値 ---
+    let targetHtml = '';
+    if (cmd) {
+        const ft = (v, d) => { const n = parseFloat(v); return isNaN(n) ? '--' : n.toFixed(d); };
+        const fdeg = (v) => { const n = parseFloat(v); return isNaN(n) ? '--' : (n * 180 / Math.PI).toFixed(1) + '°'; };
+        const tcell = (label, val) =>
+            `<td style="padding:1px 6px 1px 0;font-size:0.78rem"><span style="color:#6c757d">${label}</span> ${val}</td>`;
+        if (cmd.position_target_mode) {
+            const t = cmd.position_target_mode;
+            targetHtml = `<table style="width:100%;border-collapse:collapse"><tr>
+                ${tcell('X', ft(t.target_x, 3))}
+                ${tcell('Y', ft(t.target_y, 3))}
+                ${tcell('θ', fdeg(cmd.target_theta))}
+            </tr></table>`;
+        } else if (cmd.simple_velocity_target_mode) {
+            const t = cmd.simple_velocity_target_mode;
+            targetHtml = `<table style="width:100%;border-collapse:collapse"><tr>
+                ${tcell('Vx', ft(t.target_vx, 3))}
+                ${tcell('Vy', ft(t.target_vy, 3))}
+                ${tcell('θ', fdeg(cmd.target_theta))}
+            </tr></table>`;
+        } else if (cmd.polar_velocity_target_mode) {
+            const t = cmd.polar_velocity_target_mode;
+            targetHtml = `<table style="width:100%;border-collapse:collapse"><tr>
+                ${tcell('r', ft(t.target_velocity_r, 3))}
+                ${tcell('θ', fdeg(t.target_velocity_theta))}
+                ${tcell('向き', fdeg(cmd.target_theta))}
+            </tr></table>`;
+        } else if (cmd.target_theta != null) {
+            targetHtml = `<table style="width:100%;border-collapse:collapse"><tr>
+                ${tcell('θ', fdeg(cmd.target_theta))}
+            </tr></table>`;
+        }
+    }
+    if (!targetHtml) targetHtml = '<span class="text-secondary" style="font-size:0.82rem">データなし</span>';
+    document.getElementById('panel-target').innerHTML = targetHtml;
+
+    // --- プランニング要素 ---
+    let factorsHtml = '';
+    if (cmd?.planning_factors?.length) {
+        for (const f of cmd.planning_factors) {
+            const stateVal = parseFloat(f.state);
+            const pct = isNaN(stateVal) ? 0 : Math.max(0, Math.min(100, stateVal * 100));
+            const stateStr = isNaN(stateVal) ? String(f.state) : stateVal.toFixed(3);
+            factorsHtml += `
+<div style="margin-bottom:0.5rem">
+  <div style="display:flex; justify-content:space-between; font-size:0.8rem">
+    <span>${f.name}</span>
+    <span class="text-secondary">${stateStr}</span>
+  </div>
+  <div class="factor-bar"><div class="factor-bar-fill" style="width:${pct}%"></div></div>
+</div>`;
+        }
+    } else {
+        factorsHtml = '<span class="text-secondary" style="font-size:0.82rem">データなし</span>';
+    }
+    document.getElementById('panel-factors').innerHTML = factorsHtml;
+
+    // --- ハードウェア ---
+    let hwHtml = '';
+    const fb = state.feedback;
+    const fmt = (v, digits) => { const n = parseFloat(v); return isNaN(n) ? '--' : n.toFixed(digits); };
+    if (fb) {
+        if (fb.voltage?.length) hwHtml += row('電圧', `${fmt(fb.voltage[0], 2)} V`);
+        if (fb.temperatures?.length) hwHtml += row('最高温度', `${Math.max(...fb.temperatures.map(parseFloat))} °C`);
+        if (fb.yaw_angle != null) hwHtml += row('Yaw角', `${fmt(fb.yaw_angle, 2)} °`);
+        if (fb.odom_speed != null) hwHtml += row('オドム速度', `${fmt(fb.odom_speed, 3)} m/s`);
+        if (fb.ball_sensor != null) hwHtml += row('ボールセンサ', fb.ball_sensor ? '<span class="text-success">検知</span>' : '未検知');
+    }
+    if (state.ping_ms !== null) hwHtml += row('Ping', `${fmt(state.ping_ms, 1)} ms`);
+    if (!hwHtml) hwHtml = row('--', '<span class="text-secondary">データなし</span>');
+    document.getElementById('panel-hw').innerHTML = hwHtml;
 }
 
 // ---- Control Commands -----------------------------------------------------
@@ -429,7 +591,7 @@ function refreshPiStatus() {
 
 // ---- Main -----------------------------------------------------------------
 
-initGrid();
+initTable();
 renderAll();
 connectWebSocket();
 


### PR DESCRIPTION
## 概要
ロボット管理画面（robot_manager.html）のUIをカード型グリッドからテーブル型に変更し、各ロボットの詳細情報を閲覧できるサイドパネルを追加した。

<img width="1318" height="752" alt="image" src="https://github.com/user-attachments/assets/d319f7c8-df7d-4d69-b793-e8627d1d3eed" />


## 背景・根本原因
カード型レイアウトでは13台を一覧するために縦スクロールが多く発生し、全台の状態を俯瞰しにくかった。また、位置・制御状態などの詳細情報を確認する手段がなかった。

## 変更内容

- カード型グリッドをBootstrapテーブル（table-sm / table-hover）に変更
- ステータス列にStart/Stopボタンを統合（`host_lancher.py`と同様の操作UI）
- 各行に詳細ボタン（<i class="fas fa-info-circle"></i>）を追加
- 右スライドインサイドパネルを実装（5セクション構成）
  - **位置・速度**: X/Y/θ・Vx/Vy/ωを2行コンパクト表示（角度はdeg換算）
  - **目標値**: 制御モードに応じた目標位置/速度/極座標をコンパクト表示
  - **Session/スキル**: プランナー名・制御モード・キック/ドリブル状態
  - **プランニング要素**: `planning_factors`をバープログレスで可視化
  - **ハードウェア**: 電圧・温度・Yaw角・ボールセンサ・Ping
- `world_model` / `control_targets` / `robot_commands` メッセージを新たに受信
- 全数値フィールドを`parseFloat()`経由で保護し型エラーを防止

## テスト方法
- [ ] ブラウザで `http://<host>:8090/robot_manager.html` を開きテーブル表示を確認
- [ ] WebSocket接続後にデータが正しく各列に反映されることを確認
- [ ] 詳細ボタンをクリックしてサイドパネルが開き各情報が表示されることを確認
- [ ] Start/Stop・全台起動/全台停止ボタンが正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)