### PR TITLE
refactor: DiagnosticHelperクラスを追加してdiagnostic_updaterボイラープレートを共通化

### DIFF
--- a/crane_local_planner/include/crane_local_planner/local_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/local_planner.hpp
@@ -8,11 +8,11 @@
 #define CRANE_LOCAL_PLANNER__LOCAL_PLANNER_HPP_
 
 #include <crane_comm/diagnosed_publisher.hpp>
+#include <crane_comm/diagnostic_helper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 #include <crane_msgs/msg/robot_commands.hpp>
 #include <crane_msgs/msg/world_model.hpp>
 #include <crane_physics/kicker_model.hpp>
-#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <functional>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
@@ -87,7 +87,9 @@ public:
   explicit LocalPlannerComponent(const rclcpp::NodeOptions & options)
   : rclcpp::Node("local_planner", options),
     commands_pub(this, "/robot_commands", 10, 50., 70.),
-    diagnostic_updater_(this)
+    diagnostic_helper_(
+      this, "local_planner", "local_planner/path_planning", this,
+      &LocalPlannerComponent::updateDiagnostics)
   {
     declare_parameter("planner", "rvo2");
     auto planner_str = get_parameter("planner").as_string();
@@ -118,11 +120,6 @@ public:
     control_targets_sub = this->create_subscription<crane_msgs::msg::RobotCommands>(
       "/control_targets", 10,
       std::bind(&LocalPlannerComponent::callbackPositionCommands, this, std::placeholders::_1));
-
-    // 診断Updater設定
-    diagnostic_updater_.setHardwareID("local_planner");
-    diagnostic_updater_.add(
-      "local_planner/path_planning", this, &LocalPlannerComponent::updateDiagnostics);
   }
 
   auto callbackPositionCommands(const crane_msgs::msg::RobotCommands &) -> void;
@@ -142,7 +139,7 @@ private:
 
   KickPowerCalculator kick_power_calculator;
 
-  diagnostic_updater::Updater diagnostic_updater_;
+  DiagnosticHelper diagnostic_helper_;
 
   size_t dropped_command_count_last_cycle_ = 0;
   size_t dropped_command_count_total_ = 0;

--- a/crane_local_planner/src/crane_local_planner.cpp
+++ b/crane_local_planner/src/crane_local_planner.cpp
@@ -168,7 +168,7 @@ auto LocalPlannerComponent::callbackPositionCommands(const crane_msgs::msg::Robo
     publishFallback();
   }
   // 診断情報を更新
-  diagnostic_updater_.force_update();
+  diagnostic_helper_.forceUpdate();
 }
 
 auto LocalPlannerComponent::updateDiagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat)

--- a/crane_play_switcher/package.xml
+++ b/crane_play_switcher/package.xml
@@ -14,7 +14,6 @@
   <depend>crane_msgs</depend>
   <depend>crane_utils</depend>
   <depend>crane_visualization_interfaces</depend>
-  <depend>diagnostic_updater</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>robocup_ssl_msgs</depend>

--- a/crane_session_coordinator/include/crane_session_coordinator/session_coordinator.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/session_coordinator.hpp
@@ -9,6 +9,7 @@
 
 #include <chrono>
 #include <crane_comm/diagnosed_publisher.hpp>
+#include <crane_comm/diagnostic_helper.hpp>
 #include <crane_msg_wrappers/play_situation_wrapper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 #include <crane_msgs/msg/game_analysis.hpp>
@@ -18,7 +19,6 @@
 #include <crane_sessions/session_base.hpp>
 #include <crane_visualization_interfaces/crane_visualizer_wrapper.hpp>
 #include <deque>
-#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <memory>
 #include <optional>
 #include <rclcpp/rclcpp.hpp>
@@ -96,7 +96,7 @@ private:
   VisualizerMessageBuilder::SharedPtr visualizer =
     std::make_shared<VisualizerMessageBuilder>("coordinator");
 
-  diagnostic_updater::Updater diagnostic_updater_;
+  DiagnosticHelper diagnostic_helper_;
 
   std::string prev_session_name_;
 };

