### PR TITLE
feat: RVO2 plannerに速度ダンピング（D成分）を追加して位置収束性能を改善

### DIFF
--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -73,9 +73,9 @@ limitations under the License.
   <arg name="robot_acceleration.velocity_threshold" default="1.0" description="高速域・低速域のしきい値 [m/s]"/>
 
   <!-- 経路計画用の減速度パラメータ（実行側の90%以下に設定して計画と実行の不一致によるオーバーシュートを防止） -->
-  <arg name="planning_deceleration" default="2.5" description="減速計算用の減速度 [m/s^2]"/>
+  <arg name="planning_deceleration" default="1.5" description="減速計算用の減速度 [m/s^2]"/>
   <!-- 経路計画用の加速度パラメータ（加速フェーズ専用、減速度より高い値を設定可能） -->
-  <arg name="planning_acceleration" default="4.0" description="加速フェーズの計画用加速度 [m/s^2]"/>
+  <arg name="planning_acceleration" default="3.0" description="加速フェーズの計画用加速度 [m/s^2]"/>
 
   <!-- ============================================================ -->
   <!-- フィールド/試合設定 -->
@@ -124,6 +124,7 @@ limitations under the License.
       <param name="planning_deceleration" value="$(var planning_deceleration)"/>
       <param name="planning_acceleration" value="$(var planning_acceleration)"/>
       <param name="rvo_radius" value="0.15"/>
+      <param name="velocity_damping_gain" value="0.0"/>
       <!-- KickerModel統合：YAML設定ファイルから読み込み -->
       <param name="kicker_physics_config" value="$(find-pkg-share crane_world_model_publisher)/config/kicker_physics.yaml"/>
     </node>

--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -73,9 +73,7 @@ limitations under the License.
   <arg name="robot_acceleration.velocity_threshold" default="1.0" description="高速域・低速域のしきい値 [m/s]"/>
 
   <!-- 経路計画用の減速度パラメータ（実行側の90%以下に設定して計画と実行の不一致によるオーバーシュートを防止） -->
-  <arg name="planning_deceleration.high_speed" default="2.5" description="高速域での減速計算用の減速度 [m/s^2]"/>
-  <arg name="planning_deceleration.low_speed" default="2.5" description="低速域での減速計算用の減速度 [m/s^2]"/>
-  <arg name="planning_deceleration.velocity_threshold" default="1.0" description="高速域・低速域のしきい値 [m/s]"/>
+  <arg name="planning_deceleration" default="2.5" description="減速計算用の減速度 [m/s^2]"/>
   <!-- 経路計画用の加速度パラメータ（加速フェーズ専用、減速度より高い値を設定可能） -->
   <arg name="planning_acceleration" default="4.0" description="加速フェーズの計画用加速度 [m/s^2]"/>
 
@@ -123,9 +121,7 @@ limitations under the License.
     <node pkg="crane_local_planner" exec="crane_local_planner_node" output="screen">
       <param name="planner" value="rvo2"/>
       <param name="max_vel" value="$(var max_vel)"/>
-      <param name="planning_deceleration.high_speed" value="$(var planning_deceleration.high_speed)"/>
-      <param name="planning_deceleration.low_speed" value="$(var planning_deceleration.low_speed)"/>
-      <param name="planning_deceleration.velocity_threshold" value="$(var planning_deceleration.velocity_threshold)"/>
+      <param name="planning_deceleration" value="$(var planning_deceleration)"/>
       <param name="planning_acceleration" value="$(var planning_acceleration)"/>
       <param name="rvo_radius" value="0.15"/>
       <!-- KickerModel統合：YAML設定ファイルから読み込み -->
@@ -148,9 +144,7 @@ limitations under the License.
     <node pkg="crane_local_planner" exec="crane_local_planner_node" output="screen">
       <param name="planner" value="rvo2"/>
       <param name="max_vel" value="$(var max_vel)"/>
-      <param name="planning_deceleration.high_speed" value="$(var planning_deceleration.high_speed)"/>
-      <param name="planning_deceleration.low_speed" value="$(var planning_deceleration.low_speed)"/>
-      <param name="planning_deceleration.velocity_threshold" value="$(var planning_deceleration.velocity_threshold)"/>
+      <param name="planning_deceleration" value="$(var planning_deceleration)"/>
       <param name="planning_acceleration" value="$(var planning_acceleration)"/>
       <param name="straight_kick_power_array" value="[0.0, 0.4, 1.0, 1.0]"/>
       <param name="straight_kick_speed_array" value="[0.0, 2.0, 4.0, 7.5]"/>

