### PR TITLE
feat: ibis_sender_nodeにpacket_type対応とsim時のアドレス自動設定を追加

### DIFF
--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -21,6 +21,9 @@ limitations under the License.
   <arg name="vision_port" default="" description="SSL-Visionと接続するためのマルチキャストポート（空の場合はsimに基づいて自動設定）"/>
   <arg name="referee_port" default="" description="Game Controllerと接続するためのマルチキャストポート（空の場合はsimに基づいて自動設定）"/>
   <arg name="tracker_port" default="" description="SSL Trackerと接続するためのマルチキャストポート（空の場合はsimに基づいて自動設定）"/>
+  <arg name="packet_type" default="ibis" description="送信パケット種別: ibis（実機バイナリ）/ ssl（SSL RobotControl protobuf）/ grsim（grSim legacy protobuf）"/>
+  <arg name="ibis_target_address" default="" description="送信先アドレス（空の場合はsimに基づいて自動設定: sim=true → 127.0.0.1, sim=false → 192.168.20.255）"/>
+  <arg name="ibis_target_port" default="12345" description="ibis_sender_nodeの送信先ポート（packet_type=ibisのみ使用）"/>
 
   <!-- ============================================================ -->
   <!-- チーム/動作モード設定 -->
@@ -31,6 +34,11 @@ limitations under the License.
   <!-- ============================================================ -->
   <!-- ネットワークポート自動設定（sim引数に基づく） -->
   <!-- ============================================================ -->
+  <!-- ibis_target_address の自動解決（sim フラグに基づく） -->
+  <let name="ibis_target_address_final" value="127.0.0.1" if="$(eval &quot;'$(var ibis_target_address)' == '' and '$(var sim)' == 'true'&quot;)"/>
+  <let name="ibis_target_address_final" value="192.168.20.255" if="$(eval &quot;'$(var ibis_target_address)' == '' and '$(var sim)' == 'false'&quot;)"/>
+  <let name="ibis_target_address_final" value="$(var ibis_target_address)" unless="$(eval &quot;'$(var ibis_target_address)' == ''&quot;)"/>
+
   <!-- sim=trueの場合（独自ポート） -->
   <let name="vision_port_final" value="10020" if="$(eval &quot;'$(var vision_port)' == '' and '$(var sim)' == 'true'&quot;)"/>
   <let name="referee_port_final" value="11003" if="$(eval &quot;'$(var referee_port)' == '' and '$(var sim)' == 'true'&quot;)"/>
@@ -116,7 +124,7 @@ limitations under the License.
   <!-- ============================================================ -->
   <!-- プランニング/制御系 -->
   <!-- ============================================================ -->
-  <!-- シミュレータ用（local_planner + sender） -->
+  <!-- local_planner: シミュレータ用設定 -->
   <group if="$(var sim)">
     <node pkg="crane_local_planner" exec="crane_local_planner_node" output="screen">
       <param name="planner" value="rvo2"/>
@@ -128,19 +136,9 @@ limitations under the License.
       <!-- KickerModel統合：YAML設定ファイルから読み込み -->
       <param name="kicker_physics_config" value="$(find-pkg-share crane_world_model_publisher)/config/kicker_physics.yaml"/>
     </node>
-
-    <node pkg="crane_sender" exec="sim_sender_node">
-      <param name="no_movement" value="false"/>
-      <param name="latency_ms" value="0.0"/>
-      <param name="sim_mode" value="$(var sim)"/>
-      <param name="kick_power_limit_straight" value="1.0"/>
-      <param name="kick_power_limit_chip" value="1.0"/>
-      <param name="chip_angle_deg" value="30.0"/>
-      <param name="theta_p_gain" value="3.0"/>
-    </node>
   </group>
 
-  <!-- 実機用（local_planner + sender） -->
+  <!-- local_planner: 実機用設定 -->
   <group unless="$(var sim)">
     <node pkg="crane_local_planner" exec="crane_local_planner_node" output="screen">
       <param name="planner" value="rvo2"/>
@@ -152,19 +150,30 @@ limitations under the License.
       <param name="chip_kick_power_array" value="[0.0, 0.8, 1.0]"/>
       <param name="chip_kick_distance_array" value="[0.0, 0.5, 1.5]"/>
     </node>
