### PR TITLE
fix(crane_sessions): ボールがペナルティエリア付近でディフェンダーが離れるバグを修正

### DIFF
--- a/crane_sessions/src/defender_session.cpp
+++ b/crane_sessions/src/defender_session.cpp
@@ -34,7 +34,18 @@ DefenderSession::calculatePositionCommand(const std::vector<RobotIdentifier> & r
     if (
       (world_model->ball().pos - world_model->getOurGoalCenter()).norm() <
       world_model->fieldSize().y() * 0.5) {
-      return getDefenseLinePoints(robots.size(), ball_line, world_model);
+      // ball_lineが防御ラインと交差しない場合のフォールバック
+      // ボールがPA境界〜防御ライン間にいるとき、ball_line(ball→goal)が防御ラインの内側を向くため交差しない
+      auto defense_parameter = getDefenseLinePointParameter(ball_line, world_model);
+      Segment effective_ball_line = ball_line;
+      if (not defense_parameter) {
+        effective_ball_line = Segment{
+          world_model->getOurGoalCenter(),
+          ball.pos + (ball.pos - world_model->getOurGoalCenter()).normalized() * 2.0};
+        defense_parameter = getDefenseLinePointParameter(effective_ball_line, world_model);
+      }
+      return getDefenseLinePoints(
+        robots.size(), effective_ball_line, world_model, false, defense_parameter);
     } else {
       return getDefenseArcPoints(robots.size(), ball_line, world_model);
     }
@@ -52,7 +63,14 @@ DefenderSession::calculatePositionCommand(const std::vector<RobotIdentifier> & r
           command->enablePlacementAvoidance();
         } else {
           command->disableAnyAreaAvoidance();
-          command->enableGoalAreaAvoidance();
+          // INPLAY時のみPA回避を有効化
+          // INPLAY: PA回避offset=0.1m < defense_offset=0.2m → 有効で安全
+          // STOP/セットプレイ: PA回避offset=0.3m > defense_offset=0.2m → 競合するため無効
+          if (
+            world_model->getMsg().play_situation.command.value ==
+            crane_msgs::msg::PlaySituation::INPLAY) {
+            command->enableGoalAreaAvoidance();
+          }
         }
       });
     return {SessionBase::Status::RUNNING, robot_commands};


### PR DESCRIPTION
## 概要

ボールが自陣ペナルティエリア境界付近にある場合に、ディフェンダーが防御位置を離れて敵ロボットの肉薄を許してしまう問題を2つの根本原因から修正する。

## 背景・根本原因

2026-03-21のRoboDragons戦のrosbag解析から特定。

### 問題1（致命的）: nulloptフォールバック欠如

ボールがPA境界〜防御ライン（PA+0.2m）の間にいる場合:
- `ball_line`（ball→goal）が防御ラインの内側を向くため交差しない
- `getDefenseLinePointParameter` が `nullopt` を返す
- `getDefenseLinePoints` が空のベクターを返す
- **全ディフェンダーが `stopHere()` で停止し、ボール周辺が無防備になる**

`TotalDefenseSession` には同じ状況のフォールバックがあるが、ゲームで使用される `DefenderSession` にはなかった。

### 問題2（中程度）: STOP時のPA回避オフセット競合

- `DEFENSE_OFFSET_X = 0.2m`（防御ライン位置）
- `PENALTY_AREA_OFFSET_STOP = 0.3m`（STOP時のPA回避マージン）
- STOP/セットプレイ時に防御ターゲット（PA+0.2m）がPA回避ゾーン（PA+0.3m）内に入り、ローカルプランナーが押し出していた

## 変更内容

**`crane_sessions/src/defender_session.cpp` のみ変更**

- `TotalDefenseSession` と同じフォールバック処理を追加: `ball_line` が防御ラインと交差しない場合、ゴール→ボール→2m先の逆方向セグメントで再計算
- INPLAY時のみ `enableGoalAreaAvoidance()` を有効化（PA回避offset=0.1m < defense=0.2m で安全）、STOP/セットプレイ時は無効化（競合回避）

## テスト方法

- [x] `colcon build --packages-select crane_sessions` でビルド確認（警告なし・エラーなし）
- [ ] シミュレーションでボールをPA境界付近に配置し、ディフェンダーが防御ライン上に正しく配置されることを確認
- [ ] 通常のINPLAY状態でディフェンダーが正しくボールとゴールの間に配置されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)