--- a/crane_local_planner/include/crane_local_planner/planner_base.hpp
+++ b/crane_local_planner/include/crane_local_planner/planner_base.hpp
@@ -24,17 +24,8 @@ public:
     world_model = std::make_shared<WorldModelWrapper>(node);
 
     // 経路計画用の減速度パラメータを読み込み
-    node.declare_parameter("planning_deceleration.high_speed", 4.5);
-    planning_deceleration_high_speed =
-      node.get_parameter("planning_deceleration.high_speed").as_double();
-
-    node.declare_parameter("planning_deceleration.low_speed", 1.8);
-    planning_deceleration_low_speed =
-      node.get_parameter("planning_deceleration.low_speed").as_double();
-
-    node.declare_parameter("planning_deceleration.velocity_threshold", 1.5);
-    planning_deceleration_velocity_threshold =
-      node.get_parameter("planning_deceleration.velocity_threshold").as_double();
+    node.declare_parameter("planning_deceleration", 2.5);
+    planning_deceleration = node.get_parameter("planning_deceleration").as_double();
 
     // 経路計画用の加速度パラメータを読み込み（減速度とは別に設定）
     node.declare_parameter("planning_acceleration", 5.0);
@@ -82,9 +73,7 @@ protected:
   WorldModelWrapper::SharedPtr world_model;
 
   // 経路計画用の減速度パラメータ
-  double planning_deceleration_high_speed;
-  double planning_deceleration_low_speed;
-  double planning_deceleration_velocity_threshold;
+  double planning_deceleration;
   // 経路計画用の加速度パラメータ（加速フェーズに使用）
   double planning_acceleration;
 };

--- a/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
@@ -133,6 +133,10 @@ private:
   // 加速度は減速度の何倍にするかという係数
   ParameterWithEvent<double> acceleration_factor;
 
+  // D成分ゲイン: 現在速度に比例したダンピング項のゲイン
+  // target_vel = position_error - velocity_damping_gain * current_vel
+  double velocity_damping_gain = 0.5;
+
   rclcpp::Subscription<crane_msgs::msg::RobotFeedbackArray>::SharedPtr sub_feedback_array;
 
   crane_msgs::msg::RobotFeedbackArray latest_feedback;

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -81,6 +81,9 @@ RVO2Planner::RVO2Planner(rclcpp::Node & node)
   node.declare_parameter("enable_velocity_plan_trace", false);
   enable_velocity_plan_trace = node.get_parameter("enable_velocity_plan_trace").as_bool();
 
+  node.declare_parameter("velocity_damping_gain", velocity_damping_gain);
+  velocity_damping_gain = node.get_parameter("velocity_damping_gain").as_double();
+
   rvo_sim = std::make_unique<RVO::RVOSimulator>(
     RVO_TIME_STEP, RVO_NEIGHBOR_DIST, RVO_MAX_NEIGHBORS, RVO_TIME_HORIZON, RVO_TIME_HORIZON_OBST,
     RVO_RADIUS, RVO_MAX_SPEED);
@@ -221,14 +224,21 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
 
     double max_vel = resolveMaxVelocityFactors(command, MAX_VEL) + 0.1;
 
-    Velocity target_vel;
-    target_vel << (pos_mode.target_x - current_position.x()),
-      pos_mode.target_y - current_position.y();
-    target_vel = target_vel.normalized() * (target_vel.norm() + 0.1);
-    target_vel *= 1.0;
+    // P成分: 位置誤差に基づく目標速度（PD制御のP項）
+    Velocity target_vel = position_diff.cast<double>();
 
-    // 目標速度を位置差分から直接計算（シンプルアプローチ）
-    // 目標方向ベクトルをmax_velでクランプして使用する
+    // D成分: 現在速度によるダンピング（PD制御のD項）
+    // target_vel = Kp * position_error - Kd * current_velocity
+    // Kpは暗黙的に1.0。Kdはvelocity_damping_gainパラメータで調整可能。
+    // これによりオーバーシュートと振動を抑制し位置収束性能を向上させる。
+    const Eigen::Vector2d current_vel(command.current_velocity.x, command.current_velocity.y);
+    target_vel -= velocity_damping_gain * current_vel;
+
+    // ダンピングが強すぎて目標と逆方向になった場合は0にクランプ
+    if (position_diff.norm() > 0.01 && target_vel.dot(position_diff.cast<double>()) < 0.0) {
+      target_vel.setZero();
+    }
+
     if (target_vel.norm() > max_vel) {
       target_vel = target_vel.normalized() * max_vel;
     }

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -224,13 +224,18 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
 
     double max_vel = resolveMaxVelocityFactors(command, MAX_VEL) + 0.1;
 