-
-    <node pkg="crane_sender" exec="ibis_sender_node">
-      <param name="no_movement" value="false"/>
-      <param name="latency_ms" value="100.0"/>
-      <param name="sim_mode" value="$(var sim)"/>
-      <param name="kick_power_limit_straight" value="0.5"/>
-      <param name="kick_power_limit_chip" value="1.0"/>
-      <param name="robot_acceleration.acceleration" value="$(var robot_acceleration.acceleration)"/>
-      <param name="robot_acceleration.deceleration_high" value="$(var robot_acceleration.deceleration_high)"/>
-      <param name="robot_acceleration.deceleration_low" value="$(var robot_acceleration.deceleration_low)"/>
-      <param name="robot_acceleration.velocity_threshold" value="$(var robot_acceleration.velocity_threshold)"/>
-    </node>
   </group>
+
+  <!-- sender: 統合（packet_typeでプロトコルを切り替え） -->
+  <node pkg="crane_sender" exec="ibis_sender_node">
+    <param name="no_movement" value="false"/>
+    <param name="sim_mode" value="$(var sim)"/>
+    <param name="packet_type" value="$(var packet_type)"/>
+    <param name="target_address" value="$(var ibis_target_address_final)"/>
+    <param name="target_port" value="$(var ibis_target_port)"/>
+    <!-- sim=true: ラテンシなし・キックパワー上限なし -->
+    <param name="latency_ms" value="0.0" if="$(var sim)"/>
+    <param name="kick_power_limit_straight" value="1.0" if="$(var sim)"/>
+    <param name="kick_power_limit_chip" value="1.0" if="$(var sim)"/>
+    <param name="chip_angle_deg" value="30.0"/>
+    <param name="theta_p_gain" value="3.0"/>
+    <!-- sim=false: ラテンシあり・キックパワー制限あり・加速度設定 -->
+    <param name="latency_ms" value="100.0" unless="$(var sim)"/>
+    <param name="kick_power_limit_straight" value="0.5" unless="$(var sim)"/>
+    <param name="kick_power_limit_chip" value="1.0" unless="$(var sim)"/>
+    <param name="robot_acceleration.acceleration" value="$(var robot_acceleration.acceleration)"/>
+    <param name="robot_acceleration.deceleration_high" value="$(var robot_acceleration.deceleration_high)"/>
+    <param name="robot_acceleration.deceleration_low" value="$(var robot_acceleration.deceleration_low)"/>
+    <param name="robot_acceleration.velocity_threshold" value="$(var robot_acceleration.velocity_threshold)"/>
+  </node>
 
   <!-- ============================================================ -->
   <!-- 通信系 -->

--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -18,11 +18,11 @@ limitations under the License.
   <!-- ============================================================ -->
   <!-- ネットワーク設定 -->
   <!-- ============================================================ -->
-  <arg name="vision_port" default="" description="SSL-Visionと接続するためのマルチキャストポート（空の場合はsimに基づいて自動設定）"/>
-  <arg name="referee_port" default="" description="Game Controllerと接続するためのマルチキャストポート（空の場合はsimに基づいて自動設定）"/>
-  <arg name="tracker_port" default="" description="SSL Trackerと接続するためのマルチキャストポート（空の場合はsimに基づいて自動設定）"/>
-  <arg name="packet_type" default="ibis" description="送信パケット種別: ibis（実機バイナリ）/ ssl（SSL RobotControl protobuf）/ grsim（grSim legacy protobuf）"/>
-  <arg name="ibis_target_address" default="" description="送信先アドレス（空の場合はsimに基づいて自動設定: sim=true → 127.0.0.1, sim=false → 192.168.20.255）"/>
+  <arg name="vision_port" default="" description="SSL-Vision multicast port (empty: auto from sim flag)"/>
+  <arg name="referee_port" default="" description="Game Controller multicast port (empty: auto from sim flag)"/>
+  <arg name="tracker_port" default="" description="SSL Tracker multicast port (empty: auto from sim flag)"/>
+  <arg name="packet_type" default="ibis" description="Packet type: ibis (binary) / ssl (RobotControl protobuf) / grsim (grSim legacy protobuf)"/>
+  <arg name="ibis_target_address" default="" description="Target address (empty: auto from sim flag: sim=true -&gt; 127.0.0.1, sim=false -&gt; 192.168.20.255)"/>
   <arg name="ibis_target_port" default="12345" description="ibis_sender_nodeの送信先ポート（packet_type=ibisのみ使用）"/>
 
   <!-- ============================================================ -->
