### PR TITLE
[設定]docker devのポート競合を解消

### DIFF
--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     container_name: crane-robot-manager
     network_mode: host
     environment:
-      - HTTP_PORT=8090
+      - HTTP_PORT=8092
       - NUM_ROBOTS=13
       - ROBOT_IP_BASE=192.168.20.
       - ROBOT_IP_OFFSET=100


### PR DESCRIPTION
## 概要
crane_web_debugger と robot-manager のポート競合を解消するため、robot-manager 側の待受ポートを変更しました。

## 背景・根本原因
crane_web_debugger が 8090 を使用する一方で、docker/dev/docker-compose.yaml の robot-manager も HTTP_PORT=8090 だったため、同時起動時に競合していました。

## 変更内容
- docker/dev/docker-compose.yaml の robot-manager 環境変数を変更
- HTTP_PORT=8090 から HTTP_PORT=8092 へ更新
- crane_web_debugger 側の 8090 は維持
