### PR TITLE
fix: refereeメッセージ途絶時に安全状態(STOP)へ強制遷移するウォッチドッグを追加

### DIFF
--- a/crane_play_switcher/include/crane_play_switcher/play_switcher.hpp
+++ b/crane_play_switcher/include/crane_play_switcher/play_switcher.hpp
@@ -41,6 +41,8 @@ private:
 
   auto referee_callback(const robocup_ssl_msgs::msg::Referee & msg) -> void;
 
+  void check_referee_timeout();
+
   WorldModelWrapper::SharedPtr world_model;
 
   crane_msgs::msg::PlaySituation play_situation_msg;
@@ -62,6 +64,10 @@ private:
   } inplay_command_info;
 
   robocup_ssl_msgs::msg::Referee latest_raw_referee;
+
+  rclcpp::TimerBase::SharedPtr referee_watchdog_timer_;
+  rclcpp::Time last_referee_recv_time_;
+  bool referee_timeout_active_ = false;
 };
 }  // namespace crane
 

--- a/crane_play_switcher/src/play_switcher.cpp
+++ b/crane_play_switcher/src/play_switcher.cpp
@@ -32,6 +32,12 @@ PlaySwitcher::PlaySwitcher(const rclcpp::NodeOptions & options)
     "/referee", 10, [this](const robocup_ssl_msgs::msg::Referee & msg) { referee_callback(msg); });
 
   last_command_changed_state.stamp = now();
