### PR TITLE
feat: robot-managerをDocker Composeサービスとして追加

### DIFF
--- a/.claude/commands/session-commit.md
+++ b/.claude/commands/session-commit.md
@@ -116,8 +116,6 @@ git add <file1> <file2> ...
 ## 変更内容
 - <箇条書き>
 - <箇条書き>
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
 
 pre-commit フックで自動修正が入った場合は、修正済みファイルを再ステージして再コミットします:
@@ -154,11 +152,6 @@ PR 本文テンプレート:
 ## 変更内容
 - <箇条書き>
 
-## テスト方法
-- [ ] `colcon build --packages-select <package>` でビルド確認
-- [ ] <動作確認項目>
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
 ---

--- a/docker/README.md
+++ b/docker/README.md
@@ -47,20 +47,20 @@
 ### 開発環境の起動
 
 ```bash
-# シミュレーション環境(デフォルト) + debug_tools自動起動
+# シミュレーション環境(デフォルト)
 ./scripts/docker-dev.sh
 
-# 実機環境 + debug_tools自動起動
+# 実機環境
 ./scripts/docker-dev.sh real
 
-# バックグラウンド起動 + debug_tools自動起動
+# バックグラウンド起動
 ./scripts/docker-dev.sh -d
 ./scripts/docker-dev.sh real -d
 
-# debug_toolsなしで起動
+# robot-managerなしで起動
 ./scripts/docker-dev.sh --no-debug
 
-# 停止(debug_toolsも自動停止)
+# 停止
 ./scripts/docker-dev.sh down
 ```
 

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -15,14 +15,14 @@
 # 実機環境 + ssl-log-recorder自動起動
 ./scripts/docker-dev.sh real
 
-# バックグラウンド起動 + debug_tools自動起動
+# バックグラウンド起動
 ./scripts/docker-dev.sh -d
 ./scripts/docker-dev.sh real -d
 
-# debug_toolsなしで起動
+# robot-manager なしで起動
 ./scripts/docker-dev.sh --no-debug
 
-# 停止(debug_toolsとssl-log-recorderも自動停止)
+# 停止
 ./scripts/docker-dev.sh down
 ```
 
@@ -33,22 +33,20 @@
 **注2**: `ssl-log-recorder` は `./scripts/docker-dev.sh down` 実行時に停止します。
 `up` を Ctrl+C で終了した場合は recorder は継続起動します。
 
-**注3**: バックグラウンド起動(`-d`)時、debug_tools
-(crane_websocket_server) が自動的に起動します。
+**注3**: `robot-manager` は Docker Compose サービスとして常時定義されています。
 
-- HTTP Server: <http://localhost:8090>
-- WebSocket: ws://localhost:8091
-- `--no-debug` オプションで無効化可能
+- URL: <http://localhost:8090>
+- `--no-debug` オプションで無効化可能（`robot-manager` のみ停止）
 
-### debug_tools の手動操作
+### robot-manager の手動操作
 
-debug_tools を個別に操作したい場合は、以下のスクリプトを使用できます。
+`robot-manager` を個別に操作したい場合は、以下のスクリプトを使用できます。
 
 ```bash
-# debug_tools を起動
+# robot-manager を起動
 ./scripts/start-debug-tools.sh
 