-    // P成分: 位置誤差に基づく目標速度（PD制御のP項）
-    Velocity target_vel = position_diff.cast<double>();
+    // P成分: 台形速度プロファイル（BangBang）に基づく目標速度
+    // v = sign(d) * sqrt(2 * max_brk * |d|) — 制動距離から逆算した運動学的速度
+    // 線形スケール(Kp=1)より大幅に強いP成分となり、遠距離でも十分な速度を出せる
+    auto brk_vel = [max_brk](double d) -> double {
+      const double abs_d = std::abs(d);
+      return (abs_d > 1e-9) ? std::copysign(std::sqrt(2.0 * max_brk * abs_d), d) : 0.0;
+    };
+    Velocity target_vel;
+    target_vel << brk_vel(position_diff.x()), brk_vel(position_diff.y());
 
-    // D成分: 現在速度によるダンピング（PD制御のD項）
-    // target_vel = Kp * position_error - Kd * current_velocity
-    // Kpは暗黙的に1.0。Kdはvelocity_damping_gainパラメータで調整可能。
-    // これによりオーバーシュートと振動を抑制し位置収束性能を向上させる。
+    // D成分: 現在速度によるダンピング（オーバーシュート抑制）
+    // target_vel = P(position_error) - Kd * current_velocity
     const Eigen::Vector2d current_vel(command.current_velocity.x, command.current_velocity.y);
     target_vel -= velocity_damping_gain * current_vel;
 

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -196,9 +196,7 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
 
     double max_vel = resolveMaxVelocityFactors(command, MAX_VEL) + 0.1;
 
