### PR TITLE
fix: OUR_KICKOFF_START セッション未割当とペナルティエリア回避オフセット修正

### DIFF
--- a/crane_robot_skills/src/ball_nearby_positioner.cpp
+++ b/crane_robot_skills/src/ball_nearby_positioner.cpp
@@ -83,10 +83,13 @@ auto BallNearByPositioner::update() -> Status
   }(getParameter<std::string>("line_policy"));
 
   auto avoidEnemyPenaltyArea = [&](Point & point) {
-    const double penalty_offset =
-      (world_model()->getMsg().play_situation.command.value == crane_msgs::msg::PlaySituation::STOP)
-        ? 0.2
-        : 0.15;
+    const auto cmd = world_model()->getMsg().play_situation.command.value;
+    using PS = crane_msgs::msg::PlaySituation;
+    // INPLAY/HALT/HALF_TIME/POST_GAME以外（セットプレイ中）は拡大マージンを使用
+    // rvo2_planner の needsExpandedPenaltyAreaOffset() と同等の判定
+    const bool is_setplay =
+      (cmd != PS::INPLAY && cmd != PS::HALT && cmd != PS::HALF_TIME && cmd != PS::POST_GAME);
+    const double penalty_offset = is_setplay ? 0.2 : 0.15;
 
     if (world_model()->point_checker.isEnemyPenaltyArea(point, penalty_offset)) {
       const auto their_penalty_area = world_model()->getTheirPenaltyArea();

--- a/crane_session_coordinator/config/unified_session_config.yaml
+++ b/crane_session_coordinator/config/unified_session_config.yaml
@@ -57,6 +57,8 @@ situations:
         max_robots: 1
       - name: simple_kickoff
         max_robots: 1
+      - name: waiter
+        max_robots: 20
   OUR_PENALTY_KICK:
     description: OUR_PENALTY_KICK
     sessions:


### PR DESCRIPTION
## 概要

rosbag解析により発見した2つの問題を修正する。

## 背景・根本原因

### 問題1: OUR_KICKOFF_START 時に6台が未割当

`unified_session_config.yaml` の `OUR_KICKOFF_START` には `goalie_skill`（1台）と `simple_kickoff`（1台）しか定義されておらず、残り6台がどのセッションにも割り当てられないことが発覚。rosout に大量のWARNログが出力されており、ロボットが制御不能な状態になっていた。

### 問題2: BallNearByPositioner のペナルティエリアマージン不足

PR #1260 で `rvo2_planner` に `needsExpandedPenaltyAreaOffset()` を導入し STOP_PRE_* 等でもマージン 0.3m を確保する修正を行ったが、`BallNearByPositioner` のスキルレベルでの回避ロジックは `STOP` のみ 0.2m、それ以外は 0.15m という古い判定のままだった。STOP_PRE_* や FREE_KICK 中に SSLルール要求の 0.2m を下回る場合があった。

## 変更内容

- `crane_session_coordinator/config/unified_session_config.yaml`  
  `OUR_KICKOFF_START` に `waiter`（max_robots: 20）を追加。GKとキッカー以外はその場で待機し、INPLAY 遷移後に通常セッションへ移行する。

- `crane_robot_skills/src/ball_nearby_positioner.cpp`  
  ペナルティエリア回避オフセット判定を `needsExpandedPenaltyAreaOffset()` と同等のホワイトリスト方式に変更。INPLAY / HALT / HALF_TIME / POST_GAME 以外は全てセットプレイとして 0.2m マージンを適用する。

## テスト方法

- [x] `colcon build --packages-select crane_session_coordinator crane_robot_skills` でビルド確認
- [ ] シミュレーションでキックオフシナリオを実行し、OUR_KICKOFF_START 時のWARNログが消えることを確認
- [ ] STOP_PRE_* / FREE_KICK 中に BallNearByPositioner のロボットが敵ペナルティエリアから 0.2m 以上離れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)