@@ -152,6 +152,13 @@ limitations under the License.
     </node>
   </group>
 
+  <!-- sender パラメータ: sim フラグに基づく条件値を let で事前解決 -->
+  <!-- param タグは if/unless をサポートしないため let で分岐する -->
+  <let name="sender_latency_ms" value="0.0" if="$(var sim)"/>
+  <let name="sender_latency_ms" value="100.0" unless="$(var sim)"/>
+  <let name="sender_kick_power_limit_straight" value="1.0" if="$(var sim)"/>
+  <let name="sender_kick_power_limit_straight" value="0.5" unless="$(var sim)"/>
+
   <!-- sender: 統合（packet_typeでプロトコルを切り替え） -->
   <node pkg="crane_sender" exec="ibis_sender_node">
     <param name="no_movement" value="false"/>
@@ -159,16 +166,11 @@ limitations under the License.
     <param name="packet_type" value="$(var packet_type)"/>
     <param name="target_address" value="$(var ibis_target_address_final)"/>
     <param name="target_port" value="$(var ibis_target_port)"/>
-    <!-- sim=true: ラテンシなし・キックパワー上限なし -->
-    <param name="latency_ms" value="0.0" if="$(var sim)"/>
-    <param name="kick_power_limit_straight" value="1.0" if="$(var sim)"/>
-    <param name="kick_power_limit_chip" value="1.0" if="$(var sim)"/>
+    <param name="latency_ms" value="$(var sender_latency_ms)"/>
+    <param name="kick_power_limit_straight" value="$(var sender_kick_power_limit_straight)"/>
+    <param name="kick_power_limit_chip" value="1.0"/>
     <param name="chip_angle_deg" value="30.0"/>
     <param name="theta_p_gain" value="3.0"/>
-    <!-- sim=false: ラテンシあり・キックパワー制限あり・加速度設定 -->
-    <param name="latency_ms" value="100.0" unless="$(var sim)"/>
-    <param name="kick_power_limit_straight" value="0.5" unless="$(var sim)"/>
-    <param name="kick_power_limit_chip" value="1.0" unless="$(var sim)"/>
     <param name="robot_acceleration.acceleration" value="$(var robot_acceleration.acceleration)"/>
     <param name="robot_acceleration.deceleration_high" value="$(var robot_acceleration.deceleration_high)"/>
     <param name="robot_acceleration.deceleration_low" value="$(var robot_acceleration.deceleration_low)"/>

--- a/crane_sender/CMakeLists.txt
+++ b/crane_sender/CMakeLists.txt
@@ -47,7 +47,7 @@ target_include_directories(crane_sender_base PUBLIC include)
 
 target_link_libraries(sim_sender_component crane_sender_base ${robocup_ssl_msgs_LIBRARIES})
 target_link_libraries(sim_sender_node crane_sender_base)
