### PR TITLE
fix: 敵ペナルティキック時のゴールキーパー配置不具合を修正

### DIFF
--- a/crane_sessions/include/crane_sessions/their_penalty_kick_session.hpp
+++ b/crane_sessions/include/crane_sessions/their_penalty_kick_session.hpp
@@ -44,8 +44,13 @@ public:
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {
     auto wm = world_model;
-    return
-      [wm](const std::shared_ptr<RobotInfo> & robot) { return robot->getDistance(wm->ball().pos); };
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      // レフェリー指定ゴールキーパーIDを最優先（コスト0）
+      if (robot->id == wm->getOurGoalieId()) {
+        return 0.0;
+      }
+      return 1.0;
+    };
   }
 
 protected:
@@ -56,8 +61,10 @@ protected:
     other_robots.clear();
 
     if (!robots.empty()) {
-      // 最初のロボットをゴーリーとして選択
+      // 最初のロボットをゴーリーとして選択（suitability関数でレフェリー指定GKが優先される）
       goalie = std::make_shared<skills::Goalie>(robots[0].id, world_model);
+      // ペナルティ専用ロジックを使うためrun_inplayを無効化
+      goalie->setParameter("run_inplay", false);
 
       // 残りのロボットをother_robotsに割り当て
       for (size_t i = 1; i < robots.size(); ++i) {

--- a/crane_sessions/src/their_penalty_kick_session.cpp
+++ b/crane_sessions/src/their_penalty_kick_session.cpp
@@ -14,13 +14,21 @@ TheirPenaltyKickSession::calculatePositionCommand(
 {
   std::vector<crane_msgs::msg::RobotCommand> robot_commands;
 
-  for (auto & command : other_robots) {
-    // 関係ないロボットはボールより1m以上下がる(ルール5.3.5.3)
+  // ボールより敵ゴール寄りに1m以上離し、フィールド幅に均等分散（ルール5.3.5.3）
+  const double field_half_width = world_model->fieldSize().y() * 0.5;
+  const double ball_x = world_model->ball().pos.x();
+  const double their_goal_x = world_model->getTheirGoalCenter().x();
+  const double sign = (their_goal_x > ball_x) ? 1.0 : -1.0;
+  const double target_x = ball_x + sign * 1.1;
+  const size_t n = other_robots.size();
+  for (size_t i = 0; i < n; ++i) {
+    auto & command = other_robots[i];
     Point target{};
-    target << (world_model->getTheirGoalCenter().x() + world_model->ball().pos.x()) / 2,
-      command->getRobot()->pose.pos.y();
+    double target_y = (n > 1) ? -field_half_width + 2.0 * field_half_width * i / (n - 1) : 0.0;
+    target << target_x, target_y;
     command->setTargetPosition(target);
     command->enableBallAvoidance();
+    command->enableGoalAreaAvoidance();
     command->setMaxVelocity("TheirPenaltyKickSession for non goalie", 1.5);
     robot_commands.push_back(command->getMsg());
   }


### PR DESCRIPTION
## 概要

敵ペナルティキック（`PREPARE_PENALTY_BLUE`）時に、レフェリー指定のゴールキーパー（ID=0）がゴールに向かわず、別のロボットがゴーリー役になっていたバグを修正。また非GKロボットの配置もSSLルール準拠に改善。

## 背景・根本原因

`TheirPenaltyKickSession::getRobotSuitabilityFunc()` がボールからの距離でロボットを評価していたため、**ボール最近傍のロボット（今回の録画ではID=7）が `robots[0]` となり、ゴーリーとして選択**されていた。レフェリーが指定するゴールキーパー（ID=0）は非GK扱いでゴールライン付近に密集配置されていた。

また、Goalieスキルの `run_inplay` がデフォルトで `true` になっているため、`goalie->run()` 呼び出し時にペナルティ専用ロジックが無視される問題もあった。

## 変更内容

### `their_penalty_kick_session.hpp`
- `getRobotSuitabilityFunc()`: `getOurGoalieId()` でレフェリー指定GKをコスト0（最優先）、それ以外を1.0（均等）に変更
- `onRobotsChanged()`: Goalieスキル生成後に `run_inplay=false` を設定（ペナルティ専用ロジック有効化）

### `their_penalty_kick_session.cpp`
- 非GKロボットの配置: ボールより1.1m敵ゴール寄りのx座標に固定し、フィールド幅内でy方向に均等分散配置（SSLルール5.3.5.3準拠）
- `enableGoalAreaAvoidance()` を追加（ゴールエリア侵入防止）

## テスト方法

- [x] `colcon build --packages-select crane_sessions` でビルド確認
- [ ] シミュレーション環境で `PREPARE_PENALTY_BLUE` コマンドを発行し、ロボット0がゴール中心に移動することを確認
- [ ] 非GK7台がボールより敵ゴール寄りかつゴールエリア外に配置されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)