### PR TITLE
feat: crane_web_debuggerをMaterial 3 Expressiveデザインにリデザイン

### DIFF
--- a/crane_web_debugger/web/annotation/index.html
+++ b/crane_web_debugger/web/annotation/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0">
-  <meta name="theme-color" content="#16213e">
+  <meta name="theme-color" content="#1A2440">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CraneAnnot">

--- a/crane_web_debugger/web/annotation/manifest.json
+++ b/crane_web_debugger/web/annotation/manifest.json
@@ -6,8 +6,8 @@
   "scope": "./",
   "display": "standalone",
   "orientation": "portrait",
-  "background_color": "#1a1a2e",
-  "theme_color": "#16213e",
+  "background_color": "#121826",
+  "theme_color": "#1A2440",
   "categories": ["sports", "utilities"],
   "icons": [
     {

--- a/crane_web_debugger/web/annotation/style.css
+++ b/crane_web_debugger/web/annotation/style.css
@@ -1,45 +1,36 @@
-:root {
-  --primary: #0f4c75;
-  --secondary: #3282b8;
-  --accent: #bbe1fa;
-  --danger: #e74c3c;
-  --success: #27ae60;
-  --warning: #f39c12;
-  --info: #3498db;
-  --bg-dark: #1a1a2e;
-  --bg-light: #16213e;
-  --bg-card: #0f3460;
-  --text-primary: #ffffff;
-  --text-secondary: #bbe1fa;
-}
+/*
+ * Crane Annotation Tool - M3 Expressive Theme
+ * Imports shared design tokens, overrides for mobile-first PWA.
+ * Does NOT use Material Symbols CDN (offline PWA - uses emoji icons).
+ */
+@import url('../m3e-theme.css');
 
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  -webkit-tap-highlight-color: transparent;
+/* === Semantic aliases for annotation-specific usage === */
+:root {
+  --annot-danger: var(--md-sys-color-error);
+  --annot-success: #27AE60;
+  --annot-info: var(--md-sys-color-info);
+  --annot-warning: var(--md-sys-color-warning);
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', sans-serif;
-  background: var(--bg-dark);
-  color: var(--text-primary);
   height: 100vh;
   overflow: hidden;
   user-select: none;
   -webkit-user-select: none;
   touch-action: pan-y;
+  -webkit-tap-highlight-color: transparent;
 }
 
-/* ステータスバー */
+/* Status bar */
 #status-bar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 16px;
-  background: var(--bg-light);
+  padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-md);
+  background: var(--md-sys-color-surface-container);
   font-size: 12px;
-  border-bottom: 1px solid var(--bg-card);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
 }
 
 .status-item {
@@ -51,63 +42,64 @@ body {
 .indicator {
   width: 10px;
   height: 10px;
-  border-radius: 50%;
+  border-radius: var(--md-sys-shape-full);
   display: inline-block;
 }
 
 .indicator.online {
-  background: var(--success);
-  box-shadow: 0 0 8px var(--success);
+  background: var(--annot-success);
+  box-shadow: 0 0 8px var(--annot-success);
 }
 
 .indicator.offline {
-  background: var(--danger);
+  background: var(--annot-danger);
 }
 
-
-/* 試合情報パネル */
+/* Game info panel */
 #game-info-panel {
-  background: var(--bg-light);
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--bg-card);
+  background: var(--md-sys-color-surface-container);
+  padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-md);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
 }
 
 .game-info-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 8px;
+  gap: var(--md-sys-spacing-sm);
 }
 
 .info-card {
-  background: var(--bg-card);
+  background: var(--md-sys-color-surface-container-high);
   padding: 10px;
-  border-radius: 8px;
+  border-radius: var(--md-sys-shape-md);
   text-align: center;
 }
 
 .info-label {
   font-size: 11px;
-  color: var(--text-secondary);
+  color: var(--md-sys-color-on-surface-variant);
   margin-bottom: 4px;
-  font-weight: bold;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
 }
 
 .info-value {
   font-size: 16px;
-  color: var(--text-primary);
-  font-weight: bold;
+  color: var(--md-sys-color-on-surface);
+  font-weight: 700;
 }
 
 .game-event-banner {
-  margin-top: 8px;
-  padding: 8px 12px;
-  background: var(--warning);
-  border-radius: 8px;
+  margin-top: var(--md-sys-spacing-sm);
+  padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-md);
+  background: var(--annot-warning);
+  border-radius: var(--md-sys-shape-md);
   text-align: center;
   font-size: 13px;
-  font-weight: bold;
-  color: #000;
-  animation: fadeIn 0.3s;
+  font-weight: 700;
+  color: var(--md-sys-color-on-warning);
+  animation: fadeIn var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-decelerate);
 }
 
 .game-event-banner.hidden {
@@ -119,9 +111,9 @@ body {
   to { opacity: 1; transform: translateY(0); }
 }
 
-/* メインエリア */
+/* Quick annotation buttons */
 #quick-buttons {
-  padding: 16px;
+  padding: var(--md-sys-spacing-md);
   height: calc(100vh - 310px);
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
@@ -130,18 +122,20 @@ body {
 .button-grid-simple {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
+  gap: var(--md-sys-spacing-md);
 }
 
 .annotation-btn {
-  padding: 32px 16px;
+  padding: var(--md-sys-spacing-xl) var(--md-sys-spacing-md);
   border: none;
-  border-radius: 16px;
+  border-radius: var(--md-sys-shape-xl);
   font-size: 16px;
-  font-weight: bold;
+  font-weight: 700;
+  font-family: inherit;
   color: white;
   cursor: pointer;
-  transition: transform 0.1s, box-shadow 0.1s;
+  transition: transform var(--md-sys-motion-duration-short) var(--md-sys-motion-spring),
+              box-shadow var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
   touch-action: manipulation;
   min-height: 120px;
   display: flex;
@@ -149,26 +143,27 @@ body {
   justify-content: center;
   text-align: center;
   line-height: 1.4;
+  box-shadow: var(--md-sys-elevation-2);
 }
 
 .annotation-btn:active {
   transform: scale(0.95);
-  box-shadow: inset 0 4px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--md-sys-elevation-1);
 }
 
-.btn-issue { background: var(--danger); }
-.btn-positive { background: var(--success); }
-.btn-note { background: var(--info); }
+.btn-issue    { background: var(--annot-danger); }
+.btn-positive { background: var(--annot-success); }
+.btn-note     { background: var(--annot-info); }
 
-/* リワインドセクション */
+/* Rewind section */
 #rewind-section {
   position: fixed;
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 12px 16px;
-  background: var(--bg-light);
-  border-top: 1px solid var(--bg-card);
+  padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-md);
+  background: var(--md-sys-color-surface-container);
+  border-top: 1px solid var(--md-sys-color-outline-variant);
   z-index: 10;
 }
 
@@ -176,33 +171,35 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: var(--md-sys-spacing-sm);
   font-size: 12px;
-  color: var(--text-secondary);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .rewind-lock-btn {
   padding: 4px 12px;
-  background: var(--bg-card);
+  background: var(--md-sys-color-surface-container-high);
   border: none;
-  border-radius: 6px;
-  color: var(--text-secondary);
+  border-radius: var(--md-sys-shape-sm);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 12px;
+  font-family: inherit;
   cursor: pointer;
   display: flex;
   align-items: center;
   gap: 4px;
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
 }
 
 .rewind-lock-btn.locked {
-  background: var(--warning);
-  color: white;
+  background: var(--annot-warning);
+  color: var(--md-sys-color-on-warning);
 }
 
 .slider-container {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--md-sys-spacing-md);
 }
 
 #rewind-slider {
@@ -210,8 +207,8 @@ body {
   height: 8px;
   -webkit-appearance: none;
   appearance: none;
-  background: var(--bg-card);
-  border-radius: 4px;
+  background: var(--md-sys-color-surface-container-high);
+  border-radius: var(--md-sys-shape-full);
   outline: none;
 }
 
@@ -220,30 +217,30 @@ body {
   appearance: none;
   width: 24px;
   height: 24px;
-  background: var(--accent);
-  border-radius: 50%;
+  background: var(--md-sys-color-primary);
+  border-radius: var(--md-sys-shape-full);
   cursor: pointer;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--md-sys-elevation-2);
 }
 
 #rewind-slider::-moz-range-thumb {
   width: 24px;
   height: 24px;
-  background: var(--accent);
-  border-radius: 50%;
+  background: var(--md-sys-color-primary);
+  border-radius: var(--md-sys-shape-full);
   cursor: pointer;
   border: none;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--md-sys-elevation-2);
 }
 
 #rewind-value {
   font-size: 14px;
-  font-weight: bold;
+  font-weight: 700;
   min-width: 60px;
   text-align: right;
 }
 
-/* モーダル */
+/* Modal */
 .modal {
   position: fixed;
   inset: 0;
@@ -260,19 +257,19 @@ body {
 .modal-overlay {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.8);
+  background: var(--md-sys-color-scrim);
 }
 
 .modal-content {
   position: relative;
-  background: var(--bg-light);
-  padding: 24px;
-  border-radius: 16px;
+  background: var(--md-sys-color-surface-container-high);
+  padding: var(--md-sys-spacing-lg);
+  border-radius: var(--md-sys-shape-xl);
   width: 90%;
   max-width: 400px;
   max-height: 80vh;
   overflow-y: auto;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--md-sys-elevation-5);
 }
 
 .modal-compact {
@@ -281,20 +278,21 @@ body {
 }
 
 .modal-content h3 {
-  margin-bottom: 16px;
-  color: var(--accent);
+  margin-bottom: var(--md-sys-spacing-md);
+  color: var(--md-sys-color-primary);
   font-size: 18px;
+  font-weight: 500;
 }
 
 .form-group {
-  margin-bottom: 12px;
+  margin-bottom: var(--md-sys-spacing-sm);
 }
 
 .form-group label {
   display: block;
   margin-bottom: 6px;
   font-size: 14px;
-  color: var(--text-secondary);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .form-group input,
@@ -302,12 +300,21 @@ body {
 .form-group textarea {
   width: 100%;
   padding: 10px;
-  background: var(--bg-card);
-  border: 1px solid var(--bg-dark);
-  border-radius: 8px;
-  color: var(--text-primary);
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: var(--md-sys-shape-sm);
+  color: var(--md-sys-color-on-surface);
   font-size: 14px;
   font-family: inherit;
+  transition: border-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 1px var(--md-sys-color-primary);
 }
 
 .form-group textarea {
@@ -317,19 +324,20 @@ body {
 .btn-voice {
   width: 100%;
   padding: 14px;
-  background: var(--info);
+  background: var(--annot-info);
   border: none;
-  border-radius: 10px;
+  border-radius: var(--md-sys-shape-md);
   color: white;
   font-size: 15px;
-  font-weight: bold;
+  font-weight: 700;
+  font-family: inherit;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  margin-bottom: 16px;
-  transition: all 0.2s;
+  gap: var(--md-sys-spacing-sm);
+  margin-bottom: var(--md-sys-spacing-md);
+  transition: transform var(--md-sys-motion-duration-short) var(--md-sys-motion-spring);
 }
 
 .btn-voice:active {
@@ -337,7 +345,7 @@ body {
 }
 
 .btn-voice.recording {
-  background: var(--danger);
+  background: var(--annot-danger);
   animation: pulse 1s infinite;
 }
 
@@ -346,37 +354,37 @@ body {
   50% { opacity: 0.7; }
 }
 
-/* コンテキスト選択ボタングリッド */
+/* Context selection buttons */
 .context-buttons {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 12px;
-  margin-bottom: 16px;
+  gap: var(--md-sys-spacing-md);
+  margin-bottom: var(--md-sys-spacing-md);
 }
 
 .btn-context-big {
-  padding: 20px 16px;
-  background: var(--bg-card);
-  border: 3px solid var(--bg-dark);
-  border-radius: 12px;
-  color: var(--text-secondary);
+  padding: 20px var(--md-sys-spacing-md);
+  background: var(--md-sys-color-surface-container);
+  border: 2px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-lg);
+  color: var(--md-sys-color-on-surface-variant);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: var(--md-sys-spacing-sm);
   min-height: 100px;
+  font-family: inherit;
 }
 
 .btn-context-big:active {
   transform: scale(0.96);
-  background: var(--bg-light);
 }
 
 .btn-context-big.has-selection {
-  border-color: var(--accent);
-  background: rgba(187, 225, 250, 0.1);
+  border-color: var(--md-sys-color-primary);
+  background: color-mix(in srgb, var(--md-sys-color-primary) 8%, var(--md-sys-color-surface-container));
 }
 
 .context-icon {
@@ -390,24 +398,24 @@ body {
 
 .context-label {
   font-size: 12px;
-  color: var(--text-secondary);
+  color: var(--md-sys-color-on-surface-variant);
   margin-bottom: 4px;
 }
 
 .context-value {
   font-size: 14px;
-  font-weight: bold;
-  color: var(--text-primary);
+  font-weight: 700;
+  color: var(--md-sys-color-on-surface);
 }
 
 .btn-context-big.has-selection .context-value {
-  color: var(--accent);
+  color: var(--md-sys-color-primary);
 }
 
 .modal-actions {
   display: flex;
-  gap: 12px;
-  margin-top: 24px;
+  gap: var(--md-sys-spacing-md);
+  margin-top: var(--md-sys-spacing-lg);
 }
 
 .btn-primary,
@@ -415,37 +423,44 @@ body {
   flex: 1;
   padding: 12px;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--md-sys-shape-full);
   font-size: 14px;
-  font-weight: bold;
+  font-weight: 500;
+  font-family: inherit;
   cursor: pointer;
+  transition: transform var(--md-sys-motion-duration-short) var(--md-sys-motion-spring);
+}
+
+.btn-primary:active,
+.btn-secondary:active {
+  transform: scale(0.97);
 }
 
 .btn-primary {
-  background: var(--success);
+  background: var(--annot-success);
   color: white;
 }
 
 .btn-secondary {
-  background: var(--bg-card);
-  color: var(--text-secondary);
+  background: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
-/* 履歴パネル */
+/* History panel */
 #history-panel {
   position: fixed;
   bottom: 0;
   left: 0;
   right: 0;
   height: 60vh;
-  background: var(--bg-light);
-  border-top: 2px solid var(--accent);
-  border-radius: 16px 16px 0 0;
+  background: var(--md-sys-color-surface-container);
+  border-top: 2px solid var(--md-sys-color-primary);
+  border-radius: var(--md-sys-shape-xl) var(--md-sys-shape-xl) 0 0;
   transform: translateY(100%);
-  transition: transform 0.3s;
+  transition: transform var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-emphasized);
   z-index: 900;
   overflow-y: auto;
-  padding: 16px;
+  padding: var(--md-sys-spacing-md);
 }
 
 #history-panel:not(.hidden) {
@@ -456,15 +471,15 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 16px;
-  padding-bottom: 12px;
-  border-bottom: 1px solid var(--bg-card);
+  margin-bottom: var(--md-sys-spacing-md);
+  padding-bottom: var(--md-sys-spacing-sm);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
 }
 
 #history-close {
   background: none;
   border: none;
-  color: var(--text-secondary);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 24px;
   cursor: pointer;
   padding: 0;
@@ -477,32 +492,34 @@ body {
 }
 
 #history-list li {
-  background: var(--bg-card);
-  padding: 12px;
-  margin-bottom: 8px;
-  border-radius: 8px;
+  background: var(--md-sys-color-surface-container-high);
+  padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-md);
+  margin-bottom: var(--md-sys-spacing-sm);
+  border-radius: var(--md-sys-shape-md);
   font-size: 14px;
 }
 
 #history-list li .time {
-  color: var(--text-secondary);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 12px;
 }
 
 .history-toggle-btn {
   position: fixed;
   bottom: 90px;
-  right: 16px;
-  padding: 12px 16px;
-  background: var(--bg-card);
-  border: 2px solid var(--accent);
-  border-radius: 24px;
-  color: var(--accent);
+  right: var(--md-sys-spacing-md);
+  padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-md);
+  background: var(--md-sys-color-surface-container-high);
+  border: 2px solid var(--md-sys-color-primary);
+  border-radius: var(--md-sys-shape-full);
+  color: var(--md-sys-color-primary);
   font-size: 14px;
-  font-weight: bold;
+  font-weight: 500;
+  font-family: inherit;
   cursor: pointer;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--md-sys-elevation-3);
   z-index: 800;
