### PR TITLE
fix: 非GKロボットの味方ペナルティエリア侵入防止

### DIFF
--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -327,10 +327,30 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
         const double xmax = area.max_corner().x() + penalty_area_offset;
         const double ymin = area.min_corner().y() - penalty_area_offset;
         const double ymax = area.max_corner().y() + penalty_area_offset;
-        // ロボットがエリア内にいる場合はグローバル回避に任せる
+        // ロボットがエリア内にいる場合は最短経路で脱出させる
         if (
           current_position.x() >= xmin && current_position.x() <= xmax &&
           current_position.y() >= ymin && current_position.y() <= ymax) {
+          const double d_left = current_position.x() - xmin;
+          const double d_right = xmax - current_position.x();
+          const double d_bottom = current_position.y() - ymin;
+          const double d_top = ymax - current_position.y();
+          const double min_d = std::min({d_left, d_right, d_bottom, d_top});
+          Eigen::Vector2d escape_dir(0, 0);
+          if (min_d == d_left)
+            escape_dir = Eigen::Vector2d(-1, 0);
+          else if (min_d == d_right)
+            escape_dir = Eigen::Vector2d(1, 0);
+          else if (min_d == d_bottom)
+            escape_dir = Eigen::Vector2d(0, -1);
+          else
+            escape_dir = Eigen::Vector2d(0, 1);
+          // 脱出方向と逆に向いている成分を除去し、最低脱出速度を保証
+          const double escape_component = target_vel.dot(escape_dir);
+          if (escape_component <= 0.0) {
+            target_vel -= escape_component * escape_dir;
+            target_vel += 0.5 * escape_dir;
+          }
           return;
         }
 
@@ -340,6 +360,8 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
         const double dy_below = ymin - current_position.y();  // 下側にある場合 > 0
         const double dy_above = current_position.y() - ymax;  // 上側にある場合 > 0
 
