### PR TITLE
fix(robot-manager): docker compose down時の遅延を解消するSIGTERMハンドラを追加

### DIFF
--- a/docker/dev/robot-manager/server.py
+++ b/docker/dev/robot-manager/server.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import json
 import os
+import signal
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -189,6 +191,13 @@ class Handler(BaseHTTPRequestHandler):
 def main() -> None:
     server = ThreadingHTTPServer(("0.0.0.0", HTTP_PORT), Handler)
     print(f"robot-manager listening on http://0.0.0.0:{HTTP_PORT}")
+
+    def handle_signal(signum, frame):
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
     server.serve_forever()
 
 


### PR DESCRIPTION
## 概要

`crane-robot-manager` コンテナで `docker compose down` 時の終了が遅い問題を修正。

## 背景・根本原因

PythonプロセスがDockerコンテナのPID 1として起動すると、Linuxカーネルの仕様によりSIGTERMがデフォルトで**無視**される。  
Dockerは`docker compose down`時にSIGTERMを送信するが、それが無視されるためデフォルトのgrace period（10秒）を待ってからSIGKILLで強制終了していた。

## 変更内容

- `signal.signal(SIGTERM, ...)` でシャットダウンハンドラを明示的に登録
- `signal.signal(SIGINT, ...)` も同様に登録
- ハンドラ内で `server.shutdown()` をデーモンスレッドで呼び出し（メインスレッドは `serve_forever()` でブロック中のためデッドロック回避）

修正後は `docker compose down` が即座に完了する。