+  transition: transform var(--md-sys-motion-duration-short) var(--md-sys-motion-spring);
 }
 
 .history-toggle-btn:active {
@@ -512,18 +529,19 @@ body {
 .install-btn {
   position: fixed;
   bottom: 150px;
-  right: 16px;
-  padding: 12px 16px;
-  background: var(--success);
+  right: var(--md-sys-spacing-md);
+  padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-md);
+  background: var(--annot-success);
   border: none;
-  border-radius: 24px;
+  border-radius: var(--md-sys-shape-full);
   color: white;
   font-size: 14px;
-  font-weight: bold;
+  font-weight: 500;
+  font-family: inherit;
   cursor: pointer;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--md-sys-elevation-3);
   z-index: 800;
-  animation: slideIn 0.3s ease-out;
+  animation: slideIn var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-decelerate);
 }
 
 .install-btn:active {
@@ -535,37 +553,34 @@ body {
 }
 
 @keyframes slideIn {
-  from {
-    transform: translateX(120%);
-  }
-  to {
-    transform: translateX(0);
-  }
+  from { transform: translateX(120%); }
+  to { transform: translateX(0); }
 }
 
-/* ロボット選択UI */
+/* Robot selection */
 .team-selector {
   display: flex;
-  gap: 8px;
+  gap: var(--md-sys-spacing-sm);
 }
 
 .team-btn {
   flex: 1;
   padding: 10px;
-  background: var(--bg-card);
-  border: 2px solid var(--bg-dark);
-  border-radius: 8px;
-  color: var(--text-secondary);
+  background: var(--md-sys-color-surface-container-high);
+  border: 2px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-sm);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 14px;
-  font-weight: bold;
+  font-weight: 500;
+  font-family: inherit;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
 }
 
 .team-btn.active {
-  background: var(--secondary);
-  border-color: var(--accent);
-  color: white;
+  background: var(--md-sys-color-primary-container);
+  border-color: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary-container);
 }
 
 .team-btn:active {
@@ -575,19 +590,20 @@ body {
 .robot-id-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 8px;
+  gap: var(--md-sys-spacing-sm);
 }
 
 .robot-id-btn {
-  padding: 16px;
-  background: var(--bg-card);
-  border: 2px solid var(--bg-dark);
-  border-radius: 8px;
-  color: var(--text-primary);
+  padding: var(--md-sys-spacing-md);
+  background: var(--md-sys-color-surface-container-high);
+  border: 2px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-sm);
+  color: var(--md-sys-color-on-surface);
   font-size: 18px;
-  font-weight: bold;
+  font-weight: 700;
+  font-family: inherit;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
   min-height: 60px;
   display: flex;
   align-items: center;
@@ -599,28 +615,29 @@ body {
 }
 
 .robot-id-btn.selected {
-  background: var(--success);
-  border-color: var(--accent);
-  box-shadow: 0 0 12px var(--success);
+  background: var(--annot-success);
+  border-color: var(--md-sys-color-primary);
+  color: white;
+  box-shadow: 0 0 12px var(--annot-success);
 }
 
-/* フィールドマップUI */
+/* Field map */
 .modal-large {
   max-width: 500px;
   width: 95%;
 }
 
 .field-container {
-  background: var(--bg-card);
-  border-radius: 8px;
-  padding: 16px;
-  margin-bottom: 16px;
+  background: var(--md-sys-color-surface-container);
+  border-radius: var(--md-sys-shape-sm);
+  padding: var(--md-sys-spacing-md);
+  margin-bottom: var(--md-sys-spacing-md);
 }
 
 #field-svg {
   width: 100%;
   height: auto;
-  border-radius: 4px;
+  border-radius: var(--md-sys-shape-xs);
   cursor: crosshair;
   user-select: none;
   -webkit-user-select: none;
@@ -630,13 +647,13 @@ body {
 .field-info {
   display: flex;
   justify-content: space-between;
-  margin-top: 12px;
+  margin-top: var(--md-sys-spacing-sm);
   font-size: 13px;
-  color: var(--text-secondary);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 #position-coords {
-  font-family: 'Courier New', monospace;
-  font-weight: bold;
-  color: var(--accent);
+  font-family: var(--md-sys-typescale-mono-font-family);
+  font-weight: 700;
+  color: var(--md-sys-color-primary);
 }

--- a/crane_web_debugger/web/annotation/sw.js
+++ b/crane_web_debugger/web/annotation/sw.js
@@ -1,11 +1,12 @@
 // Service Worker for Crane Annotation Tool
-const CACHE_NAME = 'crane-annotation-v2';
+const CACHE_NAME = 'crane-annotation-v3';
 const urlsToCache = [
   './index.html',
   './app.js',
   './style.css',
   './manifest.json',
-  './icon.svg'
+  './icon.svg',
+  '../m3e-theme.css'
 ];
 
 // インストール時にキャッシュ

--- a/crane_web_debugger/web/index.html
+++ b/crane_web_debugger/web/index.html
@@ -4,308 +4,350 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Crane Debug Tools Portal</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-25..200&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="m3e-theme.css">
     <style>
         body {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             min-height: 100vh;
-            padding: 2rem 0;
+            padding: var(--md-sys-spacing-lg) 0;
         }
-        .portal-container {
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+
         .portal-header {
-            background: white;
-            border-radius: 15px;
-            padding: 2rem;
-            margin-bottom: 2rem;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+            background-color: var(--md-sys-color-surface-container);
+            border-radius: var(--md-sys-shape-xl);
+            padding: var(--md-sys-spacing-lg);
+            margin-bottom: var(--md-sys-spacing-lg);
+            box-shadow: var(--md-sys-elevation-2);
         }
-        .status-indicator {
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            display: inline-block;
-            margin-right: 8px;
+
+        .portal-header h1 {
+            font-size: 1.5rem;
+            font-weight: 500;
+            display: flex;
+            align-items: center;
+            gap: var(--md-sys-spacing-sm);
         }
-        .connected { background-color: #28a745; }
-        .disconnected { background-color: #dc3545; }
+
+        .portal-header h1 .material-symbols-outlined {
+            font-size: 32px;
+            color: var(--md-sys-color-primary);
+        }
+
+        .portal-header p {
+            color: var(--md-sys-color-on-surface-variant);
+            font-size: 0.875rem;
+            margin-top: 4px;
+        }
+
+        .connection-status {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--md-sys-spacing-sm);
+            font-size: 0.8125rem;
+            color: var(--md-sys-color-on-surface-variant);
+        }
+
+        .section-title {
+            color: var(--md-sys-color-primary);
+            font-size: 0.8125rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            margin-bottom: var(--md-sys-spacing-md);
+            margin-top: var(--md-sys-spacing-xl);
+            display: flex;
+            align-items: center;
+            gap: var(--md-sys-spacing-sm);
+        }
+
+        .section-title .material-symbols-outlined {
+            font-size: 20px;
+        }
+
+        .tool-grid {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: var(--md-sys-spacing-md);
+        }
+
+        @media (max-width: 768px) {
+            .tool-grid { grid-template-columns: 1fr; }
+        }
+
+        .tool-grid--3col {
+            grid-template-columns: repeat(3, 1fr);
+        }
+
+        @media (max-width: 768px) {
+            .tool-grid--3col { grid-template-columns: 1fr; }
+        }
+
         .tool-card {
-            background: white;
-            border-radius: 15px;
-            padding: 2rem;
-            height: 100%;
-            transition: all 0.3s ease;
+            background-color: var(--md-sys-color-surface-container-low);
+            border-radius: var(--md-sys-shape-lg);
+            padding: var(--md-sys-spacing-lg);
             cursor: pointer;
             text-decoration: none;
             color: inherit;
-            display: block;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+            display: flex;
+            flex-direction: column;
+            box-shadow: var(--md-sys-elevation-1);
             position: relative;
+            transition: box-shadow var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard),
+                        transform var(--md-sys-motion-duration-medium) var(--md-sys-motion-spring),
+                        border-radius var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard),
+                        background-color var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
         }
+
         .tool-card:hover {
-            transform: translateY(-10px);
-            box-shadow: 0 15px 35px rgba(0,0,0,0.2);
+            transform: translateY(-6px);
+            box-shadow: var(--md-sys-elevation-4);
+            border-radius: var(--md-sys-shape-xl);
+            background-color: var(--md-sys-color-surface-container);
             color: inherit;
         }
-        .tool-icon {
-            font-size: 3rem;
-            margin-bottom: 1rem;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
+
+        .tool-card:active {
+            transform: translateY(-2px) scale(0.99);
         }
-        .tool-title {
-            font-size: 1.5rem;
-            font-weight: bold;
-            margin-bottom: 0.5rem;
-        }
-        .tool-description {
-            color: #6c757d;
-            margin-bottom: 1rem;
-        }
-        .tool-features {
-            font-size: 0.9rem;
-            color: #495057;
-        }
-        .tool-features li {
-            margin-bottom: 0.25rem;
-        }
+
         .tool-card.disabled {
-            opacity: 0.6;
+            opacity: 0.5;
             cursor: not-allowed;
             pointer-events: none;
         }
-        .tool-card .badge {
-            position: absolute;
-            top: 1rem;
-            right: 1rem;
+
+        .tool-card__icon {
+            font-size: 40px;
+            margin-bottom: var(--md-sys-spacing-sm);
+            color: var(--md-sys-color-primary);
+            font-variation-settings: 'FILL' 0, 'wght' 300, 'GRAD' 0, 'opsz' 48;
         }
-        .section-title {
-            color: white;
-            font-size: 1.5rem;
-            font-weight: bold;
-            margin-bottom: 1rem;
-            margin-top: 2rem;
+
+        .tool-card__icon--tertiary {
+            color: var(--md-sys-color-tertiary);
+        }
+
+        .tool-card__title {
+            font-size: 1.125rem;
+            font-weight: 500;
+            margin-bottom: var(--md-sys-spacing-xs);
+        }
+
+        .tool-card__desc {
+            color: var(--md-sys-color-on-surface-variant);
+            font-size: 0.8125rem;
+            margin-bottom: var(--md-sys-spacing-md);
+            line-height: 1.5;
+        }
+
+        .tool-card__features {
+            list-style: none;
+            font-size: 0.8125rem;
+            color: var(--md-sys-color-on-surface-variant);
+        }
+
+        .tool-card__features li {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            margin-bottom: 4px;
+        }
+
+        .tool-card__features li .material-symbols-outlined {
+            font-size: 16px;
+            color: var(--md-sys-color-success);
+        }
+
+        .tool-card__features li .material-symbols-outlined.icon-info {
+            color: var(--md-sys-color-info);
+        }
+
+        .tool-card__badge {
+            position: absolute;
+            top: var(--md-sys-spacing-md);
+            right: var(--md-sys-spacing-md);
         }
     </style>
 </head>
 <body>
-    <div class="portal-container px-3">
-        <!-- ヘッダー -->
+    <div class="m3-container">
+        <!-- Header -->
         <div class="portal-header">
-            <div class="d-flex justify-content-between align-items-center">
+            <div class="m3-flex m3-justify-between m3-items-center">
                 <div>
-                    <h1 class="mb-2">
-                        <i class="fas fa-robot"></i> Crane Debug Tools Portal
+                    <h1>
+                        <span class="material-symbols-outlined">smart_toy</span>
+                        Crane Debug Tools Portal
                     </h1>
-                    <p class="text-muted mb-0">RoboCup SSL ロボット制御デバッグツール統合ポータル</p>
+                    <p>RoboCup SSL robot control debug tool portal</p>
                 </div>
-                <div class="text-end">
-                    <div id="connection-status">
-                        <span class="status-indicator disconnected"></span>
-                        <span id="status-text">接続確認中...</span>
-                    </div>
+                <div class="connection-status" id="connection-status">
+                    <span class="m3-connection-dot" id="connection-dot"></span>
+                    <span id="status-text">connecting...</span>
                 </div>
             </div>
         </div>
 
         <!-- Crane Debug Tools -->
-        <h2 class="section-title"><i class="fas fa-tools me-2"></i>Crane Debug Tools</h2>
-        <div class="row g-4">
-            <!-- メインビューア -->
-            <div class="col-md-6">
-                <a href="/viewer.html" class="tool-card">
-                    <div class="tool-icon">
-                        <i class="fas fa-map"></i>
-                    </div>
-                    <div class="tool-title">メインビューア</div>
-                    <div class="tool-description">
-                        SVGフィールド可視化とロボット状態一覧の統合ビュー
-                    </div>
-                    <ul class="tool-features">
-                        <li><i class="fas fa-check text-success"></i> SVGレイヤー付きフィールド描画</li>
-                        <li><i class="fas fa-check text-success"></i> ロボットカード一覧（プランナー・モード表示）</li>
-                        <li><i class="fas fa-check text-success"></i> ズーム・パン操作対応</li>
-                        <li><i class="fas fa-check text-success"></i> ゲーム情報・スコア表示</li>
-                    </ul>
-                </a>
-            </div>
+        <h2 class="section-title">
+            <span class="material-symbols-outlined">build</span>
+            Crane Debug Tools
+        </h2>
+        <div class="tool-grid">
+            <a href="/viewer.html" class="tool-card">
+                <span class="material-symbols-outlined tool-card__icon">map</span>
+                <div class="tool-card__title">Main Viewer</div>
+                <div class="tool-card__desc">
+                    SVG field visualization + robot status overview
+                </div>
+                <ul class="tool-card__features">
+                    <li><span class="material-symbols-outlined">check</span> SVG layered field rendering</li>
+                    <li><span class="material-symbols-outlined">check</span> Robot card list (planner/mode)</li>
+                    <li><span class="material-symbols-outlined">check</span> Zoom & pan controls</li>
+                    <li><span class="material-symbols-outlined">check</span> Game info & score display</li>
+                </ul>
+            </a>
 
-            <!-- ロボットテレメトリ -->
-            <div class="col-md-6">
-                <a href="/robot_telemetry.html" class="tool-card">
-                    <div class="tool-icon">
-                        <i class="fas fa-chart-line"></i>
-                    </div>
-                    <div class="tool-title">ロボットテレメトリ</div>
-                    <div class="tool-description">
-                        ロボット個別の予実プロット・詳細テレメトリ分析
-                    </div>
-                    <ul class="tool-features">
-                        <li><i class="fas fa-check text-success"></i> 推定位置・Vision位置・目標位置の比較</li>
-                        <li><i class="fas fa-check text-success"></i> 速度・角度の予実グラフ</li>
-                        <li><i class="fas fa-check text-success"></i> 速度計画誤差・修正ログ表示</li>
-                        <li><i class="fas fa-check text-success"></i> ロボットID切替（URL ?id=N）</li>
-                    </ul>
-                </a>
-            </div>
+            <a href="/robot_telemetry.html" class="tool-card">
+                <span class="material-symbols-outlined tool-card__icon">show_chart</span>
+                <div class="tool-card__title">Robot Telemetry</div>
+                <div class="tool-card__desc">
+                    Per-robot prediction/actual plots & telemetry analysis
+                </div>
+                <ul class="tool-card__features">
+                    <li><span class="material-symbols-outlined">check</span> Estimated/Vision/Target position comparison</li>
+                    <li><span class="material-symbols-outlined">check</span> Velocity & angle prediction graphs</li>
+                    <li><span class="material-symbols-outlined">check</span> Velocity correction logs</li>
+                    <li><span class="material-symbols-outlined">check</span> Robot ID switching (?id=N)</li>
+                </ul>
+            </a>
 
-            <!-- アノテーションツール -->
-            <div class="col-md-6">
-                <a href="/annotation/index.html" class="tool-card">
-                    <div class="tool-icon">
-                        <i class="fas fa-sticky-note"></i>
-                    </div>
-                    <div class="tool-title">アノテーションツール</div>
-                    <div class="tool-description">
-                        試合中のメモ記録とタイムスタンプ付きアノテーション（PWA対応）
-                    </div>
-                    <ul class="tool-features">
-                        <li><i class="fas fa-check text-success"></i> リアルタイムメモ記録</li>
-                        <li><i class="fas fa-check text-success"></i> タイムスタンプ自動付与</li>
-                        <li><i class="fas fa-check text-success"></i> PWAでオフライン利用可能</li>
-                        <li><i class="fas fa-check text-success"></i> 試合分析・振り返りに活用</li>
-                    </ul>
-                </a>
-            </div>
+            <a href="/annotation/index.html" class="tool-card">
+                <span class="material-symbols-outlined tool-card__icon tool-card__icon--tertiary">sticky_note_2</span>
+                <div class="tool-card__title">Annotation Tool</div>
+                <div class="tool-card__desc">
+                    Match-time memo recording with timestamped annotations (PWA)
+                </div>
+                <ul class="tool-card__features">
+                    <li><span class="material-symbols-outlined">check</span> Real-time memo recording</li>
+                    <li><span class="material-symbols-outlined">check</span> Automatic timestamp tagging</li>
+                    <li><span class="material-symbols-outlined">check</span> PWA offline support</li>
+                    <li><span class="material-symbols-outlined">check</span> Match analysis & review</li>
+                </ul>
+            </a>
 
-            <!-- ロボット管理 -->
-            <div class="col-md-6">
-                <a href="/robot_manager.html" class="tool-card">
-                    <div class="tool-icon">
-                        <i class="fas fa-microchip"></i>
-                    </div>
-                    <div class="tool-title">ロボット管理</div>
-                    <div class="tool-description">
-                        ロボットのハードウェア状態監視と起動制御（電圧・温度・エラー・Ping）
-                    </div>
-                    <ul class="tool-features">
-                        <li><i class="fas fa-check text-success"></i> バッテリー電圧・温度のリアルタイム監視</li>
-                        <li><i class="fas fa-check text-success"></i> エラー状態の詳細表示</li>
-                        <li><i class="fas fa-check text-success"></i> Pi起動・停止制御</li>
-                        <li><i class="fas fa-check text-success"></i> Ping・通信品質の確認</li>
-                    </ul>
-                </a>
-            </div>
+            <a href="/robot_manager.html" class="tool-card">
+                <span class="material-symbols-outlined tool-card__icon">memory</span>
+                <div class="tool-card__title">Robot Manager</div>
+                <div class="tool-card__desc">
+                    Hardware status monitoring & boot control (voltage, temp, errors, ping)
+                </div>
+                <ul class="tool-card__features">
+                    <li><span class="material-symbols-outlined">check</span> Real-time battery & temperature monitoring</li>
+                    <li><span class="material-symbols-outlined">check</span> Error state details</li>
+                    <li><span class="material-symbols-outlined">check</span> Pi start/stop control</li>
+                    <li><span class="material-symbols-outlined">check</span> Ping & communication quality</li>
+                </ul>
+            </a>
         </div>
 
         <!-- SSL Infrastructure -->
-        <h2 class="section-title"><i class="fas fa-network-wired me-2"></i>SSL Infrastructure</h2>
-        <div class="row g-4">
-            <!-- SSL Game Controller -->
-            <div class="col-md-4">
-                <a href="#" target="_blank" class="tool-card" id="game-controller-card">
-                    <span class="badge bg-secondary" id="game-controller-status">確認中...</span>
-                    <div class="tool-icon">
-                        <i class="fas fa-flag"></i>
-                    </div>
-                    <div class="tool-title">SSL Game Controller</div>
-                    <div class="tool-description">
-                        RoboCup SSL公式のゲームコントローラー（審判システム）
-                    </div>
-                    <ul class="tool-features">
-                        <li><i class="fas fa-check text-success"></i> 試合進行の管理</li>
-                        <li><i class="fas fa-check text-success"></i> レフェリーコマンド発行</li>
-                        <li><i class="fas fa-check text-success"></i> スコア・時間管理</li>
-                        <li><i class="fas fa-info-circle text-info"></i> ポート: 8081</li>
-                    </ul>
-                </a>
-            </div>
+        <h2 class="section-title">
+            <span class="material-symbols-outlined">hub</span>
+            SSL Infrastructure
+        </h2>
+        <div class="tool-grid tool-grid--3col">
+            <a href="#" target="_blank" class="tool-card" id="game-controller-card">
+                <span class="m3-badge m3-badge--secondary tool-card__badge" id="game-controller-status">checking...</span>
+                <span class="material-symbols-outlined tool-card__icon">flag</span>
+                <div class="tool-card__title">SSL Game Controller</div>
+                <div class="tool-card__desc">
+                    Official RoboCup SSL game controller (referee system)
+                </div>
+                <ul class="tool-card__features">
+                    <li><span class="material-symbols-outlined">check</span> Match progression management</li>
+                    <li><span class="material-symbols-outlined">check</span> Referee command issuing</li>
+                    <li><span class="material-symbols-outlined">check</span> Score & time management</li>
+                    <li><span class="material-symbols-outlined icon-info">info</span> Port: 8081</li>
+                </ul>
+            </a>
 
-            <!-- SSL Vision Client -->
-            <div class="col-md-4">
-                <a href="#" target="_blank" class="tool-card" id="vision-client-card">
-                    <span class="badge bg-secondary" id="vision-client-status">確認中...</span>
-                    <div class="tool-icon">
-                        <i class="fas fa-video"></i>
-                    </div>
-                    <div class="tool-title">SSL Vision Client</div>
-                    <div class="tool-description">
-                        SSL-Visionからのビジョンデータを可視化・監視
-                    </div>
-                    <ul class="tool-features">
-                        <li><i class="fas fa-check text-success"></i> ビジョンデータのリアルタイム表示</li>
-                        <li><i class="fas fa-check text-success"></i> カメラ別データの確認</li>
-                        <li><i class="fas fa-check text-success"></i> ロボット・ボール位置の監視</li>
-                        <li><i class="fas fa-info-circle text-info"></i> ポート: 8082</li>
-                    </ul>
-                </a>
-            </div>
+            <a href="#" target="_blank" class="tool-card" id="vision-client-card">
+                <span class="m3-badge m3-badge--secondary tool-card__badge" id="vision-client-status">checking...</span>
+                <span class="material-symbols-outlined tool-card__icon">videocam</span>
+                <div class="tool-card__title">SSL Vision Client</div>
+                <div class="tool-card__desc">
+                    Visualize & monitor vision data from SSL-Vision
+                </div>
+                <ul class="tool-card__features">
+                    <li><span class="material-symbols-outlined">check</span> Real-time vision data display</li>
+                    <li><span class="material-symbols-outlined">check</span> Per-camera data check</li>
+                    <li><span class="material-symbols-outlined">check</span> Robot & ball position monitoring</li>
+                    <li><span class="material-symbols-outlined icon-info">info</span> Port: 8082</li>
+                </ul>
+            </a>
 
-            <!-- SSL Status Board -->
-            <div class="col-md-4">
-                <a href="#" target="_blank" class="tool-card" id="status-board-card">
-                    <span class="badge bg-secondary" id="status-board-status">確認中...</span>
-                    <div class="tool-icon">
-                        <i class="fas fa-tv"></i>
-                    </div>
-                    <div class="tool-title">SSL Status Board</div>
-                    <div class="tool-description">
-                        試合状況をリアルタイム表示するステータスボード
-                    </div>
-                    <ul class="tool-features">
-                        <li><i class="fas fa-check text-success"></i> レフェリー情報のリアルタイム表示</li>
-                        <li><i class="fas fa-check text-success"></i> チーム・スコア・カード状況</li>
-                        <li><i class="fas fa-check text-success"></i> 試合進行のモニタリング</li>
-                        <li><i class="fas fa-info-circle text-info"></i> ポート: 8083 (simプロファイル)</li>
-                    </ul>
-                </a>
-            </div>
+            <a href="#" target="_blank" class="tool-card" id="status-board-card">
+                <span class="m3-badge m3-badge--secondary tool-card__badge" id="status-board-status">checking...</span>
+                <span class="material-symbols-outlined tool-card__icon">tv</span>
+                <div class="tool-card__title">SSL Status Board</div>
+                <div class="tool-card__desc">
+                    Real-time match status display board
+                </div>
+                <ul class="tool-card__features">
+                    <li><span class="material-symbols-outlined">check</span> Real-time referee info display</li>
+                    <li><span class="material-symbols-outlined">check</span> Team, score & card status</li>
+                    <li><span class="material-symbols-outlined">check</span> Match progression monitoring</li>
+                    <li><span class="material-symbols-outlined icon-info">info</span> Port: 8083 (sim profile)</li>
+                </ul>
+            </a>
         </div>
 
         <!-- Analysis & Calibration -->
-        <h2 class="section-title"><i class="fas fa-flask me-2"></i>Analysis & Calibration</h2>
-        <div class="row g-4 pb-4">
-            <!-- Ball Calibration UI -->
-            <div class="col-md-6">
-                <a href="#" target="_blank" class="tool-card" id="ball-calibration-card">
-                    <span class="badge bg-secondary" id="ball-calibration-status">確認中...</span>
-                    <div class="tool-icon">
-                        <i class="fas fa-futbol"></i>
-                    </div>
-                    <div class="tool-title">Ball Calibration UI</div>
-                    <div class="tool-description">
-                        ボール物理モデルパラメータのインタラクティブ最適化（Human-in-the-Loop）
-                    </div>
-                    <ul class="tool-features">
-                        <li><i class="fas fa-check text-success"></i> 軌跡データの読込・可視化</li>
-                        <li><i class="fas fa-check text-success"></i> 減速パラメータの自動最適化</li>
-                        <li><i class="fas fa-check text-success"></i> 予測軌跡のリアルタイムプレビュー</li>
-                        <li><i class="fas fa-info-circle text-info"></i> ポート: 8095</li>
-                    </ul>
-                </a>
-            </div>
+        <h2 class="section-title">
+            <span class="material-symbols-outlined">science</span>
+            Analysis & Calibration
+        </h2>
+        <div class="tool-grid" style="padding-bottom: var(--md-sys-spacing-lg);">
+            <a href="#" target="_blank" class="tool-card" id="ball-calibration-card">
+                <span class="m3-badge m3-badge--secondary tool-card__badge" id="ball-calibration-status">checking...</span>
+                <span class="material-symbols-outlined tool-card__icon tool-card__icon--tertiary">sports_soccer</span>
+                <div class="tool-card__title">Ball Calibration UI</div>
+                <div class="tool-card__desc">
+                    Interactive ball physics model parameter optimization (Human-in-the-Loop)
+                </div>
+                <ul class="tool-card__features">
+                    <li><span class="material-symbols-outlined">check</span> Trajectory data loading & visualization</li>
+                    <li><span class="material-symbols-outlined">check</span> Auto deceleration parameter optimization</li>
+                    <li><span class="material-symbols-outlined">check</span> Real-time prediction trajectory preview</li>
+                    <li><span class="material-symbols-outlined icon-info">info</span> Port: 8095</li>
+                </ul>
+            </a>
 
-            <!-- Foxglove Studio -->
-            <div class="col-md-6">
-                <a href="#" target="_blank" class="tool-card" id="foxglove-card">
-                    <span class="badge bg-secondary" id="foxglove-status">確認中...</span>
-                    <div class="tool-icon">
-                        <i class="fas fa-wave-square"></i>
-                    </div>
-                    <div class="tool-title">Foxglove Studio</div>
-                    <div class="tool-description">
-                        ROS2トピックのWebベースリアルタイム可視化・分析
-                    </div>
-                    <ul class="tool-features">
-                        <li><i class="fas fa-check text-success"></i> マルチパネルカスタムレイアウト</li>
-                        <li><i class="fas fa-check text-success"></i> ログ・TF・画像の統合ビュー</li>
-                        <li><i class="fas fa-check text-success"></i> ROS2トピックのリアルタイム可視化</li>
-                        <li><i class="fas fa-info-circle text-info"></i> WebSocket: ポート 8765</li>
-                    </ul>
-                </a>
-            </div>
+            <a href="#" target="_blank" class="tool-card" id="foxglove-card">
+                <span class="m3-badge m3-badge--secondary tool-card__badge" id="foxglove-status">checking...</span>
+                <span class="material-symbols-outlined tool-card__icon">analytics</span>
+                <div class="tool-card__title">Foxglove Studio</div>
+                <div class="tool-card__desc">
+                    Web-based real-time visualization & analysis of ROS2 topics
+                </div>
+                <ul class="tool-card__features">
+                    <li><span class="material-symbols-outlined">check</span> Multi-panel custom layout</li>
+                    <li><span class="material-symbols-outlined">check</span> Log, TF & image integrated view</li>
+                    <li><span class="material-symbols-outlined">check</span> Real-time ROS2 topic visualization</li>
+                    <li><span class="material-symbols-outlined icon-info">info</span> WebSocket: Port 8765</li>
+                </ul>
+            </a>
         </div>
     </div>
 
     <script>
         const host = window.location.hostname;
 
-        // 外部ツール定義
         const EXTERNAL_TOOLS = [
             { id: 'game-controller', url: `http://${host}:8081` },
             { id: 'vision-client',   url: `http://${host}:8082` },
@@ -316,46 +358,39 @@
               checkUrl: `http://${host}:8765` },
         ];
 
-        // WebSocket接続チェック
         function checkConnection() {
             const ws = new WebSocket(`ws://${host}:8091`);
-            const statusIndicator = document.querySelector('.status-indicator');
-            const statusText = document.getElementById('status-text');
+            const dot = document.getElementById('connection-dot');
+            const text = document.getElementById('status-text');
 
             ws.onopen = () => {
-                statusIndicator.classList.remove('disconnected');
-                statusIndicator.classList.add('connected');
-                statusText.textContent = `WebSocket接続済み (${host}:8091)`;
+                dot.classList.add('connected');
+                text.textContent = `WebSocket connected (${host}:8091)`;
                 ws.close();
             };
 
             ws.onerror = () => {
-                statusIndicator.classList.remove('connected');
-                statusIndicator.classList.add('disconnected');
-                statusText.textContent = 'WebSocket未接続 (一部ツールはオフラインでも利用可能)';
+                dot.classList.remove('connected');
+                text.textContent = 'WebSocket disconnected';
             };
         }
 
-        // 外部ツールの可用性チェック
-        async function checkExternalTool(checkUrl, card, statusBadge) {
+        async function checkExternalTool(checkUrl, card, badge) {
             try {
                 await fetch(checkUrl, {
                     mode: 'no-cors',
                     signal: AbortSignal.timeout(3000)
                 });
-                statusBadge.textContent = '利用可能';
-                statusBadge.classList.remove('bg-secondary', 'bg-danger');
-                statusBadge.classList.add('bg-success');
+                badge.textContent = 'available';
+                badge.className = 'm3-badge m3-badge--success tool-card__badge';
                 card.classList.remove('disabled');
             } catch (error) {
-                statusBadge.textContent = '利用不可';
-                statusBadge.classList.remove('bg-secondary', 'bg-success');
-                statusBadge.classList.add('bg-danger');
+                badge.textContent = 'unavailable';
+                badge.className = 'm3-badge m3-badge--error tool-card__badge';
                 card.classList.add('disabled');
             }
         }
 
-        // 各カードのhrefを初期化（初回のみ）
         function setupExternalToolLinks() {
             EXTERNAL_TOOLS.forEach(tool => {
                 const card = document.getElementById(`${tool.id}-card`);
@@ -363,24 +398,18 @@
             });
         }
 
-        // 可用性チェックを実行
         function checkAllExternalTools() {
             EXTERNAL_TOOLS.forEach(tool => {
                 const card = document.getElementById(`${tool.id}-card`);
-                const statusBadge = document.getElementById(`${tool.id}-status`);
-                checkExternalTool(tool.checkUrl || tool.url, card, statusBadge);
+                const badge = document.getElementById(`${tool.id}-status`);
+                checkExternalTool(tool.checkUrl || tool.url, card, badge);
             });
         }
 
-        // ページロード時に初期化
         checkConnection();
         setupExternalToolLinks();
         checkAllExternalTools();
-
-        // 30秒ごとに可用性を再チェック
         setInterval(checkAllExternalTools, 30000);
     </script>
-
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/crane_web_debugger/web/m3e-theme.css
+++ b/crane_web_debugger/web/m3e-theme.css
@@ -1,0 +1,907 @@
+/*
+ * Material 3 Expressive Design System for Crane Web Debugger
+ * ============================================================
+ * Dark theme optimized for debug tool usage.
+ * Based on M3 Expressive guidelines: expressive color, shape, motion, typography.
+ */
+
+/* ===== DESIGN TOKENS ===== */
+:root {
+  /* --- Color: Primary (Blue) --- */
+  --md-sys-color-primary: #A0C4FF;
+  --md-sys-color-on-primary: #003060;
+  --md-sys-color-primary-container: #1A3A5C;
+  --md-sys-color-on-primary-container: #C8E0FF;
+
+  /* --- Color: Secondary --- */
+  --md-sys-color-secondary: #B8C8E0;
+  --md-sys-color-on-secondary: #1E2A3A;
+  --md-sys-color-secondary-container: #2A3A50;
+  --md-sys-color-on-secondary-container: #D8E4F0;
+
+  /* --- Color: Tertiary (Purple accent) --- */
+  --md-sys-color-tertiary: #D0BCFF;
+  --md-sys-color-on-tertiary: #381E72;
+  --md-sys-color-tertiary-container: #4F378B;
+  --md-sys-color-on-tertiary-container: #EADDFF;
+
+  /* --- Color: Error --- */
+  --md-sys-color-error: #FFB4AB;
+  --md-sys-color-on-error: #690005;
+  --md-sys-color-error-container: #93000A;
+  --md-sys-color-on-error-container: #FFDAD6;
+
+  /* --- Color: Surface --- */
+  --md-sys-color-surface: #121826;
+  --md-sys-color-surface-dim: #0D1117;
+  --md-sys-color-surface-bright: #1E2A40;
+  --md-sys-color-surface-container-lowest: #0A0E18;
+  --md-sys-color-surface-container-low: #141C2E;
+  --md-sys-color-surface-container: #1A2440;
+  --md-sys-color-surface-container-high: #213052;
+  --md-sys-color-surface-container-highest: #2A3C64;
+  --md-sys-color-on-surface: #E2E4E8;
+  --md-sys-color-on-surface-variant: #8C929A;
+  --md-sys-color-outline: #4A5568;
+  --md-sys-color-outline-variant: #2D3748;
+  --md-sys-color-inverse-surface: #E2E4E8;
+  --md-sys-color-inverse-on-surface: #121826;
+  --md-sys-color-scrim: rgba(0, 0, 0, 0.6);
+
+  /* --- Color: Semantic (status) --- */
+  --md-sys-color-success: #66BB6A;
+  --md-sys-color-on-success: #003300;
+  --md-sys-color-success-container: #1B3A1B;
+  --md-sys-color-warning: #FFA726;
+  --md-sys-color-on-warning: #3E2800;
+  --md-sys-color-warning-container: #4A3000;
+  --md-sys-color-info: #42A5F5;
+
+  /* --- Typography --- */
+  --md-sys-typescale-font-family: 'Roboto', 'Noto Sans JP', system-ui, sans-serif;
+  --md-sys-typescale-mono-font-family: 'Roboto Mono', 'Courier New', monospace;
+
+  /* --- Shape (M3E: more rounded, organic) --- */
+  --md-sys-shape-none: 0;
+  --md-sys-shape-xs: 4px;
+  --md-sys-shape-sm: 8px;
+  --md-sys-shape-md: 12px;
+  --md-sys-shape-lg: 16px;
+  --md-sys-shape-xl: 28px;
+  --md-sys-shape-full: 9999px;
+
+  /* --- Elevation (dark theme shadows) --- */
+  --md-sys-elevation-0: none;
+  --md-sys-elevation-1: 0 1px 3px 1px rgba(0,0,0,0.15), 0 1px 2px 0 rgba(0,0,0,0.3);
+  --md-sys-elevation-2: 0 2px 6px 2px rgba(0,0,0,0.15), 0 1px 2px 0 rgba(0,0,0,0.3);
+  --md-sys-elevation-3: 0 4px 8px 3px rgba(0,0,0,0.15), 0 1px 3px 0 rgba(0,0,0,0.3);
+  --md-sys-elevation-4: 0 6px 10px 4px rgba(0,0,0,0.15), 0 2px 3px 0 rgba(0,0,0,0.3);
+  --md-sys-elevation-5: 0 8px 12px 6px rgba(0,0,0,0.15), 0 4px 4px 0 rgba(0,0,0,0.3);
+
+  /* --- Spacing --- */
+  --md-sys-spacing-xs: 4px;
+  --md-sys-spacing-sm: 8px;
+  --md-sys-spacing-md: 16px;
+  --md-sys-spacing-lg: 24px;
+  --md-sys-spacing-xl: 32px;
+  --md-sys-spacing-2xl: 48px;
+
+  /* --- Motion (M3E: physics-based) --- */
+  --md-sys-motion-duration-short: 150ms;
+  --md-sys-motion-duration-medium: 300ms;
+  --md-sys-motion-duration-long: 500ms;
+  --md-sys-motion-easing-standard: cubic-bezier(0.2, 0.0, 0, 1.0);
+  --md-sys-motion-easing-emphasized: cubic-bezier(0.2, 0.0, 0, 1.0);
+  --md-sys-motion-easing-decelerate: cubic-bezier(0.0, 0.0, 0, 1.0);
+  --md-sys-motion-easing-accelerate: cubic-bezier(0.3, 0.0, 0.8, 0.15);
+  --md-sys-motion-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+
+/* ===== BASE RESET & DEFAULTS ===== */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+body {
+  font-family: var(--md-sys-typescale-font-family);
+  background-color: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: var(--md-sys-color-primary);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--md-sys-color-on-primary-container);
+}
+
+
+/* ===== TYPOGRAPHY SCALE ===== */
+.m3-display-large   { font-size: 2.25rem;  font-weight: 500; line-height: 2.75rem; letter-spacing: -0.01em; }
+.m3-headline-large  { font-size: 1.75rem;  font-weight: 500; line-height: 2.25rem; }
+.m3-headline-medium { font-size: 1.5rem;   font-weight: 500; line-height: 2rem; }
+.m3-headline-small  { font-size: 1.25rem;  font-weight: 500; line-height: 1.75rem; }
+.m3-title-large     { font-size: 1.25rem;  font-weight: 500; line-height: 1.75rem; }
+.m3-title-medium    { font-size: 1rem;     font-weight: 500; line-height: 1.5rem;  letter-spacing: 0.01em; }
+.m3-title-small     { font-size: 0.875rem; font-weight: 500; line-height: 1.25rem; letter-spacing: 0.01em; }
+.m3-body-large      { font-size: 1rem;     font-weight: 400; line-height: 1.5rem; }
+.m3-body-medium     { font-size: 0.875rem; font-weight: 400; line-height: 1.25rem; letter-spacing: 0.015em; }
+.m3-body-small      { font-size: 0.75rem;  font-weight: 400; line-height: 1rem;    letter-spacing: 0.02em; }
+.m3-label-large     { font-size: 0.875rem; font-weight: 500; line-height: 1.25rem; letter-spacing: 0.01em; }
+.m3-label-medium    { font-size: 0.75rem;  font-weight: 500; line-height: 1rem;    letter-spacing: 0.03em; }
+.m3-label-small     { font-size: 0.6875rem;font-weight: 500; line-height: 1rem;    letter-spacing: 0.03em; }
+
+
+/* ===== MATERIAL SYMBOLS HELPER ===== */
+.material-symbols-outlined {
+  vertical-align: middle;
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+
+.icon-sm { font-size: 18px; }
+.icon-lg { font-size: 32px; }
+.icon-xl { font-size: 48px; }
+
+.icon-filled {
+  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+
+
+/* ===== TOP APP BAR ===== */
+.m3-top-app-bar {
+  display: flex;
+  align-items: center;
+  padding: 0 var(--md-sys-spacing-md);
+  height: 48px;
+  background-color: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface);
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  gap: var(--md-sys-spacing-sm);
+}
+
+.m3-top-app-bar__title {
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-sm);
+}
+
+.m3-top-app-bar__title .material-symbols-outlined {
+  color: var(--md-sys-color-primary);
+}
+
+.m3-top-app-bar__actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-md);
+}
+
+.m3-top-app-bar__nav-links {
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-xs);
+  list-style: none;
+}
+
+.m3-top-app-bar__nav-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border-radius: var(--md-sys-shape-full);
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard),
+              color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+.m3-top-app-bar__nav-links a:hover {
+  background-color: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface);
+}
+
+
+/* ===== BUTTONS ===== */
+.m3-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--md-sys-spacing-sm);
+  padding: 10px 24px;
+  border: none;
+  border-radius: var(--md-sys-shape-full);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard),
+              box-shadow var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard),
+              transform var(--md-sys-motion-duration-short) var(--md-sys-motion-spring);
+  text-decoration: none;
+  white-space: nowrap;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.m3-btn:active {
+  transform: scale(0.97);
+}
+
+/* Filled */
+.m3-btn--filled {
+  background-color: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+}
+
+.m3-btn--filled:hover {
+  box-shadow: var(--md-sys-elevation-1);
+  background-color: color-mix(in srgb, var(--md-sys-color-primary) 92%, var(--md-sys-color-on-primary));
+}
+
+/* Filled Tonal */
+.m3-btn--tonal {
+  background-color: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+}
+
+.m3-btn--tonal:hover {
+  box-shadow: var(--md-sys-elevation-1);
+  background-color: color-mix(in srgb, var(--md-sys-color-secondary-container) 88%, var(--md-sys-color-on-secondary-container));
+}
+
+/* Outlined */
+.m3-btn--outlined {
+  background-color: transparent;
+  color: var(--md-sys-color-primary);
+  border: 1px solid var(--md-sys-color-outline);
+}
+
+.m3-btn--outlined:hover {
+  background-color: color-mix(in srgb, var(--md-sys-color-primary) 8%, transparent);
+}
+
+/* Text */
+.m3-btn--text {
+  background-color: transparent;
+  color: var(--md-sys-color-primary);
+  padding: 10px 12px;
+}
+
+.m3-btn--text:hover {
+  background-color: color-mix(in srgb, var(--md-sys-color-primary) 8%, transparent);
+}
+
+/* Icon button */
+.m3-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: var(--md-sys-shape-full);
+  background: transparent;
+  color: var(--md-sys-color-on-surface-variant);
+  cursor: pointer;
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+.m3-icon-btn:hover {
+  background-color: var(--md-sys-color-surface-container-high);
+}
+
+/* Size variants */
+.m3-btn--sm {
+  padding: 6px 16px;
+  font-size: 0.75rem;
+  height: 32px;
+}
+
+.m3-icon-btn--sm {
+  width: 32px;
+  height: 32px;
+}
+
+.m3-icon-btn--sm .material-symbols-outlined {
+  font-size: 18px;
+}
+
+/* Color variants */
+.m3-btn--success {
+  background-color: var(--md-sys-color-success);
+  color: var(--md-sys-color-on-success);
+}
+
+.m3-btn--error {
+  background-color: var(--md-sys-color-error);
+  color: var(--md-sys-color-on-error);
+}
+
+.m3-btn--warning {
+  background-color: var(--md-sys-color-warning);
+  color: var(--md-sys-color-on-warning);
+}
+
+
+/* ===== CARDS ===== */
+.m3-card {
+  border-radius: var(--md-sys-shape-lg);
+  padding: var(--md-sys-spacing-md);
+  transition: box-shadow var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard),
+              transform var(--md-sys-motion-duration-medium) var(--md-sys-motion-spring),
+              border-radius var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
+}
+
+.m3-card--filled {
+  background-color: var(--md-sys-color-surface-container-highest);
+  color: var(--md-sys-color-on-surface);
+}
+
+.m3-card--elevated {
+  background-color: var(--md-sys-color-surface-container-low);
+  color: var(--md-sys-color-on-surface);
+  box-shadow: var(--md-sys-elevation-1);
+}
+
+.m3-card--elevated:hover {
+  box-shadow: var(--md-sys-elevation-3);
+}
+
+.m3-card--outlined {
+  background-color: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
+}
+
+/* Interactive card (clickable) */
+.m3-card--interactive {
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.m3-card--interactive:hover {
+  transform: translateY(-4px);
+  border-radius: var(--md-sys-shape-xl);
+  color: inherit;
+}
+
+.m3-card--interactive:active {
+  transform: translateY(-2px) scale(0.99);
+}
+
+
+/* ===== BADGE ===== */
+.m3-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 8px;
+  border-radius: var(--md-sys-shape-full);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  line-height: 1;
+  min-width: 20px;
+  min-height: 20px;
+}
+
+.m3-badge--primary {
+  background-color: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+}
+
+.m3-badge--secondary {
+  background-color: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+}
+
+.m3-badge--success {
+  background-color: var(--md-sys-color-success);
+  color: var(--md-sys-color-on-success);
+}
+
+.m3-badge--error {
+  background-color: var(--md-sys-color-error);
+  color: var(--md-sys-color-on-error);
+}
+
+.m3-badge--warning {
+  background-color: var(--md-sys-color-warning);
+  color: var(--md-sys-color-on-warning);
+}
+
+
+/* ===== DATA TABLE ===== */
+.m3-data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.m3-data-table th {
+  color: var(--md-sys-color-on-surface-variant);
+  font-weight: 500;
+  font-size: 0.75rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 8px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--md-sys-color-outline);
+  background-color: var(--md-sys-color-surface-container);
+}
+
+.m3-data-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  color: var(--md-sys-color-on-surface);
+  vertical-align: middle;
+}
+
+.m3-data-table tbody tr {
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+.m3-data-table tbody tr:hover {
+  background-color: var(--md-sys-color-surface-container-low);
+}
+
+.m3-data-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Compact table */
+.m3-data-table--compact th,
+.m3-data-table--compact td {
+  padding: 4px 8px;
+  font-size: 0.75rem;
+}
+
+/* Borderless table for detail panels */
+.m3-data-table--borderless td {
+  border-bottom: none;
+  padding: 3px 8px;
+}
+
+.m3-data-table--borderless td:first-child {
+  color: var(--md-sys-color-on-surface-variant);
+  white-space: nowrap;
+  padding-right: 12px;
+  font-size: 0.8125rem;
+}
+
+
+/* ===== DIALOG (Modal replacement) ===== */
+.m3-dialog-scrim {
+  position: fixed;
+  inset: 0;
+  background-color: var(--md-sys-color-scrim);
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard),
+              visibility var(--md-sys-motion-duration-medium);
+}
+
+.m3-dialog-scrim.open {
+  opacity: 1;
+  visibility: visible;
+}
+
+.m3-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.9);
+  z-index: 1001;
+  background-color: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface);
+  border-radius: var(--md-sys-shape-xl);
+  padding: var(--md-sys-spacing-lg);
+  max-width: 420px;
+  width: 90%;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: var(--md-sys-elevation-5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-emphasized),
+              transform var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-emphasized),
+              visibility var(--md-sys-motion-duration-medium);
+}
+
+.m3-dialog.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.m3-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--md-sys-spacing-md);
+}
+
+.m3-dialog__title {
+  font-size: 1.125rem;
+  font-weight: 500;
+  color: var(--md-sys-color-on-surface);
+}
+
+.m3-dialog__body {
+  font-size: 0.8125rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.m3-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--md-sys-spacing-sm);
+  margin-top: var(--md-sys-spacing-lg);
+}
+
+
+/* ===== EXPANSION PANEL (details/summary) ===== */
+details.m3-expansion {
+  background-color: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-md);
+  overflow: hidden;
+}
+
+details.m3-expansion summary {
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-sm);
+  padding: 10px var(--md-sys-spacing-md);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--md-sys-color-on-surface);
+  user-select: none;
+  list-style: none;
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+details.m3-expansion summary::-webkit-details-marker { display: none; }
+
+details.m3-expansion summary::after {
+  content: 'expand_more';
+  font-family: 'Material Symbols Outlined';
+  font-size: 20px;
+  margin-left: auto;
+  color: var(--md-sys-color-on-surface-variant);
+  transition: transform var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
+}
+
+details.m3-expansion[open] summary::after {
+  transform: rotate(180deg);
+}
+
+details.m3-expansion summary:hover {
+  background-color: var(--md-sys-color-surface-container-high);
+}
+
+details.m3-expansion .m3-expansion__body {
+  padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-md) var(--md-sys-spacing-md);
+}
+
+
+/* ===== LINEAR PROGRESS ===== */
+.m3-linear-progress {
+  height: 4px;
+  background-color: var(--md-sys-color-surface-container-highest);
+  border-radius: var(--md-sys-shape-full);
+  overflow: hidden;
+}
+
+.m3-linear-progress__bar {
+  height: 100%;
+  border-radius: var(--md-sys-shape-full);
+  background-color: var(--md-sys-color-primary);
+  transition: width var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
+}
+
+
+/* ===== SELECT ===== */
+.m3-select {
+  appearance: none;
+  padding: 8px 32px 8px 12px;
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: var(--md-sys-shape-sm);
+  background-color: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface);
+  font-family: inherit;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='%238C929A'%3E%3Cpath d='M7 10l5 5 5-5z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 4px center;
+  background-size: 20px;
+  transition: border-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+.m3-select:focus {
+  outline: none;
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 1px var(--md-sys-color-primary);
+}
+
+
+/* ===== CHECKBOX ===== */
+.m3-checkbox {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--md-sys-color-outline);
+  border-radius: 3px;
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard),
+              border-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+.m3-checkbox:checked {
+  background-color: var(--md-sys-color-primary);
+  border-color: var(--md-sys-color-primary);
+}
+
+.m3-checkbox:checked::after {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 1px;
+  width: 6px;
+  height: 10px;
+  border: solid var(--md-sys-color-on-primary);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+
+/* ===== CONNECTION INDICATOR ===== */
+.m3-connection-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: var(--md-sys-shape-full);
+  background-color: var(--md-sys-color-error);
+  display: inline-block;
+  flex-shrink: 0;
+  transition: background-color var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard),
+              box-shadow var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
+}
+
+.m3-connection-dot.connected {
+  background-color: var(--md-sys-color-success);
+  box-shadow: 0 0 8px var(--md-sys-color-success);
+}
+
+
+/* ===== SIDE SHEET ===== */
+.m3-side-sheet {
+  position: fixed;
+  top: 0;
+  right: -400px;
+  width: 380px;
+  height: 100%;
+  background-color: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface);
+  z-index: 1050;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--md-sys-elevation-4);
+  transition: right var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-emphasized);
+}
+
+.m3-side-sheet.open {
+  right: 0;
+}
+
+.m3-side-sheet__header {
+  padding: var(--md-sys-spacing-md);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  flex-shrink: 0;
+}
+
+.m3-side-sheet__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--md-sys-spacing-md);
+}
+
+.m3-side-sheet__section-title {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--md-sys-color-on-surface-variant);
+  margin: var(--md-sys-spacing-md) 0 var(--md-sys-spacing-xs);
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-xs);
+}
+
+.m3-side-sheet__backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 1040;
+  background-color: var(--md-sys-color-scrim);
+}
+
+
+/* ===== CHIP ===== */
+.m3-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  border-radius: var(--md-sys-shape-sm);
+  font-size: 0.75rem;
+  font-weight: 500;
+  background-color: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
+}
+
+
+/* ===== SECTION TITLE ===== */
+.m3-section-title {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--md-sys-color-on-surface-variant);
+  padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-xs) var(--md-sys-spacing-xs);
+  margin-bottom: var(--md-sys-spacing-xs);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+
+/* ===== SCROLLBAR (for dark theme) ===== */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--md-sys-color-surface-container-highest);
+  border-radius: var(--md-sys-shape-full);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--md-sys-color-outline);
+}
+
+
+/* ===== LAYOUT UTILITIES ===== */
+.m3-flex           { display: flex; }
+.m3-flex-col       { display: flex; flex-direction: column; }
+.m3-flex-row       { display: flex; flex-direction: row; }
+.m3-flex-wrap      { flex-wrap: wrap; }
+.m3-flex-1         { flex: 1; }
+.m3-flex-shrink-0  { flex-shrink: 0; }
+.m3-inline-flex    { display: inline-flex; }
+.m3-items-center   { align-items: center; }
+.m3-items-start    { align-items: flex-start; }
+.m3-items-end      { align-items: flex-end; }
+.m3-justify-center { justify-content: center; }
+.m3-justify-between{ justify-content: space-between; }
+.m3-justify-end    { justify-content: flex-end; }
+.m3-self-center    { align-self: center; }
+
+/* Grid */
+.m3-grid           { display: grid; }
+.m3-grid-cols-2    { grid-template-columns: repeat(2, 1fr); }
+.m3-grid-cols-3    { grid-template-columns: repeat(3, 1fr); }
+.m3-grid-cols-4    { grid-template-columns: repeat(4, 1fr); }
+
+@media (min-width: 768px) {
+  .m3-md-grid-cols-2 { grid-template-columns: repeat(2, 1fr); }
+  .m3-md-grid-cols-3 { grid-template-columns: repeat(3, 1fr); }
+  .m3-md-grid-cols-4 { grid-template-columns: repeat(4, 1fr); }
+}
+
+.m3-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--md-sys-spacing-md);
+}
+
+
+/* ===== SPACING UTILITIES ===== */
+.m3-gap-xs  { gap: var(--md-sys-spacing-xs); }
+.m3-gap-sm  { gap: var(--md-sys-spacing-sm); }
+.m3-gap-md  { gap: var(--md-sys-spacing-md); }
+.m3-gap-lg  { gap: var(--md-sys-spacing-lg); }
+.m3-gap-xl  { gap: var(--md-sys-spacing-xl); }
+
+.m3-p-0     { padding: 0; }
+.m3-p-xs    { padding: var(--md-sys-spacing-xs); }
+.m3-p-sm    { padding: var(--md-sys-spacing-sm); }
+.m3-p-md    { padding: var(--md-sys-spacing-md); }
+.m3-p-lg    { padding: var(--md-sys-spacing-lg); }
+.m3-px-md   { padding-left: var(--md-sys-spacing-md); padding-right: var(--md-sys-spacing-md); }
+.m3-px-lg   { padding-left: var(--md-sys-spacing-lg); padding-right: var(--md-sys-spacing-lg); }
+.m3-py-xs   { padding-top: var(--md-sys-spacing-xs); padding-bottom: var(--md-sys-spacing-xs); }
+.m3-py-sm   { padding-top: var(--md-sys-spacing-sm); padding-bottom: var(--md-sys-spacing-sm); }
+.m3-py-md   { padding-top: var(--md-sys-spacing-md); padding-bottom: var(--md-sys-spacing-md); }
+
+.m3-m-0     { margin: 0; }
+.m3-mb-0    { margin-bottom: 0; }
+.m3-mb-xs   { margin-bottom: var(--md-sys-spacing-xs); }
+.m3-mb-sm   { margin-bottom: var(--md-sys-spacing-sm); }
+.m3-mb-md   { margin-bottom: var(--md-sys-spacing-md); }
+.m3-mb-lg   { margin-bottom: var(--md-sys-spacing-lg); }
+.m3-mt-sm   { margin-top: var(--md-sys-spacing-sm); }
+.m3-mt-md   { margin-top: var(--md-sys-spacing-md); }
+.m3-ms-auto { margin-left: auto; }
+.m3-me-sm   { margin-right: var(--md-sys-spacing-sm); }
+.m3-me-md   { margin-right: var(--md-sys-spacing-md); }
+
+
+/* ===== TEXT UTILITIES ===== */
+.m3-text-primary            { color: var(--md-sys-color-primary); }
+.m3-text-secondary          { color: var(--md-sys-color-secondary); }
+.m3-text-tertiary           { color: var(--md-sys-color-tertiary); }
+.m3-text-on-surface         { color: var(--md-sys-color-on-surface); }
+.m3-text-on-surface-variant { color: var(--md-sys-color-on-surface-variant); }
+.m3-text-error              { color: var(--md-sys-color-error); }
+.m3-text-success            { color: var(--md-sys-color-success); }
+.m3-text-warning            { color: var(--md-sys-color-warning); }
+.m3-text-info               { color: var(--md-sys-color-info); }
+
+.m3-text-center  { text-align: center; }
+.m3-text-end     { text-align: right; }
+.m3-fw-medium    { font-weight: 500; }
+.m3-fw-bold      { font-weight: 700; }
+.m3-text-mono    { font-family: var(--md-sys-typescale-mono-font-family); }
+.m3-tabular-nums { font-variant-numeric: tabular-nums; }
+
+.m3-truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+
+/* ===== DISPLAY UTILITIES ===== */
+.m3-hidden     { display: none !important; }
+.m3-block      { display: block; }
+.m3-w-full     { width: 100%; }
+.m3-h-full     { height: 100%; }
+.m3-overflow-hidden  { overflow: hidden; }
+.m3-overflow-y-auto  { overflow-y: auto; }
+.m3-relative   { position: relative; }
+.m3-absolute   { position: absolute; }
+.m3-fixed      { position: fixed; }
+.m3-inset-0    { inset: 0; }