+        // 制御遅延（~50ms）分の安全マージンを加味した有効距離
+        constexpr double BRAKING_SAFETY_MARGIN = 0.05;
         if ((dx_left > 0.0 || dx_right > 0.0) && (dy_below > 0.0 || dy_above > 0.0)) {
           // 角の外側: 最近傍角頂点までのユークリッド距離でブレーキング制約を計算
           // 各軸独立制約より緩やかになり、角を回り込む際の接線方向の速度が維持される
@@ -352,8 +374,9 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
             const Eigen::Vector2d corner_dir(cdx / dist_to_corner, cdy / dist_to_corner);
             const double approach = target_vel.dot(corner_dir);
             if (approach > 0.0) {
+              const double effective_dist = std::max(dist_to_corner - BRAKING_SAFETY_MARGIN, 0.0);
               const double v_max =
-                std::sqrt(2.0 * planning_deceleration_high_speed * dist_to_corner);
+                std::sqrt(2.0 * planning_deceleration_high_speed * effective_dist);
               if (approach > v_max) {
                 target_vel -= (approach - v_max) * corner_dir;
               }
@@ -363,22 +386,30 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
           // 面の外側: 各境界面への距離を計算し、接近方向速度成分を物理制動距離内に制限する
           // 左面: ロボットが左(x < xmin)にいてxmin方向に接近中
           if (dx_left > 0.0 && target_vel.x() > 0.0) {
-            const double v_max = std::sqrt(2.0 * planning_deceleration_high_speed * dx_left);
+            const double v_max = std::sqrt(
+              2.0 * planning_deceleration_high_speed *
+              std::max(dx_left - BRAKING_SAFETY_MARGIN, 0.0));
             target_vel.x() = std::min(target_vel.x(), v_max);
           }
           // 右面: ロボットが右(x > xmax)にいてxmax方向に接近中
           if (dx_right > 0.0 && target_vel.x() < 0.0) {
-            const double v_max = std::sqrt(2.0 * planning_deceleration_high_speed * dx_right);
+            const double v_max = std::sqrt(
+              2.0 * planning_deceleration_high_speed *
+              std::max(dx_right - BRAKING_SAFETY_MARGIN, 0.0));
             target_vel.x() = std::max(target_vel.x(), -v_max);
           }
           // 下面: ロボットが下(y < ymin)にいてymin方向に接近中
           if (dy_below > 0.0 && target_vel.y() > 0.0) {
-            const double v_max = std::sqrt(2.0 * planning_deceleration_high_speed * dy_below);
+            const double v_max = std::sqrt(
+              2.0 * planning_deceleration_high_speed *
+              std::max(dy_below - BRAKING_SAFETY_MARGIN, 0.0));
             target_vel.y() = std::min(target_vel.y(), v_max);
           }
           // 上面: ロボットが上(y > ymax)にいてymax方向に接近中
           if (dy_above > 0.0 && target_vel.y() < 0.0) {
-            const double v_max = std::sqrt(2.0 * planning_deceleration_high_speed * dy_above);
+            const double v_max = std::sqrt(
+              2.0 * planning_deceleration_high_speed *
+              std::max(dy_above - BRAKING_SAFETY_MARGIN, 0.0));
             target_vel.y() = std::max(target_vel.y(), -v_max);
           }
         }

--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -121,7 +121,8 @@ void Attacker::initialize()
       // Attackerはボール取得が役割なので、転がるボールを積極的に追いかけるべきである。
       if (
         robot()->getDistance(world_model()->ball().pos) > BALL_CONTROL_DISTANCE &&
-        world_model()->ball().isMoving(MOVING_BALL_VELOCITY)) {
+        world_model()->ball().isMoving(MOVING_BALL_VELOCITY) &&
+        !world_model()->point_checker.isFriendPenaltyArea(world_model()->ball().pos, 0.15)) {
         // GameAnalysisの既存slackデータで敵との競合チェック（追加計算コストなし）
         const auto & ga = world_model()->getMsg().game_analysis;
         double my_min_slack = -100.0;
@@ -258,6 +259,13 @@ void Attacker::initialize()
     if (!in_kick_state) {
       kick_state_entry_time = std::chrono::steady_clock::now();
       in_kick_state = true;
+    }
+
+    // 味方ペナルティエリア内のボールには接近しない（GKに委ねる）
+    if (world_model()->point_checker.isFriendPenaltyArea(world_model()->ball().pos, 0.15)) {
+      command->lookAtBall();
+      command->addPlanningFactor("attacker", "WAIT_BALL_EXIT_FRIEND_PA");
+      return Status::RUNNING;
     }
 
     // 相手ペナルティエリア近辺での速度制限（ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA防止）

--- a/crane_robot_skills/src/kick.cpp
+++ b/crane_robot_skills/src/kick.cpp
@@ -59,6 +59,12 @@ void Kick::initialize()
   addStateFunction(static_cast<int>(KickState::AROUND_BALL_AND_KICK), [this]() {
     pivot_turn_entry_time_.reset();
     Point ball_pos = world_model()->ball().pos;
+    // 味方ペナルティエリア内のボールには接近しない（GKに委ねる）
+    if (world_model()->point_checker.isFriendPenaltyArea(ball_pos, 0.15)) {
+      command->lookAtBall();
+      command->addPlanningFactor("kick", "WAIT_BALL_EXIT_FRIEND_PA");
+      return Status::RUNNING;
+    }
     const double interval = std::max(getParameter<double>("around_interval"), 0.01);
     const bool go_around_ball = getParameter<bool>("go_around_ball");
     const Vector2 kick_vec = computeKickVec();

--- a/crane_robot_skills/src/receive.cpp
+++ b/crane_robot_skills/src/receive.cpp
@@ -16,6 +16,50 @@
 namespace
 {
 bool isValidPoint(const crane::Point & p) { return std::isfinite(p.x()) && std::isfinite(p.y()); }
+
+/// ボール軌道線分を味方ペナルティエリア（+offset）でクリップ。
+/// seg.first（ボール現在位置）がPA外のとき、PA侵入点で切り詰めて返す。
+/// 交差しない場合はそのまま返す。
+crane::Segment clipSegmentAtPenaltyArea(
+  const crane::Segment & seg, const crane::Box & penalty_area, double offset)
+{
+  using crane::Point;
+  using crane::Segment;
+  const double xmin = penalty_area.min_corner().x() - offset;
+  const double xmax = penalty_area.max_corner().x() + offset;
+  const double ymin = penalty_area.min_corner().y() - offset;
+  const double ymax = penalty_area.max_corner().y() + offset;
+
+  // ボール自体がPA内の場合はクリップしない（上流ガードで対処）
+  if (
+    seg.first.x() >= xmin && seg.first.x() <= xmax && seg.first.y() >= ymin &&
+    seg.first.y() <= ymax) {
+    return seg;
+  }
+
+  // 拡張PAの4辺との交点を求め、seg.firstに最も近いものをカット点とする
+  const std::array<Segment, 4> edges = {{
+    {Point(xmin, ymin), Point(xmax, ymin)},
+    {Point(xmax, ymin), Point(xmax, ymax)},
+    {Point(xmax, ymax), Point(xmin, ymax)},
+    {Point(xmin, ymax), Point(xmin, ymin)},
+  }};
+
+  double min_dist = std::numeric_limits<double>::max();
+  Point clip_point = seg.second;
+  bool found = false;
+  for (const auto & edge : edges) {
+    for (const auto & p : crane::getIntersections(seg, edge)) {
+      double d = (p - seg.first).norm();
+      if (d < min_dist) {
+        min_dist = d;
+        clip_point = p;
+        found = true;
+      }
+    }
+  }
+  return found ? Segment(seg.first, clip_point) : seg;
+}
 }  // namespace
 
 namespace crane::skills
@@ -126,8 +170,9 @@ Status Receive::update()
 Point Receive::getInterceptionPoint() const
 {
   Segment ball_line = world_model()->ball().getTrajectorySegmentByDistance(10.0);
-  Point closest_point =
-    world_model()->ball().getClosestPointToTrajectory(robot()->pose.pos, 10.0).closest_point;
+  // 味方ペナルティエリアで軌道をクリップし、PA内候補点を事前排除する
+  ball_line = clipSegmentAtPenaltyArea(ball_line, world_model()->getOurPenaltyArea(), 0.1);
+  Point closest_point = getClosestPointAndDistance(robot()->pose.pos, ball_line).closest_point;
 
   // Optionally draw ball trajectory thin and semi-transparent for both policies
   if (getParameter<bool>("viz_ball_traj")) {
@@ -180,12 +225,13 @@ Point Receive::getInterceptionPoint() const
       return oss.str();
     };
 
-    // マイナスのスラックタイムとNaN値を含むエントリを削除
+    // マイナスのスラックタイム、NaN値、味方PA内の候補点を削除
     slack_times.erase(
       std::remove_if(
         slack_times.begin(), slack_times.end(),
         [&](const auto & slack) {
-          return slack.slack_time < 0 || !isValidPoint(slack.intercept_point);
+          return slack.slack_time < 0 || !isValidPoint(slack.intercept_point) ||
+                 world_model()->point_checker.isFriendPenaltyArea(slack.intercept_point, 0.1);
         }),
       slack_times.end());
 


### PR DESCRIPTION
## 概要

INPLAY中にAttackerが味方ペナルティエリアに侵入するバグを修正する。
スキルレベルとRVO2ブレーキングの多層防御を追加し、GK以外のロボットが味方PAに入らないようにする。

## 背景・根本原因

rosbag `rosbag2_2026_03_21-19_19_23_RD` のt=400付近でロボット2番（attacker）が味方PAに約1.8秒侵入（最深 x=4.91、境界 x=4.2）。

根本原因：
- ボールが味方PA付近にあるときにRobot 2がattackerに割り当てられ、Receive→KICK(AROUND_BALL_AND_KICK)フローでPA内のボールに接近
- `Receive`スキルの`closest_point`フォールバックがPA内の点を返していた
- `Kick`・`Attacker`スキルにPA内ボールへのアクセス抑制がなかった
- RVO2のブレーキング制約がエリア内侵入後スキップされ、慣性で深部まで到達

## 変更内容

- **`attacker.cpp`**: KICK状態とRECEIVE遷移条件に味方PAガードを追加。ボールが味方PA内（offset 0.15m）の場合はGKに委ねてWAIT
- **`kick.cpp`**: `AROUND_BALL_AND_KICK`にボールが味方PA内の場合のガードを追加
- **`receive.cpp`**: ボール軌道線分を味方PA境界でクリップする`clipSegmentAtPenaltyArea()`を追加し、`getInterceptionPoint()`でball_lineとclosest_pointを事前クリップ。`slack_times`フィルタにも`isFriendPenaltyArea`チェックを追加
- **`rvo2_planner.cpp`**: エリア内スキップを最短経路脱出ロジック（最低0.5m/s脱出速度）に変更。全ブレーキング計算に5cm安全マージンを追加

## テスト方法

- [x] `colcon build --packages-select crane_robot_skills crane_local_planner` でビルド確認
- [ ] シミュレーション環境でボールを味方PA内に配置し、Attackerが侵入しないことを確認
- [ ] ボールがPA外に出た後、Attackerが正常にプレー再開することを確認
- [ ] ディフェンダーがPA付近で通常動作することを確認（マージン拡大の副作用がないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)