-target_link_libraries(ibis_sender_node crane_sender_base)
+target_link_libraries(ibis_sender_node crane_sender_base ${robocup_ssl_msgs_LIBRARIES})
 
 if (BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/crane_sender/include/crane_sender/broadcast_command_sender.hpp
+++ b/crane_sender/include/crane_sender/broadcast_command_sender.hpp
@@ -7,10 +7,10 @@
 #ifndef CRANE_SENDER__BROADCAST_COMMAND_SENDER_HPP_
 #define CRANE_SENDER__BROADCAST_COMMAND_SENDER_HPP_
 
+#include <array>
 #include <boost/asio.hpp>
 #include <cstdint>
 #include <utility>
-#include <vector>
 
 #include "crane_sender/robot_packet.h"
 
@@ -28,10 +28,14 @@ constexpr int AI_CMD_V2_ROBOT_NUM = 11;
 class BroadcastCommandSender
 {
 public:
-  explicit BroadcastCommandSender();
+  explicit BroadcastCommandSender(
+    const std::string & address = CommConfig::BROADCAST_ADDRESS,
+    int port = CommConfig::DEFAULT_PORT);
 
   void sendBroadcastPackets(
-    const std::vector<std::pair<uint8_t, RobotCommandSerializedV2>> & robot_packets,
+    const std::array<
+      std::pair<uint8_t, RobotCommandSerializedV2>, CommConfig::AI_CMD_V2_ROBOT_NUM> &
+      robot_packets,
     int check_counter);
 
 private:

--- a/crane_sender/src/broadcast_command_sender.cpp
+++ b/crane_sender/src/broadcast_command_sender.cpp
@@ -12,11 +12,10 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <string>
-#include <vector>
 
 namespace crane
 {
-BroadcastCommandSender::BroadcastCommandSender()
+BroadcastCommandSender::BroadcastCommandSender(const std::string & address, int port)
 : socket(io_service, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0))
 {
   try {
@@ -24,8 +23,7 @@ BroadcastCommandSender::BroadcastCommandSender()
     socket.set_option(boost::asio::socket_base::broadcast(true));
     RCLCPP_INFO(rclcpp::get_logger("BroadcastCommandSender"), "✓ SO_BROADCAST flag set");
 
-    std::string host = CommConfig::BROADCAST_ADDRESS;
-    int port = CommConfig::DEFAULT_PORT;
+    std::string host = address;
     endpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(host), port);
 
     // インターフェース情報の確認（デバッグ用）
@@ -49,12 +47,13 @@ BroadcastCommandSender::BroadcastCommandSender()
 }
 
 void BroadcastCommandSender::sendBroadcastPackets(
-  const std::vector<std::pair<uint8_t, RobotCommandSerializedV2>> & robot_packets,
+  const std::array<std::pair<uint8_t, RobotCommandSerializedV2>, CommConfig::AI_CMD_V2_ROBOT_NUM> &
+    robot_packets,
   [[maybe_unused]] int check_counter)
 {
   char broadcast_buf[(CommConfig::AI_CMD_V2_SIZE + 1) * CommConfig::AI_CMD_V2_ROBOT_NUM] = {};
 
-  for (size_t i = 0; i < CommConfig::AI_CMD_V2_ROBOT_NUM && i < robot_packets.size(); i++) {
+  for (size_t i = 0; i < CommConfig::AI_CMD_V2_ROBOT_NUM; i++) {
     int offset = static_cast<int>(i) * (CommConfig::AI_CMD_V2_SIZE + 1);
     broadcast_buf[offset] = static_cast<char>(i);
     memcpy(&broadcast_buf[offset + 1], robot_packets[i].second.data, CommConfig::AI_CMD_V2_SIZE);

--- a/crane_sender/src/ibis_sender_node.cpp
+++ b/crane_sender/src/ibis_sender_node.cpp
@@ -4,6 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include <robocup_ssl_msgs/grSim_Commands.pb.h>
+#include <robocup_ssl_msgs/grSim_Packet.pb.h>
+#include <robocup_ssl_msgs/ssl_simulation_robot_control.pb.h>
+
 #include <array>
 #include <class_loader/visibility_control.hpp>
 #include <cmath>
@@ -17,6 +21,8 @@
 #include <string>
 #include <vector>
 
+#include "crane_comm/udp_sender.hpp"
+#include "crane_geometry/geometry_operations.hpp"
 #include "crane_sender/broadcast_command_sender.hpp"
 #include "crane_sender/robot_packet.h"
 #include "crane_sender/sender_base.hpp"
@@ -24,19 +30,41 @@
 namespace crane
 {
 
+// 送信パケット種別
+enum class PacketType { IBIS, SSL, GRSIM };
+
 class IbisSenderNode : public SenderBase
 {
 private:
   int debug_id;
 
   std::shared_ptr<rclcpp::ParameterEventHandler> parameter_subscriber;
-
   std::shared_ptr<rclcpp::ParameterCallbackHandle> parameter_callback_handle;
 
-  std::shared_ptr<BroadcastCommandSender> broadcast_sender;
+  PacketType packet_type_{PacketType::IBIS};
+
+  // IBIS type
+  std::shared_ptr<BroadcastCommandSender> broadcast_sender_;
+
+  // SSL type
+  std::unique_ptr<UDPSender> ssl_blue_sender_;
+  std::unique_ptr<UDPSender> ssl_yellow_sender_;
+
+  // GRSIM type
+  std::unique_ptr<UDPSender> grsim_sender_;
+
+  // SSL/GRSIM type: per-robot state for theta control and acceleration limiting
+  struct PerRobotState
+  {
+    double prev_vx = 0.0;
+    double prev_vy = 0.0;
+  };
+  std::array<PerRobotState, CommConfig::AI_CMD_V2_ROBOT_NUM> robot_states_;
+
+  double theta_p_gain_{4.0};
+  double chip_angle_deg_{30.0};
 
   int counter_{0};
-  int call_count_{0};
 
 public:
   CLASS_LOADER_PUBLIC
@@ -55,12 +83,57 @@ public:
         }
       });
 
-    // ブロードキャスト送信システム初期化
-    broadcast_sender = std::make_shared<BroadcastCommandSender>();
-    RCLCPP_INFO(get_logger(), "ibis_sender_node started");
+    // packet_type パラメータ: ibis / ssl / grsim
+    declare_parameter("packet_type", std::string("ibis"));
+    const std::string packet_type_str = get_parameter("packet_type").as_string();
+
+    // 送信先アドレスとポートの設定
+    declare_parameter("target_address", std::string(CommConfig::BROADCAST_ADDRESS));
+    declare_parameter("target_port", CommConfig::DEFAULT_PORT);
+    declare_parameter("theta_p_gain", theta_p_gain_);
+    declare_parameter("chip_angle_deg", chip_angle_deg_);
+
+    const std::string target_address = get_parameter("target_address").as_string();
+    const int target_port = get_parameter("target_port").as_int();
+    theta_p_gain_ = get_parameter("theta_p_gain").as_double();
+    chip_angle_deg_ = get_parameter("chip_angle_deg").as_double();
+
+    if (packet_type_str == "ssl") {
+      packet_type_ = PacketType::SSL;
+      // SSL制御ポートはgrSimの標準ポートを使用（target_addressのホストに送信）
+      declare_parameter("ssl_blue_port", 10301);
+      declare_parameter("ssl_yellow_port", 10302);
+      const int blue_port = get_parameter("ssl_blue_port").as_int();
+      const int yellow_port = get_parameter("ssl_yellow_port").as_int();
+      ssl_blue_sender_ = std::make_unique<UDPSender>(target_address, blue_port);
+      ssl_yellow_sender_ = std::make_unique<UDPSender>(target_address, yellow_port);
+      RCLCPP_INFO(
+        get_logger(), "ibis_sender_node started [packet_type=ssl] (blue: %s:%d, yellow: %s:%d)",
+        target_address.c_str(), blue_port, target_address.c_str(), yellow_port);
+    } else if (packet_type_str == "grsim") {
+      packet_type_ = PacketType::GRSIM;
+      declare_parameter("grsim_port", 20011);
+      const int grsim_port = get_parameter("grsim_port").as_int();
+      grsim_sender_ = std::make_unique<UDPSender>(target_address, grsim_port);
+      RCLCPP_INFO(
+        get_logger(), "ibis_sender_node started [packet_type=grsim] (%s:%d)",
+        target_address.c_str(), grsim_port);
+    } else {
+      if (packet_type_str != "ibis") {
+        RCLCPP_WARN(
+          get_logger(), "Unknown packet_type '%s', falling back to 'ibis'",
+          packet_type_str.c_str());
+      }
+      packet_type_ = PacketType::IBIS;
+      broadcast_sender_ = std::make_shared<BroadcastCommandSender>(target_address, target_port);
+      RCLCPP_INFO(
+        get_logger(), "ibis_sender_node started [packet_type=ibis] (%s:%d)", target_address.c_str(),
+        target_port);
+    }
   }
 
 private:
+  // IBIS バイナリパケット生成
   RobotCommandV2 createRobotPacket(
     const crane_msgs::msg::RobotCommand & command, int counter,
     const std::vector<uint8_t> & available_ids)
@@ -91,7 +164,6 @@ private:
     packet.enable_chip = command.chip_enable;
     packet.stop_emergency = command.stop_flag;
 
-    // 現在の速度から加速度を選択
     double current_speed = std::hypot(command.current_velocity.x, command.current_velocity.y);
     double target_speed = resolved_max_velocity;
     double selected_acceleration = calculateAccelerationLimit(current_speed, target_speed);
@@ -105,7 +177,6 @@ private:
     packet.latency_time_ms = static_cast<uint8_t>(command.latency_ms);
     packet.elapsed_time_ms_since_last_vision = command.elapsed_time_ms_since_last_vision;
 
-    // RobotCommand は常に極座標速度モード
     packet.control_mode = POLAR_VELOCITY_TARGET_MODE;
     packet.mode_args.polar_velocity.target_global_velocity_r = target_velocity_r;
     packet.mode_args.polar_velocity.target_global_velocity_theta = target_velocity_theta;
@@ -124,50 +195,189 @@ private:
     return packet;
   }
 
-public:
-  void sendCommands(const crane_msgs::msg::RobotCommands & msg) override
+  // SSL/GRSIM 共通：極座標速度＋theta制御 → ロボットローカル速度変換
+  struct LocalVelocity
   {
-    call_count_++;
+    double vx;  // forward
+    double vy;  // left
+    double omega;
+  };
 
+  LocalVelocity convertToLocalVelocity(
+    const crane_msgs::msg::RobotCommand & command, PerRobotState & state)
+  {
+    const double target_velocity_r =
+      !command.polar_velocity_target_mode.empty()
+        ? command.polar_velocity_target_mode.front().target_velocity_r
+        : 0.0;
+    const double target_velocity_theta =
+      !command.polar_velocity_target_mode.empty()
+        ? command.polar_velocity_target_mode.front().target_velocity_theta
+        : 0.0;
+
+    // Theta P制御
+    const double theta_error = getAngleDiff(command.target_theta, command.current_pose.theta);
+    double omega = theta_p_gain_ * (-theta_error);
+    omega = std::clamp(
+      omega, -static_cast<double>(command.omega_limit), static_cast<double>(command.omega_limit));
+
+    // 遅延補正後の現在角度
+    constexpr double dt = 1.0 / 30.0;
+    const double current_theta = command.current_pose.theta + omega * delay_s;
+
+    // グローバル極座標 → ロボットローカル直交座標
+    const double velocity_theta = target_velocity_theta - current_theta;
+    const double target_vx = target_velocity_r * std::cos(velocity_theta);
+    const double target_vy = target_velocity_r * std::sin(velocity_theta);
+
+    // 加速度制限
+    const double current_speed = std::hypot(state.prev_vx, state.prev_vy);
+    const double target_speed = std::hypot(target_vx, target_vy);
+    const double acc_limit = calculateAccelerationLimit(current_speed, target_speed);
+    const double max_delta = acc_limit * dt;
+
+    const double delta_vx = target_vx - state.prev_vx;
+    const double delta_vy = target_vy - state.prev_vy;
+    const double delta_norm = std::hypot(delta_vx, delta_vy);
+
+    double out_vx, out_vy;
+    if (delta_norm > max_delta && delta_norm > 1e-9) {
+      out_vx = state.prev_vx + (delta_vx / delta_norm) * max_delta;
+      out_vy = state.prev_vy + (delta_vy / delta_norm) * max_delta;
+    } else {
+      out_vx = target_vx;
+      out_vy = target_vy;
+    }
+
+    if (command.stop_flag) {
+      out_vx = 0.0;
+      out_vy = 0.0;
+      omega = 0.0;
+    }
+
+    state.prev_vx = out_vx;
+    state.prev_vy = out_vy;
+    return {out_vx, out_vy, omega};
+  }
+
+  struct KickParams
+  {
+    double speed;
+    double angle_rad;  // 0 for flat kick
+  };
+
+  KickParams computeKick(float kick_power, bool chip_enable) const
+  {
+    constexpr double MAX_KICK_SPEED = 8.0;
+    const double kick_speed = MAX_KICK_SPEED * kick_power;
+    if (chip_enable) {
+      return {kick_speed * 0.5, chip_angle_deg_ * M_PI / 180.0};
+    }
+    return {kick_speed, 0.0};
+  }
+
+  void sendSSL(const crane_msgs::msg::RobotCommands & msg)
+  {
+    auto & sender = msg.is_yellow ? ssl_yellow_sender_ : ssl_blue_sender_;
+
+    robocup_ssl::RobotControl packet;
+    for (const auto & command : msg.robot_commands) {
+      auto cmd = packet.add_robot_commands();
+      cmd->set_id(command.robot_id);
+
+      auto & state = robot_states_[command.robot_id];
+      const auto vel = convertToLocalVelocity(command, state);
+
+      auto move_command = new robocup_ssl::RobotMoveCommand();
+      auto move_local_velocity = new robocup_ssl::MoveLocalVelocity();
+      move_local_velocity->set_forward(vel.vx);
+      move_local_velocity->set_left(vel.vy);
+      move_local_velocity->set_angular(vel.omega);
+      move_command->set_allocated_local_velocity(move_local_velocity);
+      cmd->set_allocated_move_command(move_command);
+
+      const auto kick = computeKick(command.kick_power, command.chip_enable);
+      cmd->set_kick_angle(kick.angle_rad);
+      cmd->set_kick_speed(kick.speed);
+      cmd->set_dribbler_speed(command.dribble_power * 1000.0);
+    }
+
+    std::string output;
+    packet.SerializeToString(&output);
+    sender->send(output);
+  }
+
+  void sendGrSim(const crane_msgs::msg::RobotCommands & msg)
+  {
+    robocup_ssl::grSim_Packet packet;
+    auto * commands = packet.mutable_commands();
+    commands->set_isteamyellow(msg.is_yellow);
+    commands->set_timestamp(0.0);
+
+    for (const auto & command : msg.robot_commands) {
+      auto * robot_cmd = commands->add_robot_commands();
+      robot_cmd->set_id(command.robot_id);
+
+      auto & state = robot_states_[command.robot_id];
+      const auto vel = convertToLocalVelocity(command, state);
+
+      robot_cmd->set_veltangent(static_cast<float>(vel.vx));
+      robot_cmd->set_velnormal(static_cast<float>(vel.vy));
+      robot_cmd->set_velangular(static_cast<float>(vel.omega));
+      robot_cmd->set_spinner(command.dribble_power > 0.001f);
+      robot_cmd->set_wheelsspeed(false);
+
+      const auto kick = computeKick(command.kick_power, command.chip_enable);
+      robot_cmd->set_kickspeedx(static_cast<float>(kick.speed * std::cos(kick.angle_rad)));
+      robot_cmd->set_kickspeedz(static_cast<float>(kick.speed * std::sin(kick.angle_rad)));
+    }
+
+    std::string output;
+    packet.SerializeToString(&output);
+    grsim_sender_->send(output);
+  }
+
+  void sendIbis(const crane_msgs::msg::RobotCommands & msg)
+  {
     if (++counter_ > 200) {
       counter_ = 0;
     }
 
-    RCLCPP_DEBUG(
-      get_logger(), "🚀 sendCommands method called #%d (counter=%d)", call_count_, counter_);
-    RCLCPP_DEBUG(get_logger(), "  Received robot command count: %ld", msg.robot_commands.size());
-
     const auto available_ids = world_model->ours().robotsWhere().available().getIds();
 
-    // ブロードキャストモード：全ロボットのパケットを作成して一括送信
-    // 11スロット分を空パケットで初期化
-    std::vector<std::pair<uint8_t, RobotCommandSerializedV2>> robot_packets(
-      CommConfig::AI_CMD_V2_ROBOT_NUM);
+    std::array<std::pair<uint8_t, RobotCommandSerializedV2>, CommConfig::AI_CMD_V2_ROBOT_NUM>
+      robot_packets{};
     for (int i = 0; i < CommConfig::AI_CMD_V2_ROBOT_NUM; i++) {
       robot_packets[i] = {static_cast<uint8_t>(i), RobotCommandSerializedV2{}};
     }
 
-    int processed_commands = 0;
     for (const auto & command : msg.robot_commands) {
       if (command.robot_id < CommConfig::AI_CMD_V2_ROBOT_NUM) {
         RobotCommandV2 packet = createRobotPacket(command, counter_, available_ids);
         RobotCommandSerializedV2 serialized_packet;
         RobotCommandSerializedV2_serialize(&serialized_packet, &packet);
         robot_packets[command.robot_id] = {command.robot_id, serialized_packet};
-        processed_commands++;
       }
     }
 
-    RCLCPP_DEBUG(
-      get_logger(), "  Processed command count: %d/%ld", processed_commands,
-      msg.robot_commands.size());
+    broadcast_sender_->sendBroadcastPackets(robot_packets, counter_);
+  }
 
-    RCLCPP_DEBUG(
-      get_logger(), "  Packet slot usage: %d/%d slots used", processed_commands,
-      CommConfig::AI_CMD_V2_ROBOT_NUM);
-    RCLCPP_DEBUG(get_logger(), "  Broadcast preparation complete -> Start sending packet");
-
-    broadcast_sender->sendBroadcastPackets(robot_packets, counter_);
+public:
+  void sendCommands(const crane_msgs::msg::RobotCommands & msg) override
+  {
+    switch (packet_type_) {
+      case PacketType::SSL:
+        sendSSL(msg);
+        break;
+      case PacketType::GRSIM:
+        sendGrSim(msg);
+        break;
+      case PacketType::IBIS:
+      default:
+        sendIbis(msg);
+        break;
+    }
   }
 };
 }  // namespace crane