--- a/crane_web_debugger/web/robot_manager.html
+++ b/crane_web_debugger/web/robot_manager.html
@@ -3,196 +3,196 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ロボット管理 - Crane Debug Tools</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <title>Robot Manager - Crane Debug Tools</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-25..200&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="m3e-theme.css">
     <style>
-        body { background-color: #f8f9fa; }
-        .status-dot {
-            display: inline-block;
-            width: 10px;
-            height: 10px;
-            border-radius: 50%;
-            margin-right: 6px;
+        body {
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+            overflow: hidden;
         }
-        .status-dot.connected { background-color: #28a745; }
-        .status-dot.disconnected { background-color: #dc3545; }
 
-        .robot-row.has-error { background-color: rgba(220, 53, 69, 0.1); }
-        .robot-row.offline { opacity: 0.65; }
+        .main-scroll {
+            flex: 1;
+            overflow-y: auto;
+            padding: var(--md-sys-spacing-md);
+        }
 
-        .voltage-bar { height: 5px; margin-top: 3px; }
+        /* Summary bar */
+        .summary-bar {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: var(--md-sys-spacing-md);
+            background-color: var(--md-sys-color-surface-container);
+            border-radius: var(--md-sys-shape-md);
+            padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-md);
+            margin-bottom: var(--md-sys-spacing-md);
+        }
+
+        .summary-stat {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 0.8125rem;
+        }
+
+        .summary-actions {
+            margin-left: auto;
+            display: flex;
+            gap: var(--md-sys-spacing-sm);
+        }
+
+        /* Robot table */
+        .table-wrap {
+            overflow-x: auto;
+        }
+
+        .robot-row.has-error {
+            background-color: rgba(255, 180, 171, 0.08);
+        }
+
+        .robot-row.offline {
+            opacity: 0.55;
+        }
+
+        .voltage-bar {
+            height: 4px;
+            margin-top: 3px;
+        }
 
         .error-text {
-            font-size: 0.82rem;
+            font-size: 0.8125rem;
             word-break: break-word;
         }
 
-        /* Side Panel */
-        #detail-panel {
-            position: fixed;
-            top: 0;
-            right: -380px;
-            width: 360px;
-            height: 100%;
-            background: #212529;
-            color: #dee2e6;
-            z-index: 1050;
-            transition: right 0.25s ease;
-            display: flex;
-            flex-direction: column;
-            box-shadow: -4px 0 12px rgba(0,0,0,0.4);
-        }
-        #detail-panel.open { right: 0; }
-        #detail-panel .panel-header {
-            padding: 0.75rem 1rem;
-            background: #343a40;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            flex-shrink: 0;
-        }
-        #detail-panel .panel-body {
-            flex: 1;
-            overflow-y: auto;
-            padding: 0.75rem 1rem;
-        }
-        #detail-panel .section-title {
-            font-size: 0.72rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            color: #6c757d;
-            margin: 0.75rem 0 0.3rem;
-        }
-        #detail-panel table td:first-child {
-            color: #6c757d;
-            white-space: nowrap;
-            padding-right: 0.75rem;
-            font-size: 0.82rem;
-        }
-        #detail-panel table td:last-child {
-            font-size: 0.85rem;
-            font-weight: 500;
-        }
+        /* Side panel */
         #detail-panel .factor-bar {
             height: 4px;
