### PR TITLE
feat(crane_bag): mcap埋め込みメッセージ定義による動的デシリアライズへの移行

### DIFF
--- a/.claude/commands/analyze-rosbag.md
+++ b/.claude/commands/analyze-rosbag.md
@@ -29,31 +29,24 @@ $ARGUMENTS
 
 ### Step 0: Rosbag前処理（zstd圧縮対応）
 
-`crane_bag` を実行する前に、rosbagディレクトリを正常な状態にする。
-rosbag2ライブラリが `.mcap.zstd` を直接 mcap プラグインで開こうとしてエラーになるため、必ず以下のbashを実行すること。
+`crane_bag` は `mcap::McapReader` で `.mcap` を直接読むため `metadata.yaml` は不要。
+`.mcap.zstd` 形式で収録されている場合のみ、zstd を展開してから実行すること。
 
 ```bash
 BAG_DIR="<rosbag_path>"
 
-# .mcap.zstd があるが .mcap がない場合、展開する
+# .mcap.zstd があるが .mcap がない場合のみ展開
 for zst in "$BAG_DIR"/*.mcap.zstd; do
   [ -f "$zst" ] || continue
   mcap="${zst%.zstd}"
-  if [ ! -f "$mcap" ]; then
-    echo "zstd展開中: $(basename "$zst")"
-    zstd -d "$zst" -o "$mcap"
-  fi
+  [ -f "$mcap" ] && continue
+  echo "zstd展開中: $(basename "$zst")"
+  zstd -d "$zst" -o "$mcap"
 done
-
-# metadata.yaml の compression 設定を修正（.mcap.zstd を指したままだと読めない）
-META="$BAG_DIR/metadata.yaml"
-if [ -f "$META" ] && grep -q 'compression_format: zstd' "$META"; then
-  sed -i 's/compression_format: zstd/compression_format: ""/' "$META"
-  sed -i 's/compression_mode: FILE/compression_mode: NONE/' "$META"
-  sed -i 's/\.mcap\.zstd/.mcap/g' "$META"
-  echo "metadata.yaml を更新しました（圧縮設定を解除）"
-fi
 ```
+
+> `.mcap` ファイルが既に存在する場合は Step 0 をスキップしてよい。
+> `crane_bag` にディレクトリを渡すと内部の `.mcap` ファイルを自動検出する。
 
 ### Step 1: Bag情報の確認
 

--- a/crane_bag/CMakeLists.txt
+++ b/crane_bag/CMakeLists.txt
@@ -35,6 +35,7 @@ target_compile_definitions(crane_bag PRIVATE span_CONFIG_SELECT_SPAN=1)
 target_link_libraries(crane_bag
   rosx_introspection::rosx_introspection
   mcap_vendor::mcap
+  magic_enum::magic_enum
 )
 
 ament_auto_package()

--- a/crane_bag/CMakeLists.txt
+++ b/crane_bag/CMakeLists.txt
@@ -25,7 +25,16 @@ ament_auto_add_executable(crane_bag
   src/bag/bag_tracking.cpp
   src/bag/bag_control.cpp
   src/bag/bag_referee.cpp
+  src/bag/msg_extractors.cpp
 )
 target_include_directories(crane_bag PRIVATE src/bag)
+# rosx_introspectionライブラリはnonstd::span_lite::spanでコンパイルされているため、
+# C++20のstd::spanが選択されるとABIミスマッチが発生する。
+# span_CONFIG_SELECT_SPAN=1 でnonstd実装を強制する。
+target_compile_definitions(crane_bag PRIVATE span_CONFIG_SELECT_SPAN=1)
+target_link_libraries(crane_bag
+  rosx_introspection::rosx_introspection
+  mcap_vendor::mcap
+)
 
 ament_auto_package()

--- a/crane_bag/package.xml
+++ b/crane_bag/package.xml
@@ -3,20 +3,15 @@
 <package format="3">
   <name>crane_bag</name>
   <version>1.0.303</version>
-  <description>C++ Rosbag解析CLIツール</description>
+  <description>C++ Rosbag解析CLIツール（mcap埋め込みメッセージ定義を使った動的デシリアライズ）</description>
   <maintainer email="ibis.ssl.team@gmail.com">ibis ssl</maintainer>
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>crane_msg_wrappers</depend>
-  <depend>crane_msgs</depend>
-  <depend>crane_robot_skills</depend>
-  <depend>libgoogle-glog-dev</depend>
+  <depend>mcap_vendor</depend>
   <depend>nlohmann-json-dev</depend>
-  <depend>robocup_ssl_msgs</depend>
-  <depend>rosbag2_cpp</depend>
-  <depend>rosidl_runtime_cpp</depend>
+  <depend>rosx_introspection</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>crane_lint_common</test_depend>

--- a/crane_bag/package.xml
+++ b/crane_bag/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>magic_enum</depend>
   <depend>mcap_vendor</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>rosx_introspection</depend>