--- a/docker/ssl-vision-client-config.json
+++ b/docker/ssl-vision-client-config.json
@@ -1,7 +1,7 @@
 {
-  "visionPort": 10006,
-  "trackedPort": 10010,
-  "refereePort": 10003,
+  "visionPort": 10020,
+  "trackedPort": 11010,
+  "refereePort": 11003,
   "grSimAddress": "127.0.0.1",
   "grSimPort": 20011,
   "autoBallPlacementEnabled": true,


### PR DESCRIPTION
## 概要

`ibis_sender_node` に複数のパケット形式（ibis/ssl/grsim）の切り替え機能と、
`sim:=true` 時の送信先アドレス自動設定を追加した。
grSim 側に ibis プロトコル受信機能を追加したことで、
実機と同一の送信プロトコルでシミュレーション検証が可能になる。

## 背景・根本原因

- 従来は `sim:=true` で SSL RobotControl protobuf を grSim へ送る `sim_sender_node` を使用していたが、実機（`ibis_sender_node`）と異なるコードパスが存在した
- grSim 側に ibis バイナリプロトコル受信機能を追加したため、crane 側でも対応が必要になった
- 送信先アドレスが `192.168.20.255` にハードコードされており、シミュレータへの送信に対応できていなかった

## 変更内容

- `packet_type` パラメータ追加（ibis/ssl/grsim、デフォルト: ibis）
  - **ibis**: 64バイトバイナリ UDP（実機向け、grSim ibis receiver にも対応）
  - **ssl**: SSL RobotControl protobuf（grSim 標準ポート 10301/10302）
  - **grsim**: grSim_Packet protobuf（ポート 20011）
- `sim:=true` 時に `ibis_target_address` 未指定なら `127.0.0.1` へ自動設定
- `BroadcastCommandSender` のアドレス・ポートをコンストラクタパラメータ化
- コード品質改善（simplify reviewに基づく）:
  - `robot_states_` サイズ 20 → `AI_CMD_V2_ROBOT_NUM`(11) に修正
  - `sendIbis()` の `std::vector` → `std::array` （フレームごとのヒープ確保を削除）
  - 角度正規化の while ループを `getAngleDiff()` に置き換え
  - `computeKick()` ヘルパーで sendSSL/sendGrSim のキック計算を共通化

## テスト方法

- [x] `colcon build --packages-select crane_sender` でビルド確認
- [ ] `sim:=true packet_type:=ibis` で grSim + ibis_receiver に対してロボットが動作することを確認
- [ ] `sim:=true packet_type:=ssl` で従来の SSL プロトコル動作を確認
- [ ] `sim:=false packet_type:=ibis` で実機への送信が引き続き機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)