-            background: #495057;
-            border-radius: 2px;
+            background: var(--md-sys-color-surface-container-highest);
+            border-radius: var(--md-sys-shape-full);
             margin-top: 2px;
         }
+
         #detail-panel .factor-bar-fill {
             height: 100%;
-            background: #0d6efd;
-            border-radius: 2px;
-            transition: width 0.3s;
+            background: var(--md-sys-color-primary);
+            border-radius: var(--md-sys-shape-full);
+            transition: width var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
         }
     </style>
 </head>
 <body>
-    <!-- Navbar -->
-    <nav class="navbar navbar-dark bg-dark py-2">
-        <div class="container-fluid">
-            <div class="d-flex align-items-center gap-3">
-                <a href="/" class="text-white text-decoration-none">
-                    <i class="fas fa-arrow-left"></i>
-                </a>
-                <span class="navbar-brand mb-0">
-                    <i class="fas fa-microchip me-2"></i>ロボット管理
-                </span>
-            </div>
-            <div class="text-white d-flex align-items-center">
-                <span class="status-dot disconnected" id="ws-dot"></span>
-                <small id="ws-status-text">未接続</small>
-            </div>
+    <!-- Top App Bar -->
+    <nav class="m3-top-app-bar">
+        <a href="/" class="m3-icon-btn m3-icon-btn--sm">
+            <span class="material-symbols-outlined">arrow_back</span>
+        </a>
+        <div class="m3-top-app-bar__title">
+            <span class="material-symbols-outlined">memory</span>
+            Robot Manager
+        </div>
+        <div class="m3-top-app-bar__actions">
+            <span class="m3-connection-dot" id="ws-dot"></span>
+            <span class="m3-body-small m3-text-on-surface-variant" id="ws-status-text">disconnected</span>
         </div>
     </nav>
 
-    <div class="container-fluid py-3">
+    <div class="main-scroll">
         <!-- Summary Bar -->
