### PR TITLE
fix(crane_visualization_interfaces): ament_export_dependenciesにrclcpp_componentsを追加

### DIFF
--- a/crane_visualization_interfaces/CMakeLists.txt
+++ b/crane_visualization_interfaces/CMakeLists.txt
@@ -100,6 +100,7 @@ ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   rosidl_default_runtime
   rclcpp
+  rclcpp_components
   crane_geometry
   Eigen3
   builtin_interfaces


### PR DESCRIPTION
## Summary
- `crane_visualization_interfaces`の`ament_export_dependencies`に`rclcpp_components`を追加
- PR #1316 で`aggregator_component`を追加した際にエクスポート宣言が漏れていたことが原因
- 下流パッケージ（`crane_web_debugger`）がCMake生成時に`rclcpp_components::component`ターゲットを解決できずビルド失敗していた

## Test plan
- [ ] CIのDockerビルド（ccache image / prebuilt image）が成功すること