### PR TITLE
feat: crane_web_debuggerにロボット移動コマンド送信機能を追加

### DIFF
--- a/crane_web_debugger/src/websocket_server.cpp
+++ b/crane_web_debugger/src/websocket_server.cpp
@@ -19,6 +19,8 @@
 #include <crane_msgs/msg/human_annotation.hpp>
 #include <crane_msgs/msg/ping_status_array.hpp>
 #include <crane_msgs/msg/play_situation.hpp>
+#include <crane_msgs/msg/position_target_mode.hpp>
+#include <crane_msgs/msg/robot_command.hpp>
 #include <crane_msgs/msg/robot_commands.hpp>
 #include <crane_msgs/msg/robot_feedback_array.hpp>
 #include <crane_msgs/msg/world_model.hpp>
@@ -294,6 +296,12 @@ public:
     annotation_pub_ =
       this->create_publisher<crane_msgs::msg::HumanAnnotation>("/human_annotations", 10);
 
+    // Robot move command publishers
+    move_command_pub_ =
+      this->create_publisher<crane_msgs::msg::RobotCommands>("/control_targets", 10);
+    session_injection_pub_ =
+      this->create_publisher<std_msgs::msg::String>("/session_injection", 10);
+
     // Robot feedback subscription (cached, broadcast at 10Hz via timer)
     robot_feedback_sub_ = this->create_subscription<crane_msgs::msg::RobotFeedbackArray>(
       "/robot_feedback", 10, [this](const crane_msgs::msg::RobotFeedbackArray::SharedPtr msg) {
@@ -494,6 +502,10 @@ private:
         handleRobotControl(connection, request);
       } else if (type == "poll_pi_status") {
         pollAllPiStatus();
+      } else if (type == "activate_move_mode") {
+        handleActivateMoveMode(connection);
+      } else if (type == "move_robot") {
+        handleMoveRobot(connection, request);
       } else if (type == "get_world_model") {
         // World model is automatically broadcasted, but we can send current state if needed
       } else {
@@ -543,10 +555,17 @@ private:
 
   void broadcastWorldModel(const crane_msgs::msg::WorldModel::SharedPtr msg)
   {
+    {
+      std::lock_guard<std::mutex> lock(world_model_cache_mutex_);
+      cached_is_yellow_ = msg->is_yellow;
+      cached_on_positive_half_ = msg->on_positive_half;
+    }
+
     json world_model = {
       {"type", "world_model"},
       {"timestamp", msg->header.stamp.sec * 1000000000L + msg->header.stamp.nanosec},
       {"is_yellow", msg->is_yellow},
+      {"on_positive_half", msg->on_positive_half},
       {"ball",
        {{"x", msg->ball_info.position.x},
         {"y", msg->ball_info.position.y},
@@ -1070,6 +1089,61 @@ private:
     }
   }
 
+  void handleActivateMoveMode(std::shared_ptr<WebSocketConnection> connection)
+  {
+    std_msgs::msg::String injection_msg;
+    injection_msg.data = "HALT";
+    session_injection_pub_->publish(injection_msg);
+    RCLCPP_INFO(this->get_logger(), "Move mode activated: injecting HALT session");
+    json result = {{"type", "move_mode_activated"}, {"success", true}};
+    connection->sendMessage(result.dump());
+  }
+
+  void handleMoveRobot(std::shared_ptr<WebSocketConnection> connection, const json & request)
+  {
+    int robot_id = request.value("robot_id", -1);
+    if (robot_id < 0 || robot_id > 15) {
+      json error = {{"type", "error"}, {"message", "Invalid robot_id"}};
+      connection->sendMessage(error.dump());
+      return;
+    }
+
+    crane_msgs::msg::RobotCommands commands_msg;
+    commands_msg.header.stamp = this->get_clock()->now();
+    {
+      std::lock_guard<std::mutex> lock(world_model_cache_mutex_);
+      commands_msg.is_yellow = cached_is_yellow_;
+      commands_msg.on_positive_half = cached_on_positive_half_;
+    }
+
+    crane_msgs::msg::RobotCommand cmd;
+    cmd.robot_id = static_cast<uint8_t>(robot_id);
+    cmd.control_mode = crane_msgs::msg::RobotCommand::POSITION_TARGET_MODE;
+    cmd.target_theta = request.value("target_theta", 0.0f);
+
+    crane_msgs::msg::PositionTargetMode pos_target;
+    pos_target.target_x = request.value("target_x", 0.0f);
+    pos_target.target_y = request.value("target_y", 0.0f);
+    pos_target.position_tolerance = 0.05f;
+    pos_target.speed_limit_at_target = 0.0f;
+    cmd.position_target_mode.push_back(pos_target);
+
+    commands_msg.robot_commands.push_back(cmd);
+    move_command_pub_->publish(commands_msg);
+
+    RCLCPP_INFO(
+      this->get_logger(), "Move robot %d to (%.2f, %.2f)", robot_id, pos_target.target_x,
+      pos_target.target_y);
+
+    json result = {
+      {"type", "move_robot_result"},
+      {"robot_id", robot_id},
+      {"success", true},
+      {"target_x", pos_target.target_x},
+      {"target_y", pos_target.target_y}};
+    connection->sendMessage(result.dump());
+  }
+
   void handleRobotControl(std::shared_ptr<WebSocketConnection> connection, const json & request)
   {
     int robot_id = request.value("robot_id", -1);
@@ -1159,6 +1233,13 @@ private:
   rclcpp::Subscription<crane_visualization_interfaces::msg::SvgUpdates>::SharedPtr
     visualizer_svgs_sub_;
   rclcpp::Publisher<crane_msgs::msg::HumanAnnotation>::SharedPtr annotation_pub_;
+  rclcpp::Publisher<crane_msgs::msg::RobotCommands>::SharedPtr move_command_pub_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr session_injection_pub_;
+
+  // Cached world model state for move commands
+  bool cached_is_yellow_{false};
+  bool cached_on_positive_half_{false};
+  std::mutex world_model_cache_mutex_;
 
   // Robot monitoring
   rclcpp::Subscription<crane_msgs::msg::RobotFeedbackArray>::SharedPtr robot_feedback_sub_;

--- a/crane_web_debugger/web/viewer.html
+++ b/crane_web_debugger/web/viewer.html
@@ -129,6 +129,12 @@
       border-color: #2d7dd2;
     }
 
+    #btn-move-mode.active {
+      background-color: #ffc107;
+      color: #000;
+      border-color: #ffc107;
+    }
+
     .robot-card .robot-id {
       font-size: 0.85rem;
       font-weight: 700;
@@ -462,6 +468,9 @@
         <button id="btn-zoom-in" class="btn btn-sm btn-outline-secondary py-0 px-2"><i class="fas fa-search-plus"></i></button>
         <button id="btn-zoom-out" class="btn btn-sm btn-outline-secondary py-0 px-2"><i class="fas fa-search-minus"></i></button>
         <button id="btn-zoom-reset" class="btn btn-sm btn-outline-secondary py-0 px-2"><i class="fas fa-compress-arrows-alt"></i></button>
+        <span style="border-left:1px solid #333; margin:0 4px; height:20px; display:inline-block; align-self:center;"></span>
+        <button id="btn-move-mode" class="btn btn-sm btn-outline-warning py-0 px-2" title="ロボット移動モード (Shift+クリックでロボット選択/移動)"><i class="fas fa-arrows-alt"></i></button>
+        <span id="move-status" class="text-muted" style="font-size:0.7rem; margin-left:4px;">選択: <span id="selected-robot-label">--</span></span>
         <span class="text-muted" style="font-size:0.7rem; margin-left:8px;">
           レイヤー: <span id="layer-count">0</span> | プリミティブ: <span id="prim-count">0</span>
         </span>

--- a/crane_web_debugger/web/viewer.js
+++ b/crane_web_debugger/web/viewer.js
@@ -1,6 +1,7 @@
 const CONTROL_MODE_SHORT = { 0: 'CAM', 1: 'POS', 2: 'VEL', 3: 'POL' };
 const CONTROL_MODE_LONG = { 0: 'LOCAL_CAMERA', 1: 'POSITION_TARGET', 2: 'SIMPLE_VELOCITY', 3: 'POLAR_VELOCITY' };
 const SVG_PARSER = new DOMParser();
+const ROBOT_HIT_RADIUS_M = 0.15;
 
 class CraneViewer {
     constructor() {
@@ -18,6 +19,11 @@ class CraneViewer {
 
         this.robotsOurs = {};
         this.controlTargets = {};
+
+        this.moveMode = false;
+        this.selectedRobotId = null;
+        this.isYellow = false;
+        this.onPositiveHalf = false;
 
         this.fieldUpdateTimer = null;
         this.robotUpdateTimer = null;
@@ -68,6 +74,8 @@ class CraneViewer {
             case 'control_targets': this.handleControlTargets(data); break;
             case 'robot_commands': this.handleRobotCommands(data); break;
             case 'game_info': this.handleGameInfo(data); break;
+            case 'move_mode_activated': break;
+            case 'move_robot_result': break;
         }
     }
 
@@ -171,6 +179,8 @@ class CraneViewer {
     }
 
     handleWorldModel(data) {
+        if (data.is_yellow !== undefined) this.isYellow = data.is_yellow;
+        if (data.on_positive_half !== undefined) this.onPositiveHalf = data.on_positive_half;
         if (data.robots_ours) {
             this.robotsOurs = {};
             for (const robot of data.robots_ours) {
@@ -178,6 +188,7 @@ class CraneViewer {
             }
         }
         this.scheduleRobotUpdate();
+        if (this.moveMode && this.selectedRobotId !== null) this.updateMoveOverlay();
     }
 
     handleControlTargets(data) {
@@ -294,6 +305,8 @@ class CraneViewer {
 
         container.appendChild(transformGroup);
         this.applyTransform();
+
+        if (this.moveMode) this.updateMoveOverlay();
     }
 
     applyTransform() {
@@ -420,6 +433,99 @@ class CraneViewer {
         }
     }
 
+    clientToFieldCoords(clientX, clientY) {
+        const svg = this.svgFieldEl;
+        if (!svg) return { x: 0, y: 0 };
+        const pt = svg.createSVGPoint();
+        pt.x = clientX;
+        pt.y = clientY;
+        const ctm = svg.getScreenCTM();
+        if (!ctm) return { x: 0, y: 0 };
+        const svgPt = pt.matrixTransform(ctm.inverse());
+        const fieldMmX = (svgPt.x - this.panOffset.x) / this.zoomLevel;
+        const fieldMmY = (svgPt.y - this.panOffset.y) / this.zoomLevel;
+        return { x: fieldMmX / 1000.0, y: fieldMmY / 1000.0 };
+    }
+
+    findRobotAtPosition(fieldX, fieldY) {
+        let closest = null;
+        let minDist = ROBOT_HIT_RADIUS_M;
+        for (const [id, robot] of Object.entries(this.robotsOurs)) {
+            const dx = robot.x - fieldX;
+            const dy = robot.y - fieldY;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            if (dist < minDist) {
+                minDist = dist;
+                closest = Number(id);
+            }
+        }
+        return closest;
+    }
+
+    activateMoveMode() {
+        this.moveMode = true;
+        document.getElementById('btn-move-mode')?.classList.add('active');
+        if (this.websocket?.readyState === WebSocket.OPEN) {
+            this.websocket.send(JSON.stringify({ type: 'activate_move_mode' }));
+        }
+    }
+
+    deactivateMoveMode() {
+        this.moveMode = false;
+        this.selectedRobotId = null;
+        document.getElementById('btn-move-mode')?.classList.remove('active');
+        document.getElementById('selected-robot-label').textContent = '--';
+        this.clearMoveOverlay();
+    }
+
+    sendMoveCommand(robotId, targetX, targetY) {
+        const robot = this.robotsOurs[robotId];
+        if (!robot) return;
+        if (this.websocket?.readyState !== WebSocket.OPEN) return;
+        this.websocket.send(JSON.stringify({
+            type: 'move_robot',
+            robot_id: robotId,
+            target_x: targetX,
+            target_y: targetY,
+            target_theta: robot.theta ?? 0
+        }));
+    }
+
+    updateMoveOverlay() {
+        const transformGroup = document.getElementById('svg-transform-group');
+        if (!transformGroup) return;
+        let overlay = document.getElementById('move-overlay');
+        if (!overlay) {
+            overlay = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+            overlay.id = 'move-overlay';
+            transformGroup.appendChild(overlay);
+        }
+
+        const robot = this.selectedRobotId !== null ? this.robotsOurs[this.selectedRobotId] : null;
+        if (!robot) {
+            overlay.innerHTML = '';
+            return;
+        }
+
+        let circle = overlay.querySelector('circle');
+        if (!circle) {
+            circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            circle.setAttribute('r', String(ROBOT_HIT_RADIUS_M * 1000));
+            circle.setAttribute('fill', 'none');
+            circle.setAttribute('stroke', '#00ffff');
+            circle.setAttribute('stroke-width', '20');
+            circle.setAttribute('stroke-dasharray', '40 20');
+            overlay.appendChild(circle);
+        }
+        circle.setAttribute('cx', robot.x * 1000);
+        circle.setAttribute('cy', robot.y * 1000);
+    }
+
+    clearMoveOverlay() {
+        const overlay = document.getElementById('move-overlay');
+        if (overlay) overlay.innerHTML = '';
+    }
+
     setupEventListeners() {
         document.getElementById('btn-select-all')?.addEventListener('click', () => {
             this.currentSvgData?.layers?.forEach(l => this.visibleLayers.add(l.layer));
@@ -431,6 +537,14 @@ class CraneViewer {
             this.visibleLayers.clear();
             this.updateLayerList();
             this.scheduleFieldUpdate();
+        });
+
+        document.getElementById('btn-move-mode')?.addEventListener('click', () => {
+            if (this.moveMode) {
+                this.deactivateMoveMode();
+            } else {
+                this.activateMoveMode();
+            }
         });
 
         document.getElementById('btn-zoom-in')?.addEventListener('click', () => {
@@ -460,9 +574,21 @@ class CraneViewer {
 
             svgContainer.addEventListener('mousedown', (e) => {
                 if (e.button === 0) {
-                    this.isPanning = true;
-                    this.lastPanPoint = { x: e.clientX, y: e.clientY };
-                    svgContainer.style.cursor = 'grabbing';
+                    if (e.shiftKey && this.moveMode) {
+                        const fieldPos = this.clientToFieldCoords(e.clientX, e.clientY);
+                        const hitId = this.findRobotAtPosition(fieldPos.x, fieldPos.y);
+                        if (hitId !== null) {
+                            this.selectedRobotId = hitId;
+                            document.getElementById('selected-robot-label').textContent = hitId;
+                            this.updateMoveOverlay();
+                        } else if (this.selectedRobotId !== null) {
+                            this.sendMoveCommand(this.selectedRobotId, fieldPos.x, fieldPos.y);
+                        }
+                    } else {
+                        this.isPanning = true;
+                        this.lastPanPoint = { x: e.clientX, y: e.clientY };
+                        svgContainer.style.cursor = 'grabbing';
+                    }
                 }
             });
 


### PR DESCRIPTION
## 概要

crane_web_debugger の viewer.html でフィールド上のロボットをShift+クリックで選択し、目標位置をクリックして移動コマンドを送信できる機能を追加。

## 背景・根本原因

デバッグ・調整時にWeb UIから個別ロボットを直接操作したいニーズがあった。既存のINJECTIONセッション（`/session_injection`トピック）の仕組みを活用し、移動モード有効化時に自動でHALTを注入することでsession_coordinatorとの競合を回避する。

## 変更内容

- **websocket_server.cpp**:
  - `/control_targets` パブリッシャー追加（`move_command_pub_`）
  - `/session_injection` パブリッシャー追加（`session_injection_pub_`）
  - `handleActivateMoveMode()`: HALT注入してクライアントに応答
  - `handleMoveRobot()`: WebSocketメッセージから `RobotCommands`（POSITION_TARGET_MODE）を構築してpublish
  - world_modelブロードキャストに `on_positive_half` フィールド追加

- **viewer.html**:
  - ツールバーに移動モードトグルボタン（矢印アイコン）と選択中ロボット表示を追加
  - アクティブ時の黄色ハイライトCSS追加

- **viewer.js**:
  - `ROBOT_HIT_RADIUS_M = 0.15` 定数を追加（ヒット判定・SVG半径を統一管理）
  - `clientToFieldCoords()`: クライアント座標→フィールド座標（m）変換
  - `findRobotAtPosition()`: 半径150mm以内の最近ロボットを返すヒットテスト
  - `activateMoveMode()` / `deactivateMoveMode()`: モード管理とWS送信
  - `sendMoveCommand()`: move_robotメッセージをWebSocket送信（thetaは現在値維持）
  - `updateMoveOverlay()` / `clearMoveOverlay()`: 選択ロボットのSVGハイライト（circle要素を使い回して60Hz更新に対応）
  - Shift+クリックでロボット選択→目標位置指定のマウスイベント処理

## 操作方法

1. ツールバーの `⇔` ボタンをクリックして移動モードを有効化（HALTが自動注入される）
2. フィールド上でShift+クリックしてロボットを選択（シアン点線円でハイライト）
3. ロボット選択後、フィールド上の別の位置をShift+クリックで移動コマンド送信

## テスト方法

- [x] `colcon build --packages-select crane_web_debugger` でビルド確認
- [ ] シミュレーション環境で移動モードボタンをクリック → `/session_injection` に "HALT" が届くことを確認
- [ ] Shift+クリックでロボット選択ハイライトが表示されることを確認
- [ ] 目標位置指定でロボットが移動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)