### PR TITLE
fix(crane_robot_skills): Goalieが不要なときにドリブラーを回し続けるバグを修正

### DIFF
--- a/crane_robot_skills/src/goalie.cpp
+++ b/crane_robot_skills/src/goalie.cpp
@@ -33,6 +33,7 @@ Status Goalie::update()
     situation = crane_msgs::msg::PlaySituation::INPLAY;
   }
   phase = "";
+  command->withDribble(0.0);
 
   switch (situation) {
     case crane_msgs::msg::PlaySituation::HALT:


### PR DESCRIPTION
## 問題

Goalieがボール排出フェーズ（`emitBallFromPenaltyArea`）でKickサブスキルを使用すると、Kickスキル内部で `withDribble(0.3/0.6)` が `command` に設定される。`prepareFrame()` は `dribble_power` をリセットしないため、排出後に待ち受け・シュートブロック等の非排出フェーズに遷移してもドリブラーが回り続けていた。

## 原因

- `RobotCommandWrapper` の `latest_msg.dribble_power` はフレーム間で永続する
- `prepareFrame()` は velocity / acceleration / planning のみクリアし、`dribble_power` はリセットしない
- Goalieの非排出フェーズでは `dribble_power` を明示的に 0 にしていなかった

## 修正

`Goalie::update()` の冒頭で `command->withDribble(0.0)` を毎フレーム呼ぶことでドリブラーをデフォルトOFFに設定。  
排出フェーズではKickスキルが `withDribble(0.3/0.6)` で上書きするため、排出時の動作に影響なし。

## Test plan

- [ ] Goalieがシュートブロック・待ち受け中にドリブラーが停止していることを確認
- [ ] ボール排出時（`emitBallFromPenaltyArea`）はドリブラーが正常に動作することを確認
- [ ] 排出完了後、待ち受けに戻った際にドリブラーが停止することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)