--- a/crane_session_coordinator/src/crane_session_coordinator.cpp
+++ b/crane_session_coordinator/src/crane_session_coordinator.cpp
@@ -33,7 +33,9 @@ SessionCoordinatorComponent::SessionCoordinatorComponent(const rclcpp::NodeOptio
   position_commands_pub(this, "/control_targets", 1, 50., 70.),
   robot_select_results_pub(
     create_publisher<crane_msgs::msg::RobotSelectResults>("/robot_select_results", 10)),
-  diagnostic_updater_(this)
+  diagnostic_helper_(
+    this, "session_controller", "ai_planner/planning_cycle", this,
+    &SessionCoordinatorComponent::updateDiagnostics)
 {
   crane::CraneVisualizerBuffer::activate(*this);
 
@@ -100,11 +102,6 @@ SessionCoordinatorComponent::SessionCoordinatorComponent(const rclcpp::NodeOptio
         get_logger(), "Received game_analysis: recommended_attacker_id=%d",
         latest_game_analysis_.recommended_attacker_id);
     });
-
-  // 診断Updater設定
-  diagnostic_updater_.setHardwareID("session_controller");
-  diagnostic_updater_.add(
-    "ai_planner/planning_cycle", this, &SessionCoordinatorComponent::updateDiagnostics);
 }
 
 auto SessionCoordinatorComponent::assign(const std::string & event_name) -> void
@@ -183,7 +180,7 @@ auto SessionCoordinatorComponent::onWorldModelUpdate() -> void
 
   // 診断情報を更新
   diagnostics_reporter_->recordCycle();