--- a/crane_bag/src/bag/bag_control.cpp
+++ b/crane_bag/src/bag/bag_control.cpp
@@ -12,7 +12,7 @@ namespace crane::bag
 namespace
 {
 
-ControlSnapshot extract_snapshot(double t, const crane_msgs::msg::RobotCommand & rc)
+ControlSnapshot extract_snapshot(double t, const RobotCommand & rc)
 {
   ControlSnapshot s;
   s.t = t;

--- a/crane_bag/src/bag/bag_events.cpp
+++ b/crane_bag/src/bag/bag_events.cpp
@@ -8,9 +8,7 @@
 
 #include <algorithm>
 #include <cmath>
-#include <robocup_ssl_msgs/msg/game_event_one_of_event.hpp>
-#include <robocup_ssl_msgs/msg/game_event_type.hpp>
-#include <robocup_ssl_msgs/msg/team.hpp>
+#include <map>
 #include <set>
 #include <sstream>
 #include <unordered_set>
@@ -19,12 +17,73 @@
 namespace crane::bag
 {
 
+// ─── GameEventType 定数（robocup_ssl_msgs::msg::GameEventType と同じ値）────────
+
+namespace GameEventType
+{
+constexpr int32_t UNKNOWN_GAME_EVENT_TYPE = 0;
+constexpr int32_t BALL_LEFT_FIELD_TOUCH_LINE = 6;
+constexpr int32_t BALL_LEFT_FIELD_GOAL_LINE = 7;
+constexpr int32_t AIMLESS_KICK = 11;
+constexpr int32_t ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA = 19;
+constexpr int32_t DEFENDER_IN_DEFENSE_AREA = 31;
+constexpr int32_t BOUNDARY_CROSSING = 41;
+constexpr int32_t KEEPER_HELD_BALL = 13;
+constexpr int32_t BOT_DRIBBLED_BALL_TOO_FAR = 17;
+constexpr int32_t BOT_PUSHED_BOT = 24;
+constexpr int32_t BOT_HELD_BALL_DELIBERATELY = 26;
+constexpr int32_t BOT_TIPPED_OVER = 27;
+constexpr int32_t ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA = 15;
+constexpr int32_t BOT_KICKED_BALL_TOO_FAST = 18;
+constexpr int32_t BOT_CRASH_UNIQUE = 22;
+constexpr int32_t BOT_CRASH_DRAWN = 21;
+constexpr int32_t DEFENDER_TOO_CLOSE_TO_KICK_POINT = 29;
+constexpr int32_t BOT_TOO_FAST_IN_STOP = 28;
+constexpr int32_t BOT_INTERFERED_PLACEMENT = 20;
+constexpr int32_t POSSIBLE_GOAL = 39;
+constexpr int32_t GOAL = 8;
+constexpr int32_t INVALID_GOAL = 42;
+constexpr int32_t ATTACKER_DOUBLE_TOUCHED_BALL = 14;
+constexpr int32_t PLACEMENT_SUCCEEDED = 5;
+constexpr int32_t PENALTY_KICK_FAILED = 43;
+constexpr int32_t NO_PROGRESS_IN_GAME = 2;
+constexpr int32_t PLACEMENT_FAILED = 3;
+constexpr int32_t MULTIPLE_CARDS = 32;
+constexpr int32_t MULTIPLE_FOULS = 34;
+constexpr int32_t BOT_SUBSTITUTION = 37;
+constexpr int32_t TOO_MANY_ROBOTS = 38;
+constexpr int32_t CHALLENGE_FLAG = 44;
+constexpr int32_t EMERGENCY_STOP = 45;
+constexpr int32_t UNSPORTING_BEHAVIOR_MINOR = 35;
+constexpr int32_t UNSPORTING_BEHAVIOR_MAJOR = 36;
+constexpr int32_t PREPARED = 1;
+constexpr int32_t INDIRECT_GOAL = 9;
+constexpr int32_t CHIPPED_GOAL = 10;
+constexpr int32_t KICK_TIMEOUT = 12;
+constexpr int32_t ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA = 16;
+constexpr int32_t ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA_SKIPPED = 40;
+constexpr int32_t BOT_CRASH_UNIQUE_SKIPPED = 23;
+constexpr int32_t BOT_PUSHED_BOT_SKIPPED = 25;
+constexpr int32_t DEFENDER_IN_DEFENSE_AREA_PARTIALLY = 30;
+constexpr int32_t MULTIPLE_PLACEMENT_FAILURES = 33;
+}  // namespace GameEventType
+
+// Team 定数（robocup_ssl_msgs::msg::Team と同じ値）
+namespace Team
+{
+constexpr int32_t UNKNOWN = 0;
+constexpr int32_t YELLOW = 1;
+constexpr int32_t BLUE = 2;
+}  // namespace Team
+
+// ─── 既存の実装（変更少）────────────────────────────────────────────────────────
+
 std::vector<Event> detect_play_transitions(const BagData & data)
 {
   std::vector<Event> events;
   std::string prev_cmd;
   for (const auto & tm : data.play_situations) {
-    const std::string & cmd = tm.msg.command.name;
+    const std::string & cmd = tm.msg.command_name;
     if (cmd != prev_cmd) {
       Event e;
       e.timestamp_ns = tm.timestamp_ns;
@@ -97,7 +156,6 @@ std::vector<Event> detect_kick_events(const BagData & data)
         kicking_now.insert(static_cast<int>(rc.robot_id));
       }
     }
-    // 立ち上がりエッジ
     for (int rid : kicking_now) {
       if (prev_kicking.find(rid) == prev_kicking.end()) {
         Event e;
@@ -174,101 +232,57 @@ std::vector<Event> detect_goals(const BagData & data)
 
 std::string game_event_type_to_string(int32_t v)
 {
-  using T = robocup_ssl_msgs::msg::GameEventType;
-  switch (v) {
-    case T::UNKNOWN_GAME_EVENT_TYPE:
-      return "UNKNOWN_GAME_EVENT_TYPE";
-    case T::BALL_LEFT_FIELD_TOUCH_LINE:
-      return "BALL_LEFT_FIELD_TOUCH_LINE";
-    case T::BALL_LEFT_FIELD_GOAL_LINE:
-      return "BALL_LEFT_FIELD_GOAL_LINE";
-    case T::AIMLESS_KICK:
-      return "AIMLESS_KICK";
-    case T::ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA:
-      return "ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA";
-    case T::DEFENDER_IN_DEFENSE_AREA:
-      return "DEFENDER_IN_DEFENSE_AREA";
-    case T::BOUNDARY_CROSSING:
-      return "BOUNDARY_CROSSING";
-    case T::KEEPER_HELD_BALL:
-      return "KEEPER_HELD_BALL";
-    case T::BOT_DRIBBLED_BALL_TOO_FAR:
-      return "BOT_DRIBBLED_BALL_TOO_FAR";
-    case T::BOT_PUSHED_BOT:
-      return "BOT_PUSHED_BOT";
-    case T::BOT_HELD_BALL_DELIBERATELY:
-      return "BOT_HELD_BALL_DELIBERATELY";
-    case T::BOT_TIPPED_OVER:
-      return "BOT_TIPPED_OVER";
-    case T::ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA:
-      return "ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA";
-    case T::BOT_KICKED_BALL_TOO_FAST:
-      return "BOT_KICKED_BALL_TOO_FAST";
-    case T::BOT_CRASH_UNIQUE:
-      return "BOT_CRASH_UNIQUE";
-    case T::BOT_CRASH_DRAWN:
-      return "BOT_CRASH_DRAWN";
-    case T::DEFENDER_TOO_CLOSE_TO_KICK_POINT:
-      return "DEFENDER_TOO_CLOSE_TO_KICK_POINT";
-    case T::BOT_TOO_FAST_IN_STOP:
-      return "BOT_TOO_FAST_IN_STOP";
-    case T::BOT_INTERFERED_PLACEMENT:
-      return "BOT_INTERFERED_PLACEMENT";
-    case T::POSSIBLE_GOAL:
-      return "POSSIBLE_GOAL";
-    case T::GOAL:
-      return "GOAL";
-    case T::INVALID_GOAL:
-      return "INVALID_GOAL";
-    case T::ATTACKER_DOUBLE_TOUCHED_BALL:
-      return "ATTACKER_DOUBLE_TOUCHED_BALL";
-    case T::PLACEMENT_SUCCEEDED:
-      return "PLACEMENT_SUCCEEDED";
-    case T::PENALTY_KICK_FAILED:
-      return "PENALTY_KICK_FAILED";
-    case T::NO_PROGRESS_IN_GAME:
-      return "NO_PROGRESS_IN_GAME";
-    case T::PLACEMENT_FAILED:
-      return "PLACEMENT_FAILED";
-    case T::MULTIPLE_CARDS:
-      return "MULTIPLE_CARDS";
-    case T::MULTIPLE_FOULS:
-      return "MULTIPLE_FOULS";
-    case T::BOT_SUBSTITUTION:
-      return "BOT_SUBSTITUTION";
-    case T::TOO_MANY_ROBOTS:
-      return "TOO_MANY_ROBOTS";
-    case T::CHALLENGE_FLAG:
-      return "CHALLENGE_FLAG";
-    case T::EMERGENCY_STOP:
-      return "EMERGENCY_STOP";
-    case T::UNSPORTING_BEHAVIOR_MINOR:
-      return "UNSPORTING_BEHAVIOR_MINOR";
-    case T::UNSPORTING_BEHAVIOR_MAJOR:
-      return "UNSPORTING_BEHAVIOR_MAJOR";
-    case T::PREPARED:
-      return "PREPARED";
-    case T::INDIRECT_GOAL:
-      return "INDIRECT_GOAL";
-    case T::CHIPPED_GOAL:
-      return "CHIPPED_GOAL";
-    case T::KICK_TIMEOUT:
-      return "KICK_TIMEOUT";
-    case T::ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA:
-      return "ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA";
-    case T::ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA_SKIPPED:
-      return "ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA_SKIPPED";
-    case T::BOT_CRASH_UNIQUE_SKIPPED:
-      return "BOT_CRASH_UNIQUE_SKIPPED";
-    case T::BOT_PUSHED_BOT_SKIPPED:
-      return "BOT_PUSHED_BOT_SKIPPED";
-    case T::DEFENDER_IN_DEFENSE_AREA_PARTIALLY:
-      return "DEFENDER_IN_DEFENSE_AREA_PARTIALLY";
-    case T::MULTIPLE_PLACEMENT_FAILURES:
-      return "MULTIPLE_PLACEMENT_FAILURES";
-    default:
-      return "GAME_EVENT(" + std::to_string(v) + ")";
-  }
+  static const std::map<int32_t, const char *> m = {
+    {GameEventType::UNKNOWN_GAME_EVENT_TYPE, "UNKNOWN_GAME_EVENT_TYPE"},
+    {GameEventType::BALL_LEFT_FIELD_TOUCH_LINE, "BALL_LEFT_FIELD_TOUCH_LINE"},
+    {GameEventType::BALL_LEFT_FIELD_GOAL_LINE, "BALL_LEFT_FIELD_GOAL_LINE"},
+    {GameEventType::AIMLESS_KICK, "AIMLESS_KICK"},
+    {GameEventType::ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA, "ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA"},
+    {GameEventType::DEFENDER_IN_DEFENSE_AREA, "DEFENDER_IN_DEFENSE_AREA"},
+    {GameEventType::BOUNDARY_CROSSING, "BOUNDARY_CROSSING"},
+    {GameEventType::KEEPER_HELD_BALL, "KEEPER_HELD_BALL"},
+    {GameEventType::BOT_DRIBBLED_BALL_TOO_FAR, "BOT_DRIBBLED_BALL_TOO_FAR"},
+    {GameEventType::BOT_PUSHED_BOT, "BOT_PUSHED_BOT"},
+    {GameEventType::BOT_HELD_BALL_DELIBERATELY, "BOT_HELD_BALL_DELIBERATELY"},
+    {GameEventType::BOT_TIPPED_OVER, "BOT_TIPPED_OVER"},
+    {GameEventType::ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA, "ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA"},
+    {GameEventType::BOT_KICKED_BALL_TOO_FAST, "BOT_KICKED_BALL_TOO_FAST"},
+    {GameEventType::BOT_CRASH_UNIQUE, "BOT_CRASH_UNIQUE"},
+    {GameEventType::BOT_CRASH_DRAWN, "BOT_CRASH_DRAWN"},
+    {GameEventType::DEFENDER_TOO_CLOSE_TO_KICK_POINT, "DEFENDER_TOO_CLOSE_TO_KICK_POINT"},
+    {GameEventType::BOT_TOO_FAST_IN_STOP, "BOT_TOO_FAST_IN_STOP"},
+    {GameEventType::BOT_INTERFERED_PLACEMENT, "BOT_INTERFERED_PLACEMENT"},
+    {GameEventType::POSSIBLE_GOAL, "POSSIBLE_GOAL"},
+    {GameEventType::GOAL, "GOAL"},
+    {GameEventType::INVALID_GOAL, "INVALID_GOAL"},
+    {GameEventType::ATTACKER_DOUBLE_TOUCHED_BALL, "ATTACKER_DOUBLE_TOUCHED_BALL"},
+    {GameEventType::PLACEMENT_SUCCEEDED, "PLACEMENT_SUCCEEDED"},
+    {GameEventType::PENALTY_KICK_FAILED, "PENALTY_KICK_FAILED"},
+    {GameEventType::NO_PROGRESS_IN_GAME, "NO_PROGRESS_IN_GAME"},
+    {GameEventType::PLACEMENT_FAILED, "PLACEMENT_FAILED"},
+    {GameEventType::MULTIPLE_CARDS, "MULTIPLE_CARDS"},
+    {GameEventType::MULTIPLE_FOULS, "MULTIPLE_FOULS"},
+    {GameEventType::BOT_SUBSTITUTION, "BOT_SUBSTITUTION"},
+    {GameEventType::TOO_MANY_ROBOTS, "TOO_MANY_ROBOTS"},
+    {GameEventType::CHALLENGE_FLAG, "CHALLENGE_FLAG"},
+    {GameEventType::EMERGENCY_STOP, "EMERGENCY_STOP"},
+    {GameEventType::UNSPORTING_BEHAVIOR_MINOR, "UNSPORTING_BEHAVIOR_MINOR"},
+    {GameEventType::UNSPORTING_BEHAVIOR_MAJOR, "UNSPORTING_BEHAVIOR_MAJOR"},
+    {GameEventType::PREPARED, "PREPARED"},
+    {GameEventType::INDIRECT_GOAL, "INDIRECT_GOAL"},
+    {GameEventType::CHIPPED_GOAL, "CHIPPED_GOAL"},
+    {GameEventType::KICK_TIMEOUT, "KICK_TIMEOUT"},
+    {GameEventType::ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA,
+     "ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA"},
+    {GameEventType::ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA_SKIPPED,
+     "ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA_SKIPPED"},
+    {GameEventType::BOT_CRASH_UNIQUE_SKIPPED, "BOT_CRASH_UNIQUE_SKIPPED"},
+    {GameEventType::BOT_PUSHED_BOT_SKIPPED, "BOT_PUSHED_BOT_SKIPPED"},
+    {GameEventType::DEFENDER_IN_DEFENSE_AREA_PARTIALLY, "DEFENDER_IN_DEFENSE_AREA_PARTIALLY"},
+    {GameEventType::MULTIPLE_PLACEMENT_FAILURES, "MULTIPLE_PLACEMENT_FAILURES"},
+  };
+  auto it = m.find(v);
+  return it != m.end() ? it->second : "GAME_EVENT(" + std::to_string(v) + ")";
 }
 
 namespace
@@ -276,148 +290,118 @@ namespace
 
 const std::unordered_set<int32_t> & foul_event_types()
 {
-  using T = robocup_ssl_msgs::msg::GameEventType;
   static const std::unordered_set<int32_t> s = {
-    T::BOT_PUSHED_BOT,
-    T::BOT_PUSHED_BOT_SKIPPED,
-    T::BOT_HELD_BALL_DELIBERATELY,
-    T::BOT_TIPPED_OVER,
-    T::BOT_TOO_FAST_IN_STOP,
-    T::DEFENDER_TOO_CLOSE_TO_KICK_POINT,
-    T::DEFENDER_IN_DEFENSE_AREA,
-    T::DEFENDER_IN_DEFENSE_AREA_PARTIALLY,
-    T::ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA,
-    T::ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA,
-    T::ATTACKER_DOUBLE_TOUCHED_BALL,
-    T::ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA,
-    T::ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA_SKIPPED,
-    T::BOT_CRASH_UNIQUE,
-    T::BOT_CRASH_UNIQUE_SKIPPED,
-    T::BOT_CRASH_DRAWN,
-    T::BOT_KICKED_BALL_TOO_FAST,
-    T::BOT_DRIBBLED_BALL_TOO_FAR,
-    T::BOUNDARY_CROSSING,
-    T::KEEPER_HELD_BALL,
-    T::BOT_INTERFERED_PLACEMENT,
-    T::UNSPORTING_BEHAVIOR_MINOR,
-    T::UNSPORTING_BEHAVIOR_MAJOR,
-    T::MULTIPLE_FOULS,
-    T::AIMLESS_KICK,
+    GameEventType::BOT_PUSHED_BOT,
+    GameEventType::BOT_PUSHED_BOT_SKIPPED,
+    GameEventType::BOT_HELD_BALL_DELIBERATELY,
+    GameEventType::BOT_TIPPED_OVER,
+    GameEventType::BOT_TOO_FAST_IN_STOP,
+    GameEventType::DEFENDER_TOO_CLOSE_TO_KICK_POINT,
+    GameEventType::DEFENDER_IN_DEFENSE_AREA,
+    GameEventType::DEFENDER_IN_DEFENSE_AREA_PARTIALLY,
+    GameEventType::ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA,
+    GameEventType::ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA,
+    GameEventType::ATTACKER_DOUBLE_TOUCHED_BALL,
+    GameEventType::ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA,
+    GameEventType::ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA_SKIPPED,
+    GameEventType::BOT_CRASH_UNIQUE,
+    GameEventType::BOT_CRASH_UNIQUE_SKIPPED,
+    GameEventType::BOT_CRASH_DRAWN,
+    GameEventType::BOT_KICKED_BALL_TOO_FAST,
+    GameEventType::BOT_DRIBBLED_BALL_TOO_FAR,
+    GameEventType::BOUNDARY_CROSSING,
+    GameEventType::KEEPER_HELD_BALL,
+    GameEventType::BOT_INTERFERED_PLACEMENT,
+    GameEventType::UNSPORTING_BEHAVIOR_MINOR,
+    GameEventType::UNSPORTING_BEHAVIOR_MAJOR,
+    GameEventType::MULTIPLE_FOULS,
+    GameEventType::AIMLESS_KICK,
   };
   return s;
 }
 
 std::string team_name(int32_t team_value)
 {
-  using Team = robocup_ssl_msgs::msg::Team;
   if (team_value == Team::YELLOW) return "YELLOW";
   if (team_value == Team::BLUE) return "BLUE";
   return "UNKNOWN";
 }
 
-std::string foul_description(const robocup_ssl_msgs::msg::GameEvent & ge)
+std::string foul_description(const GameEventInfo & ge)
 {
-  using T = robocup_ssl_msgs::msg::GameEventType;
-  const auto & ev = ge.event;
-  const std::string type_name = game_event_type_to_string(ge.type.value);
+  const std::string type_name = game_event_type_to_string(ge.type_value);
   char buf[256];
 
-  switch (ge.type.value) {
-    case T::BOT_CRASH_UNIQUE:
-    case T::BOT_CRASH_UNIQUE_SKIPPED: {
-      const auto & e = ev.bot_crash_unique;
+  switch (ge.type_value) {
+    case GameEventType::BOT_CRASH_UNIQUE:
+    case GameEventType::BOT_CRASH_UNIQUE_SKIPPED:
       std::snprintf(
         buf, sizeof(buf), "%s: %s violator=%u victim=%u at (%.2f,%.2f) speed=%.2fm/s",
-        type_name.c_str(), team_name(e.by_team.value).c_str(), e.violator, e.victim, e.location.x,
-        e.location.y, e.crash_speed);
+        type_name.c_str(), team_name(ge.by_team_value).c_str(), ge.violator, ge.victim,
+        ge.location_x, ge.location_y, ge.crash_speed);
       return buf;
-    }
-    case T::BOT_TOO_FAST_IN_STOP: {
-      const auto & e = ev.bot_too_fast_in_stop;
+    case GameEventType::BOT_TOO_FAST_IN_STOP:
       std::snprintf(
         buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f) speed=%.2fm/s", type_name.c_str(),
-        team_name(e.by_team.value).c_str(), e.by_bot, e.location.x, e.location.y, e.speed);
+        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y, ge.speed);
       return buf;
-    }
-    case T::BOT_PUSHED_BOT:
-    case T::BOT_PUSHED_BOT_SKIPPED: {
-      const auto & e = ev.bot_pushed_bot;
+    case GameEventType::BOT_PUSHED_BOT:
+    case GameEventType::BOT_PUSHED_BOT_SKIPPED:
       std::snprintf(
         buf, sizeof(buf), "%s: %s violator=%u victim=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(e.by_team.value).c_str(), e.violator, e.victim, e.location.x, e.location.y);
+        team_name(ge.by_team_value).c_str(), ge.violator, ge.victim, ge.location_x, ge.location_y);
       return buf;
-    }
-    case T::BOT_DRIBBLED_BALL_TOO_FAR: {
-      const auto & e = ev.bot_dribbled_ball_too_far;
+    case GameEventType::BOT_DRIBBLED_BALL_TOO_FAR:
       std::snprintf(
-        buf, sizeof(buf), "%s: %s bot=%u", type_name.c_str(), team_name(e.by_team.value).c_str(),
-        e.by_bot);
+        buf, sizeof(buf), "%s: %s bot=%u", type_name.c_str(), team_name(ge.by_team_value).c_str(),
+        ge.by_bot);
       return buf;
-    }
-    case T::KEEPER_HELD_BALL: {
-      const auto & e = ev.keeper_held_ball;
+    case GameEventType::KEEPER_HELD_BALL:
       std::snprintf(
         buf, sizeof(buf), "%s: %s at (%.2f,%.2f) duration=%.2fs", type_name.c_str(),
-        team_name(e.by_team.value).c_str(), e.location.x, e.location.y, e.duration);
+        team_name(ge.by_team_value).c_str(), ge.location_x, ge.location_y, ge.duration);
       return buf;
-    }
-    case T::DEFENDER_IN_DEFENSE_AREA:
-    case T::DEFENDER_IN_DEFENSE_AREA_PARTIALLY: {
-      const auto & e = ev.defender_in_defense_area;
+    case GameEventType::DEFENDER_IN_DEFENSE_AREA:
+    case GameEventType::DEFENDER_IN_DEFENSE_AREA_PARTIALLY:
       std::snprintf(
         buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(e.by_team.value).c_str(), e.by_bot, e.location.x, e.location.y);
+        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
       return buf;
-    }
-    case T::ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA: {
-      const auto & e = ev.attacker_too_close_to_defense_area;
+    case GameEventType::ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA:
       std::snprintf(
         buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(e.by_team.value).c_str(), e.by_bot, e.location.x, e.location.y);
+        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
       return buf;
-    }
-    case T::ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA: {
-      const auto & e = ev.attacker_touched_ball_in_defense_area;
+    case GameEventType::ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA:
       std::snprintf(
         buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(e.by_team.value).c_str(), e.by_bot, e.location.x, e.location.y);
+        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
       return buf;
-    }
-    case T::BOT_HELD_BALL_DELIBERATELY: {
-      const auto & e = ev.bot_held_ball_deliberately;
+    case GameEventType::BOT_HELD_BALL_DELIBERATELY:
       std::snprintf(
         buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(e.by_team.value).c_str(), e.by_bot, e.location.x, e.location.y);
+        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
       return buf;
-    }
-    case T::BOT_INTERFERED_PLACEMENT: {
-      const auto & e = ev.bot_interfered_placement;
+    case GameEventType::BOT_INTERFERED_PLACEMENT:
       std::snprintf(
-        buf, sizeof(buf), "%s: %s bot=%u", type_name.c_str(), team_name(e.by_team.value).c_str(),
-        e.by_bot);
+        buf, sizeof(buf), "%s: %s bot=%u", type_name.c_str(), team_name(ge.by_team_value).c_str(),
+        ge.by_bot);
       return buf;
-    }
-    case T::ATTACKER_DOUBLE_TOUCHED_BALL: {
-      const auto & e = ev.attacker_double_touched_ball;
+    case GameEventType::ATTACKER_DOUBLE_TOUCHED_BALL:
       std::snprintf(
         buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(e.by_team.value).c_str(), e.by_bot, e.location.x, e.location.y);
+        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
       return buf;
-    }
-    case T::BOT_KICKED_BALL_TOO_FAST: {
-      const auto & e = ev.bot_kicked_ball_too_fast;
+    case GameEventType::BOT_KICKED_BALL_TOO_FAST:
       std::snprintf(
-        buf, sizeof(buf), "%s: %s bot=%u", type_name.c_str(), team_name(e.by_team.value).c_str(),
-        e.by_bot);
+        buf, sizeof(buf), "%s: %s bot=%u", type_name.c_str(), team_name(ge.by_team_value).c_str(),
+        ge.by_bot);
       return buf;
-    }
-    case T::AIMLESS_KICK: {
-      const auto & e = ev.aimless_kick;
+    case GameEventType::AIMLESS_KICK:
       std::snprintf(
         buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(e.by_team.value).c_str(), e.by_bot, e.location.x, e.location.y);
+        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
       return buf;
-    }
     default:
       return type_name;
   }
@@ -431,16 +415,14 @@ std::vector<Event> detect_fouls(const BagData & data)
   if (data.referees.empty()) return events;
 
   int64_t bag_start = data.info.start_time_ns;
-  // 重複排除: (type_value, command_counter) ペア
   std::set<std::pair<int32_t, uint32_t>> seen;
 
   for (const auto & tm : data.referees) {
     const auto & msg = tm.msg;
     for (const auto & ge : msg.game_events) {
-      int32_t type_val = ge.type.value;
-      if (foul_event_types().find(type_val) == foul_event_types().end()) continue;
+      if (foul_event_types().find(ge.type_value) == foul_event_types().end()) continue;
 
-      auto key = std::make_pair(type_val, msg.command_counter);
+      auto key = std::make_pair(ge.type_value, msg.command_counter);
       if (seen.count(key)) continue;
       seen.insert(key);
 

--- a/crane_bag/src/bag/bag_events.cpp
+++ b/crane_bag/src/bag/bag_events.cpp
@@ -270,7 +270,20 @@ std::string foul_description(const GameEventInfo & ge)
         buf, sizeof(buf), "%s: %s violator=%u victim=%u at (%.2f,%.2f)", type_name.c_str(),
         team_name(ge.by_team_value).c_str(), ge.violator, ge.victim, ge.location_x, ge.location_y);
       return buf;
+    case GameEventType::DEFENDER_IN_DEFENSE_AREA:
+    case GameEventType::DEFENDER_IN_DEFENSE_AREA_PARTIALLY:
+    case GameEventType::ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA:
+    case GameEventType::ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA:
+    case GameEventType::BOT_HELD_BALL_DELIBERATELY:
+    case GameEventType::ATTACKER_DOUBLE_TOUCHED_BALL:
+    case GameEventType::AIMLESS_KICK:
+      std::snprintf(
+        buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
+        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
+      return buf;
     case GameEventType::BOT_DRIBBLED_BALL_TOO_FAR:
+    case GameEventType::BOT_INTERFERED_PLACEMENT:
+    case GameEventType::BOT_KICKED_BALL_TOO_FAST:
       std::snprintf(
         buf, sizeof(buf), "%s: %s bot=%u", type_name.c_str(), team_name(ge.by_team_value).c_str(),
         ge.by_bot);
@@ -279,47 +292,6 @@ std::string foul_description(const GameEventInfo & ge)
       std::snprintf(
         buf, sizeof(buf), "%s: %s at (%.2f,%.2f) duration=%.2fs", type_name.c_str(),
         team_name(ge.by_team_value).c_str(), ge.location_x, ge.location_y, ge.duration);
-      return buf;
-    case GameEventType::DEFENDER_IN_DEFENSE_AREA:
-    case GameEventType::DEFENDER_IN_DEFENSE_AREA_PARTIALLY:
-      std::snprintf(
-        buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
-      return buf;
-    case GameEventType::ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA:
-      std::snprintf(
-        buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
-      return buf;
-    case GameEventType::ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA:
-      std::snprintf(
-        buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
-      return buf;
-    case GameEventType::BOT_HELD_BALL_DELIBERATELY:
-      std::snprintf(
-        buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
-      return buf;
-    case GameEventType::BOT_INTERFERED_PLACEMENT:
-      std::snprintf(
-        buf, sizeof(buf), "%s: %s bot=%u", type_name.c_str(), team_name(ge.by_team_value).c_str(),
-        ge.by_bot);
-      return buf;
-    case GameEventType::ATTACKER_DOUBLE_TOUCHED_BALL:
-      std::snprintf(
-        buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
-      return buf;
-    case GameEventType::BOT_KICKED_BALL_TOO_FAST:
-      std::snprintf(
-        buf, sizeof(buf), "%s: %s bot=%u", type_name.c_str(), team_name(ge.by_team_value).c_str(),
-        ge.by_bot);
-      return buf;
-    case GameEventType::AIMLESS_KICK:
-      std::snprintf(
-        buf, sizeof(buf), "%s: %s bot=%u at (%.2f,%.2f)", type_name.c_str(),
-        team_name(ge.by_team_value).c_str(), ge.by_bot, ge.location_x, ge.location_y);
       return buf;
     default:
       return type_name;
@@ -368,30 +340,17 @@ std::vector<Event> detect_events(const BagData & data, const std::vector<std::st
   };
 
   std::vector<Event> all;
-  if (has(EVENT_PLAY)) {
-    auto v = detect_play_transitions(data);
+  auto append_if = [&](const char * type, auto fn) {
+    if (!has(type)) return;
+    auto v = fn();
     all.insert(all.end(), v.begin(), v.end());
-  }
-  if (has(EVENT_ROLE)) {
-    auto v = detect_role_changes(data);
-    all.insert(all.end(), v.begin(), v.end());
-  }
-  if (has(EVENT_KICK)) {
-    auto v = detect_kick_events(data);
-    all.insert(all.end(), v.begin(), v.end());
-  }
-  if (has(EVENT_BALL_SPEED)) {
-    auto v = detect_ball_speed_spikes(data);
-    all.insert(all.end(), v.begin(), v.end());
-  }
-  if (has(EVENT_GOAL)) {
-    auto v = detect_goals(data);
-    all.insert(all.end(), v.begin(), v.end());
-  }
-  if (has(EVENT_FOUL)) {
-    auto v = detect_fouls(data);
-    all.insert(all.end(), v.begin(), v.end());
-  }
+  };
+  append_if(EVENT_PLAY, [&] { return detect_play_transitions(data); });
+  append_if(EVENT_ROLE, [&] { return detect_role_changes(data); });
+  append_if(EVENT_KICK, [&] { return detect_kick_events(data); });
+  append_if(EVENT_BALL_SPEED, [&] { return detect_ball_speed_spikes(data); });
+  append_if(EVENT_GOAL, [&] { return detect_goals(data); });
+  append_if(EVENT_FOUL, [&] { return detect_fouls(data); });
 
   std::sort(all.begin(), all.end(), [](const Event & a, const Event & b) {
     return a.timestamp_ns < b.timestamp_ns;

--- a/crane_bag/src/bag/bag_events.cpp
+++ b/crane_bag/src/bag/bag_events.cpp
@@ -8,7 +8,7 @@
 
 #include <algorithm>
 #include <cmath>
-#include <map>
+#include <magic_enum/magic_enum.hpp>
 #include <set>
 #include <sstream>
 #include <unordered_set>
@@ -17,64 +17,33 @@
 namespace crane::bag
 {
 
-// ─── GameEventType 定数（robocup_ssl_msgs::msg::GameEventType と同じ値）────────
+// ─── GameEventType / Team（robocup_ssl_msgs と同じ値）────────────────────────
 
-namespace GameEventType
-{
-constexpr int32_t UNKNOWN_GAME_EVENT_TYPE = 0;
-constexpr int32_t BALL_LEFT_FIELD_TOUCH_LINE = 6;
-constexpr int32_t BALL_LEFT_FIELD_GOAL_LINE = 7;
-constexpr int32_t AIMLESS_KICK = 11;
-constexpr int32_t ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA = 19;
-constexpr int32_t DEFENDER_IN_DEFENSE_AREA = 31;
-constexpr int32_t BOUNDARY_CROSSING = 41;
-constexpr int32_t KEEPER_HELD_BALL = 13;
-constexpr int32_t BOT_DRIBBLED_BALL_TOO_FAR = 17;
-constexpr int32_t BOT_PUSHED_BOT = 24;
-constexpr int32_t BOT_HELD_BALL_DELIBERATELY = 26;
-constexpr int32_t BOT_TIPPED_OVER = 27;
-constexpr int32_t ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA = 15;
-constexpr int32_t BOT_KICKED_BALL_TOO_FAST = 18;
-constexpr int32_t BOT_CRASH_UNIQUE = 22;
-constexpr int32_t BOT_CRASH_DRAWN = 21;
-constexpr int32_t DEFENDER_TOO_CLOSE_TO_KICK_POINT = 29;
-constexpr int32_t BOT_TOO_FAST_IN_STOP = 28;
-constexpr int32_t BOT_INTERFERED_PLACEMENT = 20;
-constexpr int32_t POSSIBLE_GOAL = 39;
-constexpr int32_t GOAL = 8;
-constexpr int32_t INVALID_GOAL = 42;
-constexpr int32_t ATTACKER_DOUBLE_TOUCHED_BALL = 14;
-constexpr int32_t PLACEMENT_SUCCEEDED = 5;
-constexpr int32_t PENALTY_KICK_FAILED = 43;
-constexpr int32_t NO_PROGRESS_IN_GAME = 2;
-constexpr int32_t PLACEMENT_FAILED = 3;
-constexpr int32_t MULTIPLE_CARDS = 32;
-constexpr int32_t MULTIPLE_FOULS = 34;
-constexpr int32_t BOT_SUBSTITUTION = 37;
-constexpr int32_t TOO_MANY_ROBOTS = 38;
-constexpr int32_t CHALLENGE_FLAG = 44;
-constexpr int32_t EMERGENCY_STOP = 45;
-constexpr int32_t UNSPORTING_BEHAVIOR_MINOR = 35;
-constexpr int32_t UNSPORTING_BEHAVIOR_MAJOR = 36;
-constexpr int32_t PREPARED = 1;
-constexpr int32_t INDIRECT_GOAL = 9;
-constexpr int32_t CHIPPED_GOAL = 10;
-constexpr int32_t KICK_TIMEOUT = 12;
-constexpr int32_t ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA = 16;
-constexpr int32_t ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA_SKIPPED = 40;
-constexpr int32_t BOT_CRASH_UNIQUE_SKIPPED = 23;
-constexpr int32_t BOT_PUSHED_BOT_SKIPPED = 25;
-constexpr int32_t DEFENDER_IN_DEFENSE_AREA_PARTIALLY = 30;
-constexpr int32_t MULTIPLE_PLACEMENT_FAILURES = 33;
-}  // namespace GameEventType
+// clang-format off
+enum class GameEventType : int32_t {
+  UNKNOWN_GAME_EVENT_TYPE = 0,  PREPARED = 1,             NO_PROGRESS_IN_GAME = 2,
+  PLACEMENT_FAILED = 3,         PLACEMENT_SUCCEEDED = 5,  BALL_LEFT_FIELD_TOUCH_LINE = 6,
+  BALL_LEFT_FIELD_GOAL_LINE = 7, GOAL = 8,                INDIRECT_GOAL = 9,
+  CHIPPED_GOAL = 10,            AIMLESS_KICK = 11,        KICK_TIMEOUT = 12,
+  KEEPER_HELD_BALL = 13,        ATTACKER_DOUBLE_TOUCHED_BALL = 14,
+  ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA = 15,
+  ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA = 16,
+  BOT_DRIBBLED_BALL_TOO_FAR = 17, BOT_KICKED_BALL_TOO_FAST = 18,
+  ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA = 19, BOT_INTERFERED_PLACEMENT = 20,
+  BOT_CRASH_DRAWN = 21,         BOT_CRASH_UNIQUE = 22,    BOT_CRASH_UNIQUE_SKIPPED = 23,
+  BOT_PUSHED_BOT = 24,          BOT_PUSHED_BOT_SKIPPED = 25,
+  BOT_HELD_BALL_DELIBERATELY = 26, BOT_TIPPED_OVER = 27, BOT_TOO_FAST_IN_STOP = 28,
+  DEFENDER_TOO_CLOSE_TO_KICK_POINT = 29,   DEFENDER_IN_DEFENSE_AREA_PARTIALLY = 30,
+  DEFENDER_IN_DEFENSE_AREA = 31, MULTIPLE_CARDS = 32,     MULTIPLE_PLACEMENT_FAILURES = 33,
+  MULTIPLE_FOULS = 34,          UNSPORTING_BEHAVIOR_MINOR = 35,
+  UNSPORTING_BEHAVIOR_MAJOR = 36, BOT_SUBSTITUTION = 37, TOO_MANY_ROBOTS = 38,
+  POSSIBLE_GOAL = 39,           ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA_SKIPPED = 40,
+  BOUNDARY_CROSSING = 41,       INVALID_GOAL = 42,        PENALTY_KICK_FAILED = 43,
+  CHALLENGE_FLAG = 44,          EMERGENCY_STOP = 45,
+};
+// clang-format on
 
-// Team 定数（robocup_ssl_msgs::msg::Team と同じ値）
-namespace Team
-{
-constexpr int32_t UNKNOWN = 0;
-constexpr int32_t YELLOW = 1;
-constexpr int32_t BLUE = 2;
-}  // namespace Team
+enum class Team : int32_t { UNKNOWN = 0, YELLOW = 1, BLUE = 2 };
 
 // ─── 既存の実装（変更少）────────────────────────────────────────────────────────
 
@@ -232,65 +201,16 @@ std::vector<Event> detect_goals(const BagData & data)
 
 std::string game_event_type_to_string(int32_t v)
 {
-  static const std::map<int32_t, const char *> m = {
-    {GameEventType::UNKNOWN_GAME_EVENT_TYPE, "UNKNOWN_GAME_EVENT_TYPE"},
-    {GameEventType::BALL_LEFT_FIELD_TOUCH_LINE, "BALL_LEFT_FIELD_TOUCH_LINE"},
-    {GameEventType::BALL_LEFT_FIELD_GOAL_LINE, "BALL_LEFT_FIELD_GOAL_LINE"},
-    {GameEventType::AIMLESS_KICK, "AIMLESS_KICK"},
-    {GameEventType::ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA, "ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA"},
-    {GameEventType::DEFENDER_IN_DEFENSE_AREA, "DEFENDER_IN_DEFENSE_AREA"},
-    {GameEventType::BOUNDARY_CROSSING, "BOUNDARY_CROSSING"},
-    {GameEventType::KEEPER_HELD_BALL, "KEEPER_HELD_BALL"},
-    {GameEventType::BOT_DRIBBLED_BALL_TOO_FAR, "BOT_DRIBBLED_BALL_TOO_FAR"},
-    {GameEventType::BOT_PUSHED_BOT, "BOT_PUSHED_BOT"},
-    {GameEventType::BOT_HELD_BALL_DELIBERATELY, "BOT_HELD_BALL_DELIBERATELY"},
-    {GameEventType::BOT_TIPPED_OVER, "BOT_TIPPED_OVER"},
-    {GameEventType::ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA, "ATTACKER_TOUCHED_BALL_IN_DEFENSE_AREA"},
-    {GameEventType::BOT_KICKED_BALL_TOO_FAST, "BOT_KICKED_BALL_TOO_FAST"},
-    {GameEventType::BOT_CRASH_UNIQUE, "BOT_CRASH_UNIQUE"},
-    {GameEventType::BOT_CRASH_DRAWN, "BOT_CRASH_DRAWN"},
-    {GameEventType::DEFENDER_TOO_CLOSE_TO_KICK_POINT, "DEFENDER_TOO_CLOSE_TO_KICK_POINT"},
-    {GameEventType::BOT_TOO_FAST_IN_STOP, "BOT_TOO_FAST_IN_STOP"},
-    {GameEventType::BOT_INTERFERED_PLACEMENT, "BOT_INTERFERED_PLACEMENT"},
-    {GameEventType::POSSIBLE_GOAL, "POSSIBLE_GOAL"},
-    {GameEventType::GOAL, "GOAL"},
-    {GameEventType::INVALID_GOAL, "INVALID_GOAL"},
-    {GameEventType::ATTACKER_DOUBLE_TOUCHED_BALL, "ATTACKER_DOUBLE_TOUCHED_BALL"},
-    {GameEventType::PLACEMENT_SUCCEEDED, "PLACEMENT_SUCCEEDED"},
-    {GameEventType::PENALTY_KICK_FAILED, "PENALTY_KICK_FAILED"},
-    {GameEventType::NO_PROGRESS_IN_GAME, "NO_PROGRESS_IN_GAME"},
-    {GameEventType::PLACEMENT_FAILED, "PLACEMENT_FAILED"},
-    {GameEventType::MULTIPLE_CARDS, "MULTIPLE_CARDS"},
-    {GameEventType::MULTIPLE_FOULS, "MULTIPLE_FOULS"},
-    {GameEventType::BOT_SUBSTITUTION, "BOT_SUBSTITUTION"},
-    {GameEventType::TOO_MANY_ROBOTS, "TOO_MANY_ROBOTS"},
-    {GameEventType::CHALLENGE_FLAG, "CHALLENGE_FLAG"},
-    {GameEventType::EMERGENCY_STOP, "EMERGENCY_STOP"},
-    {GameEventType::UNSPORTING_BEHAVIOR_MINOR, "UNSPORTING_BEHAVIOR_MINOR"},
-    {GameEventType::UNSPORTING_BEHAVIOR_MAJOR, "UNSPORTING_BEHAVIOR_MAJOR"},
-    {GameEventType::PREPARED, "PREPARED"},
-    {GameEventType::INDIRECT_GOAL, "INDIRECT_GOAL"},
-    {GameEventType::CHIPPED_GOAL, "CHIPPED_GOAL"},
-    {GameEventType::KICK_TIMEOUT, "KICK_TIMEOUT"},
-    {GameEventType::ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA,
-     "ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA"},
-    {GameEventType::ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA_SKIPPED,
-     "ATTACKER_TOUCHED_OPPONENT_IN_DEFENSE_AREA_SKIPPED"},
-    {GameEventType::BOT_CRASH_UNIQUE_SKIPPED, "BOT_CRASH_UNIQUE_SKIPPED"},
-    {GameEventType::BOT_PUSHED_BOT_SKIPPED, "BOT_PUSHED_BOT_SKIPPED"},
-    {GameEventType::DEFENDER_IN_DEFENSE_AREA_PARTIALLY, "DEFENDER_IN_DEFENSE_AREA_PARTIALLY"},
-    {GameEventType::MULTIPLE_PLACEMENT_FAILURES, "MULTIPLE_PLACEMENT_FAILURES"},
-  };
-  auto it = m.find(v);
-  return it != m.end() ? it->second : "GAME_EVENT(" + std::to_string(v) + ")";
+  auto e = magic_enum::enum_cast<GameEventType>(v);
+  return e ? std::string(magic_enum::enum_name(*e)) : "GAME_EVENT(" + std::to_string(v) + ")";
 }
 
 namespace
 {
 
-const std::unordered_set<int32_t> & foul_event_types()
+const std::unordered_set<GameEventType> & foul_event_types()
 {
-  static const std::unordered_set<int32_t> s = {
+  static const std::unordered_set<GameEventType> s = {
     GameEventType::BOT_PUSHED_BOT,
     GameEventType::BOT_PUSHED_BOT_SKIPPED,
     GameEventType::BOT_HELD_BALL_DELIBERATELY,
@@ -322,9 +242,8 @@ const std::unordered_set<int32_t> & foul_event_types()
 
 std::string team_name(int32_t team_value)
 {
-  if (team_value == Team::YELLOW) return "YELLOW";
-  if (team_value == Team::BLUE) return "BLUE";
-  return "UNKNOWN";
+  auto t = magic_enum::enum_cast<Team>(team_value);
+  return t ? std::string(magic_enum::enum_name(*t)) : "UNKNOWN";
 }
 
 std::string foul_description(const GameEventInfo & ge)
@@ -332,7 +251,7 @@ std::string foul_description(const GameEventInfo & ge)
   const std::string type_name = game_event_type_to_string(ge.type_value);
   char buf[256];
 
-  switch (ge.type_value) {
+  switch (static_cast<GameEventType>(ge.type_value)) {
     case GameEventType::BOT_CRASH_UNIQUE:
     case GameEventType::BOT_CRASH_UNIQUE_SKIPPED:
       std::snprintf(
@@ -420,7 +339,7 @@ std::vector<Event> detect_fouls(const BagData & data)
   for (const auto & tm : data.referees) {
     const auto & msg = tm.msg;
     for (const auto & ge : msg.game_events) {
-      if (foul_event_types().find(ge.type_value) == foul_event_types().end()) continue;
+      if (!foul_event_types().count(static_cast<GameEventType>(ge.type_value))) continue;
 
       auto key = std::make_pair(ge.type_value, msg.command_counter);
       if (seen.count(key)) continue;

--- a/crane_bag/src/bag/bag_json.hpp
+++ b/crane_bag/src/bag/bag_json.hpp
@@ -59,30 +59,14 @@ inline void to_json(nlohmann::json & j, const Event & v)
   };
 }
 
-// RobotState
-inline void to_json(nlohmann::json & j, const RobotState & v)
-{
-  j = {
-    {"t", v.t},
-    {"robot_id", v.robot_id},
-    {"x", v.x},
-    {"y", v.y},
-    {"theta", v.theta},
-    {"vx", v.vx},
-    {"vy", v.vy},
-    {"speed", v.speed},
-    {"dist_to_ball", v.dist_to_ball},
-    {"detected", v.detected},
-  };
-}
-
-// BallState
-inline void to_json(nlohmann::json & j, const BallState & v)
-{
-  j = {
-    {"t", v.t}, {"x", v.x}, {"y", v.y}, {"vx", v.vx}, {"vy", v.vy}, {"speed", v.speed},
-  };
-}
+// RobotState / BallState
+// clang-format off
+// clang-format off
+// NOLINTNEXTLINE(whitespace/line_length)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(RobotState, t, robot_id, x, y, theta, vx, vy, speed, dist_to_ball, detected)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BallState, t, x, y, vx, vy, speed)
+// clang-format on
+// clang-format on
 
 // ControlSnapshot
 inline void to_json(nlohmann::json & j, const ControlSnapshot & v)
@@ -123,18 +107,11 @@ inline void to_json(nlohmann::json & j, const FactorTransition & v)
   };
 }
 
-// RefereeSnapshot::TeamSnapshot
-inline void to_json(nlohmann::json & j, const RefereeSnapshot::TeamSnapshot & v)
-{
-  j = {
-    {"name", v.name},
-    {"score", v.score},
-    {"yellow_cards", v.yellow_cards},
-    {"red_cards", v.red_cards},
-    {"foul_counter", v.foul_counter},
-    {"goalkeeper", v.goalkeeper},
-  };
-}
+// TeamInfo (= RefereeSnapshot::TeamSnapshot)
+// clang-format off
+// NOLINTNEXTLINE(whitespace/line_length)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(TeamInfo, name, score, yellow_cards, red_cards, foul_counter, goalkeeper)
+// clang-format on
 
 // RefereeSnapshot
 inline void to_json(nlohmann::json & j, const RefereeSnapshot & v)

--- a/crane_bag/src/bag/bag_reader.cpp
+++ b/crane_bag/src/bag/bag_reader.cpp
@@ -8,6 +8,7 @@
 
 #include <filesystem>
 #include <mcap/reader.hpp>
+#include <regex>
 #include <rosx_introspection/deserializer.hpp>
 #include <rosx_introspection/ros_parser.hpp>
 #include <rosx_introspection/ros_type.hpp>
@@ -120,21 +121,10 @@ BagData BagReader::read(
   data.info = populate_bag_info(bag_path, reader);
 
   // --- rosx_introspection パーサを構築 ---
-  // 対象トピックのチャンネルに対してのみパーサを登録
+  // readSummary() のスキーマID対応は bagによっては不正確なため、
+  // メッセージイテレーション中に view.schema から直接登録する。
   RosMsgParser::ParsersCollection<RosMsgParser::FastCDR_Deserializer> parsers;
-
-  for (const auto & [ch_id, ch] : reader.channels()) {
-    if (target_topics().find(ch->topic) == target_topics().end()) continue;
-
-    auto schema_it = reader.schemas().find(ch->schemaId);
-    if (schema_it == reader.schemas().end()) continue;
-
-    const auto & schema = *schema_it->second;
-    if (schema.encoding != "ros2msg") continue;
-
-    std::string definition = schema_data_to_string(schema);
-    parsers.registerParser(ch->topic, RosMsgParser::ROSType(schema.name), definition);
-  }
+  std::unordered_set<std::string> registered_topics;
 
   // --- 時間範囲フィルタを設定 ---
   mcap::Timestamp start_ts = 0;
@@ -153,19 +143,32 @@ BagData BagReader::read(
     const std::string & topic = view.channel->topic;
     if (targets.find(topic) == targets.end()) continue;
 
+    // 初回出現時にパーサを登録（view.schema はチャンネルに紐付く正確なスキーマ）
+    if (registered_topics.find(topic) == registered_topics.end()) {
+      if (view.schema && view.schema->encoding == "ros2msg") {
+        std::string definition = schema_data_to_string(*view.schema);
+        // rosx_introspection は bounded sequence 記法 [<=N] を isArray=false に誤パースする。
+        // [] (unbounded) に正規化して可変長シーケンスとして正しく扱わせる。
+        definition = std::regex_replace(definition, std::regex(R"(\[<=\d+\])"), "[]");
+        parsers.registerParser(topic, RosMsgParser::ROSType(view.schema->name), definition);
+        registered_topics.insert(topic);
+      }
+    }
+
     const uint8_t * raw = reinterpret_cast<const uint8_t *>(view.message.data);
     size_t raw_size = view.message.dataSize;
+    if (raw_size == 0) continue;
 
-    // ROS2 CDR encapsulation header（4バイト: 00 01 00 00）をスキップ
-    if (raw_size < 4) continue;
-    RosMsgParser::Span<const uint8_t> buf(raw + 4, raw_size - 4);
-
-    const RosMsgParser::FlatMessage * flat = parsers.deserialize(topic, buf);
-    if (!flat) continue;
+    // FastCDR_Deserializer が DDS_CDR モードで encapsulation header（00 01 00 00）を
+    // 自前で読み込む。スキップせずそのまま渡す。
+    RosMsgParser::Span<const uint8_t> buf(raw, raw_size);
 
     int64_t ts = static_cast<int64_t>(view.message.logTime);
 
     try {
+      const RosMsgParser::FlatMessage * flat = parsers.deserialize(topic, buf);
+      if (!flat) continue;
+
       if (topic == "/play_situation") {
         data.play_situations.push_back({ts, extract_play_situation(*flat)});
       } else if (topic == "/world_model") {

--- a/crane_bag/src/bag/bag_reader.cpp
+++ b/crane_bag/src/bag/bag_reader.cpp
@@ -53,6 +53,36 @@ const std::unordered_set<std::string> & target_topics()
   return s;
 }
 
+/// readSummary 済みの McapReader から BagInfo を構築する共通ロジック
+BagInfo populate_bag_info(const std::string & bag_path, const mcap::McapReader & reader)
+{
+  BagInfo info;
+  info.path = bag_path;
+
+  const auto & stats = reader.statistics();
+  if (stats.has_value()) {
+    info.start_time_ns = static_cast<int64_t>(stats->messageStartTime);
+    int64_t end_ns = static_cast<int64_t>(stats->messageEndTime);
+    info.end_time_ns = end_ns;
+    info.duration_sec = static_cast<double>(end_ns - info.start_time_ns) / 1e9;
+    for (const auto & [ch_id, count] : stats->channelMessageCounts) {
+      auto ch_it = reader.channels().find(ch_id);
+      if (ch_it != reader.channels().end()) {
+        info.topic_counts[ch_it->second->topic] += count;
+      }
+    }
+  }
+
+  for (const auto & [ch_id, ch] : reader.channels()) {
+    auto it = reader.schemas().find(ch->schemaId);
+    if (it != reader.schemas().end()) {
+      info.topic_types[ch->topic] = it->second->name;
+    }
+  }
+
+  return info;
+}
+
 }  // namespace
 
 BagInfo BagReader::read_info(const std::string & bag_path)
@@ -67,41 +97,7 @@ BagInfo BagReader::read_info(const std::string & bag_path)
   }
 
   (void)reader.readSummary(mcap::ReadSummaryMethod::AllowFallbackScan);
-
-  BagInfo info;
-  info.path = bag_path;
-
-  // 統計情報からタイムスタンプを取得
-  const auto & stats = reader.statistics();
-  if (stats.has_value()) {
-    info.start_time_ns = static_cast<int64_t>(stats->messageStartTime);
-    int64_t end_ns = static_cast<int64_t>(stats->messageEndTime);
-    info.end_time_ns = end_ns;
-    info.duration_sec = static_cast<double>(end_ns - info.start_time_ns) / 1e9;
-  }
-
-  // トピックごとのメッセージ数と型名を収集
-  const auto & channels = reader.channels();
-  const auto & schemas = reader.schemas();
-
-  for (const auto & [ch_id, ch] : channels) {
-    info.topic_counts[ch->topic] = 0;  // 詳細カウントは summary から
-    auto it = schemas.find(ch->schemaId);
-    if (it != schemas.end()) {
-      info.topic_types[ch->topic] = it->second->name;
-    }
-  }
-
-  // メッセージ数はsummaryのチャンネル統計から取得
-  if (stats.has_value()) {
-    for (const auto & [ch_id, count] : stats->channelMessageCounts) {
-      auto ch_it = channels.find(ch_id);
-      if (ch_it != channels.end()) {
-        info.topic_counts[ch_it->second->topic] += count;
-      }
-    }
-  }
-
+  BagInfo info = populate_bag_info(bag_path, reader);
   reader.close();
   return info;
 }
@@ -121,30 +117,7 @@ BagData BagReader::read(
   (void)reader.readSummary(mcap::ReadSummaryMethod::AllowFallbackScan);
 
   BagData data;
-
-  // --- BagInfo を読み込み ---
-  const auto & stats = reader.statistics();
-  if (stats.has_value()) {
-    data.info.start_time_ns = static_cast<int64_t>(stats->messageStartTime);
-    int64_t end_ns = static_cast<int64_t>(stats->messageEndTime);
-    data.info.end_time_ns = end_ns;
-    data.info.duration_sec = static_cast<double>(end_ns - data.info.start_time_ns) / 1e9;
-    for (const auto & [ch_id, count] : stats->channelMessageCounts) {
-      auto ch_it = reader.channels().find(ch_id);
-      if (ch_it != reader.channels().end()) {
-        data.info.topic_counts[ch_it->second->topic] += count;
-      }
-    }
-  }
-  data.info.path = bag_path;
-
-  // トピック型名を収集
-  for (const auto & [ch_id, ch] : reader.channels()) {
-    auto it = reader.schemas().find(ch->schemaId);
-    if (it != reader.schemas().end()) {
-      data.info.topic_types[ch->topic] = it->second->name;
-    }
-  }
+  data.info = populate_bag_info(bag_path, reader);
 
   // --- rosx_introspection パーサを構築 ---
   // 対象トピックのチャンネルに対してのみパーサを登録
@@ -166,7 +139,7 @@ BagData BagReader::read(
   // --- 時間範囲フィルタを設定 ---
   mcap::Timestamp start_ts = 0;
   mcap::Timestamp end_ts = mcap::MaxTime;
-  if (time_range && stats.has_value()) {
+  if (time_range && data.info.start_time_ns != 0) {
     int64_t bag_start = data.info.start_time_ns;
     start_ts =
       static_cast<mcap::Timestamp>(bag_start + static_cast<int64_t>(time_range->first * 1e9));

--- a/crane_bag/src/bag/bag_reader.cpp
+++ b/crane_bag/src/bag/bag_reader.cpp
@@ -7,11 +7,14 @@
 #include "bag_reader.hpp"
 
 #include <filesystem>
-#include <rclcpp/serialization.hpp>
-#include <rosbag2_cpp/reader.hpp>
-#include <rosbag2_storage/storage_filter.hpp>
-#include <rosbag2_storage/storage_options.hpp>
+#include <mcap/reader.hpp>
+#include <rosx_introspection/deserializer.hpp>
+#include <rosx_introspection/ros_parser.hpp>
+#include <rosx_introspection/ros_type.hpp>
+#include <stdexcept>
 #include <unordered_set>
+
+#include "msg_extractors.hpp"
 
 namespace crane::bag
 {
@@ -20,39 +23,27 @@ namespace
 {
 
 /// bag_path がディレクトリの場合、その中の .mcap ファイルを探して返す。
-std::string resolve_bag_uri(const std::string & bag_path)
+std::string resolve_mcap_path(const std::string & bag_path)
 {
   std::filesystem::path p(bag_path);
   if (std::filesystem::is_directory(p)) {
     for (const auto & entry : std::filesystem::directory_iterator(p)) {
       if (entry.path().extension() == ".mcap") {
-        return p.string();
+        return entry.path().string();
       }
     }
+    throw std::runtime_error("ディレクトリ内に .mcap ファイルが見つかりません: " + bag_path);
   }
   return bag_path;
 }
 
-rosbag2_storage::StorageOptions make_storage_options(const std::string & uri)
+/// mcap::Schema の data（ByteArray）を文字列に変換
+std::string schema_data_to_string(const mcap::Schema & schema)
 {
-  rosbag2_storage::StorageOptions opts;
-  opts.uri = uri;
-  return opts;
+  return std::string(reinterpret_cast<const char *>(schema.data.data()), schema.data.size());
 }
 
-template <typename MsgT>
-void deserialize_and_push(
-  const std::shared_ptr<rosbag2_storage::SerializedBagMessage> & bag_message,
-  std::vector<TimestampedMsg<MsgT>> & out)
-{
-  rclcpp::SerializedMessage serialized(*bag_message->serialized_data);
-  rclcpp::Serialization<MsgT> ser;
-  MsgT msg;
-  ser.deserialize_message(&serialized, &msg);
-  out.push_back({bag_message->recv_timestamp, std::move(msg)});
-}
-
-/// 対象トピックのセット（bag_reader.cpp 内で共有）
+/// 対象トピックのセット
 const std::unordered_set<std::string> & target_topics()
 {
   static const std::unordered_set<std::string> s = {
@@ -62,101 +53,169 @@ const std::unordered_set<std::string> & target_topics()
   return s;
 }
 
-/// BagMetadata からメタ情報を収集する共通処理
-BagInfo collect_bag_info(
-  const std::string & bag_path, const rosbag2_storage::BagMetadata & meta,
-  const std::vector<rosbag2_storage::TopicMetadata> & topic_types_vec)
-{
-  std::map<std::string, std::string> topic_types;
-  for (const auto & t : topic_types_vec) {
-    topic_types[t.name] = t.type;
-  }
-
-  std::map<std::string, size_t> topic_counts;
-  for (const auto & t : meta.topics_with_message_count) {
-    topic_counts[t.topic_metadata.name] = t.message_count;
-  }
-
-  int64_t start_ns =
-    std::chrono::duration_cast<std::chrono::nanoseconds>(meta.starting_time.time_since_epoch())
-      .count();
-  int64_t duration_ns = meta.duration.count();
-
-  return BagInfo{
-    bag_path,
-    static_cast<double>(duration_ns) / 1e9,
-    start_ns,
-    start_ns + duration_ns,
-    std::move(topic_counts),
-    std::move(topic_types),
-  };
-}
-
 }  // namespace
 
 BagInfo BagReader::read_info(const std::string & bag_path)
 {
-  std::string uri = resolve_bag_uri(bag_path);
-  rosbag2_cpp::Reader reader;
-  reader.open(make_storage_options(uri));
-  // get_metadata() はメッセージを読まずにメタデータYAMLから取得
-  return collect_bag_info(bag_path, reader.get_metadata(), reader.get_all_topics_and_types());
+  const std::string mcap_path = resolve_mcap_path(bag_path);
+
+  mcap::McapReader reader;
+  auto status = reader.open(mcap_path);
+  if (!status.ok()) {
+    throw std::runtime_error(
+      "mcapファイルを開けません: " + mcap_path + " (" + status.message + ")");
+  }
+
+  (void)reader.readSummary(mcap::ReadSummaryMethod::AllowFallbackScan);
+
+  BagInfo info;
+  info.path = bag_path;
+
+  // 統計情報からタイムスタンプを取得
+  const auto & stats = reader.statistics();
+  if (stats.has_value()) {
+    info.start_time_ns = static_cast<int64_t>(stats->messageStartTime);
+    int64_t end_ns = static_cast<int64_t>(stats->messageEndTime);
+    info.end_time_ns = end_ns;
+    info.duration_sec = static_cast<double>(end_ns - info.start_time_ns) / 1e9;
+  }
+
+  // トピックごとのメッセージ数と型名を収集
+  const auto & channels = reader.channels();
+  const auto & schemas = reader.schemas();
+
+  for (const auto & [ch_id, ch] : channels) {
+    info.topic_counts[ch->topic] = 0;  // 詳細カウントは summary から
+    auto it = schemas.find(ch->schemaId);
+    if (it != schemas.end()) {
+      info.topic_types[ch->topic] = it->second->name;
+    }
+  }
+
+  // メッセージ数はsummaryのチャンネル統計から取得
+  if (stats.has_value()) {
+    for (const auto & [ch_id, count] : stats->channelMessageCounts) {
+      auto ch_it = channels.find(ch_id);
+      if (ch_it != channels.end()) {
+        info.topic_counts[ch_it->second->topic] += count;
+      }
+    }
+  }
+
+  reader.close();
+  return info;
 }
 
 BagData BagReader::read(
   const std::string & bag_path, std::optional<std::pair<double, double>> time_range)
 {
-  std::string uri = resolve_bag_uri(bag_path);
+  const std::string mcap_path = resolve_mcap_path(bag_path);
 
-  // メタデータからBagInfoを取得（メッセージ読み込みなし）
-  rosbag2_cpp::Reader meta_reader;
-  meta_reader.open(make_storage_options(uri));
-  BagInfo bag_info =
-    collect_bag_info(bag_path, meta_reader.get_metadata(), meta_reader.get_all_topics_and_types());
-  // meta_reader はここでスコープを抜けてclose
-
-  // 時間範囲フィルタをストレージレベルで指定（読み込みループ外で制限）
-  auto storage_opts = make_storage_options(uri);
-  if (time_range) {
-    auto [ns_start, ns_end] = make_ns_range(bag_info.start_time_ns, time_range);
-    storage_opts.start_time_ns = ns_start;
-    storage_opts.end_time_ns = ns_end;
+  mcap::McapReader reader;
+  auto open_status = reader.open(mcap_path);
+  if (!open_status.ok()) {
+    throw std::runtime_error(
+      "mcapファイルを開けません: " + mcap_path + " (" + open_status.message + ")");
   }
 
-  rosbag2_cpp::Reader reader;
-  reader.open(storage_opts);
-
-  // トピックフィルタ（7トピック以外はストレージレベルでスキップ）
-  rosbag2_storage::StorageFilter filter;
-  filter.topics = std::vector<std::string>(target_topics().begin(), target_topics().end());
-  reader.set_filter(filter);
+  (void)reader.readSummary(mcap::ReadSummaryMethod::AllowFallbackScan);
 
   BagData data;
-  data.info = std::move(bag_info);
 
-  // ワンパスで直接デシリアライズ（RawMsg バッファなし）
-  while (reader.has_next()) {
-    auto bag_msg = reader.read_next();
-    const auto & topic = bag_msg->topic_name;
-    if (topic == "/play_situation") {
-      deserialize_and_push(bag_msg, data.play_situations);
-    } else if (topic == "/world_model") {
-      deserialize_and_push(bag_msg, data.world_models);
-    } else if (topic == "/control_targets") {
-      deserialize_and_push(bag_msg, data.control_targets);
-    } else if (topic == "/robot_commands") {
-      deserialize_and_push(bag_msg, data.robot_commands);
-    } else if (topic == "/game_analysis") {
-      deserialize_and_push(bag_msg, data.game_analyses);
-    } else if (topic == "/robot_select_results") {
-      deserialize_and_push(bag_msg, data.robot_select_results);
-    } else if (topic == "/rosout") {
-      deserialize_and_push(bag_msg, data.rosout);
-    } else if (topic == "/referee") {
-      deserialize_and_push(bag_msg, data.referees);
+  // --- BagInfo を読み込み ---
+  const auto & stats = reader.statistics();
+  if (stats.has_value()) {
+    data.info.start_time_ns = static_cast<int64_t>(stats->messageStartTime);
+    int64_t end_ns = static_cast<int64_t>(stats->messageEndTime);
+    data.info.end_time_ns = end_ns;
+    data.info.duration_sec = static_cast<double>(end_ns - data.info.start_time_ns) / 1e9;
+    for (const auto & [ch_id, count] : stats->channelMessageCounts) {
+      auto ch_it = reader.channels().find(ch_id);
+      if (ch_it != reader.channels().end()) {
+        data.info.topic_counts[ch_it->second->topic] += count;
+      }
+    }
+  }
+  data.info.path = bag_path;
+
+  // トピック型名を収集
+  for (const auto & [ch_id, ch] : reader.channels()) {
+    auto it = reader.schemas().find(ch->schemaId);
+    if (it != reader.schemas().end()) {
+      data.info.topic_types[ch->topic] = it->second->name;
     }
   }
 
+  // --- rosx_introspection パーサを構築 ---
+  // 対象トピックのチャンネルに対してのみパーサを登録
+  RosMsgParser::ParsersCollection<RosMsgParser::FastCDR_Deserializer> parsers;
+
+  for (const auto & [ch_id, ch] : reader.channels()) {
+    if (target_topics().find(ch->topic) == target_topics().end()) continue;
+
+    auto schema_it = reader.schemas().find(ch->schemaId);
+    if (schema_it == reader.schemas().end()) continue;
+
+    const auto & schema = *schema_it->second;
+    if (schema.encoding != "ros2msg") continue;
+
+    std::string definition = schema_data_to_string(schema);
+    parsers.registerParser(ch->topic, RosMsgParser::ROSType(schema.name), definition);
+  }
+
+  // --- 時間範囲フィルタを設定 ---
+  mcap::Timestamp start_ts = 0;
+  mcap::Timestamp end_ts = mcap::MaxTime;
+  if (time_range && stats.has_value()) {
+    int64_t bag_start = data.info.start_time_ns;
+    start_ts =
+      static_cast<mcap::Timestamp>(bag_start + static_cast<int64_t>(time_range->first * 1e9));
+    end_ts =
+      static_cast<mcap::Timestamp>(bag_start + static_cast<int64_t>(time_range->second * 1e9));
+  }
+
+  // --- メッセージをワンパスで読み込み ---
+  const auto & targets = target_topics();
+  for (const auto & view : reader.readMessages(start_ts, end_ts)) {
+    const std::string & topic = view.channel->topic;
+    if (targets.find(topic) == targets.end()) continue;
+
+    const uint8_t * raw = reinterpret_cast<const uint8_t *>(view.message.data);
+    size_t raw_size = view.message.dataSize;
+
+    // ROS2 CDR encapsulation header（4バイト: 00 01 00 00）をスキップ
+    if (raw_size < 4) continue;
+    RosMsgParser::Span<const uint8_t> buf(raw + 4, raw_size - 4);
+
+    const RosMsgParser::FlatMessage * flat = parsers.deserialize(topic, buf);
+    if (!flat) continue;
+
+    int64_t ts = static_cast<int64_t>(view.message.logTime);
+
+    try {
+      if (topic == "/play_situation") {
+        data.play_situations.push_back({ts, extract_play_situation(*flat)});
+      } else if (topic == "/world_model") {
+        data.world_models.push_back({ts, extract_world_model(*flat)});
+      } else if (topic == "/control_targets") {
+        data.control_targets.push_back({ts, extract_robot_commands(*flat)});
+      } else if (topic == "/robot_commands") {
+        data.robot_commands.push_back({ts, extract_robot_commands(*flat)});
+      } else if (topic == "/game_analysis") {
+        data.game_analyses.push_back({ts, extract_game_analysis(*flat)});
+      } else if (topic == "/robot_select_results") {
+        data.robot_select_results.push_back({ts, extract_robot_select_results(*flat)});
+      } else if (topic == "/rosout") {
+        data.rosout.push_back({ts, extract_log_message(*flat)});
+      } else if (topic == "/referee") {
+        data.referees.push_back({ts, extract_referee(*flat)});
+      }
+    } catch (const std::exception &) {
+      // デシリアライズ失敗は静かにスキップ（古いbagでのフィールド不足等）
+    }
+  }
+
+  reader.close();
   return data;
 }
 

--- a/crane_bag/src/bag/bag_reader.hpp
+++ b/crane_bag/src/bag/bag_reader.hpp
@@ -33,9 +33,9 @@ struct TimestampedMsg
 struct BagInfo
 {
   std::string path;
-  double duration_sec;
-  int64_t start_time_ns;
-  int64_t end_time_ns;
+  double duration_sec = 0.0;
+  int64_t start_time_ns = 0;
+  int64_t end_time_ns = 0;
   std::map<std::string, size_t> topic_counts;
   std::map<std::string, std::string> topic_types;
 };

--- a/crane_bag/src/bag/bag_reader.hpp
+++ b/crane_bag/src/bag/bag_reader.hpp
@@ -6,20 +6,14 @@
 
 #pragma once
 
-#include <chrono>
-#include <crane_msgs/msg/game_analysis.hpp>
-#include <crane_msgs/msg/play_situation.hpp>
-#include <crane_msgs/msg/robot_commands.hpp>
-#include <crane_msgs/msg/robot_select_results.hpp>
-#include <crane_msgs/msg/world_model.hpp>
 #include <limits>
 #include <map>
 #include <optional>
-#include <rcl_interfaces/msg/log.hpp>
-#include <robocup_ssl_msgs/msg/referee.hpp>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "bag_types.hpp"
 
 namespace crane::bag
 {
@@ -49,14 +43,14 @@ struct BagInfo
 struct BagData
 {
   BagInfo info;
-  std::vector<TimestampedMsg<crane_msgs::msg::PlaySituation>> play_situations;
-  std::vector<TimestampedMsg<crane_msgs::msg::WorldModel>> world_models;
-  std::vector<TimestampedMsg<crane_msgs::msg::RobotCommands>> control_targets;
-  std::vector<TimestampedMsg<crane_msgs::msg::RobotCommands>> robot_commands;
-  std::vector<TimestampedMsg<crane_msgs::msg::GameAnalysis>> game_analyses;
-  std::vector<TimestampedMsg<crane_msgs::msg::RobotSelectResults>> robot_select_results;
-  std::vector<TimestampedMsg<rcl_interfaces::msg::Log>> rosout;
-  std::vector<TimestampedMsg<robocup_ssl_msgs::msg::Referee>> referees;
+  std::vector<TimestampedMsg<PlaySituation>> play_situations;
+  std::vector<TimestampedMsg<WorldModel>> world_models;
+  std::vector<TimestampedMsg<RobotCommands>> control_targets;
+  std::vector<TimestampedMsg<RobotCommands>> robot_commands;
+  std::vector<TimestampedMsg<GameAnalysis>> game_analyses;
+  std::vector<TimestampedMsg<RobotSelectResults>> robot_select_results;
+  std::vector<TimestampedMsg<LogMessage>> rosout;
+  std::vector<TimestampedMsg<Referee>> referees;
 
   /// 指定間隔でサンプリングしたポインタ列を返す
   template <typename MsgT>
@@ -65,7 +59,7 @@ struct BagData
   {
     std::vector<const TimestampedMsg<MsgT> *> result;
     int64_t interval_ns = static_cast<int64_t>(interval_sec * 1e9);
-    int64_t last_ns = 0;  // タイムスタンプはエポックからのns（>>0）なので最初は必ず通過
+    int64_t last_ns = 0;
     for (const auto & m : msgs) {
       if (m.timestamp_ns - last_ns >= interval_ns) {
         result.push_back(&m);

--- a/crane_bag/src/bag/bag_referee.cpp
+++ b/crane_bag/src/bag/bag_referee.cpp
@@ -58,19 +58,8 @@ RefereeSnapshot make_snapshot(const TimestampedMsg<Referee> & tm, int64_t bag_st
   snap.stage_name = stage_to_string(msg.stage_value);
   snap.command_counter = msg.command_counter;
 
-  snap.yellow.name = msg.yellow.name;
-  snap.yellow.score = msg.yellow.score;
-  snap.yellow.yellow_cards = msg.yellow.yellow_cards;
-  snap.yellow.red_cards = msg.yellow.red_cards;
-  snap.yellow.foul_counter = msg.yellow.foul_counter;
-  snap.yellow.goalkeeper = msg.yellow.goalkeeper;
-
-  snap.blue.name = msg.blue.name;
-  snap.blue.score = msg.blue.score;
-  snap.blue.yellow_cards = msg.blue.yellow_cards;
-  snap.blue.red_cards = msg.blue.red_cards;
-  snap.blue.foul_counter = msg.blue.foul_counter;
-  snap.blue.goalkeeper = msg.blue.goalkeeper;
+  snap.yellow = msg.yellow;
+  snap.blue = msg.blue;
 
   snap.has_designated_position = (msg.has_field & REFEREE_DESIGNATED_POSITION_FIELD_SET) != 0;
   snap.designated_x = snap.has_designated_position ? msg.designated_position_x / 1000.0f : 0.0f;

--- a/crane_bag/src/bag/bag_referee.cpp
+++ b/crane_bag/src/bag/bag_referee.cpp
@@ -6,8 +6,7 @@
 
 #include "bag_referee.hpp"
 
-#include <crane_msg_wrappers/play_situation_wrapper.hpp>
-#include <robocup_ssl_msgs/msg/referee.hpp>
+#include <map>
 
 namespace crane::bag
 {
@@ -15,18 +14,48 @@ namespace crane::bag
 namespace
 {
 
-using RefereeMsg = robocup_ssl_msgs::msg::Referee;
+// ─── Referee コマンド文字列ルックアップ ────────────────────────────────────────
+// robocup_ssl_msgs::msg::RefereeCommand / RefereeStage の整数定数と同じ値
 
-RefereeSnapshot make_snapshot(const TimestampedMsg<RefereeMsg> & tm, int64_t bag_start_ns)
+static const std::map<int, std::string> referee_command_map = {
+  {0, "HALT"},
+  {1, "STOP"},
+  {2, "NORMAL_START"},
+  {3, "FORCE_START"},
+  {4, "PREPARE_KICKOFF_YELLOW"},
+  {5, "PREPARE_KICKOFF_BLUE"},
+  {6, "PREPARE_PENALTY_YELLOW"},
+  {7, "PREPARE_PENALTY_BLUE"},
+  {8, "DIRECT_FREE_YELLOW"},
+  {9, "DIRECT_FREE_BLUE"},
+  {10, "INDIRECT_FREE_YELLOW"},
+  {11, "INDIRECT_FREE_BLUE"},
+  {12, "TIMEOUT_YELLOW"},
+  {13, "TIMEOUT_BLUE"},
+  {14, "GOAL_YELLOW"},
+  {15, "GOAL_BLUE"},
+  {16, "BALL_PLACEMENT_YELLOW"},
+  {17, "BALL_PLACEMENT_BLUE"},
+};
+
+static const std::map<int, std::string> stage_map = {
+  {0, "NORMAL_FIRST_HALF_PRE"},  {1, "NORMAL_FIRST_HALF"},  {2, "NORMAL_HALF_TIME"},
+  {3, "NORMAL_SECOND_HALF_PRE"}, {4, "NORMAL_SECOND_HALF"}, {5, "EXTRA_TIME_BREAK"},
+  {6, "EXTRA_FIRST_HALF_PRE"},   {7, "EXTRA_FIRST_HALF"},   {8, "EXTRA_HALF_TIME"},
+  {9, "EXTRA_SECOND_HALF_PRE"},  {10, "EXTRA_SECOND_HALF"}, {11, "PENALTY_SHOOTOUT_BREAK"},
+  {12, "PENALTY_SHOOTOUT"},      {13, "POST_GAME"},
+};
+
+RefereeSnapshot make_snapshot(const TimestampedMsg<Referee> & tm, int64_t bag_start_ns)
 {
   const auto & msg = tm.msg;
   RefereeSnapshot snap;
   snap.t = tm.t(bag_start_ns);
   snap.timestamp_ns = tm.timestamp_ns;
-  snap.command_value = msg.command.value;
-  snap.command_name = command_to_string(msg.command.value);
-  snap.stage_value = msg.stage.value;
-  snap.stage_name = stage_to_string(msg.stage.value);
+  snap.command_value = msg.command_value;
+  snap.command_name = command_to_string(msg.command_value);
+  snap.stage_value = msg.stage_value;
+  snap.stage_name = stage_to_string(msg.stage_value);
   snap.command_counter = msg.command_counter;
 
   snap.yellow.name = msg.yellow.name;
@@ -43,13 +72,13 @@ RefereeSnapshot make_snapshot(const TimestampedMsg<RefereeMsg> & tm, int64_t bag
   snap.blue.foul_counter = msg.blue.foul_counter;
   snap.blue.goalkeeper = msg.blue.goalkeeper;
 
-  snap.has_designated_position = (msg.has_field & RefereeMsg::DESIGNATED_POSITION_FIELD_SET) != 0;
-  snap.designated_x = snap.has_designated_position ? msg.designated_position.x / 1000.0f : 0.0f;
-  snap.designated_y = snap.has_designated_position ? msg.designated_position.y / 1000.0f : 0.0f;
+  snap.has_designated_position = (msg.has_field & REFEREE_DESIGNATED_POSITION_FIELD_SET) != 0;
+  snap.designated_x = snap.has_designated_position ? msg.designated_position_x / 1000.0f : 0.0f;
+  snap.designated_y = snap.has_designated_position ? msg.designated_position_y / 1000.0f : 0.0f;
 
-  snap.has_next_command = (msg.has_field & RefereeMsg::NEXT_COMMAND_FIELD_SET) != 0;
-  snap.next_command_value = snap.has_next_command ? msg.next_command.value : 0;
-  snap.next_command_name = snap.has_next_command ? command_to_string(msg.next_command.value) : "";
+  snap.has_next_command = (msg.has_field & REFEREE_NEXT_COMMAND_FIELD_SET) != 0;
+  snap.next_command_value = snap.has_next_command ? msg.next_command_value : 0;
+  snap.next_command_name = snap.has_next_command ? command_to_string(msg.next_command_value) : "";
 
   snap.current_action_time_remaining_us = msg.current_action_time_remaining;
   return snap;
@@ -90,12 +119,14 @@ std::vector<RefereeSnapshot> sample_referee(const BagData & data, double interva
 
 std::string command_to_string(int32_t cmd)
 {
-  return crane::getRefereeCommandText(static_cast<uint32_t>(cmd));
+  auto it = referee_command_map.find(cmd);
+  return it != referee_command_map.end() ? it->second : "UNKNOWN";
 }
 
 std::string stage_to_string(int32_t stage)
 {
-  return crane::getStageText(static_cast<uint32_t>(stage));
+  auto it = stage_map.find(stage);
+  return it != stage_map.end() ? it->second : "UNKNOWN";
 }
 
 }  // namespace crane::bag

--- a/crane_bag/src/bag/bag_referee.cpp
+++ b/crane_bag/src/bag/bag_referee.cpp
@@ -6,45 +6,36 @@
 
 #include "bag_referee.hpp"
 
-#include <map>
+#include <magic_enum/magic_enum.hpp>
 
 namespace crane::bag
 {
 
+// ─── Referee コマンド / ステージ（robocup_ssl_msgs と同じ値）─────────────────
+
+// clang-format off
+enum class RefereeCommand : int32_t {
+  HALT = 0,              STOP = 1,              NORMAL_START = 2,         FORCE_START = 3,
+  PREPARE_KICKOFF_YELLOW = 4, PREPARE_KICKOFF_BLUE = 5,
+  PREPARE_PENALTY_YELLOW = 6, PREPARE_PENALTY_BLUE = 7,
+  DIRECT_FREE_YELLOW = 8,     DIRECT_FREE_BLUE = 9,
+  INDIRECT_FREE_YELLOW = 10,  INDIRECT_FREE_BLUE = 11,
+  TIMEOUT_YELLOW = 12,        TIMEOUT_BLUE = 13,
+  GOAL_YELLOW = 14,           GOAL_BLUE = 15,
+  BALL_PLACEMENT_YELLOW = 16, BALL_PLACEMENT_BLUE = 17,
+};
+
+enum class RefereeStage : int32_t {
+  NORMAL_FIRST_HALF_PRE = 0,  NORMAL_FIRST_HALF = 1,  NORMAL_HALF_TIME = 2,
+  NORMAL_SECOND_HALF_PRE = 3, NORMAL_SECOND_HALF = 4, EXTRA_TIME_BREAK = 5,
+  EXTRA_FIRST_HALF_PRE = 6,   EXTRA_FIRST_HALF = 7,   EXTRA_HALF_TIME = 8,
+  EXTRA_SECOND_HALF_PRE = 9,  EXTRA_SECOND_HALF = 10, PENALTY_SHOOTOUT_BREAK = 11,
+  PENALTY_SHOOTOUT = 12,      POST_GAME = 13,
+};
+// clang-format on
+
 namespace
 {
-
-// ─── Referee コマンド文字列ルックアップ ────────────────────────────────────────
-// robocup_ssl_msgs::msg::RefereeCommand / RefereeStage の整数定数と同じ値
-
-const std::map<int, std::string> referee_command_map = {
-  {0, "HALT"},
-  {1, "STOP"},
-  {2, "NORMAL_START"},
-  {3, "FORCE_START"},
-  {4, "PREPARE_KICKOFF_YELLOW"},
-  {5, "PREPARE_KICKOFF_BLUE"},
-  {6, "PREPARE_PENALTY_YELLOW"},
-  {7, "PREPARE_PENALTY_BLUE"},
-  {8, "DIRECT_FREE_YELLOW"},
-  {9, "DIRECT_FREE_BLUE"},
-  {10, "INDIRECT_FREE_YELLOW"},
-  {11, "INDIRECT_FREE_BLUE"},
-  {12, "TIMEOUT_YELLOW"},
-  {13, "TIMEOUT_BLUE"},
-  {14, "GOAL_YELLOW"},
-  {15, "GOAL_BLUE"},
-  {16, "BALL_PLACEMENT_YELLOW"},
-  {17, "BALL_PLACEMENT_BLUE"},
-};
-
-const std::map<int, std::string> stage_map = {
-  {0, "NORMAL_FIRST_HALF_PRE"},  {1, "NORMAL_FIRST_HALF"},  {2, "NORMAL_HALF_TIME"},
-  {3, "NORMAL_SECOND_HALF_PRE"}, {4, "NORMAL_SECOND_HALF"}, {5, "EXTRA_TIME_BREAK"},
-  {6, "EXTRA_FIRST_HALF_PRE"},   {7, "EXTRA_FIRST_HALF"},   {8, "EXTRA_HALF_TIME"},
-  {9, "EXTRA_SECOND_HALF_PRE"},  {10, "EXTRA_SECOND_HALF"}, {11, "PENALTY_SHOOTOUT_BREAK"},
-  {12, "PENALTY_SHOOTOUT"},      {13, "POST_GAME"},
-};
 
 RefereeSnapshot make_snapshot(const TimestampedMsg<Referee> & tm, int64_t bag_start_ns)
 {
@@ -108,14 +99,14 @@ std::vector<RefereeSnapshot> sample_referee(const BagData & data, double interva
 
 std::string command_to_string(int32_t cmd)
 {
-  auto it = referee_command_map.find(cmd);
-  return it != referee_command_map.end() ? it->second : "UNKNOWN";
+  auto e = magic_enum::enum_cast<RefereeCommand>(cmd);
+  return e ? std::string(magic_enum::enum_name(*e)) : "UNKNOWN";
 }
 
 std::string stage_to_string(int32_t stage)
 {
-  auto it = stage_map.find(stage);
-  return it != stage_map.end() ? it->second : "UNKNOWN";
+  auto e = magic_enum::enum_cast<RefereeStage>(stage);
+  return e ? std::string(magic_enum::enum_name(*e)) : "UNKNOWN";
 }
 
 }  // namespace crane::bag

--- a/crane_bag/src/bag/bag_referee.cpp
+++ b/crane_bag/src/bag/bag_referee.cpp
@@ -17,7 +17,7 @@ namespace
 // ─── Referee コマンド文字列ルックアップ ────────────────────────────────────────
 // robocup_ssl_msgs::msg::RefereeCommand / RefereeStage の整数定数と同じ値
 
-static const std::map<int, std::string> referee_command_map = {
+const std::map<int, std::string> referee_command_map = {
   {0, "HALT"},
   {1, "STOP"},
   {2, "NORMAL_START"},
@@ -38,7 +38,7 @@ static const std::map<int, std::string> referee_command_map = {
   {17, "BALL_PLACEMENT_BLUE"},
 };
 
-static const std::map<int, std::string> stage_map = {
+const std::map<int, std::string> stage_map = {
   {0, "NORMAL_FIRST_HALF_PRE"},  {1, "NORMAL_FIRST_HALF"},  {2, "NORMAL_HALF_TIME"},
   {3, "NORMAL_SECOND_HALF_PRE"}, {4, "NORMAL_SECOND_HALF"}, {5, "EXTRA_TIME_BREAK"},
   {6, "EXTRA_FIRST_HALF_PRE"},   {7, "EXTRA_FIRST_HALF"},   {8, "EXTRA_HALF_TIME"},

--- a/crane_bag/src/bag/bag_referee.hpp
+++ b/crane_bag/src/bag/bag_referee.hpp
@@ -25,15 +25,7 @@ struct RefereeSnapshot
   int32_t stage_value;
   uint32_t command_counter;
 
-  struct TeamSnapshot
-  {
-    std::string name;
-    uint32_t score;
-    uint32_t yellow_cards;
-    uint32_t red_cards;
-    uint32_t foul_counter;
-    uint32_t goalkeeper;
-  };
+  using TeamSnapshot = TeamInfo;
   TeamSnapshot yellow;
   TeamSnapshot blue;
 

--- a/crane_bag/src/bag/bag_survey.cpp
+++ b/crane_bag/src/bag/bag_survey.cpp
@@ -33,7 +33,7 @@ std::string fmt_pos(double x, double y)
   return buf;
 }
 
-std::string fmt_factors(const std::vector<crane_msgs::msg::NamedString> & factors)
+std::string fmt_factors(const std::vector<NamedString> & factors)
 {
   if (factors.empty()) return "(empty)";
   std::string s;
@@ -50,7 +50,7 @@ std::string section_play_situations(const BagData & data)
   oss << "=== PLAY SITUATIONS ===\n";
   for (const auto & tm : data.play_situations) {
     double t = tm.t(data.info.start_time_ns);
-    oss << "  " << fmt_t(t) << ": " << tm.msg.command.name << ", reason=" << tm.msg.reason_text
+    oss << "  " << fmt_t(t) << ": " << tm.msg.command_name << ", reason=" << tm.msg.reason_text
         << "\n";
   }
   return oss.str();
@@ -66,9 +66,9 @@ std::string section_role_assignments(const BagData & data)
     oss << "  " << fmt_t(t) << ":\n";
     for (const auto & r : tm.msg.results) {
       oss << "    " << r.name << ": selected=[";
-      for (size_t i = 0; i < r.selected_robots.size(); ++i) {
-        if (i > 0) oss << ", ";
-        oss << static_cast<int>(r.selected_robots[i]);
+      for (size_t ri = 0; ri < r.selected_robots.size(); ++ri) {
+        if (ri > 0) oss << ", ";
+        oss << static_cast<int>(r.selected_robots[ri]);
       }
       oss << "]\n";
     }

--- a/crane_bag/src/bag/bag_survey.cpp
+++ b/crane_bag/src/bag/bag_survey.cpp
@@ -145,8 +145,10 @@ std::string section_velocity_status(const BagData & data, double interval = 10.0
 
   for (const auto * tm : BagData::sample(data.robot_commands, interval)) {
     double t = tm->t(data.info.start_time_ns);
-    std::vector<int> zero_robots;
-    std::vector<std::pair<int, double>> moving_robots;
+    std::ostringstream zero_oss, moving_oss;
+    zero_oss << "[";
+    moving_oss << "[";
+    bool first_zero = true, first_moving = true;
 
     for (const auto & rc : tm->msg.robot_commands) {
       double vr = 0.0;
@@ -154,28 +156,21 @@ std::string section_velocity_status(const BagData & data, double interval = 10.0
         vr = rc.polar_velocity_target_mode[0].target_velocity_r;
       }
       if (std::abs(vr) < 0.01 && !rc.stop_flag) {
-        zero_robots.push_back(static_cast<int>(rc.robot_id));
+        if (!first_zero) zero_oss << ", ";
+        zero_oss << static_cast<int>(rc.robot_id);
+        first_zero = false;
       } else if (std::abs(vr) >= 0.01) {
-        moving_robots.emplace_back(static_cast<int>(rc.robot_id), vr);
+        char tmp[32];
+        std::snprintf(tmp, sizeof(tmp), "(%d, %.2f)", static_cast<int>(rc.robot_id), vr);
+        if (!first_moving) moving_oss << ", ";
+        moving_oss << tmp;
+        first_moving = false;
       }
     }
-
-    std::string zero_str = "[";
-    for (size_t i = 0; i < zero_robots.size(); ++i) {
-      if (i > 0) zero_str += ", ";
-      zero_str += std::to_string(zero_robots[i]);
-    }
-    zero_str += "]";
-
-    std::string moving_str = "[";
-    for (size_t i = 0; i < moving_robots.size(); ++i) {
-      if (i > 0) moving_str += ", ";
-      char tmp[32];
-      std::snprintf(
-        tmp, sizeof(tmp), "(%d, %.2f)", moving_robots[i].first, moving_robots[i].second);
-      moving_str += tmp;
-    }
-    moving_str += "]";
+    zero_oss << "]";
+    moving_oss << "]";
+    std::string zero_str = zero_oss.str();
+    std::string moving_str = moving_oss.str();
 
     std::snprintf(
       buf, sizeof(buf), "  t=%.2f: zero_v=%s, moving=%s\n", t, zero_str.c_str(),

--- a/crane_bag/src/bag/bag_types.hpp
+++ b/crane_bag/src/bag/bag_types.hpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/// mcap埋め込みメッセージ定義を使った動的デシリアライズのためのプレーンC++構造体。
+/// ROSメッセージヘッダに依存しないため、定義が変わった古いrosbagも読み込める。
+
+namespace crane::bag
+{
+
+// ─── 幾何プリミティブ ─────────────────────────────────────────────────────────
+
+struct Point2D
+{
+  double x = 0, y = 0;
+};
+
+struct Point3D
+{
+  double x = 0, y = 0, z = 0;
+};
+
+struct Pose2D
+{
+  double x = 0, y = 0, theta = 0;
+};
+
+// ─── WorldModel ───────────────────────────────────────────────────────────────
+
+struct BallInfo
+{
+  Point3D position;
+  Point2D velocity;
+};
+
+struct RobotInfo
+{
+  uint8_t id = 0;
+  Pose2D pose;
+  Point2D velocity;
+  bool available_vision = false;
+};
+
+struct FieldInfo
+{
+  double x = 0, y = 0;  // フィールド寸法 [m]
+};
+
+struct WorldModel
+{
+  BallInfo ball_info;
+  FieldInfo field_info;
+  bool is_yellow = false;
+  std::vector<RobotInfo> robot_info_ours;
+  std::vector<RobotInfo> robot_info_theirs;
+};
+
+// ─── PlaySituation ────────────────────────────────────────────────────────────
+
+struct PlaySituation
+{
+  std::string command_name;
+  std::string reason_text;
+};
+
+// ─── RobotCommands ────────────────────────────────────────────────────────────
+
+struct NamedString
+{
+  std::string name;
+  std::string value;
+};
+
+struct PositionTarget
+{
+  float target_x = 0, target_y = 0;
+};
+
+struct PolarVelocityTarget
+{
+  float target_velocity_r = 0, target_velocity_theta = 0;
+};
+
+struct RobotCommand
+{
+  uint8_t robot_id = 0;
+  float kick_power = 0;
+  float dribble_power = 0;
+  bool stop_flag = false;
+  bool chip_enable = false;
+  std::string planner_name;
+  std::vector<NamedString> planning_factors;
+  std::vector<PositionTarget> position_target_mode;
+  std::vector<PolarVelocityTarget> polar_velocity_target_mode;
+};
+
+struct RobotCommands
+{
+  std::vector<RobotCommand> robot_commands;
+};
+
+// ─── GameAnalysis ─────────────────────────────────────────────────────────────
+
+struct GameAnalysis
+{
+  int32_t recommended_attacker_id = 0;
+  float attacker_suitability_score = 0;
+  int32_t pass_target_id = 0;
+};
+
+// ─── RobotSelectResults ───────────────────────────────────────────────────────
+
+struct SelectResult
+{
+  std::string name;
+  std::vector<uint8_t> selected_robots;
+};
+
+struct RobotSelectResults
+{
+  std::vector<SelectResult> results;
+};
+
+// ─── Log (rosout) ─────────────────────────────────────────────────────────────
+
+struct LogMessage
+{
+  uint8_t level = 0;
+  std::string name;
+  std::string msg;
+};
+
+// ─── Referee ─────────────────────────────────────────────────────────────────
+
+struct TeamInfo
+{
+  std::string name;
+  uint32_t score = 0;
+  uint32_t yellow_cards = 0;
+  uint32_t red_cards = 0;
+  uint32_t foul_counter = 0;
+  uint32_t goalkeeper = 0;
+};
+
+/// ファウル種別ごとに必要なフィールドをフラット化して保持。
+/// CDR上では全サブフィールドが存在するため、type_valueに応じて
+/// 該当フィールドのみを読み取る（他フィールドはゼロ初期化）。
+struct GameEventInfo
+{
+  int32_t type_value = 0;
+  int32_t by_team_value = 0;
+  uint32_t violator = 0;
+  uint32_t victim = 0;
+  uint32_t by_bot = 0;
+  float location_x = 0, location_y = 0;
+  float crash_speed = 0;
+  float speed = 0;
+  float duration = 0;
+};
+
+struct Referee
+{
+  int32_t command_value = 0;
+  uint32_t command_counter = 0;
+  int32_t stage_value = 0;
+  TeamInfo yellow;
+  TeamInfo blue;
+  uint32_t has_field = 0;
+  float designated_position_x = 0, designated_position_y = 0;
+  int32_t next_command_value = 0;
+  int32_t current_action_time_remaining = 0;
+  std::vector<GameEventInfo> game_events;
+};
+
+// ─── Referee has_field ビットマスク定数 ───────────────────────────────────────
+// robocup_ssl_msgs::msg::Referee と同じ値を持つ（IDLで定義）
+
+constexpr uint32_t REFEREE_DESIGNATED_POSITION_FIELD_SET = 256;
+constexpr uint32_t REFEREE_NEXT_COMMAND_FIELD_SET = 1024;
+
+}  // namespace crane::bag

--- a/crane_bag/src/bag/msg_extractors.cpp
+++ b/crane_bag/src/bag/msg_extractors.cpp
@@ -1,0 +1,524 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "msg_extractors.hpp"
+
+#include <cmath>
+#include <string_view>
+#include <unordered_map>
+
+namespace crane::bag
+{
+
+namespace
+{
+
+// ─── FlatMessage アクセサユーティリティ ────────────────────────────────────────
+
+/// FlatMessage の数値フィールド（value）を suffix でルックアップするキャッシュ。
+/// 構築コストを避けるため、呼び出し元が毎回再構築せずに再利用できるよう設計。
+struct FlatValueMap
+{
+  std::unordered_map<std::string, double> numeric;    // path -> double
+  std::unordered_map<std::string, std::string> text;  // path -> string
+
+  void build(const RosMsgParser::FlatMessage & flat)
+  {
+    numeric.clear();
+    text.clear();
+    for (const auto & [fv, var] : flat.value) {
+      std::string key = fv.toStdString();
+      numeric[key] = var.convert<double>();
+    }
+    for (const auto & [fv, s] : flat.name) {
+      std::string key = fv.toStdString();
+      text[key] = s;
+    }
+  }
+
+  // サフィックスが一致する最初の数値を返す（トピック名プレフィックスを無視）
+  double get_d(const std::string & suffix, double def = 0.0) const
+  {
+    for (const auto & [k, v] : numeric) {
+      if (
+        k.size() >= suffix.size() &&
+        k.compare(k.size() - suffix.size(), suffix.size(), suffix) == 0) {
+        return v;
+      }
+    }
+    return def;
+  }
+
+  // 完全パス（先頭の /topic/ から始まる）で数値を返す
+  double get_d_exact(const std::string & path, double def = 0.0) const
+  {
+    auto it = numeric.find(path);
+    return it != numeric.end() ? it->second : def;
+  }
+
+  // 完全パスで文字列を返す
+  std::string get_s_exact(const std::string & path, const std::string & def = "") const
+  {
+    auto it = text.find(path);
+    return it != text.end() ? it->second : def;
+  }
+
+  // サフィックスが一致する最初の文字列を返す
+  std::string get_s(const std::string & suffix, const std::string & def = "") const
+  {
+    for (const auto & [k, v] : text) {
+      if (
+        k.size() >= suffix.size() &&
+        k.compare(k.size() - suffix.size(), suffix.size(), suffix) == 0) {
+        return v;
+      }
+    }
+    return def;
+  }
+
+  // 配列の要素数をカウント（プレフィックス "/<field>." を持つキーの最大インデックス+1）
+  size_t count_array(const std::string & prefix) const
+  {
+    size_t max_idx = 0;
+    bool found = false;
+    for (const auto & [k, v] : numeric) {
+      if (k.size() > prefix.size() && k.compare(0, prefix.size(), prefix) == 0) {
+        // prefix の次の文字から数字を読む
+        size_t dot_pos = k.find('.', prefix.size());
+        if (dot_pos == std::string::npos) continue;
+        // prefix は "<topic>/array_field" 形式 → 次は ".<idx>/<subfield>"
+        // 実際のパスは "<topic>/array_field.N/<subfield>"
+        size_t start = prefix.size();
+        if (k[start] != '.') continue;
+        size_t end = k.find('/', start + 1);
+        if (end == std::string::npos) end = k.size();
+        size_t idx = 0;
+        try {
+          idx = std::stoull(k.substr(start + 1, end - start - 1));
+        } catch (...) {
+          continue;
+        }
+        if (idx >= max_idx) max_idx = idx + 1;
+        found = true;
+      }
+    }
+    // textにも配列要素があるかチェック
+    for (const auto & [k, v] : text) {
+      if (k.size() > prefix.size() && k.compare(0, prefix.size(), prefix) == 0) {
+        size_t start = prefix.size();
+        if (k[start] != '.') continue;
+        size_t end = k.find('/', start + 1);
+        if (end == std::string::npos) end = k.size();
+        size_t idx = 0;
+        try {
+          idx = std::stoull(k.substr(start + 1, end - start - 1));
+        } catch (...) {
+          continue;
+        }
+        if (idx >= max_idx) max_idx = idx + 1;
+        found = true;
+      }
+    }
+    return found ? max_idx : 0;
+  }
+
+  // 配列要素の完全パスを生成するヘルパー
+  static std::string arr_path(const std::string & prefix, size_t idx, const std::string & field)
+  {
+    return prefix + "." + std::to_string(idx) + "/" + field;
+  }
+};
+
+// ─── トピック名からプレフィックスを生成 ────────────────────────────────────────
+// FlatMessage のフィールドパスは "<topic_name>/<field>" 形式
+// topic_name が "/world_model" の場合 prefix は "/world_model"
+
+std::string topic_prefix(const RosMsgParser::FlatMessage & flat)
+{
+  if (flat.value.empty() && flat.name.empty()) return "";
+  if (!flat.value.empty()) {
+    const std::string path = flat.value[0].first.toStdString();
+    auto pos = path.find('/', 1);  // 先頭の / をスキップして次の / を探す
+    return pos != std::string::npos ? path.substr(0, pos) : path;
+  }
+  const std::string path = flat.name[0].first.toStdString();
+  auto pos = path.find('/', 1);
+  return pos != std::string::npos ? path.substr(0, pos) : path;
+}
+
+}  // namespace
+
+// ─── WorldModel ───────────────────────────────────────────────────────────────
+
+WorldModel extract_world_model(const RosMsgParser::FlatMessage & flat)
+{
+  FlatValueMap m;
+  m.build(flat);
+  const std::string p = topic_prefix(flat);
+
+  WorldModel wm;
+
+  // ball_info
+  wm.ball_info.position.x = m.get_d_exact(p + "/ball_info/position/x");
+  wm.ball_info.position.y = m.get_d_exact(p + "/ball_info/position/y");
+  wm.ball_info.position.z = m.get_d_exact(p + "/ball_info/position/z");
+  wm.ball_info.velocity.x = m.get_d_exact(p + "/ball_info/velocity/x");
+  wm.ball_info.velocity.y = m.get_d_exact(p + "/ball_info/velocity/y");
+
+  // field_info
+  wm.field_info.x = m.get_d_exact(p + "/field_info/x");
+  wm.field_info.y = m.get_d_exact(p + "/field_info/y");
+
+  // is_yellow
+  wm.is_yellow = m.get_d_exact(p + "/is_yellow") != 0.0;
+
+  // robot_info_ours
+  const std::string ours_prefix = p + "/robot_info_ours";
+  size_t n_ours = m.count_array(ours_prefix);
+  wm.robot_info_ours.resize(n_ours);
+  for (size_t i = 0; i < n_ours; ++i) {
+    auto & r = wm.robot_info_ours[i];
+    r.id = static_cast<uint8_t>(m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "id")));
+    r.pose.x = m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "pose/x"));
+    r.pose.y = m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "pose/y"));
+    r.pose.theta = m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "pose/theta"));
+    r.velocity.x = m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "velocity/x"));
+    r.velocity.y = m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "velocity/y"));
+    r.available_vision =
+      m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "available_vision")) != 0.0;
+  }
+
+  // robot_info_theirs
+  const std::string theirs_prefix = p + "/robot_info_theirs";
+  size_t n_theirs = m.count_array(theirs_prefix);
+  wm.robot_info_theirs.resize(n_theirs);
+  for (size_t i = 0; i < n_theirs; ++i) {
+    auto & r = wm.robot_info_theirs[i];
+    r.id = static_cast<uint8_t>(m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "id")));
+    r.pose.x = m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "pose/x"));
+    r.pose.y = m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "pose/y"));
+    r.pose.theta = m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "pose/theta"));
+    r.velocity.x = m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "velocity/x"));
+    r.velocity.y = m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "velocity/y"));
+    r.available_vision =
+      m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "available_vision")) != 0.0;
+  }
+
+  return wm;
+}
+
+// ─── PlaySituation ────────────────────────────────────────────────────────────
+
+PlaySituation extract_play_situation(const RosMsgParser::FlatMessage & flat)
+{
+  FlatValueMap m;
+  m.build(flat);
+  const std::string p = topic_prefix(flat);
+
+  PlaySituation ps;
+  ps.command_name = m.get_s_exact(p + "/command/name");
+  ps.reason_text = m.get_s_exact(p + "/reason_text");
+  return ps;
+}
+
+// ─── RobotCommands ────────────────────────────────────────────────────────────
+
+RobotCommands extract_robot_commands(const RosMsgParser::FlatMessage & flat)
+{
+  FlatValueMap m;
+  m.build(flat);
+  const std::string p = topic_prefix(flat);
+
+  RobotCommands rc;
+  const std::string cmds_prefix = p + "/robot_commands";
+  size_t n = m.count_array(cmds_prefix);
+  rc.robot_commands.resize(n);
+
+  for (size_t i = 0; i < n; ++i) {
+    auto & cmd = rc.robot_commands[i];
+    cmd.robot_id =
+      static_cast<uint8_t>(m.get_d_exact(FlatValueMap::arr_path(cmds_prefix, i, "robot_id")));
+    cmd.kick_power =
+      static_cast<float>(m.get_d_exact(FlatValueMap::arr_path(cmds_prefix, i, "kick_power")));
+    cmd.dribble_power =
+      static_cast<float>(m.get_d_exact(FlatValueMap::arr_path(cmds_prefix, i, "dribble_power")));
+    cmd.stop_flag = m.get_d_exact(FlatValueMap::arr_path(cmds_prefix, i, "stop_flag")) != 0.0;
+    cmd.chip_enable = m.get_d_exact(FlatValueMap::arr_path(cmds_prefix, i, "chip_enable")) != 0.0;
+    cmd.planner_name = m.get_s_exact(FlatValueMap::arr_path(cmds_prefix, i, "planner_name"));
+
+    // planning_factors
+    const std::string pf_prefix = FlatValueMap::arr_path(cmds_prefix, i, "planning_factors");
+    size_t n_pf = m.count_array(pf_prefix);
+    cmd.planning_factors.resize(n_pf);
+    for (size_t j = 0; j < n_pf; ++j) {
+      cmd.planning_factors[j].name = m.get_s_exact(FlatValueMap::arr_path(pf_prefix, j, "name"));
+      cmd.planning_factors[j].value = m.get_s_exact(FlatValueMap::arr_path(pf_prefix, j, "value"));
+    }
+
+    // position_target_mode
+    const std::string pos_prefix = FlatValueMap::arr_path(cmds_prefix, i, "position_target_mode");
+    size_t n_pos = m.count_array(pos_prefix);
+    cmd.position_target_mode.resize(n_pos);
+    for (size_t j = 0; j < n_pos; ++j) {
+      cmd.position_target_mode[j].target_x =
+        static_cast<float>(m.get_d_exact(FlatValueMap::arr_path(pos_prefix, j, "target_x")));
+      cmd.position_target_mode[j].target_y =
+        static_cast<float>(m.get_d_exact(FlatValueMap::arr_path(pos_prefix, j, "target_y")));
+    }
+
+    // polar_velocity_target_mode
+    const std::string vel_prefix =
+      FlatValueMap::arr_path(cmds_prefix, i, "polar_velocity_target_mode");
+    size_t n_vel = m.count_array(vel_prefix);
+    cmd.polar_velocity_target_mode.resize(n_vel);
+    for (size_t j = 0; j < n_vel; ++j) {
+      cmd.polar_velocity_target_mode[j].target_velocity_r = static_cast<float>(
+        m.get_d_exact(FlatValueMap::arr_path(vel_prefix, j, "target_velocity_r")));
+      cmd.polar_velocity_target_mode[j].target_velocity_theta = static_cast<float>(
+        m.get_d_exact(FlatValueMap::arr_path(vel_prefix, j, "target_velocity_theta")));
+    }
+  }
+
+  return rc;
+}
+
+// ─── GameAnalysis ─────────────────────────────────────────────────────────────
+
+GameAnalysis extract_game_analysis(const RosMsgParser::FlatMessage & flat)
+{
+  FlatValueMap m;
+  m.build(flat);
+  const std::string p = topic_prefix(flat);
+
+  GameAnalysis ga;
+  ga.recommended_attacker_id = static_cast<int32_t>(m.get_d_exact(p + "/recommended_attacker_id"));
+  ga.attacker_suitability_score =
+    static_cast<float>(m.get_d_exact(p + "/attacker_suitability_score"));
+  ga.pass_target_id = static_cast<int32_t>(m.get_d_exact(p + "/pass_target_id"));
+  return ga;
+}
+
+// ─── RobotSelectResults ───────────────────────────────────────────────────────
+
+RobotSelectResults extract_robot_select_results(const RosMsgParser::FlatMessage & flat)
+{
+  FlatValueMap m;
+  m.build(flat);
+  const std::string p = topic_prefix(flat);
+
+  RobotSelectResults rsr;
+  const std::string results_prefix = p + "/results";
+  size_t n = m.count_array(results_prefix);
+  rsr.results.resize(n);
+
+  for (size_t i = 0; i < n; ++i) {
+    auto & r = rsr.results[i];
+    r.name = m.get_s_exact(FlatValueMap::arr_path(results_prefix, i, "name"));
+
+    const std::string robots_prefix = FlatValueMap::arr_path(results_prefix, i, "selected_robots");
+    size_t n_robots = m.count_array(robots_prefix);
+    r.selected_robots.resize(n_robots);
+    for (size_t j = 0; j < n_robots; ++j) {
+      // selected_robots の要素はプリミティブ (uint8) → "selected_robots.j" にサブフィールドなし
+      // rosx_introspectionはプリミティブ配列要素を "array.j" として格納する
+      const std::string elem_key = robots_prefix + "." + std::to_string(j);
+      auto it = m.numeric.find(elem_key);
+      r.selected_robots[j] = (it != m.numeric.end()) ? static_cast<uint8_t>(it->second) : 0;
+    }
+  }
+
+  return rsr;
+}
+
+// ─── LogMessage (rosout) ─────────────────────────────────────────────────────
+
+LogMessage extract_log_message(const RosMsgParser::FlatMessage & flat)
+{
+  FlatValueMap m;
+  m.build(flat);
+  const std::string p = topic_prefix(flat);
+
+  LogMessage log;
+  log.level = static_cast<uint8_t>(m.get_d_exact(p + "/level"));
+  log.name = m.get_s_exact(p + "/name");
+  log.msg = m.get_s_exact(p + "/msg");
+  return log;
+}
+
+// ─── Referee ─────────────────────────────────────────────────────────────────
+
+Referee extract_referee(const RosMsgParser::FlatMessage & flat)
+{
+  FlatValueMap m;
+  m.build(flat);
+  const std::string p = topic_prefix(flat);
+
+  Referee ref;
+  ref.command_value = static_cast<int32_t>(m.get_d_exact(p + "/command/value"));
+  ref.command_counter = static_cast<uint32_t>(m.get_d_exact(p + "/command_counter"));
+  ref.stage_value = static_cast<int32_t>(m.get_d_exact(p + "/stage/value"));
+  ref.has_field = static_cast<uint32_t>(m.get_d_exact(p + "/has_field"));
+  ref.current_action_time_remaining =
+    static_cast<int32_t>(m.get_d_exact(p + "/current_action_time_remaining"));
+
+  // yellow
+  ref.yellow.name = m.get_s_exact(p + "/yellow/name");
+  ref.yellow.score = static_cast<uint32_t>(m.get_d_exact(p + "/yellow/score"));
+  ref.yellow.yellow_cards = static_cast<uint32_t>(m.get_d_exact(p + "/yellow/yellow_cards"));
+  ref.yellow.red_cards = static_cast<uint32_t>(m.get_d_exact(p + "/yellow/red_cards"));
+  ref.yellow.foul_counter = static_cast<uint32_t>(m.get_d_exact(p + "/yellow/foul_counter"));
+  ref.yellow.goalkeeper = static_cast<uint32_t>(m.get_d_exact(p + "/yellow/goalkeeper"));
+
+  // blue
+  ref.blue.name = m.get_s_exact(p + "/blue/name");
+  ref.blue.score = static_cast<uint32_t>(m.get_d_exact(p + "/blue/score"));
+  ref.blue.yellow_cards = static_cast<uint32_t>(m.get_d_exact(p + "/blue/yellow_cards"));
+  ref.blue.red_cards = static_cast<uint32_t>(m.get_d_exact(p + "/blue/red_cards"));
+  ref.blue.foul_counter = static_cast<uint32_t>(m.get_d_exact(p + "/blue/foul_counter"));
+  ref.blue.goalkeeper = static_cast<uint32_t>(m.get_d_exact(p + "/blue/goalkeeper"));
+
+  // designated_position（has_field にかかわらず値を読む。表示側でフラグチェック）
+  ref.designated_position_x = static_cast<float>(m.get_d_exact(p + "/designated_position/x"));
+  ref.designated_position_y = static_cast<float>(m.get_d_exact(p + "/designated_position/y"));
+
+  // next_command
+  ref.next_command_value = static_cast<int32_t>(m.get_d_exact(p + "/next_command/value"));
+
+  // game_events
+  const std::string ge_prefix = p + "/game_events";
+  size_t n_ge = m.count_array(ge_prefix);
+  ref.game_events.resize(n_ge);
+
+  for (size_t i = 0; i < n_ge; ++i) {
+    auto & ge = ref.game_events[i];
+    ge.type_value =
+      static_cast<int32_t>(m.get_d_exact(FlatValueMap::arr_path(ge_prefix, i, "type/value")));
+
+    // event サブフィールドを共通フィールドにマッピング
+    // 全サブフィールドが存在するため type_value で選択的に読み出す
+    const std::string ev = FlatValueMap::arr_path(ge_prefix, i, "event");
+
+    // by_team（複数のイベント種別で共通）
+    // いずれかのサブメッセージの by_team/value を探す（最初に見つかったものを使用）
+    for (const auto & sub : {
+           ev + "/bot_crash_unique/by_team/value",
+           ev + "/bot_crash_unique_skipped/by_team/value",
+           ev + "/bot_too_fast_in_stop/by_team/value",
+           ev + "/bot_pushed_bot/by_team/value",
+           ev + "/bot_pushed_bot_skipped/by_team/value",
+           ev + "/bot_dribbled_ball_too_far/by_team/value",
+           ev + "/keeper_held_ball/by_team/value",
+           ev + "/defender_in_defense_area/by_team/value",
+           ev + "/attacker_too_close_to_defense_area/by_team/value",
+           ev + "/attacker_touched_ball_in_defense_area/by_team/value",
+           ev + "/bot_held_ball_deliberately/by_team/value",
+           ev + "/bot_interfered_placement/by_team/value",
+           ev + "/attacker_double_touched_ball/by_team/value",
+           ev + "/bot_kicked_ball_too_fast/by_team/value",
+           ev + "/aimless_kick/by_team/value",
+         }) {
+      auto it = m.numeric.find(sub);
+      if (it != m.numeric.end() && it->second != 0.0) {
+        ge.by_team_value = static_cast<int32_t>(it->second);
+        break;
+      }
+    }
+
+    // violator（bot_crash_unique 系）
+    {
+      auto it = m.numeric.find(ev + "/bot_crash_unique/violator");
+      if (it == m.numeric.end()) it = m.numeric.find(ev + "/bot_crash_unique_skipped/violator");
+      if (it != m.numeric.end()) ge.violator = static_cast<uint32_t>(it->second);
+    }
+
+    // victim（bot_crash_unique 系）
+    {
+      auto it = m.numeric.find(ev + "/bot_crash_unique/victim");
+      if (it == m.numeric.end()) it = m.numeric.find(ev + "/bot_crash_unique_skipped/victim");
+      if (it != m.numeric.end()) ge.victim = static_cast<uint32_t>(it->second);
+    }
+
+    // victim for bot_pushed_bot
+    {
+      auto it = m.numeric.find(ev + "/bot_pushed_bot/victim");
+      if (it == m.numeric.end()) it = m.numeric.find(ev + "/bot_pushed_bot_skipped/victim");
+      if (it != m.numeric.end() && ge.victim == 0) ge.victim = static_cast<uint32_t>(it->second);
+    }
+
+    // by_bot（複数種別）
+    for (const auto & key : {
+           ev + "/bot_too_fast_in_stop/by_bot",
+           ev + "/bot_dribbled_ball_too_far/by_bot",
+           ev + "/defender_in_defense_area/by_bot",
+           ev + "/attacker_too_close_to_defense_area/by_bot",
+           ev + "/attacker_touched_ball_in_defense_area/by_bot",
+           ev + "/bot_held_ball_deliberately/by_bot",
+           ev + "/bot_interfered_placement/by_bot",
+           ev + "/attacker_double_touched_ball/by_bot",
+           ev + "/bot_kicked_ball_too_fast/by_bot",
+           ev + "/aimless_kick/by_bot",
+         }) {
+      auto it = m.numeric.find(key);
+      if (it != m.numeric.end() && it->second != 0.0) {
+        ge.by_bot = static_cast<uint32_t>(it->second);
+        break;
+      }
+    }
+
+    // location（bot_crash_unique 優先、次いで各種イベント）
+    for (const auto & [x_key, y_key] : std::vector<std::pair<std::string, std::string>>{
+           {ev + "/bot_crash_unique/location/x", ev + "/bot_crash_unique/location/y"},
+           {ev + "/bot_too_fast_in_stop/location/x", ev + "/bot_too_fast_in_stop/location/y"},
+           {ev + "/bot_pushed_bot/location/x", ev + "/bot_pushed_bot/location/y"},
+           {ev + "/bot_pushed_bot_skipped/location/x", ev + "/bot_pushed_bot_skipped/location/y"},
+           {ev + "/keeper_held_ball/location/x", ev + "/keeper_held_ball/location/y"},
+           {ev + "/defender_in_defense_area/location/x",
+            ev + "/defender_in_defense_area/location/y"},
+           {ev + "/attacker_too_close_to_defense_area/location/x",
+            ev + "/attacker_too_close_to_defense_area/location/y"},
+           {ev + "/attacker_touched_ball_in_defense_area/location/x",
+            ev + "/attacker_touched_ball_in_defense_area/location/y"},
+           {ev + "/bot_held_ball_deliberately/location/x",
+            ev + "/bot_held_ball_deliberately/location/y"},
+           {ev + "/attacker_double_touched_ball/location/x",
+            ev + "/attacker_double_touched_ball/location/y"},
+           {ev + "/aimless_kick/location/x", ev + "/aimless_kick/location/y"},
+         }) {
+      auto xi = m.numeric.find(x_key);
+      auto yi = m.numeric.find(y_key);
+      if (
+        xi != m.numeric.end() &&
+        (xi->second != 0.0 || (yi != m.numeric.end() && yi->second != 0.0))) {
+        ge.location_x = static_cast<float>(xi->second);
+        ge.location_y = (yi != m.numeric.end()) ? static_cast<float>(yi->second) : 0.0f;
+        break;
+      }
+    }
+
+    // crash_speed
+    {
+      auto it = m.numeric.find(ev + "/bot_crash_unique/crash_speed");
+      if (it == m.numeric.end()) it = m.numeric.find(ev + "/bot_crash_unique_skipped/crash_speed");
+      if (it != m.numeric.end()) ge.crash_speed = static_cast<float>(it->second);
+    }
+
+    // speed（bot_too_fast_in_stop）
+    {
+      auto it = m.numeric.find(ev + "/bot_too_fast_in_stop/speed");
+      if (it != m.numeric.end()) ge.speed = static_cast<float>(it->second);
+    }
+
+    // duration（keeper_held_ball）
+    {
+      auto it = m.numeric.find(ev + "/keeper_held_ball/duration");
+      if (it != m.numeric.end()) ge.duration = static_cast<float>(it->second);
+    }
+  }
+
+  return ref;
+}
+
+}  // namespace crane::bag

--- a/crane_bag/src/bag/msg_extractors.cpp
+++ b/crane_bag/src/bag/msg_extractors.cpp
@@ -39,19 +39,6 @@ struct FlatValueMap
     }
   }
 
-  // サフィックスが一致する最初の数値を返す（トピック名プレフィックスを無視）
-  double get_d(const std::string & suffix, double def = 0.0) const
-  {
-    for (const auto & [k, v] : numeric) {
-      if (
-        k.size() >= suffix.size() &&
-        k.compare(k.size() - suffix.size(), suffix.size(), suffix) == 0) {
-        return v;
-      }
-    }
-    return def;
-  }
-
   // 完全パス（先頭の /topic/ から始まる）で数値を返す
   double get_d_exact(const std::string & path, double def = 0.0) const
   {
@@ -66,62 +53,29 @@ struct FlatValueMap
     return it != text.end() ? it->second : def;
   }
 
-  // サフィックスが一致する最初の文字列を返す
-  std::string get_s(const std::string & suffix, const std::string & def = "") const
-  {
-    for (const auto & [k, v] : text) {
-      if (
-        k.size() >= suffix.size() &&
-        k.compare(k.size() - suffix.size(), suffix.size(), suffix) == 0) {
-        return v;
-      }
-    }
-    return def;
-  }
-
   // 配列の要素数をカウント（プレフィックス "/<field>." を持つキーの最大インデックス+1）
   size_t count_array(const std::string & prefix) const
   {
     size_t max_idx = 0;
     bool found = false;
-    for (const auto & [k, v] : numeric) {
-      if (k.size() > prefix.size() && k.compare(0, prefix.size(), prefix) == 0) {
-        // prefix の次の文字から数字を読む
-        size_t dot_pos = k.find('.', prefix.size());
-        if (dot_pos == std::string::npos) continue;
-        // prefix は "<topic>/array_field" 形式 → 次は ".<idx>/<subfield>"
-        // 実際のパスは "<topic>/array_field.N/<subfield>"
+
+    auto scan = [&](const auto & map) {
+      for (const auto & [k, v] : map) {
+        if (k.size() <= prefix.size() || k.compare(0, prefix.size(), prefix) != 0) continue;
         size_t start = prefix.size();
         if (k[start] != '.') continue;
         size_t end = k.find('/', start + 1);
         if (end == std::string::npos) end = k.size();
-        size_t idx = 0;
         try {
-          idx = std::stoull(k.substr(start + 1, end - start - 1));
+          size_t idx = std::stoull(k.substr(start + 1, end - start - 1));
+          if (idx >= max_idx) max_idx = idx + 1;
+          found = true;
         } catch (...) {
-          continue;
         }
-        if (idx >= max_idx) max_idx = idx + 1;
-        found = true;
       }
-    }
-    // textにも配列要素があるかチェック
-    for (const auto & [k, v] : text) {
-      if (k.size() > prefix.size() && k.compare(0, prefix.size(), prefix) == 0) {
-        size_t start = prefix.size();
-        if (k[start] != '.') continue;
-        size_t end = k.find('/', start + 1);
-        if (end == std::string::npos) end = k.size();
-        size_t idx = 0;
-        try {
-          idx = std::stoull(k.substr(start + 1, end - start - 1));
-        } catch (...) {
-          continue;
-        }
-        if (idx >= max_idx) max_idx = idx + 1;
-        found = true;
-      }
-    }
+    };
+    scan(numeric);
+    scan(text);
     return found ? max_idx : 0;
   }
 
@@ -175,37 +129,23 @@ WorldModel extract_world_model(const RosMsgParser::FlatMessage & flat)
   // is_yellow
   wm.is_yellow = m.get_d_exact(p + "/is_yellow") != 0.0;
 
-  // robot_info_ours
-  const std::string ours_prefix = p + "/robot_info_ours";
-  size_t n_ours = m.count_array(ours_prefix);
-  wm.robot_info_ours.resize(n_ours);
-  for (size_t i = 0; i < n_ours; ++i) {
-    auto & r = wm.robot_info_ours[i];
-    r.id = static_cast<uint8_t>(m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "id")));
-    r.pose.x = m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "pose/x"));
-    r.pose.y = m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "pose/y"));
-    r.pose.theta = m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "pose/theta"));
-    r.velocity.x = m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "velocity/x"));
-    r.velocity.y = m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "velocity/y"));
-    r.available_vision =
-      m.get_d_exact(FlatValueMap::arr_path(ours_prefix, i, "available_vision")) != 0.0;
-  }
-
-  // robot_info_theirs
-  const std::string theirs_prefix = p + "/robot_info_theirs";
-  size_t n_theirs = m.count_array(theirs_prefix);
-  wm.robot_info_theirs.resize(n_theirs);
-  for (size_t i = 0; i < n_theirs; ++i) {
-    auto & r = wm.robot_info_theirs[i];
-    r.id = static_cast<uint8_t>(m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "id")));
-    r.pose.x = m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "pose/x"));
-    r.pose.y = m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "pose/y"));
-    r.pose.theta = m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "pose/theta"));
-    r.velocity.x = m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "velocity/x"));
-    r.velocity.y = m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "velocity/y"));
-    r.available_vision =
-      m.get_d_exact(FlatValueMap::arr_path(theirs_prefix, i, "available_vision")) != 0.0;
-  }
+  auto fill_robots = [&](const std::string & prefix, std::vector<RobotInfo> & out) {
+    size_t n = m.count_array(prefix);
+    out.resize(n);
+    for (size_t i = 0; i < n; ++i) {
+      auto & r = out[i];
+      r.id = static_cast<uint8_t>(m.get_d_exact(FlatValueMap::arr_path(prefix, i, "id")));
+      r.pose.x = m.get_d_exact(FlatValueMap::arr_path(prefix, i, "pose/x"));
+      r.pose.y = m.get_d_exact(FlatValueMap::arr_path(prefix, i, "pose/y"));
+      r.pose.theta = m.get_d_exact(FlatValueMap::arr_path(prefix, i, "pose/theta"));
+      r.velocity.x = m.get_d_exact(FlatValueMap::arr_path(prefix, i, "velocity/x"));
+      r.velocity.y = m.get_d_exact(FlatValueMap::arr_path(prefix, i, "velocity/y"));
+      r.available_vision =
+        m.get_d_exact(FlatValueMap::arr_path(prefix, i, "available_vision")) != 0.0;
+    }
+  };
+  fill_robots(p + "/robot_info_ours", wm.robot_info_ours);
+  fill_robots(p + "/robot_info_theirs", wm.robot_info_theirs);
 
   return wm;
 }