+  last_referee_recv_time_ = now();
+
+  constexpr double REFEREE_WATCHDOG_PERIOD_SEC = 0.5;
+  referee_watchdog_timer_ = create_wall_timer(
+    std::chrono::duration<double>(REFEREE_WATCHDOG_PERIOD_SEC),
+    [this]() { check_referee_timeout(); });
 
   session_injection_sub = create_subscription<std_msgs::msg::String>(
     "/session_injection", 1, [&](const std_msgs::msg::String & msg) {
@@ -68,6 +74,11 @@ PlaySwitcher::PlaySwitcher(const rclcpp::NodeOptions & options)
 auto PlaySwitcher::referee_callback(const robocup_ssl_msgs::msg::Referee & msg) -> void
 {
   ScopedTimer process_timer(process_time_pub);
+  last_referee_recv_time_ = now();
+  if (referee_timeout_active_) {
+    RCLCPP_WARN(get_logger(), "レフェリーメッセージの受信が復帰しました");
+    referee_timeout_active_ = false;
+  }
   using crane_msgs::msg::PlaySituation;
   using robocup_ssl_msgs::msg::Referee;
 
@@ -275,6 +286,38 @@ auto PlaySwitcher::referee_callback(const robocup_ssl_msgs::msg::Referee & msg) 
 #undef NORMAL_START_MAPPING
 #undef REDIRECT_MAPPING
 #undef CMD_MAPPING
+
+void PlaySwitcher::check_referee_timeout()
+{
+  using crane_msgs::msg::PlaySituation;
+  constexpr double REFEREE_TIMEOUT_SEC = 1.0;
+
+  if ((now() - last_referee_recv_time_).seconds() <= REFEREE_TIMEOUT_SEC) {
+    return;
+  }
+
+  // 既に安全な状態（HALT/STOP/HALF_TIME/POST_GAME）の場合は何もしない
+  const int current_cmd = play_situation_msg.command.value;
+  if (
+    current_cmd == PlaySituation::HALT || current_cmd == PlaySituation::STOP ||
+    current_cmd == PlaySituation::HALF_TIME || current_cmd == PlaySituation::POST_GAME) {
+    return;
+  }
+
+  if (!referee_timeout_active_) {
+    RCLCPP_WARN(
+      get_logger(),
+      "レフェリーメッセージが%.1f秒以上受信できていません。安全のためSTOPに遷移します。"
+      "（最終受信からの経過時間: %.1f秒）",
+      REFEREE_TIMEOUT_SEC, (now() - last_referee_recv_time_).seconds());
+    referee_timeout_active_ = true;
+  }
+
+  play_situation_msg.command = getSituationCommandNamedInt(PlaySituation::STOP);
+  play_situation_msg.reason_text = "レフェリーメッセージタイムアウト：安全のためSTOPに遷移";
+  play_situation_msg.header.stamp = now();
+  play_situation_pub->publish(play_situation_msg);
+}
 
 }  // namespace crane
 

--- a/crane_play_switcher/src/play_switcher.cpp
+++ b/crane_play_switcher/src/play_switcher.cpp
@@ -292,11 +292,13 @@ void PlaySwitcher::check_referee_timeout()
   using crane_msgs::msg::PlaySituation;
   constexpr double REFEREE_TIMEOUT_SEC = 1.0;
 
-  if ((now() - last_referee_recv_time_).seconds() <= REFEREE_TIMEOUT_SEC) {
+  const rclcpp::Time current_time = now();
+  const double elapsed_sec = (current_time - last_referee_recv_time_).seconds();
+
+  if (elapsed_sec <= REFEREE_TIMEOUT_SEC) {
     return;
   }
 
-  // 既に安全な状態（HALT/STOP/HALF_TIME/POST_GAME）の場合は何もしない
   const int current_cmd = play_situation_msg.command.value;
   if (
     current_cmd == PlaySituation::HALT || current_cmd == PlaySituation::STOP ||
@@ -304,18 +306,18 @@ void PlaySwitcher::check_referee_timeout()
     return;
   }
 
-  if (!referee_timeout_active_) {
-    RCLCPP_WARN(
-      get_logger(),
-      "レフェリーメッセージが%.1f秒以上受信できていません。安全のためSTOPに遷移します。"
-      "（最終受信からの経過時間: %.1f秒）",
-      REFEREE_TIMEOUT_SEC, (now() - last_referee_recv_time_).seconds());
-    referee_timeout_active_ = true;
+  if (referee_timeout_active_) {
+    return;
   }
+
+  RCLCPP_WARN(
+    get_logger(), "レフェリーメッセージが%.1f秒受信できていません。安全のためSTOPに遷移します。",
+    elapsed_sec);
+  referee_timeout_active_ = true;
 
   play_situation_msg.command = getSituationCommandNamedInt(PlaySituation::STOP);
   play_situation_msg.reason_text = "レフェリーメッセージタイムアウト：安全のためSTOPに遷移";
-  play_situation_msg.header.stamp = now();
+  play_situation_msg.header.stamp = current_time;
   play_situation_pub->publish(play_situation_msg);
 }
 


### PR DESCRIPTION
## Summary

- 試合中にrefereeトピックの受信が途絶した場合、craneがINPLAY状態のまま動作を継続するバグを修正
- `PlaySwitcher`に500ms周期のウォッチドッグタイマーを追加し、1秒以上referee受信がない場合はplay_situationをSTOPへ強制遷移させる

## 背景

2026-03-27の試合rosbagを解析したところ、後半にrefereeメッセージの受信が約85秒間途絶し、その間GCがSTOP→BALL_PLACEMENT_BLUEを送信していたにもかかわらずcraneはINPLAY状態のまま攻撃動作を継続。結果として19回のBOT_INTERFERED_PLACEMENTファウルが発生した。

既存コードにはボール/Trackerの0.1秒タイムアウト検知はあったが、refereeメッセージに対する同等の機構が存在しなかった。

## 変更内容

### `crane_play_switcher`

- `last_referee_recv_time_`：referee受信ごとに更新
- `referee_watchdog_timer_`：500ms周期でタイムアウト検知
- `referee_timeout_active_`：タイムアウト状態フラグ（復帰ログ用）
- `check_referee_timeout()`：タイムアウト検知メソッド
  - 1.0秒以上受信がなく、かつ動作中状態（HALT/STOP/HALF_TIME/POST_GAME以外）の場合にSTOPへ遷移
  - 遷移は初回1回のみpublish（SessionCoordinatorの100msタイマーが以降を担保）
  - 受信復帰時にWARNログで通知

## Test plan

- [ ] `colcon build --packages-select crane_play_switcher` が成功することを確認
- [ ] シミュレーション環境でGCとの接続を意図的に切断し、1秒以内にSTOPへ遷移することを確認
- [ ] 接続復帰後に通常動作へ戻ることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)