-        <div class="row mb-3">
-            <div class="col">
-                <div class="card shadow-sm">
-                    <div class="card-body py-2">
-                        <div class="d-flex flex-wrap align-items-center gap-3">
-                            <span>
-                                <i class="fas fa-robot text-success me-1"></i>
-                                稼働中: <strong id="active-count">0</strong>
-                            </span>
-                            <span>
-                                <i class="fas fa-exclamation-triangle text-danger me-1"></i>
-                                エラー: <strong id="error-count">0</strong>
-                            </span>
-                            <span>
-                                <i class="fas fa-signal text-info me-1"></i>
-                                フィードバック受信: <strong id="feedback-count">0</strong>
-                            </span>
-                            <div class="ms-auto d-flex gap-2">
-                                <button class="btn btn-sm btn-success" onclick="startAll()">
-                                    <i class="fas fa-play me-1"></i>全台起動
-                                </button>
-                                <button class="btn btn-sm btn-danger" onclick="stopAll()">
-                                    <i class="fas fa-stop me-1"></i>全台停止
-                                </button>
-                                <button class="btn btn-sm btn-outline-secondary" onclick="refreshPiStatus()">
-                                    <i class="fas fa-sync-alt me-1"></i>状態更新
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+        <div class="summary-bar">
+            <span class="summary-stat">
+                <span class="material-symbols-outlined icon-sm m3-text-success">smart_toy</span>
+                Active: <strong id="active-count">0</strong>
+            </span>
+            <span class="summary-stat">
+                <span class="material-symbols-outlined icon-sm m3-text-error">warning</span>
+                Errors: <strong id="error-count">0</strong>
+            </span>
+            <span class="summary-stat">
+                <span class="material-symbols-outlined icon-sm m3-text-info">signal_cellular_alt</span>
+                Feedback: <strong id="feedback-count">0</strong>
+            </span>
+            <div class="summary-actions">
+                <button class="m3-btn m3-btn--sm m3-btn--success" onclick="startAll()">
+                    <span class="material-symbols-outlined icon-sm">play_arrow</span> Start All
+                </button>
+                <button class="m3-btn m3-btn--sm m3-btn--error" onclick="stopAll()">
+                    <span class="material-symbols-outlined icon-sm">stop</span> Stop All
+                </button>
+                <button class="m3-btn m3-btn--sm m3-btn--outlined" onclick="refreshPiStatus()">
+                    <span class="material-symbols-outlined icon-sm">sync</span> Refresh
+                </button>
             </div>
         </div>
 
-        <!-- Detail Side Panel -->
-        <div id="detail-panel">
-            <div class="panel-header">
-                <span><i class="fas fa-robot me-2"></i><strong id="panel-title">Robot #--</strong></span>
-                <button class="btn btn-sm btn-outline-secondary" onclick="closeDetailPanel()">
-                    <i class="fas fa-times"></i>
+        <!-- Side Sheet (detail panel) -->
+        <div class="m3-side-sheet" id="detail-panel">
+            <div class="m3-side-sheet__header">
+                <span class="m3-flex m3-items-center m3-gap-sm">
+                    <span class="material-symbols-outlined">smart_toy</span>
+                    <strong id="panel-title">Robot #--</strong>
+                </span>
+                <button class="m3-icon-btn m3-icon-btn--sm" onclick="closeDetailPanel()">
+                    <span class="material-symbols-outlined">close</span>
                 </button>
             </div>
-            <div class="panel-body">
-                <!-- 位置・速度 -->
-                <div class="section-title"><i class="fas fa-map-marker-alt me-1"></i>位置・速度</div>
+            <div class="m3-side-sheet__body">
+                <div class="m3-side-sheet__section-title">
+                    <span class="material-symbols-outlined icon-sm">location_on</span> Position / Velocity
+                </div>
                 <div id="panel-pose"></div>
-                <!-- 目標値 -->
-                <div class="section-title"><i class="fas fa-crosshairs me-1"></i>目標値</div>
+
+                <div class="m3-side-sheet__section-title">
+                    <span class="material-symbols-outlined icon-sm">gps_fixed</span> Targets
+                </div>
                 <div id="panel-target"></div>
-                <!-- Session / スキル -->
-                <div class="section-title"><i class="fas fa-layer-group me-1"></i>Session / スキル</div>
-                <table class="table table-sm table-borderless table-dark mb-0">
+
+                <div class="m3-side-sheet__section-title">
+                    <span class="material-symbols-outlined icon-sm">layers</span> Session / Skill
+                </div>
+                <table class="m3-data-table m3-data-table--borderless m3-mb-0">
                     <tbody id="panel-session"></tbody>
                 </table>
-                <!-- プランニング要素 -->
-                <div class="section-title"><i class="fas fa-sliders-h me-1"></i>プランニング要素</div>
+
+                <div class="m3-side-sheet__section-title">
+                    <span class="material-symbols-outlined icon-sm">tune</span> Planning Factors
+                </div>
                 <div id="panel-factors"></div>
-                <!-- ハードウェア -->
-                <div class="section-title"><i class="fas fa-microchip me-1"></i>ハードウェア</div>
-                <table class="table table-sm table-borderless table-dark mb-0">
+
+                <div class="m3-side-sheet__section-title">
+                    <span class="material-symbols-outlined icon-sm">memory</span> Hardware
+                </div>
+                <table class="m3-data-table m3-data-table--borderless m3-mb-0">
                     <tbody id="panel-hw"></tbody>
                 </table>
-                <div class="mt-3">
-                    <a id="panel-telemetry-link" href="#" class="btn btn-sm btn-primary w-100">
-                        <i class="fas fa-chart-line me-1"></i>テレメトリを開く
+
+                <div class="m3-mt-md">
+                    <a id="panel-telemetry-link" href="#" class="m3-btn m3-btn--filled m3-w-full">
+                        <span class="material-symbols-outlined icon-sm">show_chart</span> Open Telemetry
                     </a>
                 </div>
             </div>
         </div>
-        <div id="panel-backdrop" onclick="closeDetailPanel()"
-             style="display:none; position:fixed; inset:0; z-index:1040; background:rgba(0,0,0,0.3)"></div>
+        <div id="panel-backdrop" class="m3-side-sheet__backdrop" onclick="closeDetailPanel()"></div>
 
         <!-- Robot Table -->
-        <div class="table-responsive">
-            <table class="table table-sm table-hover align-middle">
-                <thead class="table-dark">
+        <div class="table-wrap">
+            <table class="m3-data-table">
+                <thead>
                     <tr>
                         <th>ID</th>
-                        <th>ステータス / 操作</th>
-                        <th style="min-width:110px">電圧</th>
-                        <th>最高温度</th>
+                        <th>Status / Controls</th>
+                        <th style="min-width:110px">Voltage</th>
+                        <th>Max Temp</th>
                         <th>Ping</th>
-                        <th>通信</th>
-                        <th>エラー</th>
+                        <th>Comm</th>
+                        <th>Error</th>
                         <th></th>
                     </tr>
                 </thead>
@@ -202,6 +202,5 @@
     </div>
 
     <script src="robot_manager.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/crane_web_debugger/web/robot_manager.js
+++ b/crane_web_debugger/web/robot_manager.js
@@ -69,11 +69,11 @@ function setWsStatus(connected) {
     const dot = document.getElementById('ws-dot');
     const text = document.getElementById('ws-status-text');
     if (connected) {
-        dot.className = 'status-dot connected';
-        text.textContent = '接続済み';
+        dot.className = 'm3-connection-dot connected';
+        text.textContent = 'connected';
     } else {
-        dot.className = 'status-dot disconnected';
-        text.textContent = '未接続';
+        dot.className = 'm3-connection-dot';
+        text.textContent = 'disconnected';
     }
 }
 
@@ -229,31 +229,31 @@ function getOverallStatus(id) {
 }
 
 const STATUS_CONFIG = {
-    'Running': { badge: 'bg-success',          label: '稼働中' },
-    'Stopped': { badge: 'bg-warning text-dark', label: '停止中' },
-    'Error':   { badge: 'bg-danger',            label: 'エラー' },
-    'Offline': { badge: 'bg-secondary',         label: 'オフライン' },
+    'Running': { badge: 'm3-badge--success', label: 'Running' },
+    'Stopped': { badge: 'm3-badge--warning', label: 'Stopped' },
+    'Error':   { badge: 'm3-badge--error',   label: 'Error' },
+    'Offline': { badge: 'm3-badge--secondary', label: 'Offline' },
 };
 
 function statusBadgeClass(status) {
-    return STATUS_CONFIG[status]?.badge ?? 'bg-secondary';
+    return STATUS_CONFIG[status]?.badge ?? 'm3-badge--secondary';
 }
 
 function statusLabel(status) {
     return STATUS_CONFIG[status]?.label ?? (status || '不明');
 }
 
-function voltageBarClass(v) {
-    if (v < 22.0) return 'bg-danger';
-    if (v < 23.0) return 'bg-warning';
-    return 'bg-success';
+function voltageBarColor(v) {
+    if (v < 22.0) return 'var(--md-sys-color-error)';
+    if (v < 23.0) return 'var(--md-sys-color-warning)';
+    return 'var(--md-sys-color-success)';
 }
 
 function pingClass(ms) {
-    if (ms === null) return 'text-secondary';
-    if (ms > PING_CRIT) return 'text-danger';
-    if (ms > PING_WARN) return 'text-warning';
-    return 'text-success';
+    if (ms === null) return 'm3-text-on-surface-variant';
+    if (ms > PING_CRIT) return 'm3-text-error';
+    if (ms > PING_WARN) return 'm3-text-warning';
+    return 'm3-text-success';
 }
 
 function renderRobotRow(id) {
@@ -271,7 +271,7 @@ function renderRobotRow(id) {
 
     // Status badge
     const badge = document.getElementById(`badge-${id}`);
-    badge.className = `badge ${statusBadgeClass(overallStatus)}`;
+    badge.className = `m3-badge ${statusBadgeClass(overallStatus)}`;
     badge.textContent = statusLabel(overallStatus);
 
     // Voltage
@@ -281,14 +281,14 @@ function renderRobotRow(id) {
         const v = fb.voltage[0];
         const pct = Math.max(0, Math.min(100, (v - VOLTAGE_MIN) / (VOLTAGE_MAX - VOLTAGE_MIN) * 100));
         voltageEl.textContent = `${v.toFixed(2)} V`;
-        voltageEl.className = `fw-medium ${v < 22.0 ? 'text-danger' : v < 23.0 ? 'text-warning' : 'text-success'}`;
+        voltageEl.className = `m3-fw-medium ${v < 22.0 ? 'm3-text-error' : v < 23.0 ? 'm3-text-warning' : 'm3-text-success'}`;
         voltageBarEl.style.width = `${pct}%`;
-        voltageBarEl.className = `progress-bar ${voltageBarClass(v)}`;
+        voltageBarEl.style.backgroundColor = voltageBarColor(v);
     } else {
         voltageEl.textContent = '--';
-        voltageEl.className = 'fw-medium text-secondary';
+        voltageEl.className = 'm3-fw-medium m3-text-on-surface-variant';
         voltageBarEl.style.width = '0%';
-        voltageBarEl.className = 'progress-bar bg-secondary';
+        voltageBarEl.style.backgroundColor = 'var(--md-sys-color-surface-container-highest)';
     }
 
     // Temperature
@@ -296,40 +296,40 @@ function renderRobotRow(id) {
     if (fb && fb.temperatures && fb.temperatures.length > 0) {
         const maxTemp = Math.max(...fb.temperatures);
         tempEl.textContent = `${maxTemp} °C`;
-        tempEl.className = `fw-medium ${maxTemp >= TEMP_WARN ? 'text-danger' : ''}`;
+        tempEl.className = `m3-fw-medium ${maxTemp >= TEMP_WARN ? 'm3-text-error' : ''}`;
     } else {
         tempEl.textContent = '--';
-        tempEl.className = 'fw-medium text-secondary';
+        tempEl.className = 'm3-fw-medium m3-text-on-surface-variant';
     }
 
     // Ping
     const pingEl = document.getElementById(`ping-${id}`);
     if (state.ping_ms !== null) {
         pingEl.textContent = `${state.ping_ms.toFixed(1)} ms`;
-        pingEl.className = `fw-medium ${pingClass(state.ping_ms)}`;
+        pingEl.className = `m3-fw-medium ${pingClass(state.ping_ms)}`;
     } else {
         pingEl.textContent = '--';
-        pingEl.className = 'fw-medium text-secondary';
+        pingEl.className = 'm3-fw-medium m3-text-on-surface-variant';
     }
 
     // Packet frequency
     const freqEl = document.getElementById(`freq-${id}`);
     if (fb) {
         freqEl.textContent = `${fb.packet_frequency_hz.toFixed(1)} Hz`;
-        freqEl.className = `fw-medium ${fb.packet_frequency_hz < 50 ? 'text-warning' : 'text-success'}`;
+        freqEl.className = `m3-fw-medium ${fb.packet_frequency_hz < 50 ? 'm3-text-warning' : 'm3-text-success'}`;
     } else {
         freqEl.textContent = '--';
-        freqEl.className = 'fw-medium text-secondary';
+        freqEl.className = 'm3-fw-medium m3-text-on-surface-variant';
     }
 
     // Error
     const errorEl = document.getElementById(`error-${id}`);
     if (fb && fb.error_info) {
         errorEl.textContent = getErrorString(fb.error_id, fb.error_info);
-        errorEl.className = 'error-text text-danger';
+        errorEl.className = 'error-text m3-text-error';
     } else {
         errorEl.textContent = 'OK';
-        errorEl.className = 'error-text text-success';
+        errorEl.className = 'error-text m3-text-success';
     }
 }
 
@@ -365,33 +365,33 @@ function renderAll() {
 function createRobotRow(id) {
     return `
 <tr class="robot-row" id="robot-row-${id}">
-    <td><i class="fas fa-robot me-1 text-secondary"></i><strong>#${id}</strong></td>
+    <td><span class="material-symbols-outlined icon-sm m3-text-on-surface-variant" style="vertical-align:middle;margin-right:4px">smart_toy</span><strong>#${id}</strong></td>
     <td>
-        <div class="d-flex align-items-center gap-2">
-            <span class="badge bg-secondary" id="badge-${id}" style="min-width:60px">不明</span>
-            <div class="btn-group btn-group-sm" role="group">
-                <button class="btn btn-outline-success" onclick="sendRobotControl(${id}, 'start')" title="Start">
-                    <i class="fas fa-play"></i>
+        <div class="m3-flex m3-items-center m3-gap-sm">
+            <span class="m3-badge m3-badge--secondary" id="badge-${id}" style="min-width:60px">--</span>
+            <div class="m3-flex m3-gap-xs">
+                <button class="m3-icon-btn m3-icon-btn--sm" onclick="sendRobotControl(${id}, 'start')" title="Start" style="color:var(--md-sys-color-success)">
+                    <span class="material-symbols-outlined icon-sm">play_arrow</span>
                 </button>
-                <button class="btn btn-outline-danger" onclick="sendRobotControl(${id}, 'stop')" title="Stop">
-                    <i class="fas fa-stop"></i>
+                <button class="m3-icon-btn m3-icon-btn--sm" onclick="sendRobotControl(${id}, 'stop')" title="Stop" style="color:var(--md-sys-color-error)">
+                    <span class="material-symbols-outlined icon-sm">stop</span>
                 </button>
             </div>
         </div>
     </td>
     <td>
-        <span class="fw-medium text-secondary" id="voltage-${id}">--</span>
-        <div class="progress voltage-bar">
-            <div class="progress-bar bg-secondary" id="voltage-bar-${id}" style="width:0%"></div>
+        <span class="m3-fw-medium m3-text-on-surface-variant" id="voltage-${id}">--</span>
+        <div class="m3-linear-progress voltage-bar">
+            <div class="m3-linear-progress__bar" id="voltage-bar-${id}" style="width:0%"></div>
         </div>
     </td>
-    <td><span class="fw-medium text-secondary" id="temp-${id}">--</span></td>
-    <td><span class="fw-medium text-secondary" id="ping-${id}">--</span></td>
-    <td><span class="fw-medium text-secondary" id="freq-${id}">--</span></td>
-    <td><span class="error-text text-success" id="error-${id}">OK</span></td>
+    <td><span class="m3-fw-medium m3-text-on-surface-variant" id="temp-${id}">--</span></td>
+    <td><span class="m3-fw-medium m3-text-on-surface-variant" id="ping-${id}">--</span></td>
+    <td><span class="m3-fw-medium m3-text-on-surface-variant" id="freq-${id}">--</span></td>
+    <td><span class="error-text m3-text-success" id="error-${id}">OK</span></td>
     <td>
-        <button class="btn btn-sm btn-outline-info" onclick="openDetailPanel(${id})" title="詳細">
-            <i class="fas fa-info-circle"></i>
+        <button class="m3-icon-btn m3-icon-btn--sm" onclick="openDetailPanel(${id})" title="Details" style="color:var(--md-sys-color-info)">
+            <span class="material-symbols-outlined icon-sm">info</span>
         </button>
     </td>
 </tr>`;
@@ -439,7 +439,7 @@ function refreshDetailPanel(id) {
         const fp = (v, d) => { const n = parseFloat(v); return isNaN(n) ? '--' : n.toFixed(d); };
         const deg = (v) => { const n = parseFloat(v); return isNaN(n) ? '--' : (n * 180 / Math.PI).toFixed(1); };
         const cell = (label, val) =>
-            `<td style="padding:1px 6px 1px 0;font-size:0.78rem"><span style="color:#6c757d">${label}</span> ${val}</td>`;
+            `<td style="padding:1px 6px 1px 0;font-size:0.78rem"><span style="color:var(--md-sys-color-on-surface-variant)">${label}</span> ${val}</td>`;
         poseHtml = `
 <table style="width:100%;border-collapse:collapse">
   <tr>
@@ -454,7 +454,7 @@ function refreshDetailPanel(id) {
   </tr>`;
         if (pose.available_vision != null) {
             const flag = (ok, label) =>
-                ok ? `<span class="text-success">${label}</span>` : `<span class="text-secondary">${label}</span>`;
+                ok ? `<span class="m3-text-success">${label}</span>` : `<span class="m3-text-on-surface-variant">${label}</span>`;
             poseHtml += `<tr><td colspan="3" style="padding-top:4px;font-size:0.78rem">
                 ${flag(pose.available_vision, 'Vision')}
                 ${flag(pose.available_feedback, 'FB')}
@@ -463,7 +463,7 @@ function refreshDetailPanel(id) {
         }
         poseHtml += '</table>';
     } else {
-        poseHtml = '<span class="text-secondary" style="font-size:0.82rem">データなし</span>';
+        poseHtml = '<span class="m3-text-on-surface-variant m3-body-small">No data</span>';
     }
     document.getElementById('panel-pose').innerHTML = poseHtml;
 
@@ -472,15 +472,15 @@ function refreshDetailPanel(id) {
     if (cmd) {
         const fc = (v, d) => { const n = parseFloat(v); return isNaN(n) ? '--' : n.toFixed(d); };
         const modeName = CONTROL_MODE_LONG[cmd.control_mode] ?? `MODE_${cmd.control_mode}`;
-        sessionHtml += row('プランナー', cmd.planner_name || '--');
-        sessionHtml += row('制御モード', modeName);
+        sessionHtml += row('Planner', cmd.planner_name || '--');
+        sessionHtml += row('Control Mode', modeName);
         const kick = parseFloat(cmd.kick_power);
-        sessionHtml += row('キック', kick > 0 ? `<span class="text-warning">${fc(cmd.kick_power, 2)}</span>` : '0');
+        sessionHtml += row('Kick', kick > 0 ? `<span class="m3-text-warning">${fc(cmd.kick_power, 2)}</span>` : '0');
         const drib = parseFloat(cmd.dribble_power);
-        sessionHtml += row('ドリブル', drib > 0 ? `<span class="text-info">${fc(cmd.dribble_power, 2)}</span>` : '0');
-        sessionHtml += row('チップ', cmd.chip_enable ? '<span class="text-warning">ON</span>' : 'OFF');
+        sessionHtml += row('Dribble', drib > 0 ? `<span class="m3-text-info">${fc(cmd.dribble_power, 2)}</span>` : '0');
+        sessionHtml += row('Chip', cmd.chip_enable ? '<span class="m3-text-warning">ON</span>' : 'OFF');
     } else {
-        sessionHtml = row('--', '<span class="text-secondary">データなし</span>');
+        sessionHtml = row('--', '<span class="m3-text-on-surface-variant">No data</span>');
     }
     document.getElementById('panel-session').innerHTML = sessionHtml;
 
@@ -490,7 +490,7 @@ function refreshDetailPanel(id) {
         const ft = (v, d) => { const n = parseFloat(v); return isNaN(n) ? '--' : n.toFixed(d); };
         const fdeg = (v) => { const n = parseFloat(v); return isNaN(n) ? '--' : (n * 180 / Math.PI).toFixed(1) + '°'; };
         const tcell = (label, val) =>
-            `<td style="padding:1px 6px 1px 0;font-size:0.78rem"><span style="color:#6c757d">${label}</span> ${val}</td>`;
+            `<td style="padding:1px 6px 1px 0;font-size:0.78rem"><span style="color:var(--md-sys-color-on-surface-variant)">${label}</span> ${val}</td>`;
         if (cmd.position_target_mode) {
             const t = cmd.position_target_mode;
             targetHtml = `<table style="width:100%;border-collapse:collapse"><tr>
@@ -518,7 +518,7 @@ function refreshDetailPanel(id) {
             </tr></table>`;
         }
     }
-    if (!targetHtml) targetHtml = '<span class="text-secondary" style="font-size:0.82rem">データなし</span>';
+    if (!targetHtml) targetHtml = '<span class="m3-text-on-surface-variant m3-body-small">No data</span>';
     document.getElementById('panel-target').innerHTML = targetHtml;
 
     // --- プランニング要素 ---
@@ -532,13 +532,13 @@ function refreshDetailPanel(id) {
 <div style="margin-bottom:0.5rem">
   <div style="display:flex; justify-content:space-between; font-size:0.8rem">
     <span>${f.name}</span>
-    <span class="text-secondary">${stateStr}</span>
+    <span class="m3-text-on-surface-variant">${stateStr}</span>
   </div>
   <div class="factor-bar"><div class="factor-bar-fill" style="width:${pct}%"></div></div>
 </div>`;
         }
     } else {
-        factorsHtml = '<span class="text-secondary" style="font-size:0.82rem">データなし</span>';
+        factorsHtml = '<span class="m3-text-on-surface-variant m3-body-small">No data</span>';
     }
     document.getElementById('panel-factors').innerHTML = factorsHtml;
 
@@ -547,14 +547,14 @@ function refreshDetailPanel(id) {
     const fb = state.feedback;
     const fmt = (v, digits) => { const n = parseFloat(v); return isNaN(n) ? '--' : n.toFixed(digits); };
     if (fb) {
-        if (fb.voltage?.length) hwHtml += row('電圧', `${fmt(fb.voltage[0], 2)} V`);
-        if (fb.temperatures?.length) hwHtml += row('最高温度', `${Math.max(...fb.temperatures.map(parseFloat))} °C`);
-        if (fb.yaw_angle != null) hwHtml += row('Yaw角', `${fmt(fb.yaw_angle, 2)} °`);
-        if (fb.odom_speed != null) hwHtml += row('オドム速度', `${fmt(fb.odom_speed, 3)} m/s`);
-        if (fb.ball_sensor != null) hwHtml += row('ボールセンサ', fb.ball_sensor ? '<span class="text-success">検知</span>' : '未検知');
+        if (fb.voltage?.length) hwHtml += row('Voltage', `${fmt(fb.voltage[0], 2)} V`);
+        if (fb.temperatures?.length) hwHtml += row('Max Temp', `${Math.max(...fb.temperatures.map(parseFloat))} °C`);
+        if (fb.yaw_angle != null) hwHtml += row('Yaw', `${fmt(fb.yaw_angle, 2)} °`);
+        if (fb.odom_speed != null) hwHtml += row('Odom Speed', `${fmt(fb.odom_speed, 3)} m/s`);
+        if (fb.ball_sensor != null) hwHtml += row('Ball Sensor', fb.ball_sensor ? '<span class="m3-text-success">Detected</span>' : 'None');
     }
     if (state.ping_ms !== null) hwHtml += row('Ping', `${fmt(state.ping_ms, 1)} ms`);
-    if (!hwHtml) hwHtml = row('--', '<span class="text-secondary">データなし</span>');
+    if (!hwHtml) hwHtml = row('--', '<span class="m3-text-on-surface-variant">No data</span>');
     document.getElementById('panel-hw').innerHTML = hwHtml;
 }
 

--- a/crane_web_debugger/web/robot_telemetry.html
+++ b/crane_web_debugger/web/robot_telemetry.html
@@ -4,16 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Robot Telemetry - Crane</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-25..200&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="m3e-theme.css">
   <style>
     html, body {
       height: 100%;
       margin: 0;
       overflow: hidden;
-      background: #0d1117;
-      color: #e0e0e0;
-      font-family: system-ui, sans-serif;
     }
 
     body {
@@ -21,28 +21,13 @@
       flex-direction: column;
     }
 
-    .navbar {
-      flex-shrink: 0;
-      background: #16213e !important;
-      border-bottom: 1px solid #0f3460;
-    }
-
-    #status-dot {
-      width: 10px; height: 10px;
-      border-radius: 50%;
-      background: #dc3545;
-      display: inline-block;
-      transition: background 0.3s;
-    }
-    #status-dot.connected { background: #28a745; }
-
     #header-bar {
       display: flex;
       align-items: center;
-      gap: 12px;
-      padding: 6px 12px;
-      background: #16213e;
-      border-bottom: 1px solid #0f3460;
+      gap: var(--md-sys-spacing-md);
+      padding: 6px var(--md-sys-spacing-md);
+      background: var(--md-sys-color-surface-container);
+      border-bottom: 1px solid var(--md-sys-color-outline-variant);
       flex-shrink: 0;
       font-size: 0.85rem;
     }
@@ -50,20 +35,11 @@
     #header-bar .robot-id-badge {
       font-size: 1.1rem;
       font-weight: 700;
-      background: #0f3460;
-      border: 1px solid #1a4a7a;
-      border-radius: 6px;
+      background: var(--md-sys-color-primary-container);
+      border: 1px solid var(--md-sys-color-outline-variant);
+      border-radius: var(--md-sys-shape-sm);
       padding: 2px 10px;
-      color: #7ec8e3;
-    }
-
-    #header-bar .info-chip {
-      background: #0f3460;
-      border: 1px solid #1a4a7a;
-      border-radius: 4px;
-      padding: 2px 8px;
-      font-size: 0.75rem;
-      color: #ccc;
+      color: var(--md-sys-color-primary);
     }
 
     #scroll-area {
@@ -72,23 +48,32 @@
       padding: 10px;
     }
 
-    #scroll-area::-webkit-scrollbar { width: 6px; }
-    #scroll-area::-webkit-scrollbar-thumb { background: #0f3460; border-radius: 3px; }
+    .chart-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 10px;
+    }
+
+    @media (max-width: 768px) {
+      .chart-grid { grid-template-columns: 1fr; }
+    }
 
     .chart-card {
-      background: #16213e;
-      border: 1px solid #1a4a7a;
-      border-radius: 8px;
+      background: var(--md-sys-color-surface-container);
+      border: 1px solid var(--md-sys-color-outline-variant);
+      border-radius: var(--md-sys-shape-md);
       padding: 10px;
-      margin-bottom: 10px;
     }
 
     .chart-card h6 {
       font-size: 0.75rem;
-      color: #7ec8e3;
+      color: var(--md-sys-color-primary);
       text-transform: uppercase;
       letter-spacing: 0.06em;
       margin-bottom: 6px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
     }
 
     .chart-wrapper {
@@ -96,20 +81,26 @@
       height: 180px;
     }
 
