### PR TITLE
feat: TIGERs対戦CIにcraneのrosbagをartifactとして追加

### DIFF
--- a/.github/workflows/match-vs-tigers.yaml
+++ b/.github/workflows/match-vs-tigers.yaml
@@ -113,6 +113,8 @@ jobs:
         run: |
           mkdir -p docker/match-vs-tigers/ssl-logs
           chmod 777 docker/match-vs-tigers/ssl-logs
+          mkdir -p docker/match-vs-tigers/crane-rosbag
+          chmod 777 docker/match-vs-tigers/crane-rosbag
           docker compose -f docker/match-vs-tigers/docker-compose.yaml up -d
         env:
           CRANE_TAG: ${{ env.CRANE_TAG }}
@@ -192,6 +194,24 @@ jobs:
         with:
           name: match-ssl-log-${{ github.sha }}
           path: ssl-logs-artifact/
+          if-no-files-found: warn
+
+      - name: Get crane rosbag
+        if: always()
+        run: |
+          echo "crane-rosbagディレクトリの内容:"
+          ls -la docker/match-vs-tigers/crane-rosbag/ || echo "ディレクトリが見つかりません"
+          sudo chmod -R a+r docker/match-vs-tigers/crane-rosbag/ 2>/dev/null || true
+          mkdir -p crane-rosbag-artifact
+          cp -r docker/match-vs-tigers/crane-rosbag/* crane-rosbag-artifact/ 2>/dev/null || echo "rosbagファイルが見つかりません"
+          ls -la crane-rosbag-artifact/ || true
+
+      - name: Upload crane rosbag
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: match-crane-rosbag-${{ github.sha }}
+          path: crane-rosbag-artifact/
           if-no-files-found: warn
 
       - name: Show match result

--- a/docker/match-vs-tigers/.gitignore
+++ b/docker/match-vs-tigers/.gitignore
@@ -6,3 +6,6 @@ results/*.txt
 
 # SSL log recorder output
 ssl-logs/
+
+# crane rosbag output
+crane-rosbag/

--- a/docker/match-vs-tigers/docker-compose.yaml
+++ b/docker/match-vs-tigers/docker-compose.yaml
@@ -56,8 +56,11 @@ services:
     image: ghcr.io/ibis-ssl/crane:${CRANE_TAG:-match-local}
     container_name: match_crane
     network_mode: host
+    volumes:
+      - ./crane-rosbag:/root/crane-rosbag
     command: |
       bash -c "
+      cd /root/crane-rosbag &&
       source /root/ibis_ws/install/setup.bash &&
       ros2 launch crane_bringup crane.launch.xml sim:=true speak:=false vision_port:=10020 referee_port:=11003 team:=ibis
       "


### PR DESCRIPTION
## 概要
TIGERs対戦CI（match-vs-tigers）でcraneのrosbag（mcap形式、zstd圧縮）をGitHub Artifactとしてアップロードするようにした。

## 背景・根本原因
これまでrosbagはcraneコンテナ内のみに存在し、試合終了後にコンテナが削除されると消失していた。rosbagを保持することでFoxglove等のツールで試合を詳細に再現・分析できるようになる。

## 変更内容
- `docker/match-vs-tigers/docker-compose.yaml`: craneサービスに`./crane-rosbag:/root/crane-rosbag`のバインドマウントを追加し、CWDを変更することでrosbag記録先をホスト側ディレクトリに変更
- `.github/workflows/match-vs-tigers.yaml`: `crane-rosbag/`ディレクトリの作成・権限付与、rosbag取得・アップロードステップを追加（`match-crane-rosbag-{sha}`としてアップロード）
- `docker/match-vs-tigers/.gitignore`: `crane-rosbag/`を除外パターンに追加

## テスト方法
- [ ] CIを実行し、`match-crane-rosbag-*`アーティファクトが作成されることを確認
- [ ] ダウンロードしたrosbagをFoxgloveで開けることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)