### PR TITLE
refactor(docker): Docker imageのレイヤー構造最適化とdocker-compose設定修正

### DIFF
--- a/docker/ccache/Dockerfile
+++ b/docker/ccache/Dockerfile
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
     cd .. && \
     source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --symlink-install --cmake-args '-DCMAKE_BUILD_TYPE=Release' && \
+    colcon build --cmake-args '-DCMAKE_BUILD_TYPE=Release' && \
     ccache -s && \
     rm -rf build/ log/ && \
     cd src && rm -rf * && mkdir crane

--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -65,8 +65,6 @@ services:
     volumes:
       - ./config:/config:rw
     network_mode: host
-    ports:
-      - 8081:8081/tcp
 
   ssl-vision-client:
     image: ghcr.io/ibis-ssl/ssl-vision-client:develop
@@ -76,8 +74,6 @@ services:
     volumes:
       - ./ssl-vision-client-config.json:/config.json:rw
     network_mode: host
-    ports:
-      - 8082:8082/tcp
 
   ssl-status-board:
     image: robocupssl/ssl-status-board:2.12.3
@@ -87,8 +83,6 @@ services:
       - --refereeAddress
       - 224.5.23.1:11003
     network_mode: host
-    ports:
-      - 8083:8083/tcp
     profiles:
       - sim
 

--- a/docker/match-vs-tigers/.dockerignore
+++ b/docker/match-vs-tigers/.dockerignore
@@ -1,0 +1,9 @@
+results/
+ssl-logs/
+crane-rosbag/
+config/
+scripts/
+*.md
+.gitignore
+docker-compose.yaml
+Dockerfile.match-controller

--- a/docker/prebuilt/Dockerfile
+++ b/docker/prebuilt/Dockerfile
@@ -21,5 +21,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 RUN cd .. && \
     source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --symlink-install --cmake-args '-DCMAKE_BUILD_TYPE=Release' && \
+    colcon build --cmake-args '-DCMAKE_BUILD_TYPE=Release' && \
+    rm -rf build/ log/ && \
     cd src && rm -rf * && mkdir crane

--- a/docker/scenario/Dockerfile
+++ b/docker/scenario/Dockerfile
@@ -1,7 +1,6 @@
 FROM ghcr.io/ibis-ssl/crane:base
 
 ENV ROS_OVERLAY=/root/ibis_ws
-ENV PATH=$PATH:/usr/local/go/bin
 WORKDIR $ROS_OVERLAY/src
 SHELL ["/bin/bash", "-c"]
 
@@ -17,10 +16,9 @@ ENV PATH="/usr/lib/ccache:${PATH}" \
 
 COPY dependency_*.repos crane/
 
-RUN vcs import . < crane/dependency_${ROS_DISTRO}.repos
-
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    vcs import . < crane/dependency_${ROS_DISTRO}.repos && \
     apt-get update && \
     apt-get install -y ros-${ROS_DISTRO}-rosidl-cmake ros-${ROS_DISTRO}-rosidl-default-generators && \
     rosdep update && \
@@ -33,13 +31,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && \
     rosdep install -riy --from-paths crane
 
-RUN ccache -sv
-
 RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
     cd .. && \
     source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --cmake-args '-DCMAKE_BUILD_TYPE=Release'
-
-RUN ccache -sv
-
-RUN cd .. && rm -rf build/ log/
+    colcon build --cmake-args '-DCMAKE_BUILD_TYPE=Release' && \
+    ccache -s && \
+    rm -rf build/ log/ && \
+    cd src && rm -rf * && mkdir crane

--- a/docker/scenario/docker-compose.local.yaml
+++ b/docker/scenario/docker-compose.local.yaml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   erforce-sim:
     image: ghcr.io/ibis-ssl/framework-simulatorcli:latest

--- a/docker/scenario/docker-compose.yaml
+++ b/docker/scenario/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   erforce-sim:
     image: ghcr.io/ibis-ssl/framework-simulatorcli:latest


### PR DESCRIPTION
## 概要

Docker imageのレイヤー構造の問題修正、ビルド設定の統一、docker-composeの不整合修正を行いました。

## 背景・根本原因

- `scenario/Dockerfile` で `rm -rf build/ log/` がビルドRUNと別レイヤーになっており、Docker union FSの仕様上データが実際には削除されずイメージが肥大化していた
- `prebuilt/Dockerfile` では `build/` と `log/` が削除されておらず、数百MB〜GBの中間生成物がイメージに含まれていた
- `--symlink-install` 使用後に `src/` を削除するためPythonパッケージのsymlinkが破損するリスクがあった
- docker-compose設定に `network_mode: host` と `ports:` の同時指定（無効）、非推奨の `version:` キーが残存していた

## 変更内容

### Dockerfile最適化
- **scenario/Dockerfile**: 8 RUN → 3 RUN に削減
  - 重複 `ENV PATH` の削除（base imageと重複）
  - `vcs import` をaptインストール・rosdepのRUNに統合（キャッシュマウント有効化）
  - `ccache -sv` の不要なデバッグRUN×2を削除
  - colcon build と `rm -rf build/ log/` を同一RUNに統合（イメージ肥大化の根本修正）
  - src/ の削除を追加
- **prebuilt/Dockerfile**: `--symlink-install` 削除、`rm -rf build/ log/` をビルドRUNに追加
- **ccache/Dockerfile**: `--symlink-install` 削除

### docker-compose修正
- **dev/docker-compose.yaml**: `network_mode: host` 使用サービスから無効な `ports:` を削除
- **scenario/docker-compose.yaml, docker-compose.local.yaml**: 非推奨の `version: "3.1"` を削除

### .dockerignore追加
- **match-vs-tigers/.dockerignore**: ビルドに不要な `results/`, `ssl-logs/`, `crane-rosbag/`, `config/`, `scripts/` 等を除外

## テスト

`docker/scenario/Dockerfile` をローカルビルド済み・動作確認済み:
- 24 craneパッケージの認識 ✅
- `crane.launch.xml` の存在確認 ✅
- `build/` `log/` が最終イメージに含まれないことを確認 ✅
- `src/` が空（ソース削除済み）であることを確認 ✅