--- a/crane_bag/src/bag/msg_extractors.cpp
+++ b/crane_bag/src/bag/msg_extractors.cpp
@@ -85,7 +85,7 @@ struct FlatValueMap
     return std::nullopt;
   }
 
-  // 配列の要素数をカウント（プレフィックス "/<field>." を持つキーの最大インデックス+1）
+  // 配列の要素数をカウント（rosx_introspectionは "prefix[N]/field" 形式でキーを生成する）
   size_t count_array(const std::string & prefix) const
   {
     size_t max_idx = 0;
@@ -94,11 +94,11 @@ struct FlatValueMap
     auto scan_key = [&](const std::string & k) {
       if (k.size() <= prefix.size() || k.compare(0, prefix.size(), prefix) != 0) return;
       size_t start = prefix.size();
-      if (k[start] != '.') return;
-      size_t end = k.find('/', start + 1);
-      if (end == std::string::npos) end = k.size();
+      if (k[start] != '[') return;
+      size_t close = k.find(']', start + 1);
+      if (close == std::string::npos) return;
       try {
-        size_t idx = std::stoull(k.substr(start + 1, end - start - 1));
+        size_t idx = std::stoull(k.substr(start + 1, close - start - 1));
         if (idx >= max_idx) max_idx = idx + 1;
         found = true;
       } catch (...) {
@@ -109,10 +109,10 @@ struct FlatValueMap
     return found ? max_idx : 0;
   }
 
-  // 配列要素の完全パスを生成するヘルパー
+  // 配列要素の完全パスを生成するヘルパー（rosx_introspectionの "prefix[N]/field" 形式）
   static std::string arr_path(const std::string & prefix, size_t idx, const std::string & field)
   {
-    return prefix + "." + std::to_string(idx) + "/" + field;
+    return prefix + "[" + std::to_string(idx) + "]/" + field;
   }
 };
 
@@ -262,7 +262,7 @@ RobotSelectResults extract_robot_select_results(const RosMsgParser::FlatMessage 
     for (size_t j = 0; j < n_robots; ++j) {
       // selected_robots の要素はプリミティブ (uint8) → "selected_robots.j" にサブフィールドなし
       // rosx_introspectionはプリミティブ配列要素を "array.j" として格納する
-      const std::string elem_key = robots_prefix + "." + std::to_string(j);
+      const std::string elem_key = robots_prefix + "[" + std::to_string(j) + "]";
       auto it = m.numeric.find(elem_key);
       r.selected_robots[j] = (it != m.numeric.end()) ? static_cast<uint8_t>(it->second) : 0;
     }

--- a/crane_bag/src/bag/msg_extractors.cpp
+++ b/crane_bag/src/bag/msg_extractors.cpp
@@ -23,21 +23,22 @@ namespace
 /// 構築コストを避けるため、呼び出し元が毎回再構築せずに再利用できるよう設計。
 struct FlatValueMap
 {
-  std::unordered_map<std::string, double> numeric;    // path -> double
-  std::unordered_map<std::string, std::string> text;  // path -> string
+  std::unordered_map<std::string, double> numeric;
+  std::unordered_map<std::string, std::string> text;
+  std::string prefix;
 
-  void build(const RosMsgParser::FlatMessage & flat)
+  explicit FlatValueMap(const RosMsgParser::FlatMessage & flat)
   {
-    numeric.clear();
-    text.clear();
-    for (const auto & [fv, var] : flat.value) {
-      std::string key = fv.toStdString();
-      numeric[key] = var.convert<double>();
-    }
-    for (const auto & [fv, s] : flat.name) {
-      std::string key = fv.toStdString();
-      text[key] = s;
-    }
+    auto find_prefix = [](const std::string & path) {
+      auto pos = path.find('/', 1);
+      return pos != std::string::npos ? path.substr(0, pos) : path;
+    };
+    if (!flat.value.empty())
+      prefix = find_prefix(flat.value[0].first.toStdString());
+    else if (!flat.name.empty())
+      prefix = find_prefix(flat.name[0].first.toStdString());
+    for (const auto & [fv, var] : flat.value) numeric[fv.toStdString()] = var.convert<double>();
+    for (const auto & [fv, s] : flat.name) text[fv.toStdString()] = s;
   }
 
   // 完全パスで各型の値を返す
@@ -115,32 +116,14 @@ struct FlatValueMap
   }
 };
 
-// ─── トピック名からプレフィックスを生成 ────────────────────────────────────────
-// FlatMessage のフィールドパスは "<topic_name>/<field>" 形式
-// topic_name が "/world_model" の場合 prefix は "/world_model"
-
-std::string topic_prefix(const RosMsgParser::FlatMessage & flat)
-{
-  if (flat.value.empty() && flat.name.empty()) return "";
-  if (!flat.value.empty()) {
-    const std::string path = flat.value[0].first.toStdString();
-    auto pos = path.find('/', 1);  // 先頭の / をスキップして次の / を探す
-    return pos != std::string::npos ? path.substr(0, pos) : path;
-  }
-  const std::string path = flat.name[0].first.toStdString();
-  auto pos = path.find('/', 1);
-  return pos != std::string::npos ? path.substr(0, pos) : path;
-}
-
 }  // namespace
 
 // ─── WorldModel ───────────────────────────────────────────────────────────────
 
 WorldModel extract_world_model(const RosMsgParser::FlatMessage & flat)
 {
-  FlatValueMap m;
-  m.build(flat);
-  const std::string p = topic_prefix(flat);
+  const FlatValueMap m(flat);
+  const std::string & p = m.prefix;
 
   WorldModel wm;
 
@@ -183,9 +166,8 @@ WorldModel extract_world_model(const RosMsgParser::FlatMessage & flat)
 
 PlaySituation extract_play_situation(const RosMsgParser::FlatMessage & flat)
 {
-  FlatValueMap m;
-  m.build(flat);
-  const std::string p = topic_prefix(flat);
+  const FlatValueMap m(flat);
+  const std::string & p = m.prefix;
 
   PlaySituation ps;
   ps.command_name = m.get_s_exact(p + "/command/name");
@@ -197,9 +179,8 @@ PlaySituation extract_play_situation(const RosMsgParser::FlatMessage & flat)
 
 RobotCommands extract_robot_commands(const RosMsgParser::FlatMessage & flat)
 {
-  FlatValueMap m;
-  m.build(flat);
-  const std::string p = topic_prefix(flat);
+  const FlatValueMap m(flat);
+  const std::string & p = m.prefix;
 
   RobotCommands rc;
   const std::string cmds_prefix = p + "/robot_commands";
@@ -249,9 +230,8 @@ RobotCommands extract_robot_commands(const RosMsgParser::FlatMessage & flat)
 
 GameAnalysis extract_game_analysis(const RosMsgParser::FlatMessage & flat)
 {
-  FlatValueMap m;
-  m.build(flat);
-  const std::string p = topic_prefix(flat);
+  const FlatValueMap m(flat);
+  const std::string & p = m.prefix;
 
   GameAnalysis ga;
   ga.recommended_attacker_id = m.get_i32(p + "/recommended_attacker_id");
@@ -264,9 +244,8 @@ GameAnalysis extract_game_analysis(const RosMsgParser::FlatMessage & flat)
 
 RobotSelectResults extract_robot_select_results(const RosMsgParser::FlatMessage & flat)
 {
-  FlatValueMap m;
-  m.build(flat);
-  const std::string p = topic_prefix(flat);
+  const FlatValueMap m(flat);
+  const std::string & p = m.prefix;
 
   RobotSelectResults rsr;
   const std::string results_prefix = p + "/results";
@@ -296,9 +275,8 @@ RobotSelectResults extract_robot_select_results(const RosMsgParser::FlatMessage 
 
 LogMessage extract_log_message(const RosMsgParser::FlatMessage & flat)
 {
-  FlatValueMap m;
-  m.build(flat);
-  const std::string p = topic_prefix(flat);
+  const FlatValueMap m(flat);
+  const std::string & p = m.prefix;
 
   LogMessage log;
   log.level = m.get_u8(p + "/level");
@@ -311,9 +289,8 @@ LogMessage extract_log_message(const RosMsgParser::FlatMessage & flat)
 
 Referee extract_referee(const RosMsgParser::FlatMessage & flat)
 {
-  FlatValueMap m;
-  m.build(flat);
-  const std::string p = topic_prefix(flat);
+  const FlatValueMap m(flat);
+  const std::string & p = m.prefix;
 
   auto fill_team = [&](TeamInfo & ti, const std::string & cp) {
     ti.name = m.get_s_exact(cp + "/name");

--- a/crane_bag/src/bag/msg_extractors.cpp
+++ b/crane_bag/src/bag/msg_extractors.cpp
@@ -7,6 +7,7 @@
 #include "msg_extractors.hpp"
 
 #include <cmath>
+#include <optional>
 #include <string_view>
 #include <unordered_map>
 
@@ -39,18 +40,48 @@ struct FlatValueMap
     }
   }
 
-  // 完全パス（先頭の /topic/ から始まる）で数値を返す
+  // 完全パスで各型の値を返す
   double get_d_exact(const std::string & path, double def = 0.0) const
   {
     auto it = numeric.find(path);
     return it != numeric.end() ? it->second : def;
   }
+  int32_t get_i32(const std::string & path) const
+  {
+    return static_cast<int32_t>(get_d_exact(path));
+  }
+  uint32_t get_u32(const std::string & path) const
+  {
+    return static_cast<uint32_t>(get_d_exact(path));
+  }
+  float get_f(const std::string & path) const { return static_cast<float>(get_d_exact(path)); }
+  uint8_t get_u8(const std::string & path) const { return static_cast<uint8_t>(get_d_exact(path)); }
+  bool get_b(const std::string & path) const { return get_d_exact(path) != 0.0; }
 
-  // 完全パスで文字列を返す
   std::string get_s_exact(const std::string & path, const std::string & def = "") const
   {
     auto it = text.find(path);
     return it != text.end() ? it->second : def;
+  }
+
+  // keys を順に検索し最初に見つかった非ゼロ値を返す
+  std::optional<double> find_first_nonzero(std::initializer_list<std::string> keys) const
+  {
+    for (const auto & k : keys) {
+      auto it = numeric.find(k);
+      if (it != numeric.end() && it->second != 0.0) return it->second;
+    }
+    return std::nullopt;
+  }
+
+  // keys を順に検索し最初に見つかった値を返す（ゼロ含む）
+  std::optional<double> find_first(std::initializer_list<std::string> keys) const
+  {
+    for (const auto & k : keys) {
+      auto it = numeric.find(k);
+      if (it != numeric.end()) return it->second;
+    }
+    return std::nullopt;
   }
 
   // 配列の要素数をカウント（プレフィックス "/<field>." を持つキーの最大インデックス+1）
@@ -177,46 +208,37 @@ RobotCommands extract_robot_commands(const RosMsgParser::FlatMessage & flat)
 
   for (size_t i = 0; i < n; ++i) {
     auto & cmd = rc.robot_commands[i];
-    cmd.robot_id =
-      static_cast<uint8_t>(m.get_d_exact(FlatValueMap::arr_path(cmds_prefix, i, "robot_id")));
-    cmd.kick_power =
-      static_cast<float>(m.get_d_exact(FlatValueMap::arr_path(cmds_prefix, i, "kick_power")));
-    cmd.dribble_power =
-      static_cast<float>(m.get_d_exact(FlatValueMap::arr_path(cmds_prefix, i, "dribble_power")));
-    cmd.stop_flag = m.get_d_exact(FlatValueMap::arr_path(cmds_prefix, i, "stop_flag")) != 0.0;
-    cmd.chip_enable = m.get_d_exact(FlatValueMap::arr_path(cmds_prefix, i, "chip_enable")) != 0.0;
-    cmd.planner_name = m.get_s_exact(FlatValueMap::arr_path(cmds_prefix, i, "planner_name"));
+    auto ap = [&](const std::string & f) { return FlatValueMap::arr_path(cmds_prefix, i, f); };
+    cmd.robot_id = m.get_u8(ap("robot_id"));
+    cmd.kick_power = m.get_f(ap("kick_power"));
+    cmd.dribble_power = m.get_f(ap("dribble_power"));
+    cmd.stop_flag = m.get_b(ap("stop_flag"));
+    cmd.chip_enable = m.get_b(ap("chip_enable"));
+    cmd.planner_name = m.get_s_exact(ap("planner_name"));
 
-    // planning_factors
-    const std::string pf_prefix = FlatValueMap::arr_path(cmds_prefix, i, "planning_factors");
-    size_t n_pf = m.count_array(pf_prefix);
-    cmd.planning_factors.resize(n_pf);
-    for (size_t j = 0; j < n_pf; ++j) {
+    const std::string pf_prefix = ap("planning_factors");
+    cmd.planning_factors.resize(m.count_array(pf_prefix));
+    for (size_t j = 0; j < cmd.planning_factors.size(); ++j) {
       cmd.planning_factors[j].name = m.get_s_exact(FlatValueMap::arr_path(pf_prefix, j, "name"));
       cmd.planning_factors[j].value = m.get_s_exact(FlatValueMap::arr_path(pf_prefix, j, "value"));
     }
 
-    // position_target_mode
-    const std::string pos_prefix = FlatValueMap::arr_path(cmds_prefix, i, "position_target_mode");
-    size_t n_pos = m.count_array(pos_prefix);
-    cmd.position_target_mode.resize(n_pos);
-    for (size_t j = 0; j < n_pos; ++j) {
+    const std::string pos_prefix = ap("position_target_mode");
+    cmd.position_target_mode.resize(m.count_array(pos_prefix));
+    for (size_t j = 0; j < cmd.position_target_mode.size(); ++j) {
       cmd.position_target_mode[j].target_x =
-        static_cast<float>(m.get_d_exact(FlatValueMap::arr_path(pos_prefix, j, "target_x")));
+        m.get_f(FlatValueMap::arr_path(pos_prefix, j, "target_x"));
       cmd.position_target_mode[j].target_y =
-        static_cast<float>(m.get_d_exact(FlatValueMap::arr_path(pos_prefix, j, "target_y")));
+        m.get_f(FlatValueMap::arr_path(pos_prefix, j, "target_y"));
     }
 
-    // polar_velocity_target_mode
-    const std::string vel_prefix =
-      FlatValueMap::arr_path(cmds_prefix, i, "polar_velocity_target_mode");
-    size_t n_vel = m.count_array(vel_prefix);
-    cmd.polar_velocity_target_mode.resize(n_vel);
-    for (size_t j = 0; j < n_vel; ++j) {
-      cmd.polar_velocity_target_mode[j].target_velocity_r = static_cast<float>(
-        m.get_d_exact(FlatValueMap::arr_path(vel_prefix, j, "target_velocity_r")));
-      cmd.polar_velocity_target_mode[j].target_velocity_theta = static_cast<float>(
-        m.get_d_exact(FlatValueMap::arr_path(vel_prefix, j, "target_velocity_theta")));
+    const std::string vel_prefix = ap("polar_velocity_target_mode");
+    cmd.polar_velocity_target_mode.resize(m.count_array(vel_prefix));
+    for (size_t j = 0; j < cmd.polar_velocity_target_mode.size(); ++j) {
+      cmd.polar_velocity_target_mode[j].target_velocity_r =
+        m.get_f(FlatValueMap::arr_path(vel_prefix, j, "target_velocity_r"));
+      cmd.polar_velocity_target_mode[j].target_velocity_theta =
+        m.get_f(FlatValueMap::arr_path(vel_prefix, j, "target_velocity_theta"));
     }
   }
 
@@ -232,10 +254,9 @@ GameAnalysis extract_game_analysis(const RosMsgParser::FlatMessage & flat)
   const std::string p = topic_prefix(flat);
 
   GameAnalysis ga;
-  ga.recommended_attacker_id = static_cast<int32_t>(m.get_d_exact(p + "/recommended_attacker_id"));
-  ga.attacker_suitability_score =
-    static_cast<float>(m.get_d_exact(p + "/attacker_suitability_score"));
-  ga.pass_target_id = static_cast<int32_t>(m.get_d_exact(p + "/pass_target_id"));
+  ga.recommended_attacker_id = m.get_i32(p + "/recommended_attacker_id");
+  ga.attacker_suitability_score = m.get_f(p + "/attacker_suitability_score");
+  ga.pass_target_id = m.get_i32(p + "/pass_target_id");
   return ga;
 }
 
@@ -280,7 +301,7 @@ LogMessage extract_log_message(const RosMsgParser::FlatMessage & flat)
   const std::string p = topic_prefix(flat);
 
   LogMessage log;
-  log.level = static_cast<uint8_t>(m.get_d_exact(p + "/level"));
+  log.level = m.get_u8(p + "/level");
   log.name = m.get_s_exact(p + "/name");
   log.msg = m.get_s_exact(p + "/msg");
   return log;
@@ -294,36 +315,27 @@ Referee extract_referee(const RosMsgParser::FlatMessage & flat)
   m.build(flat);
   const std::string p = topic_prefix(flat);
 
+  auto fill_team = [&](TeamInfo & ti, const std::string & cp) {
+    ti.name = m.get_s_exact(cp + "/name");
+    ti.score = m.get_u32(cp + "/score");
+    ti.yellow_cards = m.get_u32(cp + "/yellow_cards");
+    ti.red_cards = m.get_u32(cp + "/red_cards");
+    ti.foul_counter = m.get_u32(cp + "/foul_counter");
+    ti.goalkeeper = m.get_u32(cp + "/goalkeeper");
+  };
+
   Referee ref;
-  ref.command_value = static_cast<int32_t>(m.get_d_exact(p + "/command/value"));
-  ref.command_counter = static_cast<uint32_t>(m.get_d_exact(p + "/command_counter"));
-  ref.stage_value = static_cast<int32_t>(m.get_d_exact(p + "/stage/value"));
-  ref.has_field = static_cast<uint32_t>(m.get_d_exact(p + "/has_field"));
-  ref.current_action_time_remaining =
-    static_cast<int32_t>(m.get_d_exact(p + "/current_action_time_remaining"));
-
-  // yellow
-  ref.yellow.name = m.get_s_exact(p + "/yellow/name");
-  ref.yellow.score = static_cast<uint32_t>(m.get_d_exact(p + "/yellow/score"));
-  ref.yellow.yellow_cards = static_cast<uint32_t>(m.get_d_exact(p + "/yellow/yellow_cards"));
-  ref.yellow.red_cards = static_cast<uint32_t>(m.get_d_exact(p + "/yellow/red_cards"));
-  ref.yellow.foul_counter = static_cast<uint32_t>(m.get_d_exact(p + "/yellow/foul_counter"));
-  ref.yellow.goalkeeper = static_cast<uint32_t>(m.get_d_exact(p + "/yellow/goalkeeper"));
-
-  // blue
-  ref.blue.name = m.get_s_exact(p + "/blue/name");
-  ref.blue.score = static_cast<uint32_t>(m.get_d_exact(p + "/blue/score"));
-  ref.blue.yellow_cards = static_cast<uint32_t>(m.get_d_exact(p + "/blue/yellow_cards"));
-  ref.blue.red_cards = static_cast<uint32_t>(m.get_d_exact(p + "/blue/red_cards"));
-  ref.blue.foul_counter = static_cast<uint32_t>(m.get_d_exact(p + "/blue/foul_counter"));
-  ref.blue.goalkeeper = static_cast<uint32_t>(m.get_d_exact(p + "/blue/goalkeeper"));
-
+  ref.command_value = m.get_i32(p + "/command/value");
+  ref.command_counter = m.get_u32(p + "/command_counter");
+  ref.stage_value = m.get_i32(p + "/stage/value");
+  ref.has_field = m.get_u32(p + "/has_field");
+  ref.current_action_time_remaining = m.get_i32(p + "/current_action_time_remaining");
+  fill_team(ref.yellow, p + "/yellow");
+  fill_team(ref.blue, p + "/blue");
   // designated_position（has_field にかかわらず値を読む。表示側でフラグチェック）
-  ref.designated_position_x = static_cast<float>(m.get_d_exact(p + "/designated_position/x"));
-  ref.designated_position_y = static_cast<float>(m.get_d_exact(p + "/designated_position/y"));
-
-  // next_command
-  ref.next_command_value = static_cast<int32_t>(m.get_d_exact(p + "/next_command/value"));
+  ref.designated_position_x = m.get_f(p + "/designated_position/x");
+  ref.designated_position_y = m.get_f(p + "/designated_position/y");
+  ref.next_command_value = m.get_i32(p + "/next_command/value");
 
   // game_events
   const std::string ge_prefix = p + "/game_events";
@@ -332,128 +344,94 @@ Referee extract_referee(const RosMsgParser::FlatMessage & flat)
 
   for (size_t i = 0; i < n_ge; ++i) {
     auto & ge = ref.game_events[i];
-    ge.type_value =
-      static_cast<int32_t>(m.get_d_exact(FlatValueMap::arr_path(ge_prefix, i, "type/value")));
+    ge.type_value = m.get_i32(FlatValueMap::arr_path(ge_prefix, i, "type/value"));
 
-    // event サブフィールドを共通フィールドにマッピング
-    // 全サブフィールドが存在するため type_value で選択的に読み出す
+    // 全サブフィールドが存在するため、各フィールドは複数候補パスから最初の有効値を採用
     const std::string ev = FlatValueMap::arr_path(ge_prefix, i, "event");
 
-    // by_team（複数のイベント種別で共通）
-    // いずれかのサブメッセージの by_team/value を探す（最初に見つかったものを使用）
-    for (const auto & sub : {
-           ev + "/bot_crash_unique/by_team/value",
-           ev + "/bot_crash_unique_skipped/by_team/value",
-           ev + "/bot_too_fast_in_stop/by_team/value",
-           ev + "/bot_pushed_bot/by_team/value",
-           ev + "/bot_pushed_bot_skipped/by_team/value",
-           ev + "/bot_dribbled_ball_too_far/by_team/value",
-           ev + "/keeper_held_ball/by_team/value",
-           ev + "/defender_in_defense_area/by_team/value",
-           ev + "/attacker_too_close_to_defense_area/by_team/value",
-           ev + "/attacker_touched_ball_in_defense_area/by_team/value",
-           ev + "/bot_held_ball_deliberately/by_team/value",
-           ev + "/bot_interfered_placement/by_team/value",
-           ev + "/attacker_double_touched_ball/by_team/value",
-           ev + "/bot_kicked_ball_too_fast/by_team/value",
-           ev + "/aimless_kick/by_team/value",
-         }) {
-      auto it = m.numeric.find(sub);
-      if (it != m.numeric.end() && it->second != 0.0) {
-        ge.by_team_value = static_cast<int32_t>(it->second);
-        break;
-      }
-    }
+    if (
+      auto v = m.find_first_nonzero({
+        ev + "/bot_crash_unique/by_team/value",
+        ev + "/bot_crash_unique_skipped/by_team/value",
+        ev + "/bot_too_fast_in_stop/by_team/value",
+        ev + "/bot_pushed_bot/by_team/value",
+        ev + "/bot_pushed_bot_skipped/by_team/value",
+        ev + "/bot_dribbled_ball_too_far/by_team/value",
+        ev + "/keeper_held_ball/by_team/value",
+        ev + "/defender_in_defense_area/by_team/value",
+        ev + "/attacker_too_close_to_defense_area/by_team/value",
+        ev + "/attacker_touched_ball_in_defense_area/by_team/value",
+        ev + "/bot_held_ball_deliberately/by_team/value",
+        ev + "/bot_interfered_placement/by_team/value",
+        ev + "/attacker_double_touched_ball/by_team/value",
+        ev + "/bot_kicked_ball_too_fast/by_team/value",
+        ev + "/aimless_kick/by_team/value",
+      }))
+      ge.by_team_value = static_cast<int32_t>(*v);
 
-    // violator（bot_crash_unique 系）
-    {
-      auto it = m.numeric.find(ev + "/bot_crash_unique/violator");
-      if (it == m.numeric.end()) it = m.numeric.find(ev + "/bot_crash_unique_skipped/violator");
-      if (it != m.numeric.end()) ge.violator = static_cast<uint32_t>(it->second);
-    }
+    if (
+      auto v = m.find_first(
+        {ev + "/bot_crash_unique/violator", ev + "/bot_crash_unique_skipped/violator"}))
+      ge.violator = static_cast<uint32_t>(*v);
 
-    // victim（bot_crash_unique 系）
-    {
-      auto it = m.numeric.find(ev + "/bot_crash_unique/victim");
-      if (it == m.numeric.end()) it = m.numeric.find(ev + "/bot_crash_unique_skipped/victim");
-      if (it != m.numeric.end()) ge.victim = static_cast<uint32_t>(it->second);
-    }
+    if (
+      auto v =
+        m.find_first({ev + "/bot_crash_unique/victim", ev + "/bot_crash_unique_skipped/victim"}))
+      ge.victim = static_cast<uint32_t>(*v);
+    if (ge.victim == 0)
+      if (
+        auto v =
+          m.find_first({ev + "/bot_pushed_bot/victim", ev + "/bot_pushed_bot_skipped/victim"}))
+        ge.victim = static_cast<uint32_t>(*v);
 
-    // victim for bot_pushed_bot
-    {
-      auto it = m.numeric.find(ev + "/bot_pushed_bot/victim");
-      if (it == m.numeric.end()) it = m.numeric.find(ev + "/bot_pushed_bot_skipped/victim");
-      if (it != m.numeric.end() && ge.victim == 0) ge.victim = static_cast<uint32_t>(it->second);
-    }
-
-    // by_bot（複数種別）
-    for (const auto & key : {
-           ev + "/bot_too_fast_in_stop/by_bot",
-           ev + "/bot_dribbled_ball_too_far/by_bot",
-           ev + "/defender_in_defense_area/by_bot",
-           ev + "/attacker_too_close_to_defense_area/by_bot",
-           ev + "/attacker_touched_ball_in_defense_area/by_bot",
-           ev + "/bot_held_ball_deliberately/by_bot",
-           ev + "/bot_interfered_placement/by_bot",
-           ev + "/attacker_double_touched_ball/by_bot",
-           ev + "/bot_kicked_ball_too_fast/by_bot",
-           ev + "/aimless_kick/by_bot",
-         }) {
-      auto it = m.numeric.find(key);
-      if (it != m.numeric.end() && it->second != 0.0) {
-        ge.by_bot = static_cast<uint32_t>(it->second);
-        break;
-      }
-    }
+    if (
+      auto v = m.find_first_nonzero({
+        ev + "/bot_too_fast_in_stop/by_bot",
+        ev + "/bot_dribbled_ball_too_far/by_bot",
+        ev + "/defender_in_defense_area/by_bot",
+        ev + "/attacker_too_close_to_defense_area/by_bot",
+        ev + "/attacker_touched_ball_in_defense_area/by_bot",
+        ev + "/bot_held_ball_deliberately/by_bot",
+        ev + "/bot_interfered_placement/by_bot",
+        ev + "/attacker_double_touched_ball/by_bot",
+        ev + "/bot_kicked_ball_too_fast/by_bot",
+        ev + "/aimless_kick/by_bot",
+      }))
+      ge.by_bot = static_cast<uint32_t>(*v);
 
     // location（bot_crash_unique 優先、次いで各種イベント）
-    for (const auto & [x_key, y_key] : std::vector<std::pair<std::string, std::string>>{
-           {ev + "/bot_crash_unique/location/x", ev + "/bot_crash_unique/location/y"},
-           {ev + "/bot_too_fast_in_stop/location/x", ev + "/bot_too_fast_in_stop/location/y"},
-           {ev + "/bot_pushed_bot/location/x", ev + "/bot_pushed_bot/location/y"},
-           {ev + "/bot_pushed_bot_skipped/location/x", ev + "/bot_pushed_bot_skipped/location/y"},
-           {ev + "/keeper_held_ball/location/x", ev + "/keeper_held_ball/location/y"},
-           {ev + "/defender_in_defense_area/location/x",
-            ev + "/defender_in_defense_area/location/y"},
-           {ev + "/attacker_too_close_to_defense_area/location/x",
-            ev + "/attacker_too_close_to_defense_area/location/y"},
-           {ev + "/attacker_touched_ball_in_defense_area/location/x",
-            ev + "/attacker_touched_ball_in_defense_area/location/y"},
-           {ev + "/bot_held_ball_deliberately/location/x",
-            ev + "/bot_held_ball_deliberately/location/y"},
-           {ev + "/attacker_double_touched_ball/location/x",
-            ev + "/attacker_double_touched_ball/location/y"},
-           {ev + "/aimless_kick/location/x", ev + "/aimless_kick/location/y"},
+    for (const auto & sub : {
+           std::string("bot_crash_unique"),
+           std::string("bot_too_fast_in_stop"),
+           std::string("bot_pushed_bot"),
+           std::string("bot_pushed_bot_skipped"),
+           std::string("keeper_held_ball"),
+           std::string("defender_in_defense_area"),
+           std::string("attacker_too_close_to_defense_area"),
+           std::string("attacker_touched_ball_in_defense_area"),
+           std::string("bot_held_ball_deliberately"),
+           std::string("attacker_double_touched_ball"),
+           std::string("aimless_kick"),
          }) {
-      auto xi = m.numeric.find(x_key);
-      auto yi = m.numeric.find(y_key);
+      auto xi = m.numeric.find(ev + "/" + sub + "/location/x");
+      auto yi = m.numeric.find(ev + "/" + sub + "/location/y");
       if (
         xi != m.numeric.end() &&
         (xi->second != 0.0 || (yi != m.numeric.end() && yi->second != 0.0))) {
         ge.location_x = static_cast<float>(xi->second);
-        ge.location_y = (yi != m.numeric.end()) ? static_cast<float>(yi->second) : 0.0f;
+        ge.location_y = yi != m.numeric.end() ? static_cast<float>(yi->second) : 0.0f;
         break;
       }
     }
 
-    // crash_speed
-    {
-      auto it = m.numeric.find(ev + "/bot_crash_unique/crash_speed");
-      if (it == m.numeric.end()) it = m.numeric.find(ev + "/bot_crash_unique_skipped/crash_speed");
-      if (it != m.numeric.end()) ge.crash_speed = static_cast<float>(it->second);
-    }
-
-    // speed（bot_too_fast_in_stop）
-    {
-      auto it = m.numeric.find(ev + "/bot_too_fast_in_stop/speed");
-      if (it != m.numeric.end()) ge.speed = static_cast<float>(it->second);
-    }
-
-    // duration（keeper_held_ball）
-    {
-      auto it = m.numeric.find(ev + "/keeper_held_ball/duration");
-      if (it != m.numeric.end()) ge.duration = static_cast<float>(it->second);
-    }
+    if (
+      auto v = m.find_first(
+        {ev + "/bot_crash_unique/crash_speed", ev + "/bot_crash_unique_skipped/crash_speed"}))
+      ge.crash_speed = static_cast<float>(*v);
+    if (auto v = m.find_first({ev + "/bot_too_fast_in_stop/speed"}))
+      ge.speed = static_cast<float>(*v);
+    if (auto v = m.find_first({ev + "/keeper_held_ball/duration"}))
+      ge.duration = static_cast<float>(*v);
   }
 
   return ref;

--- a/crane_bag/src/bag/msg_extractors.cpp
+++ b/crane_bag/src/bag/msg_extractors.cpp
@@ -59,23 +59,21 @@ struct FlatValueMap
     size_t max_idx = 0;
     bool found = false;
 
-    auto scan = [&](const auto & map) {
-      for (const auto & [k, v] : map) {
-        if (k.size() <= prefix.size() || k.compare(0, prefix.size(), prefix) != 0) continue;
-        size_t start = prefix.size();
-        if (k[start] != '.') continue;
-        size_t end = k.find('/', start + 1);
-        if (end == std::string::npos) end = k.size();
-        try {
-          size_t idx = std::stoull(k.substr(start + 1, end - start - 1));
-          if (idx >= max_idx) max_idx = idx + 1;
-          found = true;
-        } catch (...) {
-        }
+    auto scan_key = [&](const std::string & k) {
+      if (k.size() <= prefix.size() || k.compare(0, prefix.size(), prefix) != 0) return;
+      size_t start = prefix.size();
+      if (k[start] != '.') return;
+      size_t end = k.find('/', start + 1);
+      if (end == std::string::npos) end = k.size();
+      try {
+        size_t idx = std::stoull(k.substr(start + 1, end - start - 1));
+        if (idx >= max_idx) max_idx = idx + 1;
+        found = true;
+      } catch (...) {
       }
     };
-    scan(numeric);
-    scan(text);
+    for (const auto & [k, v] : numeric) scan_key(k);
+    for (const auto & [k, v] : text) scan_key(k);
     return found ? max_idx : 0;
   }
 

--- a/crane_bag/src/bag/msg_extractors.hpp
+++ b/crane_bag/src/bag/msg_extractors.hpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <rosx_introspection/ros_parser.hpp>
+#include <string>
+
+#include "bag_types.hpp"
+
+/// rosx_introspection の FlatMessage からプレーン構造体へ変換する関数群。
+/// FlatMessage はトピック名をルートとしたフィールドパス→値のフラットなkey-valueリスト。
+/// 例: "/world_model/ball_info/position/x" → 1.23
+/// 配列要素は "/topic/array_field.N/subfield" の形式（N はゼロ始まりのインデックス）。
+
+namespace crane::bag
+{
+
+WorldModel extract_world_model(const RosMsgParser::FlatMessage & flat);
+PlaySituation extract_play_situation(const RosMsgParser::FlatMessage & flat);
+RobotCommands extract_robot_commands(const RosMsgParser::FlatMessage & flat);
+GameAnalysis extract_game_analysis(const RosMsgParser::FlatMessage & flat);
+RobotSelectResults extract_robot_select_results(const RosMsgParser::FlatMessage & flat);
+LogMessage extract_log_message(const RosMsgParser::FlatMessage & flat);
+Referee extract_referee(const RosMsgParser::FlatMessage & flat);
+
+}  // namespace crane::bag


### PR DESCRIPTION
## 概要

`crane_bag` パッケージのデシリアライズ方式を、mcapファイルに埋め込まれたメッセージ定義を使った動的方式に移行しました。旧バージョンのrosbagを読み込む際にメッセージ定義の変更によるエラーが発生していた問題を解消します。

## 背景・根本原因

従来の実装は `rclcpp::Serialization<MsgT>` によるコンパイル時型依存のデシリアライズを使用していたため、メッセージ定義が変更された過去のrosbagを読み込むとエラーが発生していました。PR #1301（ball_calibration_ui）がPythonで同様の対応をしたのと同様に、C++で対応しました。

## 変更内容

- `rclcpp::Serialization<MsgT>` を廃止し、`mcap_vendor`（mcap::McapReader）+ `rosx_introspection`（FastCDR_Deserializer）による実行時スキーマベースのデシリアライズに移行
- ROSメッセージ型の代わりにプレーンC++構造体（`bag_types.hpp`）を新規作成
- FlatMessage→プレーン構造体の変換関数（`msg_extractors.hpp/.cpp`）を新規作成
- `crane_msgs` / `robocup_ssl_msgs` / `rosbag2_cpp` 等の依存パッケージを除去
- `mcap_vendor`、`rosx_introspection` を新たに依存追加

### 技術的詳細

- mcapに埋め込まれた `ros2msg` スキーマをそのままパーサーに渡すことで、古いbagの定義でも正しくデシリアライズ可能
- C++20の `std::span` と rosx_introspection の `nonstd::span_lite` の ABIミスマッチを `span_CONFIG_SELECT_SPAN=1` で解消
- ROS2 CDR encapsulation ヘッダ（4バイト）を手動スキップ