### PR TITLE
feat(crane_web_debugger): ポータルページをDockerコンテナへ移行 (close #1310)

### DIFF
--- a/crane_web_debugger/CMakeLists.txt
+++ b/crane_web_debugger/CMakeLists.txt
@@ -38,4 +38,4 @@ else()
   target_include_directories(crane_websocket_server PRIVATE ${OPENSSL_INCLUDE_DIR})
 endif()
 
-ament_auto_package(INSTALL_TO_SHARE web web_server)
+ament_auto_package(INSTALL_TO_SHARE web)

--- a/crane_web_debugger/package.xml
+++ b/crane_web_debugger/package.xml
@@ -9,7 +9,6 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>ament_index_cpp</depend>
   <depend>crane_msgs</depend>
   <depend>crane_visualization_interfaces</depend>
   <depend>diagnostic_msgs</depend>
@@ -18,12 +17,6 @@
   <depend>nlohmann-json-dev</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
-  <exec_depend>python3-fastapi</exec_depend>
-  <exec_depend>python3-numpy</exec_depend>
-  <exec_depend>python3-pydantic</exec_depend>
-  <exec_depend>python3-uvicorn</exec_depend>
-  <exec_depend>python3-yaml</exec_depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>crane_lint_common</test_depend>
 

--- a/crane_web_debugger/src/websocket_server.cpp
+++ b/crane_web_debugger/src/websocket_server.cpp
@@ -12,7 +12,6 @@
 #include <sys/time.h>
 
 #include <algorithm>
-#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <boost/asio.hpp>
 #include <cctype>
 #include <chrono>
@@ -240,21 +239,10 @@ private:
 class WebSocketDebugServer : public rclcpp::Node
 {
 public:
-  WebSocketDebugServer() : Node("websocket_debug_server"), port_(8090), websocket_port_(8091)
+  WebSocketDebugServer() : Node("websocket_debug_server"), websocket_port_(8091)
   {
-    this->declare_parameter("port", 8090);
     this->declare_parameter("websocket_port", 8091);
-    port_ = this->get_parameter("port").as_int();
     websocket_port_ = this->get_parameter("websocket_port").as_int();
-
-    // Get package share directory for static files
-    try {
-      package_share_dir_ = ament_index_cpp::get_package_share_directory("crane_web_debugger");
-      web_root_ = package_share_dir_ + "/web";
-    } catch (const std::exception & e) {
-      RCLCPP_WARN(this->get_logger(), "Could not find package share directory: %s", e.what());
-      web_root_ = "./web";
-    }
 
     // Initialize subscribers
     world_model_sub_ = this->create_subscription<crane_msgs::msg::WorldModel>(
@@ -399,9 +387,6 @@ public:
     // Start servers
     startServers();
 
-    RCLCPP_INFO(this->get_logger(), "WebSocket Debug Server starting on port %d", port_);
-    RCLCPP_INFO(this->get_logger(), "Web root directory: %s", web_root_.c_str());
-    RCLCPP_INFO(this->get_logger(), "HTTP: http://localhost:%d", port_);
     RCLCPP_INFO(this->get_logger(), "WebSocket: ws://localhost:%d", websocket_port_);
   }
 
@@ -410,9 +395,6 @@ public:
 private:
   void startServers()
   {
-    // Start HTTP server in separate thread
-    http_thread_ = std::thread([this]() { this->runHttpServer(); });
-
     // Start WebSocket server in separate thread
     websocket_thread_ = std::thread([this]() { this->runWebSocketServer(); });
   }
@@ -421,37 +403,8 @@ private:
   {
     running_ = false;
 
-    if (http_thread_.joinable()) {
-      http_thread_.join();
-    }
     if (websocket_thread_.joinable()) {
       websocket_thread_.join();
-    }
-  }
-
-  void runHttpServer()
-  {
-    // Check if web directory exists
-    if (!std::filesystem::exists(web_root_)) {
-      RCLCPP_ERROR(this->get_logger(), "Web directory not found: %s", web_root_.c_str());
-      return;
-    }
-
-    const std::string app_path = package_share_dir_.empty()
-                                   ? "./web_server/app.py"
-                                   : package_share_dir_ + "/web_server/app.py";
-    if (!std::filesystem::exists(app_path)) {
-      RCLCPP_ERROR(this->get_logger(), "Unified HTTP app not found: %s", app_path.c_str());
-      return;
-    }
-
-    std::string command = "python3 \"" + app_path + "\" --host 0.0.0.0 --port " +
-                          std::to_string(port_) + " --web-root \"" + web_root_ + "\" 2>/dev/null";
-    RCLCPP_INFO(
-      this->get_logger(), "Starting unified HTTP server (web root: %s)", web_root_.c_str());
-    int result = system(command.c_str());
-    if (result != 0) {
-      RCLCPP_ERROR(this->get_logger(), "Failed to start HTTP server, exit code: %d", result);
     }
   }
 
@@ -1358,11 +1311,7 @@ private:
   std::mutex control_targets_mutex_;
 
   // Server components
-  std::thread http_thread_;
   std::thread websocket_thread_;
-  std::string package_share_dir_;
-  std::string web_root_;
-  int port_;
   int websocket_port_;
   std::atomic<bool> running_{true};
 

--- a/crane_web_debugger/web/index.html
+++ b/crane_web_debugger/web/index.html
@@ -199,6 +199,7 @@
         </h2>
         <div class="tool-grid">
             <a href="/viewer.html" class="tool-card">
+                <span class="m3-badge tool-card__badge" id="viewer-crane-badge">crane: offline</span>
                 <span class="material-symbols-outlined tool-card__icon">map</span>
                 <div class="tool-card__title">Main Viewer</div>
                 <div class="tool-card__desc">
@@ -213,6 +214,7 @@
             </a>
 
             <a href="/robot_telemetry.html" class="tool-card">
+                <span class="m3-badge tool-card__badge" id="telemetry-crane-badge">crane: offline</span>
                 <span class="material-symbols-outlined tool-card__icon">show_chart</span>
                 <div class="tool-card__title">Robot Telemetry</div>
                 <div class="tool-card__desc">
@@ -227,6 +229,7 @@
             </a>
 
             <a href="/annotation/index.html" class="tool-card">
+                <span class="m3-badge m3-badge--success tool-card__badge">offline対応</span>
                 <span class="material-symbols-outlined tool-card__icon tool-card__icon--tertiary">sticky_note_2</span>
                 <div class="tool-card__title">Annotation Tool</div>
                 <div class="tool-card__desc">
@@ -241,6 +244,7 @@
             </a>
 
             <a href="/robot_manager.html" class="tool-card">
+                <span class="m3-badge tool-card__badge" id="robot-manager-crane-badge">crane: offline</span>
                 <span class="material-symbols-outlined tool-card__icon">memory</span>
                 <div class="tool-card__title">Robot Manager</div>
                 <div class="tool-card__desc">
@@ -255,6 +259,7 @@
             </a>
 
             <a href="/robot_test.html" class="tool-card">
+                <span class="m3-badge tool-card__badge" id="robot-test-crane-badge">crane: offline</span>
                 <span class="material-symbols-outlined tool-card__icon tool-card__icon--tertiary">precision_manufacturing</span>
                 <div class="tool-card__title">Robot Test</div>
                 <div class="tool-card__desc">
@@ -372,20 +377,44 @@
               checkUrl: `http://${host}:8765` },
         ];
 
-        function checkConnection() {
-            const ws = new WebSocket(`ws://${host}:8091`);
+        const CRANE_DEPENDENT_BADGES = [
+            'viewer-crane-badge',
+            'telemetry-crane-badge',
+            'robot-manager-crane-badge',
+            'robot-test-crane-badge',
+        ];
+
+        function setCraneStatus(connected) {
             const dot = document.getElementById('connection-dot');
             const text = document.getElementById('status-text');
+            dot.classList.toggle('connected', connected);
+            text.textContent = connected
+                ? `WebSocket connected (${host}:8091)`
+                : 'WebSocket disconnected';
+            CRANE_DEPENDENT_BADGES.forEach(id => {
+                const badge = document.getElementById(id);
+                if (!badge) return;
+                if (connected) {
+                    badge.textContent = 'crane: online';
+                    badge.className = 'm3-badge m3-badge--success tool-card__badge';
+                } else {
+                    badge.textContent = 'crane: offline';
+                    badge.className = 'm3-badge m3-badge--error tool-card__badge';
+                }
+            });
+        }
+
+        function checkConnection() {
+            const ws = new WebSocket(`ws://${host}:8091`);
 
             ws.onopen = () => {
-                dot.classList.add('connected');
-                text.textContent = `WebSocket connected (${host}:8091)`;
+                setCraneStatus(true);
                 ws.close();
             };
 
-            ws.onerror = () => {
-                dot.classList.remove('connected');
-                text.textContent = 'WebSocket disconnected';
+            ws.onerror = () => setCraneStatus(false);
+            ws.onclose = () => {
+                // Schedule next check (only if it never opened)
             };
         }
 
@@ -424,6 +453,7 @@
         setupExternalToolLinks();
         checkAllExternalTools();
         setInterval(checkAllExternalTools, 30000);
+        setInterval(checkConnection, 10000);
     </script>
 </body>
 </html>

--- a/crane_web_debugger/web/m3e-theme.css
+++ b/crane_web_debugger/web/m3e-theme.css
@@ -698,6 +698,30 @@ details.m3-expansion .m3-expansion__body {
   box-shadow: 0 0 8px var(--md-sys-color-success);
 }
 
+/* ===== OFFLINE BANNER ===== */
+.m3-offline-banner {
+  display: none;
+  align-items: center;
+  gap: var(--md-sys-spacing-sm);
+  background-color: var(--md-sys-color-warning-container);
+  color: var(--md-sys-color-on-warning);
+  padding: 10px var(--md-sys-spacing-lg);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.m3-offline-banner.visible {
+  display: flex;
+}
+
+.m3-offline-banner .material-symbols-outlined {
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
 
 /* ===== SIDE SHEET ===== */
 .m3-side-sheet {

--- a/crane_web_debugger/web/robot_manager.html
+++ b/crane_web_debugger/web/robot_manager.html
@@ -103,6 +103,12 @@
         </div>
     </nav>
 
+    <!-- Offline banner -->
+    <div class="m3-offline-banner" id="offline-banner">
+        <span class="material-symbols-outlined">wifi_off</span>
+        crane WebSocket未接続 (port 8091) — craneが起動すると自動で再接続します
+    </div>
+
     <div class="main-scroll">
         <!-- Summary Bar -->
         <div class="summary-bar">

--- a/crane_web_debugger/web/robot_manager.js
+++ b/crane_web_debugger/web/robot_manager.js
@@ -68,6 +68,7 @@ function connectWebSocket() {
 function setWsStatus(connected) {
     const dot = document.getElementById('ws-dot');
     const text = document.getElementById('ws-status-text');
+    const banner = document.getElementById('offline-banner');
     if (connected) {
         dot.className = 'm3-connection-dot connected';
         text.textContent = 'connected';
@@ -75,6 +76,7 @@ function setWsStatus(connected) {
         dot.className = 'm3-connection-dot';
         text.textContent = 'disconnected';
     }
+    if (banner) banner.classList.toggle('visible', !connected);
 }
 
 // ---- Message Handlers -----------------------------------------------------

--- a/crane_web_debugger/web/robot_telemetry.html
+++ b/crane_web_debugger/web/robot_telemetry.html
@@ -220,6 +220,12 @@
     </div>
   </nav>
 
+  <!-- Offline banner -->
+  <div class="m3-offline-banner" id="offline-banner">
+    <span class="material-symbols-outlined">wifi_off</span>
+    crane WebSocket未接続 (port 8091) — craneが起動すると自動で再接続します
+  </div>
+
   <!-- Header info bar -->
   <div id="header-bar">
     <span class="robot-id-badge">ID: <span id="current-robot-id">--</span></span>

--- a/crane_web_debugger/web/robot_telemetry.js
+++ b/crane_web_debugger/web/robot_telemetry.js
@@ -202,8 +202,10 @@ class RobotTelemetry {
     setStatus(connected) {
         const dot = document.getElementById('status-dot');
         const label = document.getElementById('status-label');
+        const banner = document.getElementById('offline-banner');
         if (dot) dot.classList.toggle('connected', connected);
         if (label) label.textContent = connected ? 'connected' : 'disconnected';
+        if (banner) banner.classList.toggle('visible', !connected);
     }
 
     handleMessage(data) {

--- a/crane_web_debugger/web/robot_test.html
+++ b/crane_web_debugger/web/robot_test.html
@@ -230,6 +230,12 @@
     </div>
   </div>
 
+  <!-- Offline banner -->
+  <div class="m3-offline-banner" id="offline-banner">
+    <span class="material-symbols-outlined">wifi_off</span>
+    crane WebSocket未接続 (port 8091) — craneが起動すると自動で再接続します
+  </div>
+
   <!-- Main content -->
   <div id="main-content">
     <div id="top-row">

--- a/crane_web_debugger/web/robot_test.js
+++ b/crane_web_debugger/web/robot_test.js
@@ -647,8 +647,10 @@ class RobotTestController {
     setStatus(connected) {
         const dot = document.getElementById('status-dot');
         const label = document.getElementById('status-label');
+        const banner = document.getElementById('offline-banner');
         if (dot) dot.classList.toggle('connected', connected);
         if (label) label.textContent = connected ? 'connected' : 'disconnected';
+        if (banner) banner.classList.toggle('visible', !connected);
     }
 
     // ---- UI イベント ----

--- a/crane_web_debugger/web/viewer.html
+++ b/crane_web_debugger/web/viewer.html
@@ -276,6 +276,12 @@
     </div>
   </nav>
 
+  <!-- Offline banner -->
+  <div class="m3-offline-banner" id="offline-banner">
+    <span class="material-symbols-outlined">wifi_off</span>
+    crane WebSocket未接続 (port 8091) — craneが起動すると自動で再接続します
+  </div>
+
   <!-- Main layout -->
   <div class="main-container">
 

--- a/crane_web_debugger/web/viewer.js
+++ b/crane_web_debugger/web/viewer.js
@@ -708,8 +708,10 @@ class CraneViewer {
     updateConnectionStatus(connected) {
         const dot = document.getElementById('connection-dot');
         const label = document.getElementById('connection-label');
+        const banner = document.getElementById('offline-banner');
         if (dot) dot.classList.toggle('connected', connected);
         if (label) label.textContent = connected ? 'connected' : 'disconnected';
+        if (banner) banner.classList.toggle('visible', !connected);
     }
 
     renderRobotCards() {

--- a/crane_web_debugger/web_server/requirements.txt
+++ b/crane_web_debugger/web_server/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -1,4 +1,14 @@
 services:
+  web-debugger:
+    build:
+      context: ../..
+      dockerfile: docker/dev/web-debugger/Dockerfile
+    container_name: crane-web-debugger
+    network_mode: host
+    environment:
+      - HTTP_PORT=8090
+    restart: unless-stopped
+
   ball-calibration:
     build:
       context: ./ball-calibration

--- a/docker/dev/web-debugger/Dockerfile
+++ b/docker/dev/web-debugger/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY crane_web_debugger/web_server/requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY crane_web_debugger/web_server/app.py /app/
+COPY crane_web_debugger/web /app/web
+
+EXPOSE 8090
+
+ENV HTTP_PORT=8090
+
+CMD ["sh", "-c", "python3 /app/app.py --host 0.0.0.0 --port ${HTTP_PORT} --web-root /app/web"]


### PR DESCRIPTION
## 概要

crane_web_debuggerのポータルページ（port 8090）をDockerコンテナへ移行し、craneが起動していない状態でもポータルや各ツールページにアクセスできるようにした。

## 背景・根本原因

従来はHTTPサーバー（port 8090）をC++ WebSocketノードのサブプロセスとして起動していたため、craneが未起動の場合はポータル自体にアクセス不可能だった。ball-calibrationと同様のパターンでROS非依存なHTTPサーバーをDockerコンテナへ分離することで解決する。

## 変更内容

- `docker/dev/web-debugger/Dockerfile` を新規作成（python:3.12-slim ベース、port 8090）
- `crane_web_debugger/web_server/requirements.txt` を新規作成
- `docker/dev/docker-compose.yaml` に `web-debugger` サービスを追加（`network_mode: host`, `restart: unless-stopped`）
- C++ WebSocketサーバー（`websocket_server.cpp`）からHTTPサブプロセス起動を完全削除
  - `runHttpServer()`, `http_thread_`, `port_`, `web_root_`, `package_share_dir_` を削除
  - `ament_index_cpp` への依存を削除
- 各Webページ（viewer, robot_telemetry, robot_manager, robot_test）にWebSocket未接続時のオフラインバナーを追加
- `m3e-theme.css` に `.m3-offline-banner` スタイルを追加
- ポータル（`index.html`）のcrane依存ツールカードに接続状態バッジを追加（10秒ごと更新）
  - 接続時: 緑「crane: online」/ 未接続時: 赤「crane: offline」
  - Annotation ToolはPWA対応のため「offline対応」バッジを常時表示
- `CMakeLists.txt` の `INSTALL_TO_SHARE` から `web_server` を削除
- `package.xml` から `ament_index_cpp` および Python `exec_depend` を削除