### PR TITLE
feat: local plannerをタイマー駆動に変更し、上位レイヤーから独立した周期で動作可能にする

### DIFF
--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -133,6 +133,7 @@ limitations under the License.
       <param name="planning_acceleration" value="$(var planning_acceleration)"/>
       <param name="rvo_radius" value="0.15"/>
       <param name="velocity_damping_gain" value="0.0"/>
+      <param name="update_rate_hz" value="120.0"/>
       <!-- KickerModel統合：YAML設定ファイルから読み込み -->
       <param name="kicker_physics_config" value="$(find-pkg-share crane_world_model_publisher)/config/kicker_physics.yaml"/>
     </node>
@@ -145,6 +146,7 @@ limitations under the License.
       <param name="max_vel" value="$(var max_vel)"/>
       <param name="planning_deceleration" value="$(var planning_deceleration)"/>
       <param name="planning_acceleration" value="$(var planning_acceleration)"/>
+      <param name="update_rate_hz" value="120.0"/>
       <param name="straight_kick_power_array" value="[0.0, 0.4, 1.0, 1.0]"/>
       <param name="straight_kick_speed_array" value="[0.0, 2.0, 4.0, 7.5]"/>
       <param name="chip_kick_power_array" value="[0.0, 0.8, 1.0]"/>

--- a/crane_local_planner/include/crane_local_planner/local_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/local_planner.hpp
@@ -13,8 +13,8 @@
 #include <crane_msgs/msg/robot_commands.hpp>
 #include <crane_msgs/msg/world_model.hpp>
 #include <crane_physics/kicker_model.hpp>
-#include <functional>
 #include <memory>
+#include <optional>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/float32.hpp>
 #include <string>
@@ -79,15 +79,25 @@ public:
 
     control_targets_sub = this->create_subscription<crane_msgs::msg::RobotCommands>(
       "/control_targets", 10,
-      std::bind(&LocalPlannerComponent::callbackPositionCommands, this, std::placeholders::_1));
+      [this](const crane_msgs::msg::RobotCommands & msg) { latest_commands_ = msg; });
+
+    declare_parameter("update_rate_hz", 60.0);
+    const auto update_rate_hz = get_parameter("update_rate_hz").as_double();
+    update_timer_ = create_wall_timer(
+      std::chrono::microseconds(static_cast<int64_t>(1e6 / update_rate_hz)),
+      [this]() { processLatestCommands(); });
   }
 
-  auto callbackPositionCommands(const crane_msgs::msg::RobotCommands &) -> void;
+  auto processLatestCommands() -> void;
 
   auto updateDiagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat) -> void;
 
 private:
   rclcpp::Subscription<crane_msgs::msg::RobotCommands>::SharedPtr control_targets_sub;
+
+  rclcpp::TimerBase::SharedPtr update_timer_;
+
+  std::optional<crane_msgs::msg::RobotCommands> latest_commands_;
 
   DiagnosedPublisher<crane_msgs::msg::RobotCommands> commands_pub;
 

--- a/crane_local_planner/src/crane_local_planner.cpp
+++ b/crane_local_planner/src/crane_local_planner.cpp
@@ -11,9 +11,13 @@
 
 namespace crane
 {
-auto LocalPlannerComponent::callbackPositionCommands(const crane_msgs::msg::RobotCommands & msg)
-  -> void
+auto LocalPlannerComponent::processLatestCommands() -> void
 {
+  if (!latest_commands_) {
+    return;
+  }
+  const auto & msg = *latest_commands_;
+
   if (!planner) {
     return;
   }
@@ -167,13 +171,12 @@ auto LocalPlannerComponent::callbackPositionCommands(const crane_msgs::msg::Robo
   } catch (const std::exception & e) {
     RCLCPP_ERROR_THROTTLE(
       get_logger(), *get_clock(), 1000,
-      "Unhandled exception in local_planner callback. Publishing empty /robot_commands: %s",
-      e.what());
+      "Unhandled exception in local_planner timer. Publishing empty /robot_commands: %s", e.what());
     publishFallback();
   } catch (...) {
     RCLCPP_ERROR_THROTTLE(
       get_logger(), *get_clock(), 1000,
-      "Unhandled unknown exception in local_planner callback. Publishing empty /robot_commands");
+      "Unhandled unknown exception in local_planner timer. Publishing empty /robot_commands");
     publishFallback();
   }
   // 診断情報を更新


### PR DESCRIPTION
## 概要

local plannerを `/control_targets` コールバック駆動から独自 `wall_timer` 駆動に変更し、上位レイヤーの処理周期に依存せず高周期で動作できるようにする。

## 背景・根本原因

従来の実装では `/control_targets` のコールバックが直接 RVO2 計算と `/robot_commands` のパブリッシュを行っていた。そのため local planner の実行周期が上位レイヤーのパブリッシュ周期に律速されており、local planner 単体で周期を上げることができなかった。

上位レイヤー（セッション管理・スキル計算）の計算コストが大きいため、RVO2 による回避計算とロボット指令生成の周期を独立して引き上げるために本変更を行った。

## 変更内容

- `callbackPositionCommands` を最新コマンドのキャッシュ（`latest_commands_`）のみに変更
- `processLatestCommands()` を新設し、独自 `wall_timer` で駆動（タイマーが最新 world_model で毎サイクル再計算）
- `update_rate_hz` パラメータで周期を設定可能に（sim/実機ともに 120 Hz）
- `std::bind` をラムダに統一、`std::chrono::microseconds` で周期計算を簡潔化