### PR TITLE
feat: ロボットフィードバックプロトコルの拡張とパケット品質診断

### DIFF
--- a/crane_msgs/msg/RobotFeedback.msg
+++ b/crane_msgs/msg/RobotFeedback.msg
@@ -5,6 +5,14 @@ float32 receive_interval_mean_ms
 float32 receive_interval_min_ms
 float32 receive_interval_max_ms
 float32 receive_interval_stddev_ms
+float32 feedback_age_ms
+
+uint32 valid_packet_count
+uint32 invalid_packet_count
+uint32 sync_error_count
+uint32 checksum_error_count
+uint32 size_mismatch_count
+uint32 counter_jump_count
 
 uint8 counter
 
@@ -74,7 +82,11 @@ float32[] mouse_vel
 
 float32[] voltage
 
-uint8 check_ver
+uint8 camera_pos_x_div2
+uint8 camera_pos_y
+uint8 camera_radius_div4
+uint8 camera_fps
+uint8 check_ver  # legacy alias of camera_pos_x_div2
 
 uint8 VALUES_MOUSE_ODOM_1=0
 uint8 VALUES_MOUSE_ODOM_2=1

--- a/crane_robot_receiver/CMakeLists.txt
+++ b/crane_robot_receiver/CMakeLists.txt
@@ -49,8 +49,16 @@ target_link_libraries(grsim_robot_status_node
 add_backward(grsim_robot_status_node)
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  ament_add_gtest(
+    test_robot_feedback_protocol
+    test/test_robot_feedback_protocol.cpp
+  )
+  target_include_directories(test_robot_feedback_protocol PRIVATE include)
+  ament_target_dependencies(test_robot_feedback_protocol rclcpp)
 endif()
 
 ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/crane_robot_receiver/include/crane_robot_receiver/diagnostic_publisher.hpp
+++ b/crane_robot_receiver/include/crane_robot_receiver/diagnostic_publisher.hpp
@@ -73,8 +73,9 @@ private:
   // 診断情報更新コールバック関数
   auto communicationDiagnosticCallback(
     diagnostic_updater::DiagnosticStatusWrapper & stat,
-    const crane_msgs::msg::PingStatusArray & ping_msg, const rclcpp::Time & now_time, bool sim_mode)
-    -> void;
+    const crane_msgs::msg::PingStatusArray & ping_msg,
+    const crane_msgs::msg::RobotFeedbackArray & feedback_msg, const rclcpp::Time & now_time,
+    bool sim_mode) -> void;
 
   auto batteryDiagnosticCallback(
     diagnostic_updater::DiagnosticStatusWrapper & stat,

--- a/crane_robot_receiver/include/crane_robot_receiver/robot_feedback_protocol.hpp
+++ b/crane_robot_receiver/include/crane_robot_receiver/robot_feedback_protocol.hpp
@@ -20,13 +20,19 @@ namespace crane::robot_receiver
 // ロボットフィードバックプロトコル定数
 namespace protocol
 {
-// バッファサイズ
+// パケットサイズ
+constexpr size_t PACKET_SIZE = 128;
+
+// 受信バッファサイズ
 constexpr size_t BUFFER_SIZE = 2048;
-constexpr size_t DEBUG_VALUES_END = 128;
+constexpr size_t TX_VALUE_COUNT = 14;
 
 // バイトオフセット定義
 namespace offset
 {
+constexpr int SYNC_0 = 0;
+constexpr int SYNC_1 = 1;
+constexpr int CHECKSUM = 2;
 constexpr int COUNTER = 3;
 
 constexpr int YAW_ANGLE = 4;
@@ -64,7 +70,10 @@ constexpr int ODOM_Y = 48;
 constexpr int ODOM_SPEED_X = 52;
 constexpr int ODOM_SPEED_Y = 56;
 
-constexpr int CHECK_VER = 60;
+constexpr int CAMERA_POS_X_DIV2 = 60;
+constexpr int CAMERA_POS_Y = 61;
+constexpr int CAMERA_RADIUS_DIV4 = 62;
+constexpr int CAMERA_FPS = 63;
 
 constexpr int MOUSE_ODOM_X = 64;
 constexpr int MOUSE_ODOM_Y = 68;
@@ -72,12 +81,55 @@ constexpr int MOUSE_VEL_X = 72;
 constexpr int MOUSE_VEL_Y = 76;
 
 constexpr int DEBUG_VALUES_START = 64;
+constexpr int RESERVED_START = 120;
 }  // namespace offset
 
 // 定数値
 constexpr float MOTOR_CURRENT_SCALE = 10.0f;
 constexpr int KICK_STATE_SCALE = 10;
 constexpr int FLOAT_SIZE = 4;
+constexpr uint8_t SYNC_0_VALUE = 0xAB;
+constexpr uint8_t SYNC_1_VALUE = 0xEA;
+
+struct PacketValidationResult
+{
+  bool size_valid = false;
+  bool sync_valid = false;
+  bool checksum_valid = false;
+
+  [[nodiscard]] auto valid() const -> bool { return size_valid && sync_valid && checksum_valid; }
+};
+
+template <typename BufferT>
+inline auto readRawByte(const BufferT & buffer, size_t offset) -> uint8_t
+{
+  return static_cast<uint8_t>(buffer[offset]);
+}
+
+template <typename BufferT>
+inline auto computeChecksum(const BufferT & buffer) -> uint8_t
+{
+  uint32_t checksum = 0;
+  for (size_t i = offset::COUNTER; i < PACKET_SIZE; ++i) {
+    checksum += readRawByte(buffer, i);
+  }
+  return static_cast<uint8_t>(checksum & 0xFF);
+}
+
+template <typename BufferT>
+inline auto validatePacket(const BufferT & buffer) -> PacketValidationResult
+{
+  PacketValidationResult result;
+  result.size_valid = buffer.size() == PACKET_SIZE;
+  if (!result.size_valid) {
+    return result;
+  }
+
+  result.sync_valid = readRawByte(buffer, offset::SYNC_0) == SYNC_0_VALUE &&
+                      readRawByte(buffer, offset::SYNC_1) == SYNC_1_VALUE;
+  result.checksum_valid = readRawByte(buffer, offset::CHECKSUM) == computeChecksum(buffer);
+  return result;
+}
 
 // バッファ読み取りヘルパー関数 (std::memcpyを使用)
 inline auto readFloat(const std::vector<uint8_t> & buffer, int offset) -> float
@@ -155,6 +207,28 @@ struct RobotFeedback
   std::array<float, 2> mouse_vel = {0.0f, 0.0f};
 
   std::array<float, 2> voltage = {0.0f, 0.0f};
+
+  float feedback_age_ms = 0.0f;
+
+  uint32_t valid_packet_count = 0;
+
+  uint32_t invalid_packet_count = 0;
+
+  uint32_t sync_error_count = 0;
+
+  uint32_t checksum_error_count = 0;
+
+  uint32_t size_mismatch_count = 0;
+
+  uint32_t counter_jump_count = 0;
+
+  uint8_t camera_pos_x_div2 = 0;
+
+  uint8_t camera_pos_y = 0;
+
+  uint8_t camera_radius_div4 = 0;
+
+  uint8_t camera_fps = 0;
 
   uint8_t check_ver = 0;
 

--- a/crane_robot_receiver/package.xml
+++ b/crane_robot_receiver/package.xml
@@ -19,6 +19,7 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>crane_lint_common</test_depend>
 

--- a/crane_robot_receiver/src/diagnostic_publisher.cpp
+++ b/crane_robot_receiver/src/diagnostic_publisher.cpp
@@ -79,14 +79,16 @@ auto RobotData::initializeDiagnostics(
 
   // 通信状態の診断
   updater->add(
-    diagnostic_prefix + "communication", [this, node, world_model, sim_mode, latest_ping_msg](
-                                           diagnostic_updater::DiagnosticStatusWrapper & stat) {
+    diagnostic_prefix + "communication",
+    [this, node, world_model, sim_mode, latest_ping_msg,
+     latest_feedback_msg](diagnostic_updater::DiagnosticStatusWrapper & stat) {
       if (!isRobotDetected(*world_model)) {
         stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Robot not detected");
         removeError("communication");
         return;
       }
-      communicationDiagnosticCallback(stat, *latest_ping_msg, node->now(), sim_mode);
+      communicationDiagnosticCallback(
+        stat, *latest_ping_msg, *latest_feedback_msg, node->now(), sim_mode);
     });
 
   // バッテリー状態の診断
@@ -122,27 +124,62 @@ auto RobotData::initializeDiagnostics(
 
 auto RobotData::communicationDiagnosticCallback(
   diagnostic_updater::DiagnosticStatusWrapper & stat,
-  const crane_msgs::msg::PingStatusArray & ping_msg, const rclcpp::Time & now_time, bool sim_mode)
-  -> void
+  const crane_msgs::msg::PingStatusArray & ping_msg,
+  const crane_msgs::msg::RobotFeedbackArray & feedback_msg, const rclcpp::Time & now_time,
+  bool sim_mode) -> void
 {
   auto ping = ranges::find_if(ping_msg.ping, [this](const crane_msgs::msg::PingStatus & msg) {
     return msg.robot_id == robot_id;
   });
+  auto feedback = ranges::find_if(
+    feedback_msg.feedback,
+    [this](const crane_msgs::msg::RobotFeedback & msg) { return msg.robot_id == robot_id; });
+
+  constexpr double FEEDBACK_WARN_AGE_MS = 100.0;
+  constexpr double FEEDBACK_ERROR_AGE_MS = 250.0;
+  constexpr double FEEDBACK_WARN_RATE_HZ = 20.0;
+  constexpr double FEEDBACK_ERROR_RATE_HZ = 5.0;
+
+  if (feedback != feedback_msg.feedback.end()) {
+    std::string message = "Robot feedback healthy";
+    int level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+
+    if (
+      feedback->feedback_age_ms > FEEDBACK_ERROR_AGE_MS ||
+      feedback->packet_frequency_hz < FEEDBACK_ERROR_RATE_HZ) {
+      message = "Robot feedback degraded";
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    } else if (
+      feedback->feedback_age_ms > FEEDBACK_WARN_AGE_MS ||
+      feedback->packet_frequency_hz < FEEDBACK_WARN_RATE_HZ) {
+      message = "Robot feedback warning";
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+    }
+
+    stat.summary(level, message);
+    stat.add("feedback_age_ms", feedback->feedback_age_ms);
+    stat.add("feedback_packet_frequency_hz", feedback->packet_frequency_hz);
+    stat.add("feedback_valid_packet_count", feedback->valid_packet_count);
+    stat.add("feedback_invalid_packet_count", feedback->invalid_packet_count);
+    stat.add("feedback_sync_error_count", feedback->sync_error_count);
+    stat.add("feedback_checksum_error_count", feedback->checksum_error_count);
+    stat.add("feedback_size_mismatch_count", feedback->size_mismatch_count);
+    stat.add("feedback_counter_jump_count", feedback->counter_jump_count);
+    if (ping != ping_msg.ping.end()) {
+      stat.add("ping_ms", ping->ping_ms);
+    }
+
+    if (level > 0) {
+      updateErrorMap("communication", message, level, now_time);
+    } else {
+      removeError("communication");
+    }
+    return;
+  }
 
   if (ping != ping_msg.ping.end()) {
-    std::string message;
-    int level;
-
-    if (ping->ping_ms > 50.0) {
-      message = "Ping time high";
-      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    } else if (ping->ping_ms > 10.0) {
-      message = "Communication latency medium";
-      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    } else {
-      message = "Communication OK";
-      level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-    }
+    std::string message = "Ping available, robot feedback missing";
+    int level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
 
     stat.summary(level, message);
     stat.add("ping_ms", ping->ping_ms);
@@ -162,7 +199,7 @@ auto RobotData::communicationDiagnosticCallback(
       removeError("communication");
     } else {
       // 実機環境ではERROR
-      std::string message = "No ping data received";
+      std::string message = "No robot telemetry received";
       int level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
       stat.summary(level, message);
       updateErrorMap("communication", message, level, now_time);

--- a/crane_robot_receiver/src/robot_receiver_node.cpp
+++ b/crane_robot_receiver/src/robot_receiver_node.cpp
@@ -38,11 +38,26 @@ public:
   }
 
   // asioスレッドから呼ばれる
-  void onReceive(const std::vector<char> & buf, size_t /*size*/)
+  void onReceive(const std::vector<char> & buf, size_t size)
   {
     auto stamp = clock.now();
-    RobotFeedback new_packet = parseBuffer(buf, stamp);
     std::lock_guard<std::mutex> lock(mutex_);
+    if (size != protocol::PACKET_SIZE || buf.size() < protocol::PACKET_SIZE) {
+      ++size_mismatch_count_;
+      ++invalid_packet_count_;
+      return;
+    }
+    if (
+      protocol::readRawByte(buf, protocol::offset::SYNC_0) != protocol::SYNC_0_VALUE ||
+      protocol::readRawByte(buf, protocol::offset::SYNC_1) != protocol::SYNC_1_VALUE) {
+      ++sync_error_count_;
+      ++invalid_packet_count_;
+      return;
+    }
+
+    RobotFeedback new_packet = parseBuffer(buf, stamp);
+    updateCounterStatsLocked(new_packet.counter);
+    ++valid_packet_count_;
     packet_queue_.push_back(new_packet);
     receive_timestamps_.push_back(stamp);
   }
@@ -51,6 +66,9 @@ public:
   auto getLatestFeedback() -> std::optional<RobotFeedback>
   {
     std::lock_guard<std::mutex> lock(mutex_);
+    if (last_output_) {
+      applyPacketStatsLocked(*last_output_);
+    }
     if (packet_queue_.empty()) {
       return last_output_;
     }
@@ -67,6 +85,10 @@ public:
     result.error_info = latest.error_info;
     result.error_value = latest.error_value;
     result.ball_sensor = latest.ball_sensor;
+    result.camera_pos_x_div2 = latest.camera_pos_x_div2;
+    result.camera_pos_y = latest.camera_pos_y;
+    result.camera_radius_div4 = latest.camera_radius_div4;
+    result.camera_fps = latest.camera_fps;
     result.check_ver = latest.check_ver;
     result.values = latest.values;
     std::copy(
@@ -104,6 +126,7 @@ public:
       result.voltage[i] = sum_voltage[i] / n;
     }
 
+    applyPacketStatsLocked(result);
     packet_queue_.clear();
     last_output_ = result;
     return last_output_;
@@ -121,6 +144,12 @@ public:
   {
     float packet_frequency_hz = 0.f;
     IntervalStats interval;
+    uint32_t valid_packet_count = 0;
+    uint32_t invalid_packet_count = 0;
+    uint32_t sync_error_count = 0;
+    uint32_t checksum_error_count = 0;
+    uint32_t size_mismatch_count = 0;
+    uint32_t counter_jump_count = 0;
   };
 
   // 周波数と受信間隔統計を1回のロックでまとめて取得する
@@ -133,6 +162,12 @@ public:
     if (receive_timestamps_.size() >= 2) {
       result.interval = computeIntervalStatsLocked();
     }
+    result.valid_packet_count = valid_packet_count_;
+    result.invalid_packet_count = invalid_packet_count_;
+    result.sync_error_count = sync_error_count_;
+    result.checksum_error_count = checksum_error_count_;
+    result.size_mismatch_count = size_mismatch_count_;
+    result.counter_jump_count = counter_jump_count_;
     return result;
   }
 
@@ -191,7 +226,11 @@ private:
     feedback.odom_speed[0] = protocol::readFloat(buf, protocol::offset::ODOM_SPEED_X);
     feedback.odom_speed[1] = protocol::readFloat(buf, protocol::offset::ODOM_SPEED_Y);
 
-    feedback.check_ver = protocol::readByte(buf, protocol::offset::CHECK_VER);
+    feedback.camera_pos_x_div2 = protocol::readByte(buf, protocol::offset::CAMERA_POS_X_DIV2);
+    feedback.camera_pos_y = protocol::readByte(buf, protocol::offset::CAMERA_POS_Y);
+    feedback.camera_radius_div4 = protocol::readByte(buf, protocol::offset::CAMERA_RADIUS_DIV4);
+    feedback.camera_fps = protocol::readByte(buf, protocol::offset::CAMERA_FPS);
+    feedback.check_ver = feedback.camera_pos_x_div2;
 
     // マウスセンサー
     feedback.mouse_odom[0] = protocol::readFloat(buf, protocol::offset::MOUSE_ODOM_X);
@@ -201,12 +240,36 @@ private:
 
     // デバッグ値
     feedback.values.clear();
-    for (size_t i = protocol::offset::DEBUG_VALUES_START;
-         i < protocol::DEBUG_VALUES_END - protocol::FLOAT_SIZE; i += protocol::FLOAT_SIZE) {
-      feedback.values.push_back(protocol::readFloat(buf, static_cast<int>(i)));
+    feedback.values.reserve(protocol::TX_VALUE_COUNT);
+    for (size_t i = 0; i < protocol::TX_VALUE_COUNT; ++i) {
+      const int offset =
+        protocol::offset::DEBUG_VALUES_START + static_cast<int>(i * protocol::FLOAT_SIZE);
+      feedback.values.push_back(protocol::readFloat(buf, offset));
     }
 
     return feedback;
+  }
+
+  void updateCounterStatsLocked(uint8_t counter)
+  {
+    if (has_last_counter_) {
+      const auto expected = static_cast<uint8_t>(last_counter_ + 1);
+      if (counter != expected) {
+        ++counter_jump_count_;
+      }
+    }
+    has_last_counter_ = true;
+    last_counter_ = counter;
+  }
+
+  void applyPacketStatsLocked(RobotFeedback & feedback) const
+  {
+    feedback.valid_packet_count = valid_packet_count_;
+    feedback.invalid_packet_count = invalid_packet_count_;
+    feedback.sync_error_count = sync_error_count_;
+    feedback.checksum_error_count = checksum_error_count_;
+    feedback.size_mismatch_count = size_mismatch_count_;
+    feedback.counter_jump_count = counter_jump_count_;
   }
 
   // mutex_ を保持した状態で呼ぶこと
@@ -249,6 +312,14 @@ private:
   std::vector<RobotFeedback> packet_queue_;
   std::optional<RobotFeedback> last_output_;
   std::deque<rclcpp::Time> receive_timestamps_;
+  uint32_t valid_packet_count_ = 0;
+  uint32_t invalid_packet_count_ = 0;
+  uint32_t sync_error_count_ = 0;
+  uint32_t checksum_error_count_ = 0;
+  uint32_t size_mismatch_count_ = 0;
+  uint32_t counter_jump_count_ = 0;
+  bool has_last_counter_ = false;
+  uint8_t last_counter_ = 0;
   rclcpp::Clock clock;
 };
 
@@ -313,7 +384,15 @@ public:
           robot_feedback_msg.receive_interval_min_ms = s.interval.min_ms;
           robot_feedback_msg.receive_interval_max_ms = s.interval.max_ms;
           robot_feedback_msg.receive_interval_stddev_ms = s.interval.stddev_ms;
+          robot_feedback_msg.valid_packet_count = s.valid_packet_count;
+          robot_feedback_msg.invalid_packet_count = s.invalid_packet_count;
+          robot_feedback_msg.sync_error_count = s.sync_error_count;
+          robot_feedback_msg.checksum_error_count = s.checksum_error_count;
+          robot_feedback_msg.size_mismatch_count = s.size_mismatch_count;
+          robot_feedback_msg.counter_jump_count = s.counter_jump_count;
         }
+        robot_feedback_msg.feedback_age_ms =
+          static_cast<float>((now - robot_feedback->received_stamp).nanoseconds() * 1e-6);
         robot_feedback_msg.counter = robot_feedback->counter;
         robot_feedback_msg.kick_state = robot_feedback->kick_state;
         robot_feedback_msg.temperatures.assign(
@@ -339,6 +418,10 @@ public:
           robot_feedback->mouse_vel.begin(), robot_feedback->mouse_vel.end());
         robot_feedback_msg.voltage.assign(
           robot_feedback->voltage.begin(), robot_feedback->voltage.end());
+        robot_feedback_msg.camera_pos_x_div2 = robot_feedback->camera_pos_x_div2;
+        robot_feedback_msg.camera_pos_y = robot_feedback->camera_pos_y;
+        robot_feedback_msg.camera_radius_div4 = robot_feedback->camera_radius_div4;
+        robot_feedback_msg.camera_fps = robot_feedback->camera_fps;
         robot_feedback_msg.check_ver = robot_feedback->check_ver;
         robot_feedback_msg.values = robot_feedback->values;
         msg.feedback.push_back(robot_feedback_msg);

--- a/crane_robot_receiver/test/test_robot_feedback_protocol.cpp
+++ b/crane_robot_receiver/test/test_robot_feedback_protocol.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <gtest/gtest.h>
+
+#include <array>
+
+#include "crane_robot_receiver/robot_feedback_protocol.hpp"
+
+namespace protocol = crane::robot_receiver::protocol;
+
+namespace
+{
+auto makeValidPacket() -> std::array<uint8_t, protocol::PACKET_SIZE>
+{
+  std::array<uint8_t, protocol::PACKET_SIZE> packet{};
+  packet[protocol::offset::SYNC_0] = protocol::SYNC_0_VALUE;
+  packet[protocol::offset::SYNC_1] = protocol::SYNC_1_VALUE;
+  packet[protocol::offset::COUNTER] = 42;
+  packet[protocol::offset::CAMERA_FPS] = 30;
+  packet[protocol::offset::MOTOR_CURRENT_0] = 12;
+  packet[protocol::offset::CHECKSUM] = protocol::computeChecksum(packet);
+  return packet;
+}
+}  // namespace
+
+TEST(RobotFeedbackProtocolTest, ValidPacketPassesValidation)
+{
+  const auto packet = makeValidPacket();
+  const auto result = protocol::validatePacket(packet);
+
+  EXPECT_TRUE(result.size_valid);
+  EXPECT_TRUE(result.sync_valid);
+  EXPECT_TRUE(result.checksum_valid);
+  EXPECT_TRUE(result.valid());
+}
+
+TEST(RobotFeedbackProtocolTest, InvalidChecksumIsRejected)
+{
+  auto packet = makeValidPacket();
+  ++packet[protocol::offset::CHECKSUM];
+
+  const auto result = protocol::validatePacket(packet);
+
+  EXPECT_TRUE(result.size_valid);
+  EXPECT_TRUE(result.sync_valid);
+  EXPECT_FALSE(result.checksum_valid);
+  EXPECT_FALSE(result.valid());
+}
+
+TEST(RobotFeedbackProtocolTest, InvalidSyncIsRejected)
+{
+  auto packet = makeValidPacket();
+  packet[protocol::offset::SYNC_0] = 0x00;
+
+  const auto result = protocol::validatePacket(packet);
+
+  EXPECT_TRUE(result.size_valid);
+  EXPECT_FALSE(result.sync_valid);
+  EXPECT_FALSE(result.valid());
+}
+
+TEST(RobotFeedbackProtocolTest, InvalidSizeIsRejected)
+{
+  const std::array<uint8_t, protocol::PACKET_SIZE - 1> packet{};
+
+  const auto result = protocol::validatePacket(packet);
+
+  EXPECT_FALSE(result.size_valid);
+  EXPECT_FALSE(result.valid());
+}

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -177,6 +177,7 @@ private:
   std::vector<crane_msgs::msg::RobotInfo> robot_info_[2];  // [our_team, their_team]
   FieldGeometry field_geometry_;
   bool has_vision_updated_;
+  int feedback_stale_timeout_ms_{100};
 
   // エラー継続時間を算出するためのトラッキング用構造体
   struct ErrorTracker

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -47,11 +47,13 @@ WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
   node.declare_parameter("tracker_address", std::string("224.5.23.2"));
   node.declare_parameter("tracker_port", 10010);
   node.declare_parameter("use_udp_detection", false);
+  node.declare_parameter("feedback_stale_timeout_ms", feedback_stale_timeout_ms_);
 
   config_.vision_address = node.get_parameter("vision_address").get_value<std::string>();
   config_.vision_port = node.get_parameter("vision_port").get_value<int>();
   config_.confidence_threshold = node.get_parameter("confidence_threshold").get_value<double>();
   use_udp_detection_ = node.get_parameter("use_udp_detection").get_value<bool>();
+  feedback_stale_timeout_ms_ = node.get_parameter("feedback_stale_timeout_ms").get_value<int>();
 
   // Initialize UDP receivers
 
@@ -395,6 +397,11 @@ crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
     for (auto & robot : vision_robots) {
       if (auto it = feedback_map.find(robot.id); it != feedback_map.end()) {
         const auto & feedback = *it->second;
+        const auto feedback_age_ms =
+          (current_time - rclcpp::Time(feedback.received_stamp)).seconds() * 1000.0;
+        if (feedback_age_ms > static_cast<double>(feedback_stale_timeout_ms_)) {
+          continue;
+        }
 
         // feedbackデータを含むRobotInfoを作成
         crane_msgs::msg::RobotInfo feedback_robot;


### PR DESCRIPTION
## 概要
ロボットフィードバックパケットの品質監視・診断機能とカメラ位置情報フィールドを追加する。

## 背景
ロボットからのフィードバックパケットの品質を監視・診断する仕組みが不足していた。通信不良やパケット破損の検出、カメラ位置情報の取得、古いフィードバックの除外が必要だった。

## 変更内容
- パケットバリデーション（sync bytes, checksum, size）のプロトコル定数とヘルパー関数を追加
- パケット統計カウンター（valid/invalid/sync_error/checksum_error/size_mismatch/counter_jump）を追加
- フィードバック古さ（feedback_age_ms）を計算してROSメッセージに公開
- カメラ位置フィールド（camera_pos_x_div2, camera_pos_y, camera_radius_div4, camera_fps）を追加
- 診断をpingベースからfeedback qualityベースに刷新
- world_model_data_providerで古いフィードバックを除外するstale timeoutパラメータを追加
- パケットバリデーションのgtest（test_robot_feedback_protocol）を追加
- onReceive()のsync検証をprotocol::readRawByte()で統一