-    // P成分: 台形速度プロファイル（BangBang）に基づく目標速度
-    // v = sign(d) * sqrt(2 * max_brk * |d|) — 制動距離から逆算した運動学的速度
-    // 線形スケール(Kp=1)より大幅に強いP成分となり、遠距離でも十分な速度を出せる
+    // P成分: v = sign(d) * sqrt(2 * max_brk * |d|)（制動距離から逆算した運動学的速度）
     auto brk_vel = [max_brk](double d) -> double {
       const double abs_d = std::abs(d);
       return (abs_d > 1e-9) ? std::copysign(std::sqrt(2.0 * max_brk * abs_d), d) : 0.0;
@@ -207,65 +205,18 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
     target_vel << brk_vel(position_diff.x()), brk_vel(position_diff.y());
 
     // D成分: 現在速度によるダンピング（オーバーシュート抑制）
-    // target_vel = P(position_error) - Kd * current_velocity
-    const Eigen::Vector2d current_vel(command.current_velocity.x, command.current_velocity.y);
+    const Vector2 current_vel(command.current_velocity.x, command.current_velocity.y);
     target_vel -= velocity_damping_gain * current_vel;
 
-    // ダンピングが強すぎて目標と逆方向になった場合は0にクランプ
-    if (position_diff.norm() > 0.01 && target_vel.dot(position_diff.cast<double>()) < 0.0) {
+    // ダンピングが強すぎて目標と逆方向になった場合は0にクランプ（1cm未満は位置許容内とみなす）
+    if (position_diff.norm() > 0.01 && target_vel.dot(position_diff) < 0.0) {
       target_vel.setZero();
     }
 
-    if (target_vel.norm() > max_vel) {
-      target_vel = target_vel.normalized() * max_vel;
+    const double target_vel_norm = target_vel.norm();
+    if (target_vel_norm > max_vel) {
+      target_vel *= max_vel / target_vel_norm;
     }
-
-    /*
-    // 速度超過クランプ: Vision観測誤差でmax_velをわずかに超えた速度を正規化（Sumatra adaptVel相当）
-    constexpr double MAX_VEL_TOLERANCE = 0.2;
-    Eigen::Vector2d v0(command.current_velocity.x, command.current_velocity.y);
-    if (vel > max_vel && vel < max_vel + MAX_VEL_TOLERANCE) {
-      v0 = v0 * (max_vel / vel);
-    }
-*/
-
-    /*
-    // 目標との距離を計算
-    const double dx = pos_mode.target_x - current_position.x();
-    const double dy = pos_mode.target_y - current_position.y();
-    const double distance_to_target = std::hypot(dx, dy);
-
-    // 各軸独立に減速制約を計算: v = sign(d) * sqrt(2 * max_brk * |d|)
-    // これにより現在速度方向と目標方向が異なる場合（横方向の慣性）も正しく扱える
-    auto brk_vel = [max_brk](double d) -> double {
-      const double abs_d = std::abs(d);
-      return (abs_d > 1e-9) ? std::copysign(std::sqrt(2.0 * max_brk * abs_d), d) : 0.0;
-    };
-    Eigen::Vector2d next_vel(brk_vel(dx), brk_vel(dy));
-    // 合成速度がmax_velを超えた場合はスケールダウン
-    const double next_vel_norm = next_vel.norm();
-    if (next_vel_norm > max_vel) {
-      next_vel *= max_vel / next_vel_norm;
-    }
-
-    // terminal_velocity: スキルが明示的に設定した場合のみ疑似I項として適用する
-    // 0（デフォルト・未指定）のときはBangBang軌道の出力に従い、目標で停止する
-    const double terminal_vel = command.local_planner_config.terminal_velocity;
-    const double min_distance =
-      std::max(static_cast<double>(pos_mode.position_tolerance) * 2, 0.03);  // 最低3cm
-
-    if (terminal_vel > 0 && next_vel.norm() < terminal_vel && distance_to_target > min_distance) {
-      // terminal_velocityが指定されており、低速かつ目標から離れている場合に補正
-      Eigen::Vector2d direction =
-        (Eigen::Vector2d(pos_mode.target_x, pos_mode.target_y) - current_position).normalized();
-      target_vel = direction * terminal_vel;
-    } else if (next_vel.norm() < 1e-6) {
-      // 目標到達済み
-      target_vel.setZero();
-    } else {
-      target_vel << next_vel.x(), next_vel.y();
-    }
-*/
     // 衝突ファール (crashing) 回避:
     // SSLルールでは衝突時の速度ベクトル差をロボット間直線に射影した値が
     // 1.5 m/s を超えるとファール。敵ロボットへの接近方向成分を制限する。

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -181,35 +181,7 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
     position_diff << pos_mode.target_x - current_position.x(),
       pos_mode.target_y - current_position.y();
 
-    double pre_vel = [&]() {
-      if (
-        auto it = ranges::find_if(
-          pre_commands.robot_commands,
-          [&](const auto & c) { return c.robot_id == command.robot_id; });
-        it != ranges::end(pre_commands.robot_commands)) {
-        if (it->position_target_mode.empty()) {
-          return 0.0;
-        }
-        return std::hypot(
-                 it->position_target_mode.front().target_x - current_position.x(),
-                 it->position_target_mode.front().target_y - current_position.y()) > 0.01
-                 ? vel
-                 : 0.0;
-      } else {
-        return 0.0;
-      }
-    }();
-
-    // 減速計算用の減速度を選択（現在速度に応じて高速域・低速域を選択）
-    double deceleration_for_planning;
-    if (pre_vel >= planning_deceleration_velocity_threshold) {
-      deceleration_for_planning = planning_deceleration_high_speed;
-    } else {
-      deceleration_for_planning = planning_deceleration_low_speed;
-    }
-
-    // max_brk: 停止のための減速度（planning_decelerationの値を使用）
-    double max_brk = deceleration_for_planning;
+    const double max_brk = planning_deceleration;
 
     command.local_planner_config.max_velocity_factors.emplace_back(
       crane_msgs::msg::NamedFloat()
@@ -343,7 +315,7 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
     // ペナルティエリア物理ブレーキング制約
     // ORCA（速度空間制約）はコマンド速度を制限するが、ロボットの物理慣性は考慮できない。
     // 境界までの距離に基づく「物理的に停止可能な最大接近速度」を計算してprefVelocityを制限する。
-    //   max_approach_vel = sqrt(2 * planning_deceleration_high_speed * dist_to_boundary)
+    //   max_approach_vel = sqrt(2 * planning_deceleration * dist_to_boundary)
     if (!command.local_planner_config.disable_goal_area_avoidance) {
       auto applyPhysicalBrakingConstraint = [&](const Box & area) {
         const double penalty_area_offset =
@@ -402,8 +374,7 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
             const double approach = target_vel.dot(corner_dir);
             if (approach > 0.0) {
               const double effective_dist = std::max(dist_to_corner - BRAKING_SAFETY_MARGIN, 0.0);
-              const double v_max =
-                std::sqrt(2.0 * planning_deceleration_high_speed * effective_dist);
+              const double v_max = std::sqrt(2.0 * planning_deceleration * effective_dist);
               if (approach > v_max) {
                 target_vel -= (approach - v_max) * corner_dir;
               }
@@ -414,29 +385,25 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
           // 左面: ロボットが左(x < xmin)にいてxmin方向に接近中
           if (dx_left > 0.0 && target_vel.x() > 0.0) {
             const double v_max = std::sqrt(
-              2.0 * planning_deceleration_high_speed *
-              std::max(dx_left - BRAKING_SAFETY_MARGIN, 0.0));
+              2.0 * planning_deceleration * std::max(dx_left - BRAKING_SAFETY_MARGIN, 0.0));
             target_vel.x() = std::min(target_vel.x(), v_max);
           }
           // 右面: ロボットが右(x > xmax)にいてxmax方向に接近中
           if (dx_right > 0.0 && target_vel.x() < 0.0) {
             const double v_max = std::sqrt(
-              2.0 * planning_deceleration_high_speed *
-              std::max(dx_right - BRAKING_SAFETY_MARGIN, 0.0));
+              2.0 * planning_deceleration * std::max(dx_right - BRAKING_SAFETY_MARGIN, 0.0));
             target_vel.x() = std::max(target_vel.x(), -v_max);
           }
           // 下面: ロボットが下(y < ymin)にいてymin方向に接近中
           if (dy_below > 0.0 && target_vel.y() > 0.0) {
             const double v_max = std::sqrt(
-              2.0 * planning_deceleration_high_speed *
-              std::max(dy_below - BRAKING_SAFETY_MARGIN, 0.0));
+              2.0 * planning_deceleration * std::max(dy_below - BRAKING_SAFETY_MARGIN, 0.0));
             target_vel.y() = std::min(target_vel.y(), v_max);
           }
           // 上面: ロボットが上(y > ymax)にいてymax方向に接近中
           if (dy_above > 0.0 && target_vel.y() < 0.0) {
             const double v_max = std::sqrt(
-              2.0 * planning_deceleration_high_speed *
-              std::max(dy_above - BRAKING_SAFETY_MARGIN, 0.0));
+              2.0 * planning_deceleration * std::max(dy_above - BRAKING_SAFETY_MARGIN, 0.0));
             target_vel.y() = std::max(target_vel.y(), -v_max);
           }
         }

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -194,7 +194,7 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
           .set__value(STOP_STATE_MAX_VELOCITY));
     }
 
