### PR TITLE
fix: ssl-log-recorderのgraceful shutdownをstop_signalで実現

### DIFF
--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -67,6 +67,25 @@ services:
       - 224.5.23.2:11010
     network_mode: host
 
+  ssl-log-recorder:
+    image: robocupssl/ssl-log-recorder:latest
+    container_name: crane-ssl-log-recorder
+    network_mode: host
+    restart: "no"
+    stop_signal: SIGINT
+    stop_grace_period: 30s
+    volumes:
+      - ../../:/logs
+    working_dir: /logs
+    command:
+      - -referee-address
+      - "224.5.23.1:${REFEREE_PORT:-11003}"
+      - -vision-address
+      - "224.5.23.2:${VISION_PORT:-10020}"
+      - -vision-tracker-address
+      - "224.5.23.2:${TRACKER_PORT:-11010}"
+      - -vision-legacy-enabled=false
+
   voicevox:
     image: voicevox/voicevox_engine:cpu-latest
     # image: voicevox/voicevox_engine:nvidia-latest

--- a/docker/match-vs-tigers/docker-compose.yaml
+++ b/docker/match-vs-tigers/docker-compose.yaml
@@ -109,6 +109,8 @@ services:
     image: robocupssl/ssl-log-recorder:latest
     container_name: match_log_recorder
     network_mode: host
+    stop_signal: SIGINT
+    stop_grace_period: 30s
     volumes:
       - ./ssl-logs:/logs:rw
     working_dir: /logs

--- a/scripts/docker-dev.sh
+++ b/scripts/docker-dev.sh
@@ -18,7 +18,6 @@ cd "$REPO_ROOT"
 
 COMPOSE_FILE="docker/dev/docker-compose.yaml"
 DEBUG_TOOLS_PID_FILE="/tmp/crane_debug_tools.pid"
-SSL_LOG_RECORDER_CONTAINER_NAME="crane-ssl-log-recorder"
 
 # 引数解析
 MODE="sim"
@@ -117,84 +116,11 @@ stop_debug_tools() {
     fi
 }
 
-start_ssl_log_recorder() {
-    local referee_address
-    local vision_address
-    local vision_tracker_address
-    local container_state
-
-    if [[ $MODE == "sim" ]]; then
-        referee_address="224.5.23.1:11003"
-        vision_address="224.5.23.2:10020"
-        vision_tracker_address="224.5.23.2:11010"
-    else
-        referee_address="224.5.23.1:10003"
-        vision_address="224.5.23.2:10006"
-        vision_tracker_address="224.5.23.2:10010"
-    fi
-
-    container_state=$(docker inspect -f '{{.State.Status}}' "$SSL_LOG_RECORDER_CONTAINER_NAME" 2>/dev/null || true)
-    if [[ $container_state == "running" ]]; then
-        echo "ssl-log-recorder は既に起動中です (container: $SSL_LOG_RECORDER_CONTAINER_NAME)"
-        return 0
-    fi
-
-    if [[ -n $container_state ]]; then
-        echo "既存の ssl-log-recorder コンテナを削除中 (state: $container_state)"
-        docker rm -f "$SSL_LOG_RECORDER_CONTAINER_NAME" >/dev/null 2>&1 || true
-    fi
-
-    echo "=== ssl-log-recorder を起動中 ==="
-    docker run -d \
-        --name "$SSL_LOG_RECORDER_CONTAINER_NAME" \
-        --network host \
-        -v "$REPO_ROOT:/logs" \
-        -w /logs \
-        robocupssl/ssl-log-recorder:latest \
-        -referee-address "$referee_address" \
-        -vision-address "$vision_address" \
-        -vision-tracker-address "$vision_tracker_address" >/dev/null
-
-    echo "ssl-log-recorder 起動完了"
-    echo "  Container: $SSL_LOG_RECORDER_CONTAINER_NAME"
-    echo "  保存先: $REPO_ROOT"
-    echo "  referee: $referee_address"
-    echo "  vision: $vision_address"
-    echo "  vision-tracker: $vision_tracker_address"
-}
-
-stop_ssl_log_recorder() {
-    local container_state
-    local stop_timeout=30
-    local wait_timeout=35
-
-    container_state=$(docker inspect -f '{{.State.Status}}' "$SSL_LOG_RECORDER_CONTAINER_NAME" 2>/dev/null || true)
-    if [[ -z $container_state ]]; then
-        return 0
-    fi
-
-    echo "=== ssl-log-recorder を停止中 (container: $SSL_LOG_RECORDER_CONTAINER_NAME) ==="
-
-    if [[ $container_state == "running" ]]; then
-        # ssl-log-recorder は SIGINT で正常終了処理に入る実装が多いため、先に SIGINT を試す
-        echo "SIGINT で graceful shutdown を試行します"
-        docker kill --signal=SIGINT "$SSL_LOG_RECORDER_CONTAINER_NAME" >/dev/null 2>&1 || true
-
-        if ! timeout "$wait_timeout" docker wait "$SSL_LOG_RECORDER_CONTAINER_NAME" >/dev/null 2>&1; then
-            echo "SIGINT で停止しなかったため docker stop へフォールバックします (timeout: ${stop_timeout}s)"
-            docker stop --time "$stop_timeout" "$SSL_LOG_RECORDER_CONTAINER_NAME" >/dev/null 2>&1 || true
-        fi
-    fi
-
-    docker rm "$SSL_LOG_RECORDER_CONTAINER_NAME" >/dev/null 2>&1 || true
-    echo "ssl-log-recorder 停止完了"
-}
 COMPOSE_COMMAND="$(detect_compose_command)"
 
 # downコマンドの場合はdebug_toolsも停止
 if [[ $COMPOSE_COMMAND == "down" ]]; then
     stop_debug_tools
