### PR TITLE
[設定]Claude commandsをCodex skillとして共用

### DIFF
--- a/.claude/commands/analyze-rosbag.md
+++ b/.claude/commands/analyze-rosbag.md
@@ -1,4 +1,5 @@
 ---
+name: analyze-rosbag
 description: "craneのrosbagを解析して試合状況・ロボット動作・異常を診断"
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "Agent"]
 ---

--- a/.claude/commands/rosbag-python-reference.md
+++ b/.claude/commands/rosbag-python-reference.md
@@ -1,3 +1,9 @@
+---
+name: rosbag-python-reference
+description: "crane_bag CLIで不足する低レベル項目のPython解析リファレンス"
+allowed-tools: ["Read", "Grep"]
+---
+
 # Crane Rosbag Python フィールドリファレンス
 
 crane_bag CLIでは取得できない低レベルな詳細が必要な場合に、直接MCAPを読んでPythonで解析する際のフィールドリファレンス。

--- a/.claude/commands/session-commit.md
+++ b/.claude/commands/session-commit.md
@@ -1,4 +1,5 @@
 ---
+name: session-commit
 description: "現在セッションの変更のみを選択してコミット＆PR作成（既存の無関係な変更を混入させない）"
 allowed-tools: ["Bash", "Read", "AskUserQuestion", "Glob", "Grep"]
 ---

--- a/.codex/skills/analyze-rosbag/SKILL.md
+++ b/.codex/skills/analyze-rosbag/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/analyze-rosbag.md

--- a/.codex/skills/rosbag-python-reference/SKILL.md
+++ b/.codex/skills/rosbag-python-reference/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/rosbag-python-reference.md

--- a/.codex/skills/session-commit/SKILL.md
+++ b/.codex/skills/session-commit/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/session-commit.md


### PR DESCRIPTION
## 概要
.claude/commands を正本として、Codex からも skill として再利用できるようにしました。

## 背景・根本原因
既存の .claude/commands は Claude 向け構造だったため、Codex の skill 要件（SKILL.md と name/description）を満たしていませんでした。

## 変更内容
- .claude/commands の 3 ファイルに Codex 用 frontmatter（name/description）を整備
- .codex/skills/<skill>/SKILL.md を .claude/commands/*.md へのシンボリックリンクとして追加
- コンテンツを重複コピーせず、1ソース運用に統一