-    double max_vel = resolveMaxVelocityFactors(command, MAX_VEL) + 0.1;
+    double max_vel = resolveMaxVelocityFactors(command, MAX_VEL);
 
     // P成分: v = sign(d) * sqrt(2 * max_brk * |d|)（制動距離から逆算した運動学的速度）
     auto brk_vel = [max_brk](double d) -> double {


### PR DESCRIPTION
## 概要

RVO2 plannerの目標速度生成にD成分（速度ダンピング）を追加し、位置収束時のオーバーシュート・振動を抑制する。

## 背景・根本原因

従来の目標速度生成は位置誤差に比例した速度（P成分のみ）であり、現在の速度を考慮しないためオーバーシュートが発生していた。

## 変更内容

- **P成分強化**: 線形スケール → BangBang速度公式 `v = sign(d) * sqrt(2 * max_brk * |d|)` に変更（遠距離でも十分な速度を生成）
- **D成分追加**: `target_vel -= velocity_damping_gain * current_vel`（オーバーシュート抑制）
- **パラメータ統合**: `planning_deceleration.high_speed/low_speed/velocity_threshold` の3パラメータ → `planning_deceleration` 1つに統合（D成分が速度依存切替を代替するため）
- **コードクリーンアップ**: 不要なキャスト・コメントアウトブロック・二重norm計算を除去
- **パラメータ調整**: シミュレータ用に `velocity_damping_gain=0.0` を明示（独立調整可能）

### 主要パラメータ

| パラメータ | デフォルト | 説明 |
|---|---|---|
| `velocity_damping_gain` | 0.5（実機）/ 0.0（シミュレータ） | D成分ゲイン |
| `planning_deceleration` | 1.5 m/s^2 | P成分の制動加速度 |

## テスト方法

- [x] `colcon build --packages-select crane_local_planner crane_bringup` でビルド確認
- [ ] シミュレータで目標位置への収束がスムーズか確認（振動なし）
- [ ] `velocity_damping_gain` の調整で応答を変化させられるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)