### PR TITLE
feat: Web デバッガーに /robot_commands トピックの受信処理を追加

### DIFF
--- a/crane_web_debugger/web/robot_test.js
+++ b/crane_web_debugger/web/robot_test.js
@@ -438,6 +438,9 @@ class RobotTestController {
             case 'world_model':
                 this.onWorldModel(data);
                 break;
+            case 'robot_commands':
+                this.onRobotCommands(data);
+                break;
             case 'control_targets':
                 this.onControlTargets(data);
                 break;
@@ -490,17 +493,19 @@ class RobotTestController {
         const cmd = data.commands.find(c => c.robot_id === this.selectedRobotId);
         if (!cmd) return;
 
-        // velocity_plan_trace から速度ノルムを取得
-        let cmdSpeed = null;
-        if (cmd.velocity_plan_trace && cmd.velocity_plan_trace.plan_points?.length > 0) {
-            const pt = cmd.velocity_plan_trace.plan_points[0];
-            const vx = pt.predicted_vel_x ?? 0;
-            const vy = pt.predicted_vel_y ?? 0;
-            cmdSpeed = Math.sqrt(vx * vx + vy * vy);
-        }
-        if (cmdSpeed !== null) {
-            this._pushChartPoint('cmd', cmdSpeed);
-        }
+        // backward compatibility: /control_targets が来る環境向けのフォールバック
+        const cmdSpeed = cmd.polar_velocity_target_mode?.target_velocity_r;
+        if (Number.isFinite(cmdSpeed)) this._pushChartPoint('cmd', cmdSpeed);
+    }
+
+    onRobotCommands(data) {
+        if (!data.commands || this.selectedRobotId === null) return;
+        const cmd = data.commands.find(c => c.robot_id === this.selectedRobotId);
+        if (!cmd) return;
+
+        // /robot_commands の target_velocity_r を Cmd Speed として表示
+        const cmdSpeed = cmd.polar_velocity_target_mode?.target_velocity_r;
+        if (Number.isFinite(cmdSpeed)) this._pushChartPoint('cmd', cmdSpeed);
     }
 
     onRobotFeedback(data) {


### PR DESCRIPTION
## 概要
Web デバッガーの Cmd Speed グラフが `/robot_commands` トピックから `target_velocity_r` を直接取得できるようにした。

## 背景・根本原因
従来は `/control_targets` トピックの `velocity_plan_trace` から速度を取得していたが、`/robot_commands` トピックの `polar_velocity_target_mode.target_velocity_r` を直接利用する方が適切なため変更。

## 変更内容
- `/robot_commands` トピックを受信する `onRobotCommands` ハンドラを新規追加
- メッセージルーティングに `robot_commands` ケースを追加
- `onControlTargets` は後方互換フォールバックとして `polar_velocity_target_mode?.target_velocity_r` を使用するよう変更

<img width="560" height="144" alt="image" src="https://github.com/user-attachments/assets/ab6859e6-116c-4f09-ba0f-18d99558d414" />
