### PR TITLE
fix(docker): web-debuggerコンテナのSIGTERM処理を修正

### DIFF
--- a/docker/dev/web-debugger/Dockerfile
+++ b/docker/dev/web-debugger/Dockerfile
@@ -12,4 +12,4 @@ EXPOSE 8090
 
 ENV HTTP_PORT=8090
 
-CMD ["sh", "-c", "python3 /app/app.py --host 0.0.0.0 --port ${HTTP_PORT} --web-root /app/web"]
+CMD ["sh", "-c", "exec python3 /app/app.py --host 0.0.0.0 --port ${HTTP_PORT} --web-root /app/web"]


### PR DESCRIPTION
## 概要
`docker compose down` 時に web-debugger コンテナだけ終了が遅い問題を修正しました。

## 背景・根本原因
Dockerfile の `CMD` で `sh -c` 経由で python を起動していたため、`sh` がPID 1になり、実際の `python3` プロセスへ SIGTERM が転送されませんでした。その結果、Dockerの10秒のgrace period後にSIGKILLで強制終了されていました。

## 変更内容
- `docker/dev/web-debugger/Dockerfile`: `CMD` に `exec` を追加し、`python3`（uvicorn）がPID 1を引き継ぐよう修正
  ```
  # Before
  CMD ["sh", "-c", "python3 /app/app.py ..."]
  # After
  CMD ["sh", "-c", "exec python3 /app/app.py ..."]
  ```