### PR TITLE
fix: PAバイパスサイド選択に到達可能性チェックを追加し、HALT時スキップを修正

### DIFF
--- a/crane_local_planner/include/crane_local_planner/penalty_avoidance_helper.hpp
+++ b/crane_local_planner/include/crane_local_planner/penalty_avoidance_helper.hpp
@@ -26,35 +26,73 @@ struct PenaltyBypassDecision
 {
   bool crossing_detected = false;
   bool target_overridden = false;
-  bool used_locked_side = false;
   PenaltyBypassSide selected_side = PenaltyBypassSide::TOP;
   Point waypoint = Point::Zero();
   double top_cost = 0.0;
   double bottom_cost = 0.0;
 };
 
+inline auto intersectsSegmentAABB(const Point & a, const Point & b, const Box & box) -> bool
+{
+  const double xmin = std::min(box.min_corner().x(), box.max_corner().x());
+  const double xmax = std::max(box.min_corner().x(), box.max_corner().x());
+  const double ymin = std::min(box.min_corner().y(), box.max_corner().y());
+  const double ymax = std::max(box.min_corner().y(), box.max_corner().y());
+
+  auto inside = [&](const Point & p) {
+    return xmin <= p.x() && p.x() <= xmax && ymin <= p.y() && p.y() <= ymax;
+  };
+  if (inside(a) || inside(b)) {
+    return true;
+  }
+
+  const double dx = b.x() - a.x();
+  const double dy = b.y() - a.y();
+  double t0 = 0.0;
+  double t1 = 1.0;
+  constexpr double EPS = 1e-9;
+
+  auto clip_axis = [&](double p, double q_min, double q_max) {
+    if (std::abs(p) < EPS) {
+      return q_min <= 0.0 && 0.0 <= q_max;
+    }
+    const double t_min = q_min / p;
+    const double t_max = q_max / p;
+    const double t_enter = std::min(t_min, t_max);
+    const double t_exit = std::max(t_min, t_max);
+    t0 = std::max(t0, t_enter);
+    t1 = std::min(t1, t_exit);
+    return t0 <= t1;
+  };
+
+  if (!clip_axis(dx, xmin - a.x(), xmax - a.x())) return false;
+  if (!clip_axis(dy, ymin - a.y(), ymax - a.y())) return false;
+  return true;
+}
+
 inline auto computePenaltyBypassDecision(
   const Point & current_pos, const Point & target_pos, const Box & penalty_area,
   const Point & goal_pos, const Point & penalty_area_size, double penalty_area_offset,
-  double surrounding_offset, const std::optional<PenaltyBypassSide> & locked_side,
-  double side_switch_margin, bool force_waypoint_on_crossing) -> PenaltyBypassDecision
+  double surrounding_offset, bool force_waypoint_on_crossing) -> PenaltyBypassDecision
 {
+  (void)penalty_area_size;
   PenaltyBypassDecision decision;
   Box expanded = penalty_area;
   expanded.min_corner() -= Point(penalty_area_offset, penalty_area_offset);
   expanded.max_corner() += Point(penalty_area_offset, penalty_area_offset);
 
-  const Segment move_line(current_pos, target_pos);
-  if (!bg::intersects(move_line, expanded)) {
+  if (!intersectsSegmentAABB(current_pos, target_pos, expanded)) {
     return decision;
   }
 
   decision.crossing_detected = true;
 
-  const double x_offset = std::copysign(penalty_area_size.x() + surrounding_offset, -goal_pos.x());
-  const double half_height = penalty_area_size.y() * 0.5 + surrounding_offset;
-  const Point top_corner = goal_pos + Point(x_offset, half_height);
-  const Point bottom_corner = goal_pos + Point(x_offset, -half_height);
+  // Waypoint must be outside the expanded penalty area to avoid getting
+  // re-overridden by the same crossing logic on the next cycle.
+  const double bypass_x = (goal_pos.x() < 0.0) ? (expanded.max_corner().x() + surrounding_offset)
+                                               : (expanded.min_corner().x() - surrounding_offset);
+  const Point top_corner(bypass_x, expanded.max_corner().y() + surrounding_offset);
+  const Point bottom_corner(bypass_x, expanded.min_corner().y() - surrounding_offset);
 
   decision.top_cost = (top_corner - current_pos).norm() + (target_pos - top_corner).norm();
   decision.bottom_cost = (bottom_corner - current_pos).norm() + (target_pos - bottom_corner).norm();
@@ -62,13 +100,18 @@ inline auto computePenaltyBypassDecision(
   PenaltyBypassSide selected = (decision.top_cost <= decision.bottom_cost)
                                  ? PenaltyBypassSide::TOP
                                  : PenaltyBypassSide::BOTTOM;
-  if (locked_side.has_value()) {
-    const double alternative_margin = std::abs(decision.top_cost - decision.bottom_cost);
-    if (alternative_margin < side_switch_margin) {
-      selected = locked_side.value();
-      decision.used_locked_side = true;
-    }
+
+  // If the waypoint on the selected side would still require crossing the PA to reach the target,
+  // prefer the other side (which avoids the re-crossing).
+  const Point selected_wp = (selected == PenaltyBypassSide::TOP) ? top_corner : bottom_corner;
+  const Point other_wp = (selected == PenaltyBypassSide::TOP) ? bottom_corner : top_corner;
+  if (
+    intersectsSegmentAABB(selected_wp, target_pos, expanded) &&
+    !intersectsSegmentAABB(other_wp, target_pos, expanded)) {
+    selected =
+      (selected == PenaltyBypassSide::TOP) ? PenaltyBypassSide::BOTTOM : PenaltyBypassSide::TOP;
   }
+
   decision.selected_side = selected;
   decision.waypoint = selected == PenaltyBypassSide::TOP ? top_corner : bottom_corner;
   decision.target_overridden = force_waypoint_on_crossing;

--- a/crane_local_planner/include/crane_local_planner/penalty_avoidance_helper.hpp
+++ b/crane_local_planner/include/crane_local_planner/penalty_avoidance_helper.hpp
@@ -87,8 +87,7 @@ inline auto computePenaltyBypassDecision(
 
   decision.crossing_detected = true;
 
-  // Waypoint must be outside the expanded penalty area to avoid getting
-  // re-overridden by the same crossing logic on the next cycle.
+  // ウェイポイントは拡張PAの外側に配置し、次サイクルで同じ横断判定に再捕捉されないようにする
   const double bypass_x = (goal_pos.x() < 0.0) ? (expanded.max_corner().x() + surrounding_offset)
                                                : (expanded.min_corner().x() - surrounding_offset);
   const Point top_corner(bypass_x, expanded.max_corner().y() + surrounding_offset);
@@ -100,13 +99,13 @@ inline auto computePenaltyBypassDecision(
   const bool top_reachable = !intersectsSegmentAABB(current_pos, top_corner, expanded);
   const bool bottom_reachable = !intersectsSegmentAABB(current_pos, bottom_corner, expanded);
 
-  // Short-circuit: skip target-clearance check if waypoint is unreachable.
+  // 短絡評価: ウェイポイントが到達不可なら目標地点へのクリアランスチェックをスキップ
   const bool top_fully_good =
     top_reachable && !intersectsSegmentAABB(top_corner, target_pos, expanded);
   const bool bottom_fully_good =
     bottom_reachable && !intersectsSegmentAABB(bottom_corner, target_pos, expanded);
 
-  // Priority: fully_good (2) > reachable intermediate (1) > neither (0); tie-break by cost.
+  // 優先度: fully_good(2) > 到達可能な中間WP(1) > どちらでもない(0)、同スコアはコストで比較
   auto side_score = [](bool fully_good, bool reachable, double cost) {
     return std::make_pair(fully_good ? 2 : (reachable ? 1 : 0), -cost);
   };

--- a/crane_local_planner/include/crane_local_planner/penalty_avoidance_helper.hpp
+++ b/crane_local_planner/include/crane_local_planner/penalty_avoidance_helper.hpp
@@ -97,20 +97,24 @@ inline auto computePenaltyBypassDecision(
   decision.top_cost = (top_corner - current_pos).norm() + (target_pos - top_corner).norm();
   decision.bottom_cost = (bottom_corner - current_pos).norm() + (target_pos - bottom_corner).norm();
 
-  PenaltyBypassSide selected = (decision.top_cost <= decision.bottom_cost)
-                                 ? PenaltyBypassSide::TOP
-                                 : PenaltyBypassSide::BOTTOM;
+  const bool top_reachable = !intersectsSegmentAABB(current_pos, top_corner, expanded);
+  const bool bottom_reachable = !intersectsSegmentAABB(current_pos, bottom_corner, expanded);
 
-  // If the waypoint on the selected side would still require crossing the PA to reach the target,
-  // prefer the other side (which avoids the re-crossing).
-  const Point selected_wp = (selected == PenaltyBypassSide::TOP) ? top_corner : bottom_corner;
-  const Point other_wp = (selected == PenaltyBypassSide::TOP) ? bottom_corner : top_corner;
-  if (
-    intersectsSegmentAABB(selected_wp, target_pos, expanded) &&
-    !intersectsSegmentAABB(other_wp, target_pos, expanded)) {
-    selected =
-      (selected == PenaltyBypassSide::TOP) ? PenaltyBypassSide::BOTTOM : PenaltyBypassSide::TOP;
-  }
+  // Short-circuit: skip target-clearance check if waypoint is unreachable.
+  const bool top_fully_good =
+    top_reachable && !intersectsSegmentAABB(top_corner, target_pos, expanded);
+  const bool bottom_fully_good =
+    bottom_reachable && !intersectsSegmentAABB(bottom_corner, target_pos, expanded);
+
+  // Priority: fully_good (2) > reachable intermediate (1) > neither (0); tie-break by cost.
+  auto side_score = [](bool fully_good, bool reachable, double cost) {
+    return std::make_pair(fully_good ? 2 : (reachable ? 1 : 0), -cost);
+  };
+  const PenaltyBypassSide selected =
+    (side_score(top_fully_good, top_reachable, decision.top_cost) >=
+     side_score(bottom_fully_good, bottom_reachable, decision.bottom_cost))
+      ? PenaltyBypassSide::TOP
+      : PenaltyBypassSide::BOTTOM;
 
   decision.selected_side = selected;
   decision.waypoint = selected == PenaltyBypassSide::TOP ? top_corner : bottom_corner;

--- a/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
@@ -9,7 +9,6 @@
 
 #include <rvo2_vendor/RVO/RVO.h>
 
-#include <chrono>
 #include <crane_comm/parameter_with_event.hpp>
 #include <crane_msg_wrappers/velocity_plan_tracker.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
@@ -18,7 +17,6 @@
 #include <crane_physics/pid_controller.hpp>
 #include <memory>
 #include <optional>
-#include <unordered_map>
 
 #include "penalty_avoidance_helper.hpp"
 #include "planner_base.hpp"
@@ -179,19 +177,10 @@ private:
   double PENALTY_AREA_OFFSET = 0.1;       // ペナルティエリア判定マージン [m]（グローバル回避用）
   double PENALTY_AREA_OFFSET_STOP = 0.3;  // ペナルティエリア判定マージン [m]（STOP時）
   double PENALTY_AREA_SURROUNDING_OFFSET = 0.2;         // 角回避の余白 [m]
-  double PENALTY_AREA_SIDE_LOCK_SECONDS = 0.6;          // 回避側の固定時間 [s]
-  double PENALTY_AREA_SIDE_SWITCH_MARGIN = 0.25;        // 切替に必要な距離差 [m]
   bool PENALTY_AREA_FORCE_WAYPOINT_ON_CROSSING = true;  // 横断時に強制迂回
   float PENALTY_AREA_TIME_HORIZON_OBST = 0.5f;          // RVO2障害物回避の時間ホライズン [s]
 
   bool penalty_area_obstacles_initialized = false;
-
-  struct PenaltyBypassLockState
-  {
-    PenaltyBypassSide side = PenaltyBypassSide::TOP;
-    std::chrono::steady_clock::time_point expires_at = std::chrono::steady_clock::time_point::min();
-  };
-  mutable std::unordered_map<uint16_t, PenaltyBypassLockState> penalty_bypass_lock_states_;
 
   // 加速度は減速度の何倍にするかという係数
   ParameterWithEvent<double> acceleration_factor;

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -507,9 +507,7 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
     auto robot = world_model->getOurRobot(command.robot_id);
     drawRobotRadiusWithSpeed(visualizer, robot->pose.pos, radius, vel, "yellow");
 
-    if (
-      referee_command != robocup_ssl_msgs::msg::RefereeCommand::HALT &&
-      ctx.run_target_adjustments) {
+    if (ctx.run_target_adjustments) {
       applyTargetAdjustmentPipeline(ctx, command);
     } else if (!command.position_target_mode.empty()) {
       auto & pos_mode = command.position_target_mode.front();
@@ -661,9 +659,7 @@ auto RVO2Planner::overrideTargetPosition(crane_msgs::msg::RobotCommands & msg) -
       continue;
     }
 
-    if (
-      referee_command != robocup_ssl_msgs::msg::RefereeCommand::HALT &&
-      ctx.run_target_adjustments) {
+    if (ctx.run_target_adjustments) {
       applyTargetAdjustmentPipeline(ctx, command);
     } else if (!command.position_target_mode.empty()) {
       auto & pos_mode = command.position_target_mode.front();

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -78,11 +78,6 @@ RVO2Planner::RVO2Planner(rclcpp::Node & node)
   node.declare_parameter("penalty_area_surrounding_offset", PENALTY_AREA_SURROUNDING_OFFSET);
   PENALTY_AREA_SURROUNDING_OFFSET =
     node.get_parameter("penalty_area_surrounding_offset").as_double();
-  node.declare_parameter("penalty_area_side_lock_seconds", PENALTY_AREA_SIDE_LOCK_SECONDS);
-  PENALTY_AREA_SIDE_LOCK_SECONDS = node.get_parameter("penalty_area_side_lock_seconds").as_double();
-  node.declare_parameter("penalty_area_side_switch_margin", PENALTY_AREA_SIDE_SWITCH_MARGIN);
-  PENALTY_AREA_SIDE_SWITCH_MARGIN =
-    node.get_parameter("penalty_area_side_switch_margin").as_double();
   node.declare_parameter(
     "penalty_area_force_waypoint_on_crossing", PENALTY_AREA_FORCE_WAYPOINT_ON_CROSSING);
   PENALTY_AREA_FORCE_WAYPOINT_ON_CROSSING =
@@ -159,7 +154,6 @@ auto RVO2Planner::initializePlanningFactors(crane_msgs::msg::RobotCommand & comm
   addOrUpdatePlanningFactor(command, "RVO2AdjustPenaltyArea", "0");
   addOrUpdatePlanningFactor(command, "RVO2PenaltyCrossingDetected", "0");
   addOrUpdatePlanningFactor(command, "RVO2PenaltyBypassSide", "NONE");
-  addOrUpdatePlanningFactor(command, "RVO2PenaltySideLock", "NONE");
   addOrUpdatePlanningFactor(command, "RVO2AdjustBallAvoidance", "0");
   addOrUpdatePlanningFactor(command, "RVO2AdjustPlacementAvoidance", "0");
   addOrUpdatePlanningFactor(command, "RVO2TargetFallback", "NONE");
@@ -739,23 +733,8 @@ auto RVO2Planner::adjustForPenaltyAreaAvoidance(
       needsExpandedPenaltyAreaOffset(world_model->getMsg().play_situation.command.value)
         ? PENALTY_AREA_OFFSET_STOP
         : PENALTY_AREA_OFFSET;
-    const auto now = std::chrono::steady_clock::now();
 
-    // 期限切れロック状態を掃除
-    for (auto it = penalty_bypass_lock_states_.begin(); it != penalty_bypass_lock_states_.end();) {
-      if (it->second.expires_at < now) {
-        it = penalty_bypass_lock_states_.erase(it);
-      } else {
-        ++it;
-      }
-    }
-
-    auto lock_key_for = [&](bool is_our_area) -> uint16_t {
-      return static_cast<uint16_t>(command.robot_id) * 2 + (is_our_area ? 0U : 1U);
-    };
-
-    auto avoidPenaltyArea = [&](
-                              const Box & penalty_area, const Point & goal_pos, bool is_our_area) {
+    auto avoidPenaltyArea = [&](const Box & penalty_area, const Point & goal_pos) {
       constexpr int MAX_ITERATIONS = 100;
       if (isInBox(penalty_area, current_pos, penalty_area_offset)) {
         if (std::abs(current_pos.x()) > world_model->fieldSize().x() / 2.0) {
@@ -785,38 +764,26 @@ auto RVO2Planner::adjustForPenaltyAreaAvoidance(
           target_pos += (target_pos - goal_pos).normalized() * 0.05;
         }
       }
-      const auto key = lock_key_for(is_our_area);
-      std::optional<PenaltyBypassSide> locked_side = std::nullopt;
-      if (
-        auto it = penalty_bypass_lock_states_.find(key); it != penalty_bypass_lock_states_.end()) {
-        locked_side = it->second.side;
-      }
 
       const auto decision = computePenaltyBypassDecision(
         current_pos, target_pos, penalty_area, goal_pos, world_model->penaltyAreaSize(),
-        penalty_area_offset, PENALTY_AREA_SURROUNDING_OFFSET, locked_side,
-        PENALTY_AREA_SIDE_SWITCH_MARGIN, PENALTY_AREA_FORCE_WAYPOINT_ON_CROSSING);
+        penalty_area_offset, PENALTY_AREA_SURROUNDING_OFFSET,
+        PENALTY_AREA_FORCE_WAYPOINT_ON_CROSSING);
       if (!decision.crossing_detected) {
         return;
       }
 
       addOrUpdatePlanningFactor(command, "RVO2PenaltyCrossingDetected", "1");
       addOrUpdatePlanningFactor(command, "RVO2PenaltyBypassSide", toString(decision.selected_side));
-      addOrUpdatePlanningFactor(
-        command, "RVO2PenaltySideLock", decision.used_locked_side ? "LOCKED" : "SWITCHED");
 
-      penalty_bypass_lock_states_[key] = {
-        decision.selected_side,
-        now + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-                std::chrono::duration<double>(PENALTY_AREA_SIDE_LOCK_SECONDS))};
       if (decision.target_overridden) {
         target_pos = decision.waypoint;
       }
     };
 
     // 自陣と敵陣の両方のペナルティエリアを回避
-    avoidPenaltyArea(world_model->getOurPenaltyArea(), world_model->getOurGoalCenter(), true);
-    avoidPenaltyArea(world_model->getTheirPenaltyArea(), world_model->getTheirGoalCenter(), false);
+    avoidPenaltyArea(world_model->getOurPenaltyArea(), world_model->getOurGoalCenter());
+    avoidPenaltyArea(world_model->getTheirPenaltyArea(), world_model->getTheirGoalCenter());
   }
 }
 

--- a/crane_local_planner/test/test_penalty_avoidance_helper.cpp
+++ b/crane_local_planner/test/test_penalty_avoidance_helper.cpp
@@ -28,8 +28,7 @@ auto paSize() -> Point { return Point(PA_DEPTH, PA_HALF_WIDTH * 2.0); }
 TEST(PenaltyAvoidanceHelperTest, NoCrossingDoesNotOverrideTarget)
 {
   const auto decision = computePenaltyBypassDecision(
-    Point(-2.0, 2.5), Point(-1.0, 2.5), makeOurPA(), ourGoal(), paSize(), 0.1, 0.2, std::nullopt,
-    0.25, true);
+    Point(-2.0, 2.5), Point(-1.0, 2.5), makeOurPA(), ourGoal(), paSize(), 0.1, 0.2, true);
   EXPECT_FALSE(decision.crossing_detected);
   EXPECT_FALSE(decision.target_overridden);
 }
@@ -37,51 +36,90 @@ TEST(PenaltyAvoidanceHelperTest, NoCrossingDoesNotOverrideTarget)
 TEST(PenaltyAvoidanceHelperTest, CrossingOverridesTargetWithWaypoint)
 {
   const auto decision = computePenaltyBypassDecision(
-    Point(-3.0, 0.0), Point(-5.9, 0.0), makeOurPA(), ourGoal(), paSize(), 0.1, 0.2, std::nullopt,
-    0.25, true);
+    Point(-3.0, 0.0), Point(-5.9, 0.0), makeOurPA(), ourGoal(), paSize(), 0.1, 0.2, true);
   EXPECT_TRUE(decision.crossing_detected);
   EXPECT_TRUE(decision.target_overridden);
-  EXPECT_NEAR(decision.waypoint.x(), -4.0, 1e-6);
-  EXPECT_NEAR(std::abs(decision.waypoint.y()), 2.0, 1e-6);
+  EXPECT_NEAR(decision.waypoint.x(), -3.9, 1e-6);
+  EXPECT_NEAR(std::abs(decision.waypoint.y()), 2.1, 1e-6);
 }
 
-TEST(PenaltyAvoidanceHelperTest, LockedSideIsKeptWithinSwitchMargin)
+TEST(PenaltyAvoidanceHelperTest, OutsideBypassWaypointDoesNotReTriggerCrossing)
 {
-  const auto decision = computePenaltyBypassDecision(
-    Point(-3.5, 0.0), Point(-5.0, 0.0), makeOurPA(), ourGoal(), paSize(), 0.1, 0.2,
-    PenaltyBypassSide::BOTTOM, 5.0, true);
-  EXPECT_TRUE(decision.crossing_detected);
-  EXPECT_EQ(decision.selected_side, PenaltyBypassSide::BOTTOM);
-  EXPECT_TRUE(decision.used_locked_side);
-}
-
-TEST(PenaltyAvoidanceHelperTest, BetterSideOverridesLockWhenGapIsLarge)
-{
-  const auto decision = computePenaltyBypassDecision(
-    Point(-5.5, 2.9), Point(-5.7, -2.9), makeOurPA(), ourGoal(), paSize(), 0.1, 0.2,
-    PenaltyBypassSide::BOTTOM, 0.1, true);
-  EXPECT_TRUE(decision.crossing_detected);
-  EXPECT_FALSE(decision.used_locked_side);
-  EXPECT_EQ(decision.selected_side, PenaltyBypassSide::TOP);
-}
-
-TEST(PenaltyAvoidanceHelperTest, LockPreventsSideOscillationForNearSymmetricTargets)
-{
-  // 1回目: 自動選択で側を確定
+  // 1st step: crossing target is overridden to a bypass waypoint (bottom side).
   const auto first = computePenaltyBypassDecision(
-    Point(-3.4, 0.0), Point(-5.6, 0.08), makeOurPA(), ourGoal(), paSize(), 0.1, 0.2, std::nullopt,
-    0.25, true);
+    Point(-3.0, 0.0), Point(-5.9, -0.6), makeOurPA(), ourGoal(), paSize(), 0.1, 0.2, true);
   ASSERT_TRUE(first.crossing_detected);
+  ASSERT_TRUE(first.target_overridden);
+  ASSERT_EQ(first.selected_side, PenaltyBypassSide::BOTTOM);
 
-  // 2回目以降: 目標yが微小に揺れるケースでもロック側を維持できることを確認
-  for (const double target_y : {0.10, -0.10, 0.06, -0.06, 0.02, -0.02}) {
-    const auto d = computePenaltyBypassDecision(
-      Point(-3.4, 0.0), Point(-5.6, target_y), makeOurPA(), ourGoal(), paSize(), 0.1, 0.2,
-      first.selected_side, 0.25, true);
-    EXPECT_TRUE(d.crossing_detected);
-    EXPECT_EQ(d.selected_side, first.selected_side);
-    EXPECT_TRUE(d.used_locked_side);
-  }
+  // 2nd step: once robot is on the bypass waypoint, heading to opposite-side outside target
+  // should not be considered as crossing anymore.
+  const auto second = computePenaltyBypassDecision(
+    first.waypoint, Point(-3.9, 2.5), makeOurPA(), ourGoal(), paSize(), 0.1, 0.2, true);
+  EXPECT_FALSE(second.crossing_detected);
+  EXPECT_FALSE(second.target_overridden);
+}
+
+TEST(PenaltyAvoidanceHelperTest, VerticalSegmentThroughPenaltyIsDetectedAsCrossing)
+{
+  const auto decision = computePenaltyBypassDecision(
+    Point(-4.95, -3.61), Point(-4.75, 3.08), makeOurPA(), ourGoal(), paSize(), 0.3, 0.2, true);
+  EXPECT_TRUE(decision.crossing_detected);
+  EXPECT_TRUE(decision.target_overridden);
+}
+
+// 再横断チェック: ターゲットがPA内x範囲でPA上方にある場合、TOP側が選択される
+// (コスト最小はBOTTOMだがBOTTOMからターゲットへの経路がPAを再横断するため)
+TEST(PenaltyAvoidanceHelperTest, ReCrossingCheckSelectsCorrectSideWhenTargetIsAbovePA)
+{
+  // ターゲット: PAのx範囲内(x=-4.95)、y上方(3.08) → PA再横断が起きるケース
+  // ロボット: PA下方(-3.61) → コストだけならBOTTOMが安い可能性
+  const auto decision = computePenaltyBypassDecision(
+    Point(-4.95, -3.61), Point(-4.75, 3.08), makeOurPA(), ourGoal(), paSize(), 0.3, 0.2, true);
+  ASSERT_TRUE(decision.crossing_detected);
+  // ウェイポイントからターゲットへの経路がPAを再横断しないことを確認
+  Box expanded = makeOurPA();
+  expanded.min_corner() -= Point(0.3, 0.3);
+  expanded.max_corner() += Point(0.3, 0.3);
+  EXPECT_FALSE(intersectsSegmentAABB(decision.waypoint, Point(-4.75, 3.08), expanded));
+}
+
+// 再横断チェック: ロボットPA上方・ターゲットPA下方 → BOTTOM側が選択される
+TEST(PenaltyAvoidanceHelperTest, ReCrossingCheckSelectsCorrectSideWhenTargetIsBelowPA)
+{
+  const auto decision = computePenaltyBypassDecision(
+    Point(-4.75, 3.08), Point(-4.95, -3.61), makeOurPA(), ourGoal(), paSize(), 0.3, 0.2, true);
+  ASSERT_TRUE(decision.crossing_detected);
+  Box expanded = makeOurPA();
+  expanded.min_corner() -= Point(0.3, 0.3);
+  expanded.max_corner() += Point(0.3, 0.3);
+  EXPECT_FALSE(intersectsSegmentAABB(decision.waypoint, Point(-4.95, -3.61), expanded));
+}
+
+// rosbagシナリオの再現: 味方PA(xright側)での同等ケース
+// ロボット(5.318, -3.763)からターゲット(5.194, 3.243)へ横断
+// PAをゴール右側として設定、選択ウェイポイントが再横断しないことを確認
+TEST(PenaltyAvoidanceHelperTest, RosbagScenario_RobotBelowPA_TargetAbovePA)
+{
+  // 味方PA: x=[4.2, 6.0], y=[-1.8, 1.8]、ゴール=(6.0, 0)
+  const Box our_pa(Point(4.2, -1.8), Point(6.0, 1.8));
+  const Point goal(6.0, 0.0);
+  const Point pa_size(1.8, 3.6);
+
+  const auto decision = computePenaltyBypassDecision(
+    Point(5.318, -3.763), Point(5.194, 3.243), our_pa, goal, pa_size, 0.3, 0.2, true);
+
+  ASSERT_TRUE(decision.crossing_detected);
+  ASSERT_TRUE(decision.target_overridden);
+
+  // ウェイポイントからターゲットへの経路がPAを再横断しないこと
+  Box expanded = our_pa;
+  expanded.min_corner() -= Point(0.3, 0.3);
+  expanded.max_corner() += Point(0.3, 0.3);
+  EXPECT_FALSE(intersectsSegmentAABB(decision.waypoint, Point(5.194, 3.243), expanded));
+
+  // ターゲットがPA上方なのでTOP側が選択されること
+  EXPECT_EQ(decision.selected_side, PenaltyBypassSide::TOP);
 }
 
 }  // namespace crane

--- a/crane_local_planner/test/test_penalty_avoidance_helper.cpp
+++ b/crane_local_planner/test/test_penalty_avoidance_helper.cpp
@@ -68,58 +68,82 @@ TEST(PenaltyAvoidanceHelperTest, VerticalSegmentThroughPenaltyIsDetectedAsCrossi
   EXPECT_TRUE(decision.target_overridden);
 }
 
-// 再横断チェック: ターゲットがPA内x範囲でPA上方にある場合、TOP側が選択される
-// (コスト最小はBOTTOMだがBOTTOMからターゲットへの経路がPAを再横断するため)
-TEST(PenaltyAvoidanceHelperTest, ReCrossingCheckSelectsCorrectSideWhenTargetIsAbovePA)
+// 到達可能性チェック: ロボットPA下方・ターゲットPA上方の2ステップルーティング
+// Step1: current→TOP はPA横断あり(到達不可)→ BOTTOM を中間ウェイポイントとして選択
+// Step2: BOTTOMウェイポイントから TOP fully_good → TOP 選択でターゲットへ到達
+TEST(PenaltyAvoidanceHelperTest, ReachabilityCheckSelectsBOTTOMWhenTargetIsAbovePA)
 {
-  // ターゲット: PAのx範囲内(x=-4.95)、y上方(3.08) → PA再横断が起きるケース
-  // ロボット: PA下方(-3.61) → コストだけならBOTTOMが安い可能性
-  const auto decision = computePenaltyBypassDecision(
+  Box expanded = makeOurPA();
+  expanded.min_corner() -= Point(0.3, 0.3);
+  expanded.max_corner() += Point(0.3, 0.3);
+
+  const auto step1 = computePenaltyBypassDecision(
     Point(-4.95, -3.61), Point(-4.75, 3.08), makeOurPA(), ourGoal(), paSize(), 0.3, 0.2, true);
-  ASSERT_TRUE(decision.crossing_detected);
-  // ウェイポイントからターゲットへの経路がPAを再横断しないことを確認
-  Box expanded = makeOurPA();
-  expanded.min_corner() -= Point(0.3, 0.3);
-  expanded.max_corner() += Point(0.3, 0.3);
-  EXPECT_FALSE(intersectsSegmentAABB(decision.waypoint, Point(-4.75, 3.08), expanded));
+  ASSERT_TRUE(step1.crossing_detected);
+  EXPECT_EQ(step1.selected_side, PenaltyBypassSide::BOTTOM);
+  // current → BOTTOM ウェイポイントは PA を横断しない
+  EXPECT_FALSE(intersectsSegmentAABB(Point(-4.95, -3.61), step1.waypoint, expanded));
+
+  // Step 2: BOTTOM ウェイポイントから再計画 → TOP fully_good → TOP 選択
+  const auto step2 = computePenaltyBypassDecision(
+    step1.waypoint, Point(-4.75, 3.08), makeOurPA(), ourGoal(), paSize(), 0.3, 0.2, true);
+  ASSERT_TRUE(step2.crossing_detected);
+  EXPECT_EQ(step2.selected_side, PenaltyBypassSide::TOP);
+  EXPECT_FALSE(intersectsSegmentAABB(step2.waypoint, Point(-4.75, 3.08), expanded));
 }
 
-// 再横断チェック: ロボットPA上方・ターゲットPA下方 → BOTTOM側が選択される
-TEST(PenaltyAvoidanceHelperTest, ReCrossingCheckSelectsCorrectSideWhenTargetIsBelowPA)
+// 到達可能性チェック: ロボットPA上方・ターゲットPA下方の2ステップルーティング
+// Step1: current→BOTTOM はPA横断あり(到達不可)→ TOP を中間ウェイポイントとして選択
+// Step2: TOPウェイポイントから BOTTOM fully_good → BOTTOM 選択でターゲットへ到達
+TEST(PenaltyAvoidanceHelperTest, ReachabilityCheckSelectsTOPWhenTargetIsBelowPA)
 {
-  const auto decision = computePenaltyBypassDecision(
-    Point(-4.75, 3.08), Point(-4.95, -3.61), makeOurPA(), ourGoal(), paSize(), 0.3, 0.2, true);
-  ASSERT_TRUE(decision.crossing_detected);
   Box expanded = makeOurPA();
   expanded.min_corner() -= Point(0.3, 0.3);
   expanded.max_corner() += Point(0.3, 0.3);
-  EXPECT_FALSE(intersectsSegmentAABB(decision.waypoint, Point(-4.95, -3.61), expanded));
+
+  const auto step1 = computePenaltyBypassDecision(
+    Point(-4.75, 3.08), Point(-4.95, -3.61), makeOurPA(), ourGoal(), paSize(), 0.3, 0.2, true);
+  ASSERT_TRUE(step1.crossing_detected);
+  EXPECT_EQ(step1.selected_side, PenaltyBypassSide::TOP);
+  // current → TOP ウェイポイントは PA を横断しない
+  EXPECT_FALSE(intersectsSegmentAABB(Point(-4.75, 3.08), step1.waypoint, expanded));
+
+  // Step 2: TOP ウェイポイントから再計画 → BOTTOM fully_good → BOTTOM 選択
+  const auto step2 = computePenaltyBypassDecision(
+    step1.waypoint, Point(-4.95, -3.61), makeOurPA(), ourGoal(), paSize(), 0.3, 0.2, true);
+  ASSERT_TRUE(step2.crossing_detected);
+  EXPECT_EQ(step2.selected_side, PenaltyBypassSide::BOTTOM);
+  EXPECT_FALSE(intersectsSegmentAABB(step2.waypoint, Point(-4.95, -3.61), expanded));
 }
 
-// rosbagシナリオの再現: 味方PA(xright側)での同等ケース
-// ロボット(5.318, -3.763)からターゲット(5.194, 3.243)へ横断
-// PAをゴール右側として設定、選択ウェイポイントが再横断しないことを確認
+// rosbagシナリオの再現: 味方PA(right側)でのケース
+// ロボット(5.318, -3.763)からターゲット(5.194, 3.243)への2ステップルーティング
+// Step1: BOTTOM(中間WP)選択 → Step2: TOP選択でターゲットへ到達
 TEST(PenaltyAvoidanceHelperTest, RosbagScenario_RobotBelowPA_TargetAbovePA)
 {
-  // 味方PA: x=[4.2, 6.0], y=[-1.8, 1.8]、ゴール=(6.0, 0)
   const Box our_pa(Point(4.2, -1.8), Point(6.0, 1.8));
   const Point goal(6.0, 0.0);
   const Point pa_size(1.8, 3.6);
-
-  const auto decision = computePenaltyBypassDecision(
-    Point(5.318, -3.763), Point(5.194, 3.243), our_pa, goal, pa_size, 0.3, 0.2, true);
-
-  ASSERT_TRUE(decision.crossing_detected);
-  ASSERT_TRUE(decision.target_overridden);
-
-  // ウェイポイントからターゲットへの経路がPAを再横断しないこと
   Box expanded = our_pa;
   expanded.min_corner() -= Point(0.3, 0.3);
   expanded.max_corner() += Point(0.3, 0.3);
-  EXPECT_FALSE(intersectsSegmentAABB(decision.waypoint, Point(5.194, 3.243), expanded));
 
-  // ターゲットがPA上方なのでTOP側が選択されること
-  EXPECT_EQ(decision.selected_side, PenaltyBypassSide::TOP);
+  // Step 1: PA 下方から横断 → current→TOP 不達のため BOTTOM 選択
+  const auto step1 = computePenaltyBypassDecision(
+    Point(5.318, -3.763), Point(5.194, 3.243), our_pa, goal, pa_size, 0.3, 0.2, true);
+  ASSERT_TRUE(step1.crossing_detected);
+  ASSERT_TRUE(step1.target_overridden);
+  EXPECT_EQ(step1.selected_side, PenaltyBypassSide::BOTTOM);
+  // current → BOTTOM ウェイポイントは PA を横断しない
+  EXPECT_FALSE(intersectsSegmentAABB(Point(5.318, -3.763), step1.waypoint, expanded));
+
+  // Step 2: BOTTOM ウェイポイントから再計画 → TOP fully_good → TOP 選択
+  const auto step2 = computePenaltyBypassDecision(
+    step1.waypoint, Point(5.194, 3.243), our_pa, goal, pa_size, 0.3, 0.2, true);
+  ASSERT_TRUE(step2.crossing_detected);
+  EXPECT_EQ(step2.selected_side, PenaltyBypassSide::TOP);
+  // TOP ウェイポイント → ターゲットは PA を横断しない
+  EXPECT_FALSE(intersectsSegmentAABB(step2.waypoint, Point(5.194, 3.243), expanded));
 }
 
 }  // namespace crane


### PR DESCRIPTION
## 概要

ロボットが味方ペナルティエリア（PA）を横断しようとする際にPA境界付近で停止してしまう問題を修正する。

## 背景・根本原因

rosbag解析により、PA下方からPA上方への移動時にロボットがy≈-2.145で停止することを確認。根本原因は2つ。

**1. サイド選択の欠陥 (`penalty_avoidance_helper.hpp`)**

ウェイポイント→ターゲット間の再横断チェックのみを行い、current→ウェイポイント間の到達可能性を確認していなかった。  
→ TOP側が選択されても、current→TOPパスがPA横断のため到達不可。RVO2がブロックして停止。

**2. HALT時のPA回避スキップ (`rvo2_planner.cpp`)**

`referee_command == HALT` (=0) の場合、`applyTargetAdjustmentPipeline` が呼ばれず、crossing detectionが完全にバイパスされていた。robot_test_sessionはHALT中でも移動するため直接影響を受けていた。

## 変更内容

- **`penalty_avoidance_helper.hpp`**: サイド選択を優先度スコアで一本化
  - `fully_good(2) > reachable_intermediate(1) > neither(0)` の優先度スコアで選択
  - `current→waypoint` の到達可能性チェックを追加
  - short-circuit評価で不要な `intersectsSegmentAABB` 呼び出しを削減
  - 7ケースの条件分岐をスコア比較ラムダで一本化
- **`rvo2_planner.cpp`**: `applyTargetAdjustmentPipeline` の呼び出し条件から `referee_command != HALT` ガードを削除
- **`test_penalty_avoidance_helper.cpp`**: 2ステップルーティング動作を検証するテストに更新