### PR TITLE
fix: crane_web_debugger の静的配信で symlink を許可

### DIFF
--- a/crane_web_debugger/web_server/app.py
+++ b/crane_web_debugger/web_server/app.py
@@ -232,7 +232,11 @@ def create_app(web_root: Path) -> FastAPI:
     app.include_router(api)
 
     # Existing crane_web_debugger static site (portal, viewer, telemetry, ...)
-    app.mount("/", StaticFiles(directory=str(web_root), html=True), name="web-root")
+    app.mount(
+        "/",
+        StaticFiles(directory=str(web_root), html=True, follow_symlink=True),
+        name="web-root",
+    )
     return app
 
 


### PR DESCRIPTION
## 概要
crane_web_debugger の静的ファイル配信で、symlink-install 環境でも `/` と `/viewer.html` が 404 にならないよう修正しました。

## 背景・根本原因
`colcon build --symlink-install` では web 配下がシンボリックリンクになりますが、FastAPI の `StaticFiles` が symlink を辿らない設定だったため、ポータル系ページのみ 404 になっていました。

## 変更内容
- `crane_web_debugger/web_server/app.py` の web-root マウントで `follow_symlink=True` を追加
- `/` と `/viewer.html` を symlink 環境で正常配信できるように修正
