### PR TITLE
fix: ER-Forceシミュレータの未サポートオプション(--ibis-feedback-hz)を削除

### DIFF
--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -45,7 +45,6 @@ services:
       --realism None
       --ibis-use-referee
       --ibis-feedback-team-name ibis
-      --ibis-feedback-hz 125
       --ibis-referee-port 11003
     restart: "no"
     profiles:

--- a/docker/scenario/docker-compose.local.yaml
+++ b/docker/scenario/docker-compose.local.yaml
@@ -10,7 +10,6 @@ services:
       --realism None
       --ibis-use-referee
       --ibis-feedback-team-name ibis
-      --ibis-feedback-hz 125
       --ibis-referee-port 11003
     tty: true
     stdin_open: true

--- a/docker/scenario/docker-compose.yaml
+++ b/docker/scenario/docker-compose.yaml
@@ -10,7 +10,6 @@ services:
       --realism None
       --ibis-use-referee
       --ibis-feedback-team-name ibis
-      --ibis-feedback-hz 125
       --ibis-referee-port 11003
     tty: true
     stdin_open: true


### PR DESCRIPTION
## 概要

ER-Forceシミュレータ起動時の `Unknown option 'ibis-feedback-hz'` エラーを修正するため、サポートされていない `--ibis-feedback-hz 125` オプションを全docker-composeファイルから削除する。

## 背景・根本原因

現在のER-Forceシミュレータイメージ (`ghcr.io/ibis-ssl/framework-simulatorcli:latest`) では `--ibis-feedback-hz` オプションがサポートされていない。このオプションが残っているとシミュレータが起動に失敗する。

## 変更内容

- `docker/dev/docker-compose.yaml` から `--ibis-feedback-hz 125` を削除
- `docker/scenario/docker-compose.yaml` から `--ibis-feedback-hz 125` を削除
- `docker/scenario/docker-compose.local.yaml` から `--ibis-feedback-hz 125` を削除