+    .full-width-section {
+      margin-top: 10px;
+    }
+
     .correction-bar-section {
-      background: #16213e;
-      border: 1px solid #1a4a7a;
-      border-radius: 8px;
+      background: var(--md-sys-color-surface-container);
+      border: 1px solid var(--md-sys-color-outline-variant);
+      border-radius: var(--md-sys-shape-md);
       padding: 10px;
-      margin-bottom: 10px;
     }
 
     .correction-bar-section h6 {
       font-size: 0.75rem;
-      color: #7ec8e3;
+      color: var(--md-sys-color-primary);
       text-transform: uppercase;
       letter-spacing: 0.06em;
       margin-bottom: 8px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
     }
 
     .correction-row {
@@ -123,7 +114,7 @@
     .correction-source {
       width: 100px;
       flex-shrink: 0;
-      color: #aaa;
+      color: var(--md-sys-color-on-surface-variant);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -132,204 +123,189 @@
     .correction-bar-bg {
       flex: 1;
       height: 8px;
-      background: #0f3460;
-      border-radius: 4px;
+      background: var(--md-sys-color-surface-container-highest);
+      border-radius: var(--md-sys-shape-full);
       overflow: hidden;
     }
 
     .correction-bar-fill {
       height: 100%;
-      border-radius: 4px;
-      transition: width 0.2s;
+      border-radius: var(--md-sys-shape-full);
+      transition: width var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
     }
 
     .correction-value {
       width: 50px;
       text-align: right;
-      color: #ccc;
+      color: var(--md-sys-color-on-surface-variant);
     }
 
-    .data-table {
-      background: #16213e;
-      border: 1px solid #1a4a7a;
-      border-radius: 8px;
+    .data-table-section {
+      background: var(--md-sys-color-surface-container);
+      border: 1px solid var(--md-sys-color-outline-variant);
+      border-radius: var(--md-sys-shape-md);
       padding: 10px;
-      margin-bottom: 10px;
+      margin-top: 10px;
     }
 
-    .data-table h6 {
+    .data-table-section h6 {
       font-size: 0.75rem;
-      color: #7ec8e3;
+      color: var(--md-sys-color-primary);
       text-transform: uppercase;
       letter-spacing: 0.06em;
       margin-bottom: 8px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
     }
 
-    .data-table table {
+    .data-table-section table {
       width: 100%;
       font-size: 0.75rem;
       border-collapse: collapse;
     }
 
-    .data-table th {
-      color: #6c757d;
+    .data-table-section th {
+      color: var(--md-sys-color-on-surface-variant);
       font-weight: 600;
       padding: 3px 6px;
-      border-bottom: 1px solid #1a4a7a;
+      border-bottom: 1px solid var(--md-sys-color-outline-variant);
       text-align: center;
     }
 
-    .data-table td {
+    .data-table-section td {
       padding: 3px 6px;
       text-align: center;
-      color: #e0e0e0;
-      border-bottom: 1px solid #0f3460;
+      color: var(--md-sys-color-on-surface);
+      border-bottom: 1px solid var(--md-sys-color-outline-variant);
       font-variant-numeric: tabular-nums;
     }
 
-    .data-table tr:last-child td { border-bottom: none; }
+    .data-table-section tr:last-child td { border-bottom: none; }
 
     .buffer-control {
       display: flex;
       align-items: center;
       gap: 8px;
-      padding: 6px 12px;
-      background: #0d1117;
-      border-top: 1px solid #0f3460;
+      padding: 6px var(--md-sys-spacing-md);
+      background: var(--md-sys-color-surface-dim);
+      border-top: 1px solid var(--md-sys-color-outline-variant);
       flex-shrink: 0;
       font-size: 0.75rem;
     }
 
     .buffer-control input[type=range] {
       flex: 1;
-      accent-color: #2d7dd2;
+      accent-color: var(--md-sys-color-primary);
     }
   </style>
 </head>
 <body>
 
-  <!-- Navbar -->
-  <nav class="navbar navbar-dark py-1">
-    <div class="container-fluid">
-      <div class="d-flex align-items-center gap-3">
-        <a href="/viewer.html" class="btn btn-sm btn-outline-secondary py-0">
-          <i class="fas fa-arrow-left me-1"></i>ビューアに戻る
-        </a>
-        <span class="navbar-brand mb-0 h6">
-          <i class="fas fa-chart-line me-1 text-info"></i>Robot Telemetry
-        </span>
-      </div>
-      <div class="d-flex align-items-center gap-2">
-        <label for="robot-selector" class="text-muted" style="font-size:0.8rem; margin:0;">Robot ID:</label>
-        <select id="robot-selector" class="form-select form-select-sm" style="width:80px; background:#0f3460; color:#e0e0e0; border-color:#1a4a7a;">
-        </select>
-        <span id="status-dot"></span>
-        <span id="status-label" style="font-size:0.8rem;">未接続</span>
-      </div>
+  <!-- Top App Bar -->
+  <nav class="m3-top-app-bar">
+    <a href="/viewer.html" class="m3-btn m3-btn--sm m3-btn--outlined" style="padding:4px 12px;">
+      <span class="material-symbols-outlined icon-sm">arrow_back</span> Viewer
+    </a>
+    <div class="m3-top-app-bar__title">
+      <span class="material-symbols-outlined">show_chart</span>
+      Robot Telemetry
+    </div>
+    <div class="m3-top-app-bar__actions">
+      <label for="robot-selector" class="m3-text-on-surface-variant m3-body-small">Robot ID:</label>
+      <select id="robot-selector" class="m3-select" style="width:80px;">
+      </select>
+      <span class="m3-connection-dot" id="status-dot"></span>
+      <span class="m3-body-small m3-text-on-surface-variant" id="status-label">disconnected</span>
     </div>
   </nav>
 
   <!-- Header info bar -->
   <div id="header-bar">
     <span class="robot-id-badge">ID: <span id="current-robot-id">--</span></span>
-    <span class="info-chip" id="header-planner">プランナー: --</span>
-    <span class="info-chip" id="header-mode">モード: --</span>
-    <span class="info-chip" id="header-pos">位置: (---, ---)</span>
-    <span class="info-chip" id="header-vel">速度: (---, ---)</span>
+    <span class="m3-chip" id="header-planner">Planner: --</span>
+    <span class="m3-chip" id="header-mode">Mode: --</span>
+    <span class="m3-chip" id="header-pos">Pos: (---, ---)</span>
+    <span class="m3-chip" id="header-vel">Vel: (---, ---)</span>
   </div>
 
   <!-- Scroll area -->
   <div id="scroll-area">
-    <div class="row g-2">
-      <!-- 位置 X/Y チャート -->
-      <div class="col-md-6">
-        <div class="chart-card">
-          <h6><i class="fas fa-map-marker-alt me-1"></i>位置 X / Y</h6>
-          <div class="chart-wrapper">
-            <canvas id="chart-position"></canvas>
-          </div>
+    <div class="chart-grid">
+      <div class="chart-card">
+        <h6><span class="material-symbols-outlined icon-sm">location_on</span> Position X / Y</h6>
+        <div class="chart-wrapper">
+          <canvas id="chart-position"></canvas>
         </div>
       </div>
 
-      <!-- 速度 Vx/Vy チャート -->
-      <div class="col-md-6">
-        <div class="chart-card">
-          <h6><i class="fas fa-tachometer-alt me-1"></i>速度 Vx / Vy</h6>
-          <div class="chart-wrapper">
-            <canvas id="chart-velocity"></canvas>
-          </div>
+      <div class="chart-card">
+        <h6><span class="material-symbols-outlined icon-sm">speed</span> Velocity Vx / Vy</h6>
+        <div class="chart-wrapper">
+          <canvas id="chart-velocity"></canvas>
         </div>
       </div>
 
-      <!-- 角度 theta チャート -->
-      <div class="col-md-6">
-        <div class="chart-card">
-          <h6><i class="fas fa-compass me-1"></i>角度 θ</h6>
-          <div class="chart-wrapper">
-            <canvas id="chart-theta"></canvas>
-          </div>
+      <div class="chart-card">
+        <h6><span class="material-symbols-outlined icon-sm">explore</span> Angle θ</h6>
+        <div class="chart-wrapper">
+          <canvas id="chart-theta"></canvas>
         </div>
       </div>
 
-      <!-- 予実誤差チャート -->
-      <div class="col-md-6">
-        <div class="chart-card">
-          <h6><i class="fas fa-exclamation-triangle me-1"></i>予実誤差</h6>
-          <div class="chart-wrapper">
-            <canvas id="chart-error"></canvas>
-          </div>
+      <div class="chart-card">
+        <h6><span class="material-symbols-outlined icon-sm">warning</span> Prediction Error</h6>
+        <div class="chart-wrapper">
+          <canvas id="chart-error"></canvas>
         </div>
       </div>
+    </div>
 
-      <!-- 速度修正バー -->
-      <div class="col-12">
-        <div class="correction-bar-section">
-          <h6><i class="fas fa-sliders-h me-1"></i>速度修正 (VelocityCorrection)</h6>
-          <div id="correction-bars">
-            <div style="color:#666; font-size:0.75rem;">データなし</div>
-          </div>
+    <!-- Velocity corrections -->
+    <div class="full-width-section">
+      <div class="correction-bar-section">
+        <h6><span class="material-symbols-outlined icon-sm">tune</span> Velocity Correction</h6>
+        <div id="correction-bars">
+          <div style="color:var(--md-sys-color-on-surface-variant); font-size:0.75rem;">No data</div>
         </div>
       </div>
+    </div>
 
-      <!-- 数値テーブル -->
-      <div class="col-12">
-        <div class="data-table">
-          <h6><i class="fas fa-table me-1"></i>リアルタイム数値</h6>
-          <table>
-            <thead>
-              <tr>
-                <th></th>
-                <th>推定位置 (x,y,θ)</th>
-                <th>Vision位置 (x,y,θ)</th>
-                <th>目標位置 (x,y)</th>
-                <th>推定速度 (vx,vy)</th>
-                <th>目標速度 (vx,vy)</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td style="color:#6c757d; font-weight:600;">値</td>
-                <td id="tbl-est-pos">--</td>
-                <td id="tbl-vis-pos">--</td>
-                <td id="tbl-tgt-pos">--</td>
-                <td id="tbl-est-vel">--</td>
-                <td id="tbl-tgt-vel">--</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
+    <!-- Data table -->
+    <div class="data-table-section">
+      <h6><span class="material-symbols-outlined icon-sm">table</span> Real-time Values</h6>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th>Estimated (x,y,θ)</th>
+            <th>Vision (x,y,θ)</th>
+            <th>Target (x,y)</th>
+            <th>Est. Vel (vx,vy)</th>
+            <th>Tgt. Vel (vx,vy)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style="color:var(--md-sys-color-on-surface-variant); font-weight:600;">Value</td>
+            <td id="tbl-est-pos">--</td>
+            <td id="tbl-vis-pos">--</td>
+            <td id="tbl-tgt-pos">--</td>
+            <td id="tbl-est-vel">--</td>
+            <td id="tbl-tgt-vel">--</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 
   <!-- Buffer size control -->
   <div class="buffer-control">
-    <span class="text-muted">バッファ:</span>
+    <span class="m3-text-on-surface-variant">Buffer:</span>
     <input type="range" id="buffer-size-slider" min="100" max="600" value="300" step="100">
-    <span id="buffer-size-label">300点 (30秒)</span>
+    <span id="buffer-size-label">300 pts (30s)</span>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
   <script src="robot_telemetry.js"></script>
 </body>

--- a/crane_web_debugger/web/robot_telemetry.js
+++ b/crane_web_debugger/web/robot_telemetry.js
@@ -1,24 +1,24 @@
 const CHART_COLORS = {
-    estX:     '#4fc3f7',
-    estY:     '#0288d1',
-    visX:     '#81c784',
-    visY:     '#388e3c',
-    tgtX:     '#ff8a65',
-    tgtY:     '#e64a19',
-    fbVx:     '#4fc3f7',
-    fbVy:     '#0288d1',
-    odomVx:   '#81c784',
-    odomVy:   '#388e3c',
-    mouseVx:  '#ce93d8',
-    mouseVy:  '#7b1fa2',
-    tgtVx:    '#ff8a65',
-    tgtVy:    '#e64a19',
-    estTheta: '#4fc3f7',
-    visTheta: '#81c784',
-    tgtTheta: '#ff8a65',
-    gyroYaw:  '#ce93d8',
-    velErr:   '#ef5350',
-    posErr:   '#ff9800',
+    estX:     '#A0C4FF',  // primary
+    estY:     '#5A9BD5',
+    visX:     '#66BB6A',  // success green
+    visY:     '#2E7D32',
+    tgtX:     '#D0BCFF',  // tertiary purple
+    tgtY:     '#9575CD',
+    fbVx:     '#A0C4FF',
+    fbVy:     '#5A9BD5',
+    odomVx:   '#66BB6A',
+    odomVy:   '#2E7D32',
+    mouseVx:  '#D0BCFF',
+    mouseVy:  '#9575CD',
+    tgtVx:    '#FFA726',  // warning
+    tgtVy:    '#EF6C00',
+    estTheta: '#A0C4FF',
+    visTheta: '#66BB6A',
+    tgtTheta: '#D0BCFF',
+    gyroYaw:  '#FFA726',
+    velErr:   '#FFB4AB',  // error
+    posErr:   '#FFA726',
 };
 
 const CONTROL_MODE_NAMES = {
@@ -29,9 +29,9 @@ const CONTROL_MODE_NAMES = {
 };
 
 const CORRECTION_SOURCE_COLORS = {
-    'rvo2': '#ef5350',
-    'sender_accel_limit': '#ff9800',
-    'feedback_control': '#66bb6a',
+    'rvo2': '#FFB4AB',
+    'sender_accel_limit': '#FFA726',
+    'feedback_control': '#66BB6A',
 };
 
 function makeDataset(label, color, dashed = false) {
@@ -60,20 +60,20 @@ function makeChart(canvasId, datasets, yLabel = '') {
             scales: {
                 x: {
                     type: 'linear',
-                    title: { display: true, text: '経過時間 (s)', color: '#666', font: { size: 10 } },
-                    ticks: { color: '#666', maxTicksLimit: 6, font: { size: 10 } },
-                    grid: { color: '#1a2a3a' },
+                    title: { display: true, text: 'Elapsed (s)', color: '#8C929A', font: { size: 10 } },
+                    ticks: { color: '#8C929A', maxTicksLimit: 6, font: { size: 10 } },
+                    grid: { color: '#2D3748' },
                 },
                 y: {
-                    title: { display: !!yLabel, text: yLabel, color: '#666', font: { size: 10 } },
-                    ticks: { color: '#666', maxTicksLimit: 6, font: { size: 10 } },
-                    grid: { color: '#1a2a3a' },
+                    title: { display: !!yLabel, text: yLabel, color: '#8C929A', font: { size: 10 } },
+                    ticks: { color: '#8C929A', maxTicksLimit: 6, font: { size: 10 } },
+                    grid: { color: '#2D3748' },
                 }
             },
             plugins: {
                 legend: {
                     labels: {
-                        color: '#aaa',
+                        color: '#8C929A',
                         font: { size: 10 },
                         boxWidth: 12,
                         padding: 6,
@@ -82,9 +82,9 @@ function makeChart(canvasId, datasets, yLabel = '') {
                 tooltip: {
                     mode: 'index',
                     intersect: false,
-                    backgroundColor: '#0f3460',
-                    titleColor: '#7ec8e3',
-                    bodyColor: '#e0e0e0',
+                    backgroundColor: '#213052',
+                    titleColor: '#A0C4FF',
+                    bodyColor: '#E2E4E8',
                     titleFont: { size: 10 },
                     bodyFont: { size: 10 },
                 }
@@ -116,33 +116,33 @@ class RobotTelemetry {
 
     initCharts() {
         this.charts.position = makeChart('chart-position', [
-            makeDataset('推定X', CHART_COLORS.estX),
-            makeDataset('推定Y', CHART_COLORS.estY),
-            makeDataset('目標X', CHART_COLORS.tgtX, true),
-            makeDataset('目標Y', CHART_COLORS.tgtY, true),
+            makeDataset('Est. X', CHART_COLORS.estX),
+            makeDataset('Est. Y', CHART_COLORS.estY),
+            makeDataset('Target X', CHART_COLORS.tgtX, true),
+            makeDataset('Target Y', CHART_COLORS.tgtY, true),
             makeDataset('Vision X', CHART_COLORS.visX, true),
             makeDataset('Vision Y', CHART_COLORS.visY, true),
         ], 'm');
 
         this.charts.velocity = makeChart('chart-velocity', [
-            makeDataset('推定Vx', CHART_COLORS.fbVx),
-            makeDataset('推定Vy', CHART_COLORS.fbVy),
-            makeDataset('目標Vx', CHART_COLORS.tgtVx, true),
-            makeDataset('目標Vy', CHART_COLORS.tgtVy, true),
-            makeDataset('odom Vx', CHART_COLORS.odomVx, true),
-            makeDataset('mouse Vx', CHART_COLORS.mouseVx, true),
+            makeDataset('Est. Vx', CHART_COLORS.fbVx),
+            makeDataset('Est. Vy', CHART_COLORS.fbVy),
+            makeDataset('Target Vx', CHART_COLORS.tgtVx, true),
+            makeDataset('Target Vy', CHART_COLORS.tgtVy, true),
+            makeDataset('Odom Vx', CHART_COLORS.odomVx, true),
+            makeDataset('Mouse Vx', CHART_COLORS.mouseVx, true),
         ], 'm/s');
 
         this.charts.theta = makeChart('chart-theta', [
-            makeDataset('推定θ', CHART_COLORS.estTheta),
-            makeDataset('目標θ', CHART_COLORS.tgtTheta, true),
+            makeDataset('Est. θ', CHART_COLORS.estTheta),
+            makeDataset('Target θ', CHART_COLORS.tgtTheta, true),
             makeDataset('Vision θ', CHART_COLORS.visTheta, true),
-            makeDataset('gyro yaw', CHART_COLORS.gyroYaw, true),
+            makeDataset('Gyro Yaw', CHART_COLORS.gyroYaw, true),
         ], 'rad');
 
         this.charts.error = makeChart('chart-error', [
-            makeDataset('速度誤差', CHART_COLORS.velErr),
-            makeDataset('位置誤差', CHART_COLORS.posErr),
+            makeDataset('Vel Error', CHART_COLORS.velErr),
+            makeDataset('Pos Error', CHART_COLORS.posErr),
         ], 'm / m/s');
     }
 
@@ -152,7 +152,7 @@ class RobotTelemetry {
         if (slider) {
             slider.addEventListener('input', () => {
                 this.bufferSize = parseInt(slider.value, 10);
-                if (label) label.textContent = `${this.bufferSize}点 (${Math.round(this.bufferSize / 10)}秒)`;
+                if (label) label.textContent = `${this.bufferSize} pts (${Math.round(this.bufferSize / 10)}s)`;
                 this.trimBuffers();
             });
         }
@@ -203,7 +203,7 @@ class RobotTelemetry {
         const dot = document.getElementById('status-dot');
         const label = document.getElementById('status-label');
         if (dot) dot.classList.toggle('connected', connected);
-        if (label) label.textContent = connected ? '接続済み' : '未接続';
+        if (label) label.textContent = connected ? 'connected' : 'disconnected';
     }
 
     handleMessage(data) {
@@ -301,8 +301,8 @@ class RobotTelemetry {
         if (estVel) estVel.textContent = `(${robot.vx?.toFixed(3)}, ${robot.vy?.toFixed(3)})`;
 
         // Header
-        document.getElementById('header-pos').textContent = `位置: (${robot.x?.toFixed(2)}, ${robot.y?.toFixed(2)})`;
-        document.getElementById('header-vel').textContent = `速度: (${robot.vx?.toFixed(2)}, ${robot.vy?.toFixed(2)})`;
+        document.getElementById('header-pos').textContent = `Pos: (${robot.x?.toFixed(2)}, ${robot.y?.toFixed(2)})`;
+        document.getElementById('header-vel').textContent = `Vel: (${robot.vx?.toFixed(2)}, ${robot.vy?.toFixed(2)})`;
     }
 
     pushControlTargetsData(data) {
@@ -355,8 +355,8 @@ class RobotTelemetry {
 
         // Header info
         const modeName = CONTROL_MODE_NAMES[cmd.control_mode] ?? `MODE_${cmd.control_mode}`;
-        document.getElementById('header-planner').textContent = `プランナー: ${cmd.planner_name || '--'}`;
-        document.getElementById('header-mode').textContent = `モード: ${modeName}`;
+        document.getElementById('header-planner').textContent = `Planner: ${cmd.planner_name || '--'}`;
+        document.getElementById('header-mode').textContent = `Mode: ${modeName}`;
     }
 
     pushRobotFeedbackData(data) {

--- a/crane_web_debugger/web/viewer.html
+++ b/crane_web_debugger/web/viewer.html
@@ -4,8 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Crane Viewer</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-25..200&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="m3e-theme.css">
   <style>
     html, body {
       height: 100%;
@@ -16,39 +19,6 @@
     body {
       display: flex;
       flex-direction: column;
-      background-color: #1a1a2e;
-      color: #e0e0e0;
-    }
-
-    /* Navbar */
-    .navbar {
-      flex-shrink: 0;
-      background-color: #16213e !important;
-      border-bottom: 1px solid #0f3460;
-    }
-
-    .navbar-brand {
-      font-weight: 700;
-      letter-spacing: 0.05em;
-    }
-
-    #connection-indicator {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      font-size: 0.85rem;
-    }
-
-    #connection-dot {
-      width: 10px;
-      height: 10px;
-      border-radius: 50%;
-      background-color: #dc3545;
-      transition: background-color 0.3s;
-    }
-
-    #connection-dot.connected {
-      background-color: #28a745;
     }
 
     /* Main layout */
@@ -62,8 +32,8 @@
     #sidebar {
       width: 300px;
       flex-shrink: 0;
-      background-color: #16213e;
-      border-right: 1px solid #0f3460;
+      background-color: var(--md-sys-color-surface-container);
+      border-right: 1px solid var(--md-sys-color-outline-variant);
       display: flex;
       flex-direction: column;
       overflow: hidden;
@@ -72,32 +42,7 @@
     #sidebar-scroll {
       flex: 1;
       overflow-y: auto;
-      padding: 8px;
-    }
-
-    #sidebar-scroll::-webkit-scrollbar {
-      width: 5px;
-    }
-
-    #sidebar-scroll::-webkit-scrollbar-track {
-      background: #16213e;
-    }
-
-    #sidebar-scroll::-webkit-scrollbar-thumb {
-      background: #0f3460;
-      border-radius: 3px;
-    }
-
-    /* Section titles */
-    .sidebar-section-title {
-      font-size: 0.7rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: #6c757d;
-      padding: 6px 4px 4px;
-      margin-bottom: 4px;
-      border-bottom: 1px solid #0f3460;
+      padding: var(--md-sys-spacing-sm);
     }
 
     /* Robot cards */
@@ -105,46 +50,41 @@
       display: grid;
       grid-template-columns: repeat(4, 1fr);
       gap: 4px;
-      margin-bottom: 8px;
+      margin-bottom: var(--md-sys-spacing-sm);
     }
 
     .robot-card {
-      background-color: #0f3460;
-      border: 1px solid #1a4a7a;
-      border-radius: 6px;
+      background-color: var(--md-sys-color-surface-container-high);
+      border: 1px solid var(--md-sys-color-outline-variant);
+      border-radius: var(--md-sys-shape-sm);
       padding: 4px 2px;
       text-align: center;
       cursor: pointer;
-      transition: background-color 0.15s, border-color 0.15s;
+      transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard),
+                  border-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
       min-width: 0;
     }
 
     .robot-card:hover {
-      background-color: #1a5490;
-      border-color: #2d7dd2;
+      background-color: var(--md-sys-color-surface-container-highest);
+      border-color: var(--md-sys-color-primary);
     }
 
     .robot-card.active {
-      background-color: #1a5490;
-      border-color: #2d7dd2;
-    }
-
-    #btn-move-mode.active {
-      background-color: #ffc107;
-      color: #000;
-      border-color: #ffc107;
+      background-color: var(--md-sys-color-primary-container);
+      border-color: var(--md-sys-color-primary);
     }
 
     .robot-card .robot-id {
       font-size: 0.85rem;
       font-weight: 700;
-      color: #e0e0e0;
+      color: var(--md-sys-color-on-surface);
       line-height: 1.2;
     }
 
     .robot-card .robot-planner {
       font-size: 0.55rem;
-      color: #aaa;
+      color: var(--md-sys-color-on-surface-variant);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -153,62 +93,127 @@
 
     .robot-card .robot-mode {
       font-size: 0.55rem;
-      color: #7ec8e3;
+      color: var(--md-sys-color-primary);
       line-height: 1.2;
     }
 
-    /* Popover customization */
-    .popover {
-      background-color: #16213e;
-      border: 1px solid #0f3460;
-      color: #e0e0e0;
-      max-width: 260px;
+    #btn-move-mode.active {
+      background-color: var(--md-sys-color-warning);
+      color: var(--md-sys-color-on-warning);
     }
 
-    .popover-header {
-      background-color: #0f3460;
-      color: #e0e0e0;
-      border-bottom-color: #1a4a7a;
-    }
-
-    .popover-body {
-      color: #e0e0e0;
+    /* Game info */
+    #game-info-panel {
+      background-color: var(--md-sys-color-surface-container-high);
+      border: 1px solid var(--md-sys-color-outline-variant);
+      border-radius: var(--md-sys-shape-sm);
+      padding: var(--md-sys-spacing-sm);
+      margin-bottom: var(--md-sys-spacing-sm);
       font-size: 0.8rem;
     }
 
-    .popover .popover-arrow::after {
-      border-right-color: #0f3460;
+    #game-info-panel .info-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 2px 0;
     }
 
-    /* Layer control */
-    .accordion {
-      --bs-accordion-bg: #0f3460;
-      --bs-accordion-color: #e0e0e0;
-      --bs-accordion-border-color: #1a4a7a;
-      --bs-accordion-btn-color: #e0e0e0;
-      --bs-accordion-btn-bg: #0f3460;
-      --bs-accordion-active-color: #7ec8e3;
-      --bs-accordion-active-bg: #16213e;
-      --bs-accordion-btn-focus-box-shadow: none;
-      --bs-accordion-btn-icon-filter: invert(1);
-      font-size: 0.8rem;
-      margin-bottom: 8px;
+    #game-info-panel .info-label {
+      color: var(--md-sys-color-on-surface-variant);
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
     }
 
-    .accordion-body {
-      background-color: #16213e;
-      padding: 8px;
+    #game-info-panel .info-value {
+      color: var(--md-sys-color-on-surface);
+      font-weight: 600;
     }
 
+    #score-display {
+      font-size: 1.1rem;
+      font-weight: 700;
+      text-align: center;
+      color: var(--md-sys-color-primary);
+      padding: 4px 0;
+    }
+
+    #play-situation {
+      color: var(--md-sys-color-warning);
+    }
+
+    /* Main content area */
+    #main-content {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      background-color: var(--md-sys-color-surface);
+    }
+
+    /* SVG field viewer */
+    #svg-container {
+      flex: 1;
+      overflow: hidden;
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: var(--md-sys-color-surface-dim);
+    }
+
+    #field-canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+
+    /* Zoom toolbar */
+    .zoom-toolbar {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px var(--md-sys-spacing-sm);
+      background: var(--md-sys-color-surface-dim);
+      border-bottom: 1px solid var(--md-sys-color-outline-variant);
+      flex-shrink: 0;
+    }
+
+    .zoom-toolbar .divider {
+      border-left: 1px solid var(--md-sys-color-outline);
+      height: 20px;
+      margin: 0 4px;
+    }
+
+    /* Log area */
+    #log-area {
+      height: 100px;
+      flex-shrink: 0;
+      background-color: var(--md-sys-color-surface-dim);
+      border-top: 1px solid var(--md-sys-color-outline-variant);
+      overflow-y: auto;
+      padding: 6px 10px;
+      font-family: var(--md-sys-typescale-mono-font-family);
+      font-size: 0.72rem;
+      color: var(--md-sys-color-primary);
+    }
+
+    .log-entry {
+      line-height: 1.4;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+
+    .log-entry.log-error { color: var(--md-sys-color-error); }
+    .log-entry.log-warn  { color: var(--md-sys-color-warning); }
+    .log-entry.log-info  { color: var(--md-sys-color-primary); }
+
+    /* Layer control (details/summary) */
     .layer-controls-top {
       display: flex;
       gap: 4px;
       margin-bottom: 6px;
-    }
-
-    .layer-controls-top .btn {
-      font-size: 0.7rem;
-      padding: 2px 8px;
     }
 
     #layer-list {
@@ -217,15 +222,6 @@
       gap: 3px;
       max-height: 200px;
       overflow-y: auto;
-    }
-
-    #layer-list::-webkit-scrollbar {
-      width: 4px;
-    }
-
-    #layer-list::-webkit-scrollbar-thumb {
-      background: #0f3460;
-      border-radius: 2px;
     }
 
     .layer-item {
@@ -238,126 +234,14 @@
       margin: 0;
       cursor: pointer;
       font-size: 0.75rem;
-      color: #ccc;
+      color: var(--md-sys-color-on-surface-variant);
       flex: 1;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
     }
 
-    .layer-item input[type="checkbox"] {
-      flex-shrink: 0;
-      accent-color: #2d7dd2;
-    }
-
-    /* Game info */
-    #game-info-panel {
-      background-color: #0f3460;
-      border: 1px solid #1a4a7a;
-      border-radius: 6px;
-      padding: 8px;
-      margin-bottom: 8px;
-      font-size: 0.8rem;
-    }
-
-    #game-info-panel .info-row {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 2px 0;
-    }
-
-    #game-info-panel .info-label {
-      color: #6c757d;
-      font-size: 0.7rem;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-    }
-
-    #game-info-panel .info-value {
-      color: #e0e0e0;
-      font-weight: 600;
-    }
-
-    #score-display {
-      font-size: 1.1rem;
-      font-weight: 700;
-      text-align: center;
-      color: #7ec8e3;
-      padding: 4px 0;
-    }
-
-    #play-situation {
-      color: #ffc107;
-    }
-
-    /* Main content area */
-    #main-content {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      overflow: hidden;
-      background-color: #1a1a2e;
-    }
-
-    /* SVG field viewer */
-    #svg-container {
-      flex: 1;
-      overflow: hidden;
-      position: relative;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background-color: #0d1117;
-    }
-
-    #field-canvas {
-      width: 100%;
-      height: 100%;
-      display: block;
-    }
-
-    /* Log area */
-    #log-area {
-      height: 100px;
-      flex-shrink: 0;
-      background-color: #0d1117;
-      border-top: 1px solid #0f3460;
-      overflow-y: auto;
-      padding: 6px 10px;
-      font-family: 'Courier New', monospace;
-      font-size: 0.72rem;
-      color: #7ec8e3;
-    }
-
-    #log-area::-webkit-scrollbar {
-      width: 5px;
-    }
-
-    #log-area::-webkit-scrollbar-thumb {
-      background: #0f3460;
-      border-radius: 2px;
-    }
-
-    .log-entry {
-      line-height: 1.4;
-      white-space: pre-wrap;
-      word-break: break-all;
-    }
-
-    .log-entry.log-error {
-      color: #dc3545;
-    }
-
-    .log-entry.log-warn {
-      color: #ffc107;
-    }
-
-    .log-entry.log-info {
-      color: #7ec8e3;
-    }
-
-    /* Telemetry link button in popover */
+    /* Telemetry link button */
     .telemetry-link {
       display: inline-block;
       margin-top: 6px;
@@ -367,35 +251,28 @@
 </head>
 <body>
 
-  <!-- Navbar -->
-  <nav class="navbar navbar-dark navbar-expand-lg py-1">
-    <div class="container-fluid">
-      <span class="navbar-brand mb-0 h5">
-        <i class="fa-solid fa-robot me-2 text-info"></i>Crane Viewer
+  <!-- Top App Bar -->
+  <nav class="m3-top-app-bar">
+    <div class="m3-top-app-bar__title">
+      <span class="material-symbols-outlined">smart_toy</span>
+      Crane Viewer
+    </div>
+    <div class="m3-top-app-bar__actions">
+      <span class="m3-inline-flex m3-items-center m3-gap-xs" id="connection-indicator">
+        <span class="m3-connection-dot" id="connection-dot"></span>
+        <span class="m3-body-small m3-text-on-surface-variant" id="connection-label">disconnected</span>
       </span>
-      <div class="d-flex align-items-center gap-3">
-        <span id="connection-indicator">
-          <span id="connection-dot"></span>
-          <span id="connection-label">切断</span>
-        </span>
-        <ul class="navbar-nav flex-row gap-2 mb-0">
-          <li class="nav-item">
-            <a class="nav-link py-0" href="/">
-              <i class="fa-solid fa-house me-1"></i>Portal
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link py-0" href="/robot_manager.html">
-              <i class="fa-solid fa-sliders me-1"></i>Robot Manager
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link py-0" href="/annotation/index.html">
-              <i class="fa-solid fa-pen-to-square me-1"></i>Annotation
-            </a>
-          </li>
-        </ul>
-      </div>
+      <ul class="m3-top-app-bar__nav-links">
+        <li><a href="/">
+          <span class="material-symbols-outlined icon-sm">home</span>Portal
+        </a></li>
+        <li><a href="/robot_manager.html">
+          <span class="material-symbols-outlined icon-sm">tune</span>Robot Manager
+        </a></li>
+        <li><a href="/annotation/index.html">
+          <span class="material-symbols-outlined icon-sm">edit_note</span>Annotation
+        </a></li>
+      </ul>
     </div>
   </nav>
 
@@ -407,55 +284,48 @@
       <div id="sidebar-scroll">
 
         <!-- Game info panel -->
-        <div class="sidebar-section-title">ゲーム情報</div>
+        <div class="m3-section-title">Game Info</div>
         <div id="game-info-panel">
           <div id="score-display">
             <span id="score-our">0</span> : <span id="score-their">0</span>
           </div>
           <div class="info-row">
-            <span class="info-label">状況</span>
-            <span class="info-value" id="play-situation">—</span>
+            <span class="info-label">Situation</span>
+            <span class="info-value" id="play-situation">-</span>
           </div>
           <div class="info-row">
-            <span class="info-label">ステージ</span>
-            <span class="info-value" id="game-stage">—</span>
+            <span class="info-label">Stage</span>
+            <span class="info-value" id="game-stage">-</span>
           </div>
         </div>
 
         <!-- Robot cards -->
-        <div class="sidebar-section-title">ロボット</div>
+        <div class="m3-section-title">Robots</div>
         <div id="robot-cards-grid">
           <!-- Populated by viewer.js -->
         </div>
 
         <!-- Layer control -->
-        <div class="sidebar-section-title">レイヤー</div>
-        <div class="accordion accordion-flush" id="layer-accordion">
-          <div class="accordion-item">
-            <h2 class="accordion-header">
-              <button class="accordion-button collapsed py-2" type="button"
-                      data-bs-toggle="collapse" data-bs-target="#layer-collapse"
-                      aria-expanded="false" aria-controls="layer-collapse">
-                <i class="fa-solid fa-layer-group me-2 text-info"></i>レイヤー制御
+        <div class="m3-section-title">Layers</div>
+        <details class="m3-expansion" id="layer-accordion">
+          <summary>
+            <span class="material-symbols-outlined icon-sm m3-text-primary">layers</span>
+            Layer Control
+          </summary>
+          <div class="m3-expansion__body">
+            <div class="layer-controls-top">
+              <button class="m3-btn m3-btn--sm m3-btn--outlined" id="btn-select-all">
+                Select All
               </button>
-            </h2>
-            <div id="layer-collapse" class="accordion-collapse collapse">
-              <div class="accordion-body">
-                <div class="layer-controls-top">
-                  <button class="btn btn-outline-info btn-sm" id="btn-select-all">
-                    全選択
-                  </button>
-                  <button class="btn btn-outline-secondary btn-sm" id="btn-deselect-all">
-                    全解除
-                  </button>
-                </div>
-                <div id="layer-list">
-                  <!-- Populated by viewer.js -->
-                </div>
-              </div>
+              <button class="m3-btn m3-btn--sm m3-btn--outlined" id="btn-deselect-all">
+                Deselect All
+              </button>
+            </div>
+            <div id="layer-list">
+              <!-- Populated by viewer.js -->
             </div>
           </div>
-        </div>
+        </details>
 
       </div>
     </aside>
@@ -464,46 +334,44 @@
     <main id="main-content">
 
       <!-- Zoom toolbar -->
-      <div style="display:flex; align-items:center; gap:6px; padding:4px 8px; background:#0d1117; border-bottom:1px solid #0f3460; flex-shrink:0;">
-        <button id="btn-zoom-in" class="btn btn-sm btn-outline-secondary py-0 px-2"><i class="fas fa-search-plus"></i></button>
-        <button id="btn-zoom-out" class="btn btn-sm btn-outline-secondary py-0 px-2"><i class="fas fa-search-minus"></i></button>
-        <button id="btn-zoom-reset" class="btn btn-sm btn-outline-secondary py-0 px-2"><i class="fas fa-compress-arrows-alt"></i></button>
-        <span style="border-left:1px solid #333; margin:0 4px; height:20px; display:inline-block; align-self:center;"></span>
-        <button id="btn-move-mode" class="btn btn-sm btn-outline-warning py-0 px-2" title="ロボット移動モード (Shift+クリックでロボット選択/移動)"><i class="fas fa-arrows-alt"></i></button>
-        <span id="move-status" class="text-muted" style="font-size:0.7rem; margin-left:4px;">選択: <span id="selected-robot-label">--</span></span>
-        <span class="text-muted" style="font-size:0.7rem; margin-left:8px;">
-          レイヤー: <span id="layer-count">0</span> | プリミティブ: <span id="prim-count">0</span>
+      <div class="zoom-toolbar">
+        <button id="btn-zoom-in" class="m3-icon-btn m3-icon-btn--sm"><span class="material-symbols-outlined icon-sm">zoom_in</span></button>
+        <button id="btn-zoom-out" class="m3-icon-btn m3-icon-btn--sm"><span class="material-symbols-outlined icon-sm">zoom_out</span></button>
+        <button id="btn-zoom-reset" class="m3-icon-btn m3-icon-btn--sm"><span class="material-symbols-outlined icon-sm">fit_screen</span></button>
+        <span class="divider"></span>
+        <button id="btn-move-mode" class="m3-icon-btn m3-icon-btn--sm" title="Robot move mode (Shift+click to select/move)"><span class="material-symbols-outlined icon-sm">open_with</span></button>
+        <span class="m3-text-on-surface-variant m3-label-small" id="move-status">Selected: <span id="selected-robot-label">--</span></span>
+        <span class="m3-text-on-surface-variant m3-label-small" style="margin-left:8px;">
+          Layers: <span id="layer-count">0</span> | Primitives: <span id="prim-count">0</span>
         </span>
       </div>
 
       <!-- Canvas field viewer -->
-      <div id="svg-container" style="flex:1; overflow:hidden; position:relative;">
+      <div id="svg-container">
         <canvas id="field-canvas"></canvas>
       </div>
 
       <!-- Log / status area -->
       <div id="log-area">
-        <div class="log-entry log-info">[起動] Crane Viewer を初期化中...</div>
+        <div class="log-entry log-info">[init] Initializing Crane Viewer...</div>
       </div>
 
     </main>
   </div>
 
-  <!-- Robot detail modal -->
-  <div class="modal fade" id="robot-detail-modal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-sm">
-      <div class="modal-content" style="background:#16213e; color:#e0e0e0; border:1px solid #0f3460;">
-        <div class="modal-header" style="background:#0f3460; border-bottom-color:#1a4a7a;">
-          <h6 class="modal-title" id="robot-detail-title">Robot</h6>
-          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
-        </div>
-        <div class="modal-body" id="robot-detail-body" style="font-size:0.8rem;">
-        </div>
-      </div>
+  <!-- Robot detail dialog -->
+  <div class="m3-dialog-scrim" id="robot-detail-scrim" onclick="window.__closeRobotDialog?.()"></div>
+  <div class="m3-dialog" id="robot-detail-modal" style="max-width:340px;">
+    <div class="m3-dialog__header">
+      <span class="m3-dialog__title" id="robot-detail-title">Robot</span>
+      <button class="m3-icon-btn m3-icon-btn--sm" onclick="window.__closeRobotDialog?.()">
+        <span class="material-symbols-outlined">close</span>
+      </button>
+    </div>
+    <div class="m3-dialog__body" id="robot-detail-body" style="font-size:0.8rem;">
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="viewer.js"></script>
 </body>
 </html>

--- a/crane_web_debugger/web/viewer.js
+++ b/crane_web_debugger/web/viewer.js
@@ -709,7 +709,7 @@ class CraneViewer {
         const dot = document.getElementById('connection-dot');
         const label = document.getElementById('connection-label');
         if (dot) dot.classList.toggle('connected', connected);
-        if (label) label.textContent = connected ? '接続済み' : '未接続';
+        if (label) label.textContent = connected ? 'connected' : 'disconnected';
     }
 
     renderRobotCards() {
@@ -717,7 +717,7 @@ class CraneViewer {
         if (!container) return;
         const ids = Object.keys(this.robotsOurs).map(Number).sort((a, b) => a - b);
         if (ids.length === 0) {
-            container.innerHTML = '<div style="font-size:0.7rem;color:#666;text-align:center;grid-column:span 4;padding:8px;">ロボットデータなし</div>';
+            container.innerHTML = '<div style="font-size:0.7rem;color:var(--md-sys-color-on-surface-variant);text-align:center;grid-column:span 4;padding:8px;">No robot data</div>';
             return;
         }
         container.innerHTML = '';
@@ -738,42 +738,55 @@ class CraneViewer {
         const cmd = this.controlTargets[id];
         if (!robot) return;
         const modal = document.getElementById('robot-detail-modal');
+        const scrim = document.getElementById('robot-detail-scrim');
         if (!modal) return;
         const modeName = cmd ? (CONTROL_MODE_LONG[cmd.control_mode] ?? `MODE_${cmd.control_mode}`) : '--';
         document.getElementById('robot-detail-title').textContent = `Robot ${id}`;
         let targetHtml = '';
         if (cmd?.position_target_mode) {
-            targetHtml = `<tr><td class="text-muted">目標位置</td><td>(${cmd.position_target_mode.target_x?.toFixed(3)}, ${cmd.position_target_mode.target_y?.toFixed(3)})</td></tr>`;
+            targetHtml = `<tr><td>Target Pos</td><td>(${cmd.position_target_mode.target_x?.toFixed(3)}, ${cmd.position_target_mode.target_y?.toFixed(3)})</td></tr>`;
         } else if (cmd?.simple_velocity_target_mode) {
-            targetHtml = `<tr><td class="text-muted">目標速度</td><td>(${cmd.simple_velocity_target_mode.target_vx?.toFixed(3)}, ${cmd.simple_velocity_target_mode.target_vy?.toFixed(3)})</td></tr>`;
+            targetHtml = `<tr><td>Target Vel</td><td>(${cmd.simple_velocity_target_mode.target_vx?.toFixed(3)}, ${cmd.simple_velocity_target_mode.target_vy?.toFixed(3)})</td></tr>`;
         }
         document.getElementById('robot-detail-body').innerHTML = `
-            <table class="table table-sm table-dark table-borderless mb-2"><tbody>
-                <tr><td class="text-muted" style="width:6em">制御モード</td><td>${modeName}</td></tr>
-                <tr><td class="text-muted">プランナー</td><td>${cmd?.planner_name || '--'}</td></tr>
-                <tr><td class="text-muted">推定 X</td><td>${robot.x?.toFixed(3)} m</td></tr>
-                <tr><td class="text-muted">推定 Y</td><td>${robot.y?.toFixed(3)} m</td></tr>
-                <tr><td class="text-muted">推定 θ</td><td>${robot.theta?.toFixed(3)} rad</td></tr>
-                <tr><td class="text-muted">速度 Vx</td><td>${robot.vx?.toFixed(3)} m/s</td></tr>
-                <tr><td class="text-muted">速度 Vy</td><td>${robot.vy?.toFixed(3)} m/s</td></tr>
-                <tr><td class="text-muted">ω</td><td>${robot.omega?.toFixed(3)} rad/s</td></tr>
-                <tr><td class="text-muted">Vision X</td><td>${robot.vision_x?.toFixed(3) ?? '--'}</td></tr>
-                <tr><td class="text-muted">Vision Y</td><td>${robot.vision_y?.toFixed(3) ?? '--'}</td></tr>
+            <table class="m3-data-table m3-data-table--borderless m3-mb-sm"><tbody>
+                <tr><td style="width:6em">Control Mode</td><td>${modeName}</td></tr>
+                <tr><td>Planner</td><td>${cmd?.planner_name || '--'}</td></tr>
+                <tr><td>Est. X</td><td>${robot.x?.toFixed(3)} m</td></tr>
+                <tr><td>Est. Y</td><td>${robot.y?.toFixed(3)} m</td></tr>
+                <tr><td>Est. θ</td><td>${robot.theta?.toFixed(3)} rad</td></tr>
+                <tr><td>Vel Vx</td><td>${robot.vx?.toFixed(3)} m/s</td></tr>
+                <tr><td>Vel Vy</td><td>${robot.vy?.toFixed(3)} m/s</td></tr>
+                <tr><td>ω</td><td>${robot.omega?.toFixed(3)} rad/s</td></tr>
+                <tr><td>Vision X</td><td>${robot.vision_x?.toFixed(3) ?? '--'}</td></tr>
+                <tr><td>Vision Y</td><td>${robot.vision_y?.toFixed(3) ?? '--'}</td></tr>
                 ${targetHtml}
-                <tr><td class="text-muted">目標 θ</td><td>${cmd?.target_theta?.toFixed(3) ?? '--'}</td></tr>
+                <tr><td>Target θ</td><td>${cmd?.target_theta?.toFixed(3) ?? '--'}</td></tr>
             </tbody></table>
-            <a href="/robot_telemetry.html?id=${id}" class="btn btn-sm btn-primary w-100">
-                <i class="fas fa-chart-line me-1"></i>テレメトリを開く
+            <a href="/robot_telemetry.html?id=${id}" class="m3-btn m3-btn--filled m3-btn--sm m3-w-full">
+                <span class="material-symbols-outlined icon-sm">show_chart</span> Open Telemetry
             </a>
         `;
-        bootstrap.Modal.getOrCreateInstance(modal).show();
+        modal.classList.add('open');
+        if (scrim) scrim.classList.add('open');
+        window.__closeRobotDialog = () => {
+            modal.classList.remove('open');
+            if (scrim) scrim.classList.remove('open');
+        };
+        const onKey = (e) => {
+            if (e.key === 'Escape') {
+                window.__closeRobotDialog();
+                document.removeEventListener('keydown', onKey);
+            }
+        };
+        document.addEventListener('keydown', onKey);
     }
 
     updateLayerList() {
         const container = document.getElementById('layer-list');
         if (!container) return;
         if (this.layerStore.size === 0) {
-            container.innerHTML = '<div style="font-size:0.7rem;color:#666;text-align:center;padding:6px;">レイヤーなし</div>';
+            container.innerHTML = '<div style="font-size:0.7rem;color:var(--md-sys-color-on-surface-variant);text-align:center;padding:6px;">No layers</div>';
             return;
         }
         container.innerHTML = '';
@@ -781,10 +794,10 @@ class CraneViewer {
             const item = document.createElement('div');
             item.className = 'layer-item';
             item.innerHTML = `
-                <input type="checkbox" class="form-check-input layer-cb" id="layer-${name}"
+                <input type="checkbox" class="m3-checkbox layer-cb" id="layer-${name}"
                        data-layer="${name}" ${this.visibleLayers.has(name) ? 'checked' : ''}>
-                <label class="form-check-label" for="layer-${name}">${name}</label>
-                <span class="ms-auto text-muted" style="font-size:0.65rem">${layer.primitives.length}</span>
+                <label for="layer-${name}">${name}</label>
+                <span class="m3-ms-auto m3-text-on-surface-variant" style="font-size:0.65rem">${layer.primitives.length}</span>
             `;
             container.appendChild(item);
         }


### PR DESCRIPTION
## 概要
crane_web_debuggerの全5ページ（Portal、Viewer、Robot Manager、Robot Telemetry、Annotation Tool）をMaterial 3 Expressiveデザインガイドラインに基づいてリデザイン。Bootstrap/Font Awesomeを完全除去し、統一的なダークテーマの共有デザインシステムに置き換え。

## 背景・根本原因
- ページ間でBootstrapバージョン（5.1.3/5.3.3）やテーマ（ライト/ダーク/グラデーション）が不統一
- 共有デザインシステムが存在せず、各ページが独立したインラインスタイルで定義
- Material Designが一切使用されていなかった

## 変更内容
- 共有デザインシステム `m3e-theme.css` を新規作成（M3Eカラートークン、タイポグラフィ、シェイプ、モーション、コンポーネント、ユーティリティ）
- 全ページからBootstrap CSS/JS、Font Awesome CDNを完全除去
- Font Awesome → Material Symbols Outlinedにアイコン全置換
- 全ページをM3Eダークテーマに統一（Surface #121826ベース）
- Bootstrap Modal → バニラJS M3Eダイアログ（viewer.js）
- Bootstrap Accordion → ネイティブ `<details>/<summary>`
- Chart.jsカラーパレットをM3E配色に更新
- Annotation PWA: SWキャッシュv3化、manifest色更新
- M3E Expressiveの特徴: シェイプモーフィング、物理ベースモーション、Primary/Tertiary/Semanticの3層カラーシステム

## テスト方法
- [ ] `colcon build --packages-select crane_web_debugger` でビルド確認
- [ ] 各ページをブラウザで開き、レイアウト崩れがないか目視確認
- [ ] Viewer: Canvas描画、ズーム/パン、ロボットカード、モーダル開閉、レイヤーアコーディオン
- [ ] Telemetry: Chart.jsグラフ描画、ロボットID切替
- [ ] Robot Manager: テーブル表示、サイドパネル開閉、Start/Stop操作
- [ ] Annotation: クイックボタン、モーダル、PWAインストール

🤖 Generated with [Claude Code](https://claude.com/claude-code)