-    stop_ssl_log_recorder
 fi
 
 echo "=== Docker開発環境 ==="
@@ -205,16 +131,12 @@ echo "Compose file: $COMPOSE_FILE"
 echo "引数: ${DOCKER_ARGS[*]}"
 echo ""
 
-if [[ $COMPOSE_COMMAND == "up" ]]; then
-    start_ssl_log_recorder
-fi
-
 if [[ $MODE == "sim" ]]; then
     # シミュレーション環境(status-board有効)
     docker compose -f "$COMPOSE_FILE" --profile sim "${DOCKER_ARGS[@]}"
 else
     # 実機環境(Visionポート変更、status-board無効)
-    VISION_PORT=10006 docker compose -f "$COMPOSE_FILE" "${DOCKER_ARGS[@]}"
+    VISION_PORT=10006 REFEREE_PORT=10003 TRACKER_PORT=10010 docker compose -f "$COMPOSE_FILE" "${DOCKER_ARGS[@]}"
 fi
 
 # バックグラウンド起動時のみdebug_toolsを起動


### PR DESCRIPTION
## 概要

match-vs-tigers CIが出力するSSL公式形式ログ（.log.gz）が破損して開けない問題を修正する。
ssl-log-recorderをDocker Composeの`stop_signal`で管理することで、docker-dev.shも簡略化。

## 背景・根本原因

ssl-log-recorderはSIGINTでのみgzipストリームを正常にフラッシュ・クローズする実装になっている。
しかし`docker compose down`はデフォルトでSIGTERMを送信するため、gzipフッターが書き込まれないまま
ファイルが切断され、破損した.log.gzが生成されていた。

PR #1203でdocker-dev.shにシェルスクリプトでのSIGINT手動送信を実装したが、
Docker Composeの`stop_signal: SIGINT`設定を使うことでよりシンプルに解決できる。

## 変更内容

- `docker/match-vs-tigers/docker-compose.yaml`: ssl-log-recorderに`stop_signal: SIGINT`と`stop_grace_period: 30s`を追加
- `docker/dev/docker-compose.yaml`: ssl-log-recorderサービスを新規追加（stop_signal設定込み）。sim/realのポート差異は環境変数で対応
- `scripts/docker-dev.sh`: ssl-log-recorderをdocker runで手動管理するstart/stop関数（約75行）を削除し、compose管理に一本化

## テスト結果

- [x] `docker compose config` で構文確認: **OK**
- [x] ssl-log-recorderを起動 → `docker stop`（SIGINT送信）で停止 → `gzip -t` で検証: **正常（破損なし）**

```
$ docker run -d --stop-signal SIGINT ... robocupssl/ssl-log-recorder:latest
$ docker stop ssl-log-test
$ docker run --rm -v /tmp/ssl-log-test:/logs alpine gzip -t /logs/*.log.gz
gzip: 正常（破損なし）
```

- [ ] match-vs-tigers CIを実行し、アーティファクトのlog.gzが正常に開けることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)