### PR TITLE
fix: STOP_HERE中の謎の回転を修正（setTargetTheta削除・omega_limit残留防止）

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/skill_base.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/skill_base.hpp
@@ -180,6 +180,7 @@ protected:
     command->clearPlanningFactors();
 
     auto & msg = command->getEditableMsg();
+    msg.omega_limit = 10.0;
     msg.current_pose.x = robot()->pose.pos.x();
     msg.current_pose.y = robot()->pose.pos.y();
     msg.current_pose.theta = robot()->pose.theta;

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/robot_command_wrapper.hpp
@@ -217,17 +217,13 @@ public:
     addPlanningFactor("CommandSource", name);
     switch (current_mode) {
       case crane_msgs::msg::RobotCommand::POSITION_TARGET_MODE:
-        return setTargetPosition(robot->pose.pos, 0.001)
-          .setTargetTheta(robot->pose.theta)
-          .setOmegaLimit(0.);
+        return setTargetPosition(robot->pose.pos, 0.001).setOmegaLimit(0.);
       case crane_msgs::msg::RobotCommand::POLAR_VELOCITY_TARGET_MODE:
         return setVelocityNorm(0.);
       default:
         // 不明なモードの場合は位置モードで停止
         usePositionMode();
-        return setTargetPosition(robot->pose.pos, 0.001)
-          .setTargetTheta(robot->pose.theta)
-          .setOmegaLimit(0.);
+        return setTargetPosition(robot->pose.pos, 0.001).setOmegaLimit(0.);
     }
   }
 


### PR DESCRIPTION
## 概要

STOP_HERE中に実機で発生していたyawドリフト（20秒で2°）を修正する。
`stopHere()`からVisionノイズによる不安定なtarget_theta設定を削除し、omega_limit=0のみで回転を抑制する。
また、omega_limit=0がステート遷移後に残留するバグも併せて修正する。

## 背景・根本原因

### 問題1: setTargetThetaによるVisionノイズの影響

`stopHere()`は`setTargetTheta(robot->pose.theta)`と`setOmegaLimit(0.)`を両方設定していたが、
Visionの測定ノイズにより`target_theta`が毎フレーム±0.5°変動していた。
ファームウェアへの`target_global_theta`が常に微小変化するため、
PIDコントローラが小さな角度差に反応して微小な回転を引き起こしていた可能性がある（diff_angle ≈ -0.3°〜-0.6°が持続）。

### 問題2: omega_limitの残留

`latest_msg`はスキル内でフレーム間再利用される設計だが、`prepareFrame()`がomega_limitをリセットしていなかった。
rosbag解析（674.46s）でSingleBallPlacementの`PULL_BACK_FROM_EDGE_OVER_SLEEP`→`PULL_BACK_FROM_EDGE_OVER_LEAVE`遷移時に
omega_limit=0が残留していることを確認。

## 変更内容

- **`robot_command_wrapper.hpp`**: `stopHere()`から`setTargetTheta(robot->pose.theta)`を削除
  - omega_limit=0のみで回転防止として十分
  - target_thetaは直前のステートが設定した値を維持（スキル内）またはROSデフォルト0.0（新規コマンド）
- **`skill_base.hpp`**: `prepareFrame()`に`msg.omega_limit = 10.0`を追加
  - STOP_HERE後の復帰時にomega_limitが0のまま継続しないことを保証

## テスト方法

- [x] `colcon build --packages-select crane_msg_wrappers crane_robot_skills` でビルド確認
- [ ] シミュレーションでSTOP_HERE発動→復帰のシナリオ確認
- [ ] 実機でBall Placement Avoidance停止時のyawドリフトが改善されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)