-  diagnostic_updater_.force_update();
+  diagnostic_helper_.forceUpdate();
 }
 
 auto SessionCoordinatorComponent::updateDiagnostics(

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_publisher.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_publisher.hpp
@@ -48,12 +48,12 @@ extern "C" {
 
 #include <array>
 #include <crane_comm/diagnosed_publisher.hpp>
+#include <crane_comm/diagnostic_helper.hpp>
 #include <crane_msgs/msg/ball_info.hpp>
 #include <crane_msgs/msg/game_analysis.hpp>
 #include <crane_msgs/msg/robot_info.hpp>
 #include <crane_msgs/msg/world_model.hpp>
 #include <deque>
-#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <memory>
 #include <mutex>
 #include <rclcpp/rclcpp.hpp>
@@ -87,7 +87,7 @@ private:
 
   std::unique_ptr<WorldModelDataProvider> data_provider_;
 
-  diagnostic_updater::Updater diagnostic_updater_;
+  DiagnosticHelper diagnostic_helper_;
 
   DiagnosedPublisher<crane_msgs::msg::WorldModel> pub_world_model;
 

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -32,7 +32,9 @@ static auto parseStringToIntArray(const std::string & str) -> std::vector<uint8_
 WorldModelPublisherComponent::WorldModelPublisherComponent(const rclcpp::NodeOptions & options)
 : rclcpp::Node("world_model_publisher", options),
   data_provider_(std::make_unique<WorldModelDataProvider>(*this)),
-  diagnostic_updater_(this),
+  diagnostic_helper_(
+    this, "world_model_publisher", "vision/processing", this,
+    &WorldModelPublisherComponent::updateDiagnostics),
   pub_world_model(this, "/world_model", 1, 50., 70.)
 {
   using std::chrono_literals::operator""ms;
@@ -81,11 +83,6 @@ WorldModelPublisherComponent::WorldModelPublisherComponent(const rclcpp::NodeOpt
   RCLCPP_INFO(get_logger(), "  time_step: %.2f s", slack_config.time_step);
   RCLCPP_INFO(get_logger(), "  slack_time_offset: %.2f s", slack_config.slack_time_offset);
 
-  // 診断Updater設定
-  diagnostic_updater_.setHardwareID("world_model_publisher");
-  diagnostic_updater_.add(
-    "vision/processing", this, &WorldModelPublisherComponent::updateDiagnostics);
-
   using std::chrono::operator""ms;
   timer = rclcpp::create_timer(this, get_clock(), 16ms, [this]() {
     bool available = data_provider_->available();
@@ -116,7 +113,7 @@ WorldModelPublisherComponent::WorldModelPublisherComponent(const rclcpp::NodeOpt
     }
 
     // 診断情報を更新
-    diagnostic_updater_.force_update();
+    diagnostic_helper_.forceUpdate();
   });
 }
 

--- a/utility/crane_comm/CMakeLists.txt
+++ b/utility/crane_comm/CMakeLists.txt
@@ -23,6 +23,8 @@ ament_export_include_directories(
   include
 )
 
+ament_export_dependencies(diagnostic_updater)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/utility/crane_comm/include/crane_comm/diagnostic_helper.hpp
+++ b/utility/crane_comm/include/crane_comm/diagnostic_helper.hpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_COMM__DIAGNOSTIC_HELPER_HPP_
+#define CRANE_COMM__DIAGNOSTIC_HELPER_HPP_
+
+#include <diagnostic_updater/diagnostic_updater.hpp>
+#include <functional>
+#include <string>
+
+namespace crane
+{
+
+/**
+ * @brief diagnostic_updater::Updater のライフサイクルを管理するヘルパークラス
+ *
+ * 各ノードに散在していた Updater 初期化パターン（setHardwareID + add）を
+ * コンストラクタ1行に集約する。DiagnosedPublisher と同じコンポジション哲学。
+ *
+ * 使用例:
+ * @code
+ * // ヘッダ
+ * DiagnosticHelper diagnostic_helper_;
+ *
+ * // 初期化子リスト
+ * diagnostic_helper_(this, "my_node", "my_node/status", this, &MyNode::updateDiagnostics)
+ *
+ * // コールバック/タイマー内
+ * diagnostic_helper_.forceUpdate();
+ * @endcode
+ */
+class DiagnosticHelper
+{
+public:
+  /// メンバ関数ポインタ版（既存パターン互換）
+  template <typename NodePtrT, typename T>
+  DiagnosticHelper(
+    NodePtrT node, const std::string & hardware_id, const std::string & task_name, T * obj,
+    void (T::*callback)(diagnostic_updater::DiagnosticStatusWrapper &))
+  : updater_(node)
+  {
+    updater_.setHardwareID(hardware_id);
+    updater_.add(task_name, obj, callback);
+  }
+
+  /// std::function版（ラムダ対応）
+  template <typename NodePtrT>
+  DiagnosticHelper(
+    NodePtrT node, const std::string & hardware_id, const std::string & task_name,
+    std::function<void(diagnostic_updater::DiagnosticStatusWrapper &)> callback)
+  : updater_(node)
+  {
+    updater_.setHardwareID(hardware_id);
+    updater_.add(task_name, std::move(callback));
+  }
+
+  auto forceUpdate() -> void { updater_.force_update(); }
+
+  /// 追加タスク登録が必要な場合のアクセサ
+  auto updater() -> diagnostic_updater::Updater & { return updater_; }
+
+private:
+  diagnostic_updater::Updater updater_;
+};
+
+}  // namespace crane
+
+#endif  // CRANE_COMM__DIAGNOSTIC_HELPER_HPP_

--- a/utility/crane_comm/package.xml
+++ b/utility/crane_comm/package.xml
@@ -11,6 +11,7 @@
 
   <depend>crane_geometry</depend>
 
+  <build_export_depend>diagnostic_updater</build_export_depend>
   <build_export_depend>rclcpp</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
 


### PR DESCRIPTION
## 概要

`crane_comm` に `DiagnosticHelper` クラスを新規追加し、3つのノードに散在していた `diagnostic_updater` の初期化ボイラープレートを共通化した。

## 背景・根本原因

`world_model_publisher`、`session_coordinator`、`local_planner` の3ノードで以下の同一パターンが繰り返されていた:

```cpp
// ヘッダ
diagnostic_updater::Updater diagnostic_updater_;

// 初期化子リスト
diagnostic_updater_(this)

// コンストラクタ本体（2行）
diagnostic_updater_.setHardwareID("xxx");
diagnostic_updater_.add("task", this, &Class::updateDiagnostics);

// コールバック内
diagnostic_updater_.force_update();
```

また、`crane_comm/package.xml` に `diagnostic_updater` 依存の宣言漏れがあり、`crane_play_switcher/package.xml` に未使用依存が残っていた。

## 変更内容

- `crane_comm/include/crane_comm/diagnostic_helper.hpp` を新規追加
  - コンストラクタ1行で Updater初期化 + setHardwareID + タスク登録を完結
  - `DiagnosedPublisher` と同じコンポジション哲学、header-only
  - メンバ関数ポインタ版・`std::function`版の2コンストラクタを提供
- `crane_comm/CMakeLists.txt` に `ament_export_dependencies(diagnostic_updater)` を追加
  - `diagnosed_publisher.hpp` をincludeするダウンストリームへ transitive に依存を伝播
- `crane_comm/package.xml` に `build_export_depend: diagnostic_updater` を追加（依存漏れ修正）
- `world_model_publisher` / `session_coordinator` / `local_planner` を `DiagnosticHelper` へ移行
  - コンストラクタ本体から `setHardwareID` + `add` の2行を削除
  - `updateDiagnostics` コールバックの実装は変更なし（診断ロジックは各ノードに保持）
- `crane_play_switcher/package.xml` の未使用依存 `diagnostic_updater` を削除