### PR TITLE
feat: robot packetの末尾に目標位置と終端速度を追加

### DIFF
--- a/crane_sender/include/crane_sender/robot_packet.h
+++ b/crane_sender/include/crane_sender/robot_packet.h
@@ -111,6 +111,9 @@ typedef struct
   union {
     PolarVelocityModeArgs polar_velocity;
   } mode_args;
+
+  float target_global_pos[2];
+  float terminal_velocity;
 } RobotCommandV2;
 
 typedef struct
@@ -144,6 +147,12 @@ enum Address {
   FLAGS,
   CONTROL_MODE,
   CONTROL_MODE_ARGS,
+  TARGET_GLOBAL_POS_X_HIGH = CONTROL_MODE_ARGS + MODE_ARGS_SIZE,
+  TARGET_GLOBAL_POS_X_LOW,
+  TARGET_GLOBAL_POS_Y_HIGH,
+  TARGET_GLOBAL_POS_Y_LOW,
+  TERMINAL_VELOCITY_HIGH,
+  TERMINAL_VELOCITY_LOW,
 };
 
 enum FlagAddress {
@@ -198,6 +207,15 @@ inline void RobotCommandSerializedV2_serialize(
         &command->mode_args.polar_velocity, &serialized->data[CONTROL_MODE_ARGS]);
       break;
   }
+  forward(
+    &serialized->data[TARGET_GLOBAL_POS_X_HIGH], &serialized->data[TARGET_GLOBAL_POS_X_LOW],
+    command->target_global_pos[0], 32.767);
+  forward(
+    &serialized->data[TARGET_GLOBAL_POS_Y_HIGH], &serialized->data[TARGET_GLOBAL_POS_Y_LOW],
+    command->target_global_pos[1], 32.767);
+  forward(
+    &serialized->data[TERMINAL_VELOCITY_HIGH], &serialized->data[TERMINAL_VELOCITY_LOW],
+    command->terminal_velocity, 32.767);
 }
 
 inline RobotCommandV2 RobotCommandSerializedV2_deserialize(
@@ -240,6 +258,12 @@ inline RobotCommandV2 RobotCommandSerializedV2_deserialize(
         &command.mode_args.polar_velocity, &serialized->data[CONTROL_MODE_ARGS]);
       break;
   }
+  command.target_global_pos[0] = convertTwoByteToFloat(
+    serialized->data[TARGET_GLOBAL_POS_X_HIGH], serialized->data[TARGET_GLOBAL_POS_X_LOW], 32.767);
+  command.target_global_pos[1] = convertTwoByteToFloat(
+    serialized->data[TARGET_GLOBAL_POS_Y_HIGH], serialized->data[TARGET_GLOBAL_POS_Y_LOW], 32.767);
+  command.terminal_velocity = convertTwoByteToFloat(
+    serialized->data[TERMINAL_VELOCITY_HIGH], serialized->data[TERMINAL_VELOCITY_LOW], 32.767);
   return command;
 }
 

--- a/crane_sender/src/ibis_sender_node.cpp
+++ b/crane_sender/src/ibis_sender_node.cpp
@@ -110,6 +110,17 @@ private:
     packet.mode_args.polar_velocity.target_global_velocity_r = target_velocity_r;
     packet.mode_args.polar_velocity.target_global_velocity_theta = target_velocity_theta;
 
+    if (!command.position_target_mode.empty()) {
+      const auto & pos_mode = command.position_target_mode.front();
+      packet.target_global_pos[0] = pos_mode.target_x;
+      packet.target_global_pos[1] = pos_mode.target_y;
+      packet.terminal_velocity = pos_mode.speed_limit_at_target;
+    } else {
+      packet.target_global_pos[0] = 0.0f;
+      packet.target_global_pos[1] = 0.0f;
+      packet.terminal_velocity = 0.0f;
+    }
+
     return packet;
   }
 

--- a/crane_sender/test/test_robot_packet.cpp
+++ b/crane_sender/test/test_robot_packet.cpp
@@ -44,6 +44,10 @@ TEST(RobotPacket, ENcodeDecode)
   packet.elapsed_time_ms_since_last_vision = dist_uint16(gen);
 
   {
+    packet.target_global_pos[0] = dist_32(gen);
+    packet.target_global_pos[1] = dist_32(gen);
+    packet.terminal_velocity = dist_32(gen);
+
     packet.control_mode = POLAR_VELOCITY_TARGET_MODE;
     packet.mode_args.polar_velocity.target_global_velocity_r = dist_32(gen);
     packet.mode_args.polar_velocity.target_global_velocity_theta = dist_32(gen);
@@ -81,6 +85,11 @@ TEST(RobotPacket, ENcodeDecode)
     EXPECT_NEAR(
       packet.mode_args.polar_velocity.target_global_velocity_theta,
       deserialized_packet.mode_args.polar_velocity.target_global_velocity_theta, MAX_ERROR_32);
+    EXPECT_NEAR(
+      packet.target_global_pos[0], deserialized_packet.target_global_pos[0], MAX_ERROR_32);
+    EXPECT_NEAR(
+      packet.target_global_pos[1], deserialized_packet.target_global_pos[1], MAX_ERROR_32);
+    EXPECT_NEAR(packet.terminal_velocity, deserialized_packet.terminal_velocity, MAX_ERROR_32);
   }
 }
 


### PR DESCRIPTION
## 概要
robot packet（`RobotCommandSerializedV2`）の未使用領域に目標位置（x, y）と終端速度を追加し、ロボットのオンボードコントローラに伝達できるようにします。

## 背景・根本原因
これまでrobot packetには速度コマンドのみが含まれており、ロボット側は目標位置を知ることができませんでした。64バイトバッファのうちバイト0〜27しか使用されていなかったため、未使用領域を活用してパケットサイズを変えずに情報追加します。

## 変更内容
- `RobotCommandV2` 構造体に `target_global_pos[2]` と `terminal_velocity` を追加
- `Address` enumにバイト32〜37のエントリを追加（TARGET_GLOBAL_POS_X/Y, TERMINAL_VELOCITY）
- シリアライズ・デシリアライズに対応する処理を追加
- `ibis_sender_node`: `position_target_mode` から目標位置・終端速度を取得してパケットに格納
- テストに新フィールドの初期化・検証を追加

## 後方互換性
パケットサイズは64バイトのまま不変。古いファームウェアはバイト28以降を読まないため影響なし。

## テスト方法
- [x] `colcon build --packages-select crane_sender` でビルド確認（警告なし）
- [x] `colcon test --packages-select crane_sender` で全15テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)