-# debug_tools を停止
+# robot-manager を停止
 ./scripts/stop-debug-tools.sh
 ```
 
@@ -81,7 +79,7 @@ docker compose -f docker/dev/docker-compose.yaml down
 - **ssl-status-board**: ステータスボード(simのみ)
 - **autoref-tigers**: Tigers Mannheimのオートレフェリー
 - **voicevox**: 音声合成エンジン
-- **debug_tools**: WebSocketベースのデバッグツール(docker-dev.shで自動起動)
+- **robot-manager**: ROS非依存のロボット管理Webアプリ（Start/Stop/Status）
 
 ## 設定ファイル
 

--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -1,4 +1,18 @@
 services:
+  robot-manager:
+    build:
+      context: ./robot-manager
+    container_name: crane-robot-manager
+    network_mode: host
+    environment:
+      - HTTP_PORT=8090
+      - NUM_ROBOTS=13
+      - ROBOT_IP_BASE=192.168.20.
+      - ROBOT_IP_OFFSET=100
+      - ROBOT_PORT=8000
+      - HTTP_TIMEOUT_SEC=0.8
+    restart: unless-stopped
+
   grsim:
     image: ghcr.io/ibis-ssl/grsim:latest
     container_name: grsim

--- a/docker/dev/robot-manager/Dockerfile
+++ b/docker/dev/robot-manager/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY server.py /app/server.py
+COPY web /app/web
+
+EXPOSE 8090
+
+ENV HTTP_PORT=8090
+
+CMD ["python3", "/app/server.py"]

--- a/docker/dev/robot-manager/server.py
+++ b/docker/dev/robot-manager/server.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+NUM_ROBOTS = int(os.environ.get("NUM_ROBOTS", "13"))
+ROBOT_IP_BASE = os.environ.get("ROBOT_IP_BASE", "192.168.20.")
+ROBOT_IP_OFFSET = int(os.environ.get("ROBOT_IP_OFFSET", "100"))
+ROBOT_PORT = int(os.environ.get("ROBOT_PORT", "8000"))
+HTTP_PORT = int(os.environ.get("HTTP_PORT", "8090"))
+HTTP_TIMEOUT_SEC = float(os.environ.get("HTTP_TIMEOUT_SEC", "0.8"))
+
+WEB_DIR = Path(__file__).resolve().parent / "web"
+
+
+def robot_ip(robot_id: int) -> str:
+    return f"{ROBOT_IP_BASE}{ROBOT_IP_OFFSET + robot_id}"
+
+
+def parse_status(success: bool, body_text: str, default_ok: str = "Running") -> str:
+    if not success:
+        return "Offline"
+    if not body_text:
+        return default_ok
+    try:
+        body_json = json.loads(body_text)
+    except json.JSONDecodeError:
+        return default_ok
+    status = body_json.get("status")
+    if isinstance(status, str) and status:
+        return status
+    return default_ok
+
+
+def send_pi_request(robot_id: int, method: str, path: str) -> tuple[bool, str]:
+    target = f"http://{robot_ip(robot_id)}:{ROBOT_PORT}{path}"
+    req = Request(target, method=method)
+    try:
+        with urlopen(req, timeout=HTTP_TIMEOUT_SEC) as resp:
+            ok = 200 <= resp.status < 300
+            body = resp.read().decode("utf-8", errors="replace")
+            return ok, body
+    except URLError:
+        return False, ""
+    except TimeoutError:
+        return False, ""
+    except Exception:
+        return False, ""
+
+
+def get_robot_status(robot_id: int) -> dict:
+    ok, body = send_pi_request(robot_id, "GET", "/status")
+    return {
+        "robot_id": robot_id,
+        "ip": robot_ip(robot_id),
+        "success": ok,
+        "status": parse_status(ok, body),
+    }
+
+
+def control_robot(robot_id: int, command: str) -> dict:
+    command_map = {
+        "start": ("POST", "/start"),
+        "stop": ("POST", "/stop"),
+        "status": ("GET", "/status"),
+    }
+    if command not in command_map:
+        return {
+            "robot_id": robot_id,
+            "command": command,
+            "success": False,
+            "status": "Unknown command",
+        }
+    method, path = command_map[command]
+    ok, body = send_pi_request(robot_id, method, path)
+    return {
+        "robot_id": robot_id,
+        "command": command,
+        "success": ok,
+        "status": parse_status(ok, body),
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _json(self, payload: dict | list, status: HTTPStatus = HTTPStatus.OK) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _text(self, text: str, status: HTTPStatus = HTTPStatus.OK) -> None:
+        body = text.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _serve_static(self, rel_path: str) -> None:
+        rel = rel_path.lstrip("/")
+        if rel == "":
+            rel = "index.html"
+        target = (WEB_DIR / rel).resolve()
+        if not str(target).startswith(str(WEB_DIR.resolve())) or not target.exists():
+            self._text("Not Found", HTTPStatus.NOT_FOUND)
+            return
+
+        content_type = "application/octet-stream"
+        if target.suffix == ".html":
+            content_type = "text/html; charset=utf-8"
+        elif target.suffix == ".js":
+            content_type = "application/javascript; charset=utf-8"
+        elif target.suffix == ".css":
+            content_type = "text/css; charset=utf-8"
+
+        data = target.read_bytes()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _parse_robot_id(self, text: str) -> int | None:
+        try:
+            robot_id = int(text)
+        except ValueError:
+            return None
+        if 0 <= robot_id < NUM_ROBOTS:
+            return robot_id
+        return None
+
+    def do_GET(self) -> None:
+        if self.path == "/healthz":
+            self._json({"ok": True, "service": "robot-manager"})
+            return
+
+        if self.path == "/api/robots":
+            with ThreadPoolExecutor(max_workers=min(8, NUM_ROBOTS)) as ex:
+                robots = list(ex.map(get_robot_status, range(NUM_ROBOTS)))
+            self._json({"type": "pi_status", "robots": robots})
+            return
+
+        if self.path.startswith("/api/robots/") and self.path.endswith("/status"):
+            robot_id_str = self.path[len("/api/robots/") : -len("/status")]
+            robot_id = self._parse_robot_id(robot_id_str.strip("/"))
+            if robot_id is None:
+                self._json({"error": "invalid robot_id"}, HTTPStatus.BAD_REQUEST)
+                return
+            self._json(control_robot(robot_id, "status"))
+            return
+
+        self._serve_static(self.path)
+
+    def do_POST(self) -> None:
+        if self.path.startswith("/api/robots/") and self.path.endswith("/start"):
+            robot_id_str = self.path[len("/api/robots/") : -len("/start")]
+            robot_id = self._parse_robot_id(robot_id_str.strip("/"))
+            if robot_id is None:
+                self._json({"error": "invalid robot_id"}, HTTPStatus.BAD_REQUEST)
+                return
+            self._json(control_robot(robot_id, "start"))
+            return
+
+        if self.path.startswith("/api/robots/") and self.path.endswith("/stop"):
+            robot_id_str = self.path[len("/api/robots/") : -len("/stop")]
+            robot_id = self._parse_robot_id(robot_id_str.strip("/"))
+            if robot_id is None:
+                self._json({"error": "invalid robot_id"}, HTTPStatus.BAD_REQUEST)
+                return
+            self._json(control_robot(robot_id, "stop"))
+            return
+
+        self._json({"error": "Not Found"}, HTTPStatus.NOT_FOUND)
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A003
+        return
+
+
+def main() -> None:
+    server = ThreadingHTTPServer(("0.0.0.0", HTTP_PORT), Handler)
+    print(f"robot-manager listening on http://0.0.0.0:{HTTP_PORT}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/dev/robot-manager/web/app.js
+++ b/docker/dev/robot-manager/web/app.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const tableBody = document.getElementById('table-body');
+const connDot = document.getElementById('conn-dot');
+const connText = document.getElementById('conn-text');
+
+const runningCount = document.getElementById('running-count');
+const stoppedCount = document.getElementById('stopped-count');
+const offlineCount = document.getElementById('offline-count');
+
+const refreshBtn = document.getElementById('refresh-btn');
+const startAllBtn = document.getElementById('start-all-btn');
+const stopAllBtn = document.getElementById('stop-all-btn');
+const NUM_ROBOTS = 13;
+
+let robots = [];
+let busy = false;
+
+function offlineRobots() {
+  return Array.from({ length: NUM_ROBOTS }, (_, id) => ({
+    robot_id: id,
+    ip: `192.168.20.${100 + id}`,
+    success: false,
+    status: 'Offline',
+  }));
+}
+
+function classifyStatus(status) {
+  const s = (status || '').toLowerCase();
+  if (s.includes('run')) return 'running';
+  if (s.includes('stop')) return 'stopped';
+  if (s.includes('off')) return 'offline';
+  if (s.includes('error')) return 'error';
+  return 'offline';
+}
+
+function setConnected(ok) {
+  connDot.className = `dot ${ok ? 'ok' : 'ng'}`;
+  connText.textContent = ok ? 'connected' : 'disconnected';
+}
+
+function setBusy(v) {
+  busy = v;
+  refreshBtn.disabled = v;
+  startAllBtn.disabled = v;
+  stopAllBtn.disabled = v;
+}
+
+function renderSummary() {
+  let run = 0;
+  let stop = 0;
+  let off = 0;
+  for (const r of robots) {
+    const cls = classifyStatus(r.status);
+    if (cls === 'running') run++;
+    else if (cls === 'stopped') stop++;
+    else off++;
+  }
+  runningCount.textContent = String(run);
+  stoppedCount.textContent = String(stop);
+  offlineCount.textContent = String(off);
+}
+
+function rowHtml(robot) {
+  const cls = classifyStatus(robot.status);
+  return `
+    <tr>
+      <td>#${robot.robot_id}</td>
+      <td><span class="status ${cls}">${robot.status || 'Offline'}</span></td>
+      <td>${robot.ip || '--'}</td>
+      <td>
+        <button onclick="controlRobot(${robot.robot_id}, 'start')">Start</button>
+        <button class="danger" onclick="controlRobot(${robot.robot_id}, 'stop')">Stop</button>
+      </td>
+    </tr>`;
+}
+
+function renderTable() {
+  tableBody.innerHTML = robots.map(rowHtml).join('');
+  renderSummary();
+}
+
+async function fetchRobots() {
+  try {
+    const res = await fetch('/api/robots', { cache: 'no-store' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    robots = data.robots || [];
+    renderTable();
+    setConnected(true);
+  } catch (e) {
+    setConnected(false);
+    // 通信断時は前回値を残さず、即座に Offline 表示へフォールバックする
+    robots = offlineRobots();
+    renderTable();
+  }
+}
+
+async function controlRobot(robotId, command) {
+  if (busy) return;
+  setBusy(true);
+  try {
+    const res = await fetch(`/api/robots/${robotId}/${command}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    await fetchRobots();
+  } catch (e) {
+    setConnected(false);
+  } finally {
+    setBusy(false);
+  }
+}
+
+window.controlRobot = controlRobot;
+
+async function startAll() {
+  if (busy) return;
+  setBusy(true);
+  try {
+    await Promise.all(robots.map((r) => fetch(`/api/robots/${r.robot_id}/start`, { method: 'POST' })));
+    await fetchRobots();
+  } catch (e) {
+    setConnected(false);
+    robots = offlineRobots();
+    renderTable();
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function stopAll() {
+  if (busy) return;
+  if (!window.confirm('全ロボットを停止しますか？')) return;
+  setBusy(true);
+  try {
+    await Promise.all(robots.map((r) => fetch(`/api/robots/${r.robot_id}/stop`, { method: 'POST' })));
+    await fetchRobots();
+  } catch (e) {
+    setConnected(false);
+    robots = offlineRobots();
+    renderTable();
+  } finally {
+    setBusy(false);
+  }
+}
+
+refreshBtn.addEventListener('click', fetchRobots);
+startAllBtn.addEventListener('click', startAll);
+stopAllBtn.addEventListener('click', stopAll);
+
+robots = offlineRobots();
+renderTable();
+fetchRobots();
+setInterval(fetchRobots, 4000);

--- a/docker/dev/robot-manager/web/index.html
+++ b/docker/dev/robot-manager/web/index.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Robot Manager</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f8fb;
+      --card: #ffffff;
+      --text: #1f2937;
+      --muted: #6b7280;
+      --ok: #15803d;
+      --warn: #b45309;
+      --err: #b91c1c;
+      --line: #e5e7eb;
+      --btn: #2563eb;
+      --btn-danger: #dc2626;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Noto Sans JP", system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+    }
+    .container {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 20px 16px 36px;
+    }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    h1 { margin: 0; font-size: 1.25rem; }
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 16px;
+    }
+    button {
+      border: none;
+      border-radius: 8px;
+      padding: 8px 12px;
+      font-size: 0.9rem;
+      cursor: pointer;
+      color: white;
+      background: var(--btn);
+    }
+    button.danger { background: var(--btn-danger); }
+    button.secondary { background: #374151; }
+    button:disabled { opacity: 0.55; cursor: not-allowed; }
+    .card {
+      background: var(--card);
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      overflow: hidden;
+    }
+    table { width: 100%; border-collapse: collapse; }
+    th, td {
+      text-align: left;
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--line);
+      font-size: 0.92rem;
+      vertical-align: middle;
+    }
+    th { background: #f3f4f6; font-weight: 600; }
+    tr:last-child td { border-bottom: none; }
+    .status { font-weight: 700; }
+    .status.running { color: var(--ok); }
+    .status.stopped { color: var(--warn); }
+    .status.offline, .status.error { color: var(--err); }
+    .muted { color: var(--muted); font-size: 0.85rem; }
+    .summary {
+      display: flex;
+      gap: 18px;
+      flex-wrap: wrap;
+      font-size: 0.9rem;
+      margin-bottom: 10px;
+    }
+    .summary strong { margin-left: 4px; }
+    .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      display: inline-block;
+      margin-right: 6px;
+      background: #9ca3af;
+    }
+    .dot.ok { background: var(--ok); }
+    .dot.ng { background: var(--err); }
+    @media (max-width: 720px) {
+      th:nth-child(3), td:nth-child(3) { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1>Robot Manager (Standalone)</h1>
+      <div class="muted"><span id="conn-dot" class="dot"></span><span id="conn-text">connecting...</span></div>
+    </div>
+
+    <div class="summary">
+      <div>Running:<strong id="running-count">0</strong></div>
+      <div>Stopped:<strong id="stopped-count">0</strong></div>
+      <div>Offline:<strong id="offline-count">0</strong></div>
+    </div>
+
+    <div class="toolbar">
+      <button id="refresh-btn" class="secondary">Refresh</button>
+      <button id="start-all-btn">Start All</button>
+      <button id="stop-all-btn" class="danger">Stop All</button>
+    </div>
+
+    <div class="card">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Status</th>
+            <th>IP</th>
+            <th>Control</th>
+          </tr>
+        </thead>
+        <tbody id="table-body"></tbody>
+      </table>
+    </div>
+  </div>
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/docs/packages/crane_web_debugger.md
+++ b/docs/packages/crane_web_debugger.md
@@ -37,9 +37,18 @@ ROS 2とブラウザを接続するブリッジノード。
 
 ### Webフロントエンド
 
-- ロボット管理画面（PR #1247）
 - SVGビジュアライゼーション表示
 - デバッグUI統合ポータル
+
+## ロボット管理画面の分離
+
+`robot_manager` は ROS 非依存の独立アプリとして `docker/dev/robot-manager/`
+へ分離されました。`docker/dev/docker-compose.yaml` から
+`robot-manager` コンテナとして起動します。
+
+- URL: `http://localhost:8090`
+- 機能: Start/Stop/Status（Pi HTTP API経由）
+- ROSトピック由来の表示（world_model/control_targets等）は含みません
 
 ## 依存関係
 

--- a/scripts/docker-dev.sh
+++ b/scripts/docker-dev.sh
@@ -5,9 +5,9 @@
 #
 # Examples:
 #   ./scripts/docker-dev.sh           # sim環境 + ssl-log-recorder
-#   ./scripts/docker-dev.sh -d        # sim環境(バックグラウンド) + debug_tools + ssl-log-recorder
-#   ./scripts/docker-dev.sh --no-debug  # debug_toolsなし
-#   ./scripts/docker-dev.sh down      # 停止(debug_tools/ssl-log-recorderも停止)
+#   ./scripts/docker-dev.sh -d        # sim環境(バックグラウンド)
+#   ./scripts/docker-dev.sh --no-debug  # robot-managerなし
+#   ./scripts/docker-dev.sh down      # 停止
 
 set -e
 
@@ -17,11 +17,10 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
 COMPOSE_FILE="docker/dev/docker-compose.yaml"
-DEBUG_TOOLS_PID_FILE="/tmp/crane_debug_tools.pid"
 
 # 引数解析
 MODE="sim"
-ENABLE_DEBUG_TOOLS=true
+ENABLE_ROBOT_MANAGER=true
 DOCKER_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -35,7 +34,7 @@ while [[ $# -gt 0 ]]; do
         shift
         ;;
     --no-debug)
-        ENABLE_DEBUG_TOOLS=false
+        ENABLE_ROBOT_MANAGER=false
         shift
         ;;
     *)
@@ -81,55 +80,19 @@ detect_compose_command() {
     echo "up"
 }
 
-start_debug_tools() {
-    if [[ -f $DEBUG_TOOLS_PID_FILE ]]; then
-        local old_pid
-        old_pid=$(cat "$DEBUG_TOOLS_PID_FILE")
-        if kill -0 "$old_pid" 2>/dev/null; then
-            echo "debug_tools は既に起動中です (PID: $old_pid)"
-            return 0
-        fi
-    fi
-
-    echo "=== debug_tools を起動中 ==="
-    # ROS2環境をセットアップしてノードを起動
-    # shellcheck disable=SC1090,SC1091,SC2086
-    (
-        source /opt/ros/${ROS_DISTRO:-humble}/setup.bash
-        source "$REPO_ROOT/../../install/setup.bash" 2>/dev/null || true
-        ros2 run crane_debug_tools crane_websocket_server \
-            --ros-args -p port:=8090 -p websocket_port:=8091 &
-        echo $! >"$DEBUG_TOOLS_PID_FILE"
-    )
-    echo "debug_tools 起動完了 (HTTP: 8090, WebSocket: 8091)"
-}
-
-stop_debug_tools() {
-    if [[ -f $DEBUG_TOOLS_PID_FILE ]]; then
-        local pid
-        pid=$(cat "$DEBUG_TOOLS_PID_FILE")
-        if kill -0 "$pid" 2>/dev/null; then
-            echo "=== debug_tools を停止中 (PID: $pid) ==="
-            kill "$pid" 2>/dev/null || true
-            rm -f "$DEBUG_TOOLS_PID_FILE"
-        fi
-    fi
-}
-
 COMPOSE_COMMAND="$(detect_compose_command)"
-
-# downコマンドの場合はdebug_toolsも停止
-if [[ $COMPOSE_COMMAND == "down" ]]; then
-    stop_debug_tools
-fi
 
 echo "=== Docker開発環境 ==="
 echo "モード: $MODE"
-echo "debug_tools: $ENABLE_DEBUG_TOOLS"
+echo "robot-manager: $ENABLE_ROBOT_MANAGER"
 echo "compose command: $COMPOSE_COMMAND"
 echo "Compose file: $COMPOSE_FILE"
 echo "引数: ${DOCKER_ARGS[*]}"
 echo ""
+
+if [[ $ENABLE_ROBOT_MANAGER == "false" ]] && [[ $COMPOSE_COMMAND == "up" ]]; then
+    DOCKER_ARGS+=(--scale robot-manager=0)
+fi
 
 if [[ $MODE == "sim" ]]; then
     # シミュレーション環境(status-board有効)
@@ -137,9 +100,4 @@ if [[ $MODE == "sim" ]]; then
 else
     # 実機環境(Visionポート変更、status-board無効)
     VISION_PORT=10006 REFEREE_PORT=10003 TRACKER_PORT=10010 docker compose -f "$COMPOSE_FILE" "${DOCKER_ARGS[@]}"
-fi
-
-# バックグラウンド起動時のみdebug_toolsを起動
-if [[ $ENABLE_DEBUG_TOOLS == "true" ]] && [[ $COMPOSE_COMMAND == "up" ]] && [[ " ${DOCKER_ARGS[*]} " =~ " -d " ]]; then
-    start_debug_tools
 fi

--- a/scripts/start-debug-tools.sh
+++ b/scripts/start-debug-tools.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# debug_tools (crane_websocket_server) をバックグラウンドで起動するスクリプト
+# robot-manager コンテナを起動するスクリプト
 # Usage:
 #   ./scripts/start-debug-tools.sh
 
@@ -7,32 +7,11 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-DEBUG_TOOLS_PID_FILE="/tmp/crane_debug_tools.pid"
+COMPOSE_FILE="$REPO_ROOT/docker/dev/docker-compose.yaml"
 
-# 既に起動している場合はスキップ
-if [[ -f $DEBUG_TOOLS_PID_FILE ]]; then
-    old_pid=$(cat "$DEBUG_TOOLS_PID_FILE")
-    if kill -0 "$old_pid" 2>/dev/null; then
-        echo "debug_tools は既に起動中です (PID: $old_pid)"
-        exit 0
-    fi
-fi
-
-echo "=== debug_tools を起動中 ==="
-
-# ROS2環境をセットアップしてノードを起動
-# shellcheck disable=SC1090,SC1091,SC2086
-(
-    source /opt/ros/${ROS_DISTRO:-humble}/setup.bash
-    source "$REPO_ROOT/../../install/setup.bash" 2>/dev/null || true
-    ros2 run crane_debug_tools crane_websocket_server \
-        --ros-args -p port:=8090 -p websocket_port:=8091 &
-    echo $! >"$DEBUG_TOOLS_PID_FILE"
-)
-
-echo "debug_tools 起動完了"
-echo "  HTTP Server: http://localhost:8090"
-echo "  WebSocket: ws://localhost:8091"
-echo "  PID: $(cat $DEBUG_TOOLS_PID_FILE)"
+echo "=== robot-manager を起動中 ==="
+docker compose -f "$COMPOSE_FILE" up -d robot-manager
+echo "robot-manager 起動完了"
+echo "  URL: http://localhost:8090"
 echo ""
 echo "停止するには: ./scripts/stop-debug-tools.sh"

--- a/scripts/stop-debug-tools.sh
+++ b/scripts/stop-debug-tools.sh
@@ -1,41 +1,14 @@
 #!/bin/bash
-# debug_tools (crane_websocket_server) を停止するスクリプト
+# robot-manager コンテナを停止するスクリプト
 # Usage:
 #   ./scripts/stop-debug-tools.sh
 
 set -e
 
-DEBUG_TOOLS_PID_FILE="/tmp/crane_debug_tools.pid"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$REPO_ROOT/docker/dev/docker-compose.yaml"
 
-if [[ ! -f $DEBUG_TOOLS_PID_FILE ]]; then
-    echo "debug_tools は起動していません (PIDファイルが見つかりません)"
-    exit 0
-fi
-
-pid=$(cat "$DEBUG_TOOLS_PID_FILE")
-
-if ! kill -0 "$pid" 2>/dev/null; then
-    echo "debug_tools は既に停止しています (PID: $pid は存在しません)"
-    rm -f "$DEBUG_TOOLS_PID_FILE"
-    exit 0
-fi
-
-echo "=== debug_tools を停止中 (PID: $pid) ==="
-kill "$pid" 2>/dev/null || true
-
-# プロセスが完全に終了するまで待機(最大5秒)
-for _ in {1..10}; do
-    if ! kill -0 "$pid" 2>/dev/null; then
-        break
-    fi
-    sleep 0.5
-done
-
-# 強制終了が必要な場合
-if kill -0 "$pid" 2>/dev/null; then
-    echo "プロセスが終了しないため、強制終了します..."
-    kill -9 "$pid" 2>/dev/null || true
-fi
-
-rm -f "$DEBUG_TOOLS_PID_FILE"
-echo "debug_tools 停止完了"
+echo "=== robot-manager を停止中 ==="
+docker compose -f "$COMPOSE_FILE" stop robot-manager
+echo "robot-manager 停止完了"


### PR DESCRIPTION
## 概要

`crane_debug_tools` の ROS ノード（crane_websocket_server）を PID ファイルで管理していた方式を廃止し、ROS 非依存の `robot-manager` を Docker Compose サービスとして提供する形に移行します。

## 背景・根本原因

- 旧 debug_tools は ROSビルドが必要で、起動・停止の管理がPIDファイルベースで複雑だった
- robot-manager（Pi HTTP API経由でロボットの Start/Stop/Status を管理するWebアプリ）は ROS に依存しないため、独立した Docker コンテナとして運用するほうが適切

## 変更内容

- `docker/dev/docker-compose.yaml`: `robot-manager` サービスを追加（ポート8090、host network）
- `docker/dev/robot-manager/`: Dockerfile・Python サーバー・Webフロントエンドを新規追加
- `scripts/docker-dev.sh`: PIDベース管理を削除し、`--scale robot-manager=0` で無効化する方式に変更
- `scripts/start-debug-tools.sh` / `stop-debug-tools.sh`: `docker compose` コマンドに移行
- ドキュメント更新（docker/README.md, docker/dev/README.md, docs/packages/crane_web_debugger.md）