### PR TITLE
feat: ForwardSessionを固定ライン方式からスコアマップ+ヒステリシス方式に刷新

### DIFF
--- a/crane_robot_skills/src/forward.cpp
+++ b/crane_robot_skills/src/forward.cpp
@@ -30,6 +30,14 @@ auto Forward::update() -> Status
     return Status::RUNNING;
   }
 
+  // front_point == back_point（点指定モード）: 1Dサンプリングをスキップして直接追従
+  if (line_length < 1e-4) {
+    command->setTargetPosition(front_point)
+      .lookAtBall()
+      .setMaxVelocity("Forward::max_vel", max_vel);
+    return Status::RUNNING;
+  }
+
   max_ball_distance = std::max(max_ball_distance, 0.1);
 
   // front_point -> back_pointの0.1mごとのポイントを生成

--- a/crane_sessions/include/crane_sessions/forward_session.hpp
+++ b/crane_sessions/include/crane_sessions/forward_session.hpp
@@ -38,36 +38,30 @@ public:
   auto getRobotSuitabilityFunc() const
     -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
   {
-    // フォワードライン（敵ゴール前）に近いロボットを優先
-    auto wm = world_model;  // shared_ptrをコピー
+    auto wm = world_model;
     return [wm](const std::shared_ptr<RobotInfo> & robot) {
-      // 敵ゴール位置に近いほど適している（敵陣ペナルティエリア迂回を考慮）
       return estimatePenaltyAwareDistance(
         robot->pose.pos, wm->getTheirGoalCenter(), wm->getOurPenaltyArea(), wm->getOurGoalCenter(),
         wm->getTheirPenaltyArea(), wm->getTheirGoalCenter(), wm->penaltyAreaSize());
     };
   }
 
-  int getDesiredRobotNumber(int max_robots) const override
-  {
-    // Forwardはcatch-allセッションとして余剰ロボットを全て受け入れる
-    return max_robots;
-  }
+  int getDesiredRobotNumber(int max_robots) const override { return max_robots; }
 
 protected:
-  void onRobotsChanged() override { forward_skills.clear(); }
+  void onRobotsChanged() override
+  {
+    forward_skills.clear();
+    // ロボット構成が変わった場合はヒステリシス状態もリセット
+    last_targets_.clear();
+    last_scores_.clear();
+  }
 
 private:
   /// @brief 攻撃エリアの候補点グリッドを生成する（PA内・フィールド外を除外済み）
   auto computeCandidatePoints() const -> std::vector<Point>;
 
-  /**
-   * @brief 候補点のスコアを計算する（乗算合成）
-   * @param p 評価候補点
-   * @param robot_pos 自ロボット現在位置
-   * @param forward_positions 全フォワードロボットの現在位置（自分含む）
-   * @param available_enemies 利用可能な敵ロボットリスト
-   */
+  /// @brief 候補点のスコアを計算する（乗算合成）
   auto scorePoint(
     const Point & p, const Point & robot_pos, const std::vector<Point> & forward_positions,
     const RobotList & available_enemies) const -> double;
@@ -76,6 +70,9 @@ private:
 
   /// ロボットIDごとの前回選択目標点（ヒステリシス用）
   std::unordered_map<uint8_t, Point> last_targets_;
+
+  /// ロボットIDごとの前回目標点の生スコア（ヒステリシス判定の再計算を省く）
+  std::unordered_map<uint8_t, double> last_scores_;
 };
 }  // namespace crane
 #endif  // CRANE_SESSIONS__FORWARD_SESSION_HPP_

--- a/crane_sessions/include/crane_sessions/forward_session.hpp
+++ b/crane_sessions/include/crane_sessions/forward_session.hpp
@@ -32,8 +32,6 @@ public:
   {
   }
 
-  auto createForwardLines() const -> std::vector<Segment>;
-
   auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
     -> std::pair<Status, std::vector<crane_msgs::msg::RobotCommand>> override;
 
@@ -53,20 +51,31 @@ public:
   int getDesiredRobotNumber(int max_robots) const override
   {
     // Forwardはcatch-allセッションとして余剰ロボットを全て受け入れる
-    // ライン数よりロボット数が多い場合はforward_session.cppで既存ラインを循環割当する
     return max_robots;
   }
 
 protected:
-  void onRobotsChanged() override
-  {
-    forward_skills.clear();
-    forward_line_assignments.clear();
-  }
+  void onRobotsChanged() override { forward_skills.clear(); }
 
 private:
+  /// @brief 攻撃エリアの候補点グリッドを生成する（PA内・フィールド外を除外済み）
+  auto computeCandidatePoints() const -> std::vector<Point>;
+
+  /**
+   * @brief 候補点のスコアを計算する（乗算合成）
+   * @param p 評価候補点
+   * @param robot_pos 自ロボット現在位置
+   * @param forward_positions 全フォワードロボットの現在位置（自分含む）
+   * @param available_enemies 利用可能な敵ロボットリスト
+   */
+  auto scorePoint(
+    const Point & p, const Point & robot_pos, const std::vector<Point> & forward_positions,
+    const RobotList & available_enemies) const -> double;
+
   std::vector<std::shared_ptr<skills::Forward>> forward_skills;
-  std::vector<int> forward_line_assignments;
+
+  /// ロボットIDごとの前回選択目標点（ヒステリシス用）
+  std::unordered_map<uint8_t, Point> last_targets_;
 };
 }  // namespace crane
 #endif  // CRANE_SESSIONS__FORWARD_SESSION_HPP_

--- a/crane_sessions/src/forward_session.cpp
+++ b/crane_sessions/src/forward_session.cpp
@@ -4,6 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include <algorithm>
+#include <cmath>
+#include <crane_geometry/ddps.hpp>
 #include <crane_physics/position_assignments.hpp>
 #include <crane_sessions/forward_session.hpp>
 #include <range/v3/range/conversion.hpp>
@@ -12,45 +15,110 @@
 
 namespace crane
 {
-auto ForwardSession::createForwardLines() const -> std::vector<Segment>
-{
-  std::vector<Segment> forward_lines;
 
+auto ForwardSession::computeCandidatePoints() const -> std::vector<Point>
+{
   const double goal_line_x = world_model->fieldSize().x() * 0.5;
   const double field_half_width = world_model->fieldSize().y() * 0.5;
-  constexpr double PENALTY_AREA_MARGIN = 0.3;  // SSL rule: 0.2m minimum + 0.1m safety buffer
-  const double penalty_front_x =
-    goal_line_x - world_model->penaltyAreaSize().x() - PENALTY_AREA_MARGIN;
-  const double penalty_side_y = world_model->penaltyAreaSize().y() * 0.5;
-  const double side_center_y = std::midpoint(field_half_width, penalty_side_y);
-  const double ball_x_abs = world_model->ball().pos.x() * (-world_model->getAttackSideSign());
-  const double back_x = std::clamp(ball_x_abs - 1.0, -goal_line_x + 1.0, goal_line_x - 3.0);
+  constexpr double PA_MARGIN = 0.3;  // ペナルティエリアとの距離マージン
 
-  auto push_line = [&](Point p1, Point p2) {
-    Segment line{p1, p2};
-    if (bg::distance(line, world_model->ball().pos) > 0.5) {
-      forward_lines.emplace_back(p1, p2);
-      return true;
-    } else {
-      return false;
-    }
-  };
+  // 攻撃サイドの符号（1 or -1）
+  const double side_sign = -world_model->getAttackSideSign();
 
-  push_line(Point(back_x, side_center_y), Point(goal_line_x - 1.0, side_center_y));
-  push_line(Point(back_x, -side_center_y), Point(goal_line_x - 1.0, -side_center_y));
-  push_line(Point(back_x, 0), Point(penalty_front_x, 0.));
+  // 攻撃半面のx範囲（センターライン手前0.5mからゴール前1.0m）
+  // side_sign > 0: +x方向が敵陣 → [0.5, goal_line_x-1.0]
+  // side_sign < 0: -x方向が敵陣 → [-(goal_line_x-1.0), -0.5]
+  const double x_near = side_sign * 0.5;
+  const double x_far = side_sign * (goal_line_x - 1.0);
+  const double x_min = std::min(x_near, x_far);
+  const double x_max = std::max(x_near, x_far);
 
-  const double mid_line_y = side_center_y * 0.5;
-  push_line(Point(back_x, mid_line_y), Point(penalty_front_x, mid_line_y));
-  push_line(Point(back_x, -mid_line_y), Point(penalty_front_x, -mid_line_y));
+  // グリッドの中心点（攻撃エリア中央）
+  const double center_x = (x_min + x_max) * 0.5;
+  const double center_y = 0.0;
 
-  // 攻めの方向に応じて符号を調整（練習モードreverse_attack対応）
-  for (auto & line : forward_lines) {
-    line.first.x() = -world_model->getAttackSideSign() * line.first.x();
-    line.second.x() = -world_model->getAttackSideSign() * line.second.x();
+  // x, y 方向の格子数を算出
+  constexpr float GRID_STEP = 0.5f;
+  const int nx = static_cast<int>(std::ceil((x_max - x_min) / GRID_STEP));
+  const int ny = static_cast<int>(std::ceil(2.0 * field_half_width / GRID_STEP));
+
+  std::vector<Point> raw = getPoints(Point(center_x, center_y), GRID_STEP, GRID_STEP, nx, ny);
+
+  // フィールド外・PAの中（マージン込み）を除外し、x が攻撃半面内のみ残す
+  std::vector<Point> candidates;
+  candidates.reserve(raw.size());
+  for (const auto & p : raw) {
+    if (!world_model->point_checker.isFieldInside(p, 0.2)) continue;
+    if (world_model->point_checker.isPenaltyArea(p, PA_MARGIN)) continue;
+    // 攻撃半面（センターラインより敵陣側）のみ
+    if (side_sign * p.x() < 0.3) continue;
+    candidates.push_back(p);
+  }
+  return candidates;
+}
+
+auto ForwardSession::scorePoint(
+  const Point & p, const Point & robot_pos, const std::vector<Point> & forward_positions,
+  const RobotList & available_enemies) const -> double
+{
+  double score = 1.0;
+  const auto & ball = world_model->ball();
+  const auto their_goal_center = world_model->getAttackGoalCenter();
+
+  // ---- 1. パス受取スコア（パスラインの敵距離） ----
+  Segment pass_line{ball.pos, p};
+  auto nearest_enemy =
+    world_model->getNearestRobotWithDistanceFromSegment(pass_line, available_enemies);
+  if (nearest_enemy) {
+    score *= std::clamp(nearest_enemy->distance, 0.2, 2.0) / 2.0;
   }
 
-  return forward_lines;
+  // ---- 2. ボール距離（近すぎ/遠すぎ回避） ----
+  const double dist_to_ball = (p - ball.pos).norm();
+  constexpr double MIN_PASS_DIST = 1.5;
+  constexpr double MAX_PASS_DIST = 9.0;
+  if (dist_to_ball < MIN_PASS_DIST) {
+    score *= dist_to_ball / MIN_PASS_DIST;
+  }
+  score *= (std::clamp(1.0 - dist_to_ball / MAX_PASS_DIST, 0.0, 1.0) * 0.5 + 0.5);
+
+  // ---- 3. ゴール可視角 ----
+  auto [goal_angle, goal_width] = world_model->getLargestAttackGoalAngleRangeFromPoint(p);
+  score *= (std::clamp(goal_width / 0.6, 0.0, 1.0) * 0.5 + 0.5);
+
+  // ---- 4. ボール後方回避（ゴール方向の後ろ側を減点） ----
+  const double dot = (their_goal_center - ball.pos).normalized().dot((p - ball.pos).normalized());
+  score *= std::max((dot + 0.5), 0.0);
+
+  // ---- 5. 斥力（味方スペーシング） ----
+  constexpr double MIN_TEAM_SPACING = 1.8;
+  for (const auto & fwd_pos : forward_positions) {
+    if ((fwd_pos - robot_pos).norm() < 0.01) continue;  // 自分自身をスキップ
+    const double d = (p - fwd_pos).norm();
+    if (d < MIN_TEAM_SPACING) {
+      score *= d / MIN_TEAM_SPACING;
+    }
+  }
+
+  // ---- 6. 近似ボロノイ（縄張り評価） ----
+  // 「自分が最近傍」なほどスコアが上がり、他ロボットに近い点は減点される
+  const double own_dist = (p - robot_pos).norm() + 1e-6;
+  double others_min = 1e9;
+  for (const auto & fwd_pos : forward_positions) {
+    if ((fwd_pos - robot_pos).norm() < 0.01) continue;
+    others_min = std::min(others_min, (p - fwd_pos).norm());
+  }
+  for (const auto & enemy : available_enemies) {
+    others_min = std::min(others_min, (p - enemy->pose.pos).norm());
+  }
+  if (others_min < 1e9) {
+    // own_dist < others_min → 自分が最近傍 → factor > 1 (最大1.5倍)
+    // own_dist > others_min → 他ロボットが近い → factor < 1 (最小0.2)
+    const double voronoi_factor = std::clamp(others_min / own_dist, 0.2, 1.5);
+    score *= voronoi_factor;
+  }
+
+  return score;
 }
 
 auto ForwardSession::calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
@@ -61,89 +129,136 @@ auto ForwardSession::calculatePositionCommand(const std::vector<RobotIdentifier>
     return {SessionBase::Status::RUNNING, {}};
   }
 
-  // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
+  // スキル数がロボット数と異なる場合に再生成
   if (forward_skills.size() != robots.size()) {
     forward_skills.clear();
     visualizer->layer = "skill/forward";
+    for (const auto & robot_id : robots) {
+      auto skill = std::make_shared<skills::Forward>(robot_id.id, world_model);
+      skill->setParameter("max_vel", 1.5);
+      skill->planner_visualizer = visualizer;
+      forward_skills.emplace_back(skill);
+    }
+  }
 
-    auto forward_lines = createForwardLines();
+  // ---- 候補点生成 ----
+  const auto candidates = computeCandidatePoints();
+  if (candidates.empty()) {
+    // フォールバック: 現在位置を維持
+    std::vector<crane_msgs::msg::RobotCommand> robot_commands;
+    for (auto & skill : forward_skills) {
+      skill->run();
+      robot_commands.emplace_back(skill->getRobotCommand());
+    }
+    return {SessionBase::Status::RUNNING, robot_commands};
+  }
 
-    if (forward_lines.empty()) {
+  const size_t n_robots = robots.size();
+  const size_t n_cands = candidates.size();
+
+  // ---- 全フォワードロボットの現在位置 ----
+  std::vector<Point> forward_positions =
+    robots | ranges::views::transform([this](const RobotIdentifier & id) -> Point {
+      return world_model->getRobot(id)->pose.pos;
+    }) |
+    ranges::to<std::vector>;
+
+  const auto available_enemies = world_model->theirs().robotsWhere().available().get();
+
+  // ---- スコア行列計算 ----
+  // score_matrix[robot_idx][cand_idx]
+  std::vector<std::vector<double>> score_matrix(n_robots, std::vector<double>(n_cands, 0.0));
+
+  for (size_t ri = 0; ri < n_robots; ++ri) {
+    const Point & robot_pos = forward_positions[ri];
+    const uint8_t robot_id = robots[ri].id;
+
+    for (size_t ci = 0; ci < n_cands; ++ci) {
+      double s = scorePoint(candidates[ci], robot_pos, forward_positions, available_enemies);
+
+      // ---- ヒステリシス引力（前回目標付近のスコアを引き上げ） ----
+      // BONUS * exp(-dist²/(2σ²)) で前回目標付近を優遇
+      if (last_targets_.count(robot_id)) {
+        const double dist = (candidates[ci] - last_targets_.at(robot_id)).norm();
+        constexpr double HYSTERESIS_BONUS = 0.3;
+        constexpr double HYSTERESIS_SIGMA = 1.0;
+        s *= 1.0 + HYSTERESIS_BONUS *
+                     std::exp(-dist * dist / (2.0 * HYSTERESIS_SIGMA * HYSTERESIS_SIGMA));
+      }
+
+      score_matrix[ri][ci] = s;
+
+      // 可視化（スコアを色付き円で表示）
+      if (ri == 0 && visualizer) {
+        visualizer->drawCircle(candidates[ci], s * 0.2, "lime", 3, 0.4);
+      }
+    }
+  }
+
+  // ---- スコアの正規化（最大スコアで割る） ----
+  double global_max = 1e-9;
+  for (const auto & row : score_matrix) {
+    for (double v : row) global_max = std::max(global_max, v);
+  }
+
+  // ---- 最適割当（コスト = 1 - normalized_score） ----
+  auto solution = getOptimalAssignmentsWithCost(
+    n_robots, n_cands, [&](int ri, int ci) { return 1.0 - score_matrix[ri][ci] / global_max; });
+
+  // ---- 目標点の適用とヒステリシス更新 ----
+  for (size_t i = 0; i < n_robots; ++i) {
+    const int ci = solution[i];
+    const uint8_t robot_id = robots[i].id;
+
+    if (ci < 0 || static_cast<size_t>(ci) >= n_cands) {
       RCLCPP_WARN(
         rclcpp::get_logger("ForwardSession"),
-        "Forward lines are empty. Falling back to stop-like commands.");
+        "Invalid assignment index (%d) for robot %d. Skipping.", ci, robot_id);
+      continue;
+    }
 
-      for (const auto & robot_id : robots) {
-        auto skill = std::make_shared<skills::Forward>(robot_id.id, world_model);
-        const auto robot_pos = world_model->getRobot(robot_id)->pose.pos;
-        skill->setParameter("front_point", robot_pos);
-        skill->setParameter("back_point", robot_pos);
-        skill->setParameter("max_vel", 1.5);
-        skill->planner_visualizer = visualizer;
-        forward_skills.emplace_back(skill);
+    const Point & target = candidates[ci];
+
+    // ヒステリシス: 新目標が旧目標より15%以上スコア改善した場合のみ更新
+    bool should_update = true;
+    if (last_targets_.count(robot_id)) {
+      // 現在の旧目標の非ヒステリシス補正済みスコア（元スコアで比較）
+      const Point & old_target = last_targets_.at(robot_id);
+      const double old_score =
+        scorePoint(old_target, forward_positions[i], forward_positions, available_enemies);
+      const double new_score =
+        scorePoint(target, forward_positions[i], forward_positions, available_enemies);
+      constexpr double MIN_IMPROVEMENT = 0.15;
+      // 旧目標よりも大幅に改善した場合のみ切り替え
+      // （ヒステリシスなしの生スコアで比較してチラつきを防ぐ）
+      if (new_score < old_score * (1.0 + MIN_IMPROVEMENT)) {
+        should_update = false;
       }
-    } else {
-      if (forward_lines.size() > robots.size()) {
-        forward_lines.resize(robots.size());
-      } else if (forward_lines.size() < robots.size()) {
-        // ロボット数がライン数を超える場合、既存ラインを循環的に複製して全ロボットに割当
-        size_t original_size = forward_lines.size();
-        while (forward_lines.size() < robots.size()) {
-          forward_lines.push_back(forward_lines[forward_lines.size() % original_size]);
-        }
-      }
+    }
 
-      std::vector<Point> robot_positions =
-        robots | ranges::views::transform([this](const auto & robot_id) -> Point {
-          return world_model->getRobot(robot_id)->pose.pos;
-        }) |
-        ranges::to<std::vector>;
+    const Point & final_target = should_update ? target : last_targets_.at(robot_id);
+    if (should_update) {
+      last_targets_[robot_id] = target;
+    }
 
-      auto solution = getOptimalAssignments(robot_positions, forward_lines);
+    forward_skills[i]->setParameter("front_point", final_target);
+    forward_skills[i]->setParameter("back_point", final_target);
 
-      forward_line_assignments.clear();
-      for (const auto & [index, robot_id] : robots | ranges::views::enumerate) {
-        auto skill = std::make_shared<skills::Forward>(robot_id.id, world_model);
-
-        int line_index = solution[index];
-        if (line_index < 0 || static_cast<size_t>(line_index) >= forward_lines.size()) {
-          line_index = static_cast<int>(index % forward_lines.size());
-          RCLCPP_WARN(
-            rclcpp::get_logger("ForwardSession"),
-            "Invalid assignment index (%d). Using fallback line index (%d).", solution[index],
-            line_index);
-        }
-
-        const auto & line = forward_lines[line_index];
-        skill->setParameter("front_point", line.second);
-        skill->setParameter("back_point", line.first);
-        skill->setParameter("max_vel", 1.5);
-        skill->planner_visualizer = visualizer;
-        forward_skills.emplace_back(skill);
-        forward_line_assignments.emplace_back(line_index);
+    // 選択された目標点を強調表示
+    if (visualizer) {
+      visualizer->drawCircle(final_target, 0.25, "magenta", 8, 0.9);
+      if (last_targets_.count(robot_id) && !should_update) {
+        // ヒステリシスで旧目標を保持中の場合は旧目標→新候補へ線を引く
+        visualizer->drawLine(final_target, target, "orange", 3);
       }
     }
   }
 
-  // 毎フレームback_xを更新してラインパラメータを再設定
-  if (!forward_skills.empty() && forward_line_assignments.size() == forward_skills.size()) {
-    auto current_lines = createForwardLines();
-    if (!current_lines.empty()) {
-      for (size_t i = 0; i < forward_skills.size(); ++i) {
-        const int line_index = forward_line_assignments[i];
-        if (static_cast<size_t>(line_index) < current_lines.size()) {
-          const auto & line = current_lines[line_index];
-          forward_skills[i]->setParameter("front_point", line.second);
-          forward_skills[i]->setParameter("back_point", line.first);
-        }
-      }
-    }
-  }
-
+  // ---- スキル実行 ----
   std::vector<crane_msgs::msg::RobotCommand> robot_commands;
-  for (auto forward_skill : forward_skills) {
-    forward_skill->run();
-    robot_commands.emplace_back(forward_skill->getRobotCommand());
+  for (auto & skill : forward_skills) {
+    skill->run();
+    robot_commands.emplace_back(skill->getRobotCommand());
   }
   return {SessionBase::Status::RUNNING, robot_commands};
 }

--- a/crane_sessions/src/forward_session.cpp
+++ b/crane_sessions/src/forward_session.cpp
@@ -9,6 +9,8 @@
 #include <crane_geometry/ddps.hpp>
 #include <crane_physics/position_assignments.hpp>
 #include <crane_sessions/forward_session.hpp>
+#include <limits>
+#include <numeric>
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/transform.hpp>
@@ -20,38 +22,30 @@ auto ForwardSession::computeCandidatePoints() const -> std::vector<Point>
 {
   const double goal_line_x = world_model->fieldSize().x() * 0.5;
   const double field_half_width = world_model->fieldSize().y() * 0.5;
-  constexpr double PA_MARGIN = 0.3;  // ペナルティエリアとの距離マージン
+  constexpr double PA_MARGIN = 0.3;
+  constexpr double FIELD_MARGIN = 0.2;
+  constexpr double ATTACK_HALFLINE_THRESHOLD = 0.3;
+  constexpr double GRID_STEP = 0.5;
 
-  // 攻撃サイドの符号（1 or -1）
   const double side_sign = -world_model->getAttackSideSign();
-
-  // 攻撃半面のx範囲（センターライン手前0.5mからゴール前1.0m）
-  // side_sign > 0: +x方向が敵陣 → [0.5, goal_line_x-1.0]
-  // side_sign < 0: -x方向が敵陣 → [-(goal_line_x-1.0), -0.5]
   const double x_near = side_sign * 0.5;
   const double x_far = side_sign * (goal_line_x - 1.0);
   const double x_min = std::min(x_near, x_far);
   const double x_max = std::max(x_near, x_far);
-
-  // グリッドの中心点（攻撃エリア中央）
   const double center_x = (x_min + x_max) * 0.5;
-  const double center_y = 0.0;
 
-  // x, y 方向の格子数を算出
-  constexpr float GRID_STEP = 0.5f;
   const int nx = static_cast<int>(std::ceil((x_max - x_min) / GRID_STEP));
   const int ny = static_cast<int>(std::ceil(2.0 * field_half_width / GRID_STEP));
 
-  std::vector<Point> raw = getPoints(Point(center_x, center_y), GRID_STEP, GRID_STEP, nx, ny);
+  std::vector<Point> raw = getPoints(
+    Point(center_x, 0.0), static_cast<float>(GRID_STEP), static_cast<float>(GRID_STEP), nx, ny);
 
-  // フィールド外・PAの中（マージン込み）を除外し、x が攻撃半面内のみ残す
   std::vector<Point> candidates;
   candidates.reserve(raw.size());
   for (const auto & p : raw) {
-    if (!world_model->point_checker.isFieldInside(p, 0.2)) continue;
+    if (!world_model->point_checker.isFieldInside(p, FIELD_MARGIN)) continue;
     if (world_model->point_checker.isPenaltyArea(p, PA_MARGIN)) continue;
-    // 攻撃半面（センターラインより敵陣側）のみ
-    if (side_sign * p.x() < 0.3) continue;
+    if (side_sign * p.x() < ATTACK_HALFLINE_THRESHOLD) continue;
     candidates.push_back(p);
   }
   return candidates;
@@ -65,15 +59,14 @@ auto ForwardSession::scorePoint(
   const auto & ball = world_model->ball();
   const auto their_goal_center = world_model->getAttackGoalCenter();
 
-  // ---- 1. パス受取スコア（パスラインの敵距離） ----
-  Segment pass_line{ball.pos, p};
+  // 1. パス受取スコア（パスライン上の敵距離）
   auto nearest_enemy =
-    world_model->getNearestRobotWithDistanceFromSegment(pass_line, available_enemies);
+    world_model->getNearestRobotWithDistanceFromSegment(Segment{ball.pos, p}, available_enemies);
   if (nearest_enemy) {
     score *= std::clamp(nearest_enemy->distance, 0.2, 2.0) / 2.0;
   }
 
-  // ---- 2. ボール距離（近すぎ/遠すぎ回避） ----
+  // 2. ボール距離（近すぎ/遠すぎ回避）
   const double dist_to_ball = (p - ball.pos).norm();
   constexpr double MIN_PASS_DIST = 1.5;
   constexpr double MAX_PASS_DIST = 9.0;
@@ -82,40 +75,34 @@ auto ForwardSession::scorePoint(
   }
   score *= (std::clamp(1.0 - dist_to_ball / MAX_PASS_DIST, 0.0, 1.0) * 0.5 + 0.5);
 
-  // ---- 3. ゴール可視角 ----
-  auto [goal_angle, goal_width] = world_model->getLargestAttackGoalAngleRangeFromPoint(p);
-  score *= (std::clamp(goal_width / 0.6, 0.0, 1.0) * 0.5 + 0.5);
+  // 3. ゴール可視角
+  score *=
+    (std::clamp(
+       world_model->getLargestAttackGoalAngleRangeFromPoint(p).angle_width / 0.6, 0.0, 1.0) *
+       0.5 +
+     0.5);
 
-  // ---- 4. ボール後方回避（ゴール方向の後ろ側を減点） ----
+  // 4. ボール後方回避（ゴール方向の後ろ側を減点）
   const double dot = (their_goal_center - ball.pos).normalized().dot((p - ball.pos).normalized());
   score *= std::max((dot + 0.5), 0.0);
 
-  // ---- 5. 斥力（味方スペーシング） ----
+  // 5&6. 斥力（味方スペーシング）+ 近似ボロノイ（縄張り評価）を1ループで計算
   constexpr double MIN_TEAM_SPACING = 1.8;
-  for (const auto & fwd_pos : forward_positions) {
-    if ((fwd_pos - robot_pos).norm() < 0.01) continue;  // 自分自身をスキップ
-    const double d = (p - fwd_pos).norm();
-    if (d < MIN_TEAM_SPACING) {
-      score *= d / MIN_TEAM_SPACING;
-    }
-  }
-
-  // ---- 6. 近似ボロノイ（縄張り評価） ----
-  // 「自分が最近傍」なほどスコアが上がり、他ロボットに近い点は減点される
   const double own_dist = (p - robot_pos).norm() + 1e-6;
-  double others_min = 1e9;
+  double others_min = std::numeric_limits<double>::max();
   for (const auto & fwd_pos : forward_positions) {
     if ((fwd_pos - robot_pos).norm() < 0.01) continue;
-    others_min = std::min(others_min, (p - fwd_pos).norm());
+    const double d = (p - fwd_pos).norm();
+    if (d < MIN_TEAM_SPACING) score *= d / MIN_TEAM_SPACING;
+    others_min = std::min(others_min, d);
   }
   for (const auto & enemy : available_enemies) {
     others_min = std::min(others_min, (p - enemy->pose.pos).norm());
   }
-  if (others_min < 1e9) {
-    // own_dist < others_min → 自分が最近傍 → factor > 1 (最大1.5倍)
-    // own_dist > others_min → 他ロボットが近い → factor < 1 (最小0.2)
-    const double voronoi_factor = std::clamp(others_min / own_dist, 0.2, 1.5);
-    score *= voronoi_factor;
+  if (others_min < std::numeric_limits<double>::max()) {
+    // own_dist < others_min → 自分が最近傍 → factor > 1（最大1.5倍）
+    // own_dist > others_min → 他ロボットが近い → factor < 1（最小0.2）
+    score *= std::clamp(others_min / own_dist, 0.2, 1.5);
   }
 
   return score;
@@ -141,10 +128,8 @@ auto ForwardSession::calculatePositionCommand(const std::vector<RobotIdentifier>
     }
   }
 
-  // ---- 候補点生成 ----
   const auto candidates = computeCandidatePoints();
   if (candidates.empty()) {
-    // フォールバック: 現在位置を維持
     std::vector<crane_msgs::msg::RobotCommand> robot_commands;
     for (auto & skill : forward_skills) {
       skill->run();
@@ -156,7 +141,6 @@ auto ForwardSession::calculatePositionCommand(const std::vector<RobotIdentifier>
   const size_t n_robots = robots.size();
   const size_t n_cands = candidates.size();
 
-  // ---- 全フォワードロボットの現在位置 ----
   std::vector<Point> forward_positions =
     robots | ranges::views::transform([this](const RobotIdentifier & id) -> Point {
       return world_model->getRobot(id)->pose.pos;
@@ -165,96 +149,120 @@ auto ForwardSession::calculatePositionCommand(const std::vector<RobotIdentifier>
 
   const auto available_enemies = world_model->theirs().robotsWhere().available().get();
 
-  // ---- スコア行列計算 ----
-  // score_matrix[robot_idx][cand_idx]
-  std::vector<std::vector<double>> score_matrix(n_robots, std::vector<double>(n_cands, 0.0));
+  // ---- パス1: 全候補点の生スコアを計算 ----
+  std::vector<std::vector<double>> raw_scores(n_robots, std::vector<double>(n_cands));
+  for (size_t ri = 0; ri < n_robots; ++ri) {
+    for (size_t ci = 0; ci < n_cands; ++ci) {
+      raw_scores[ri][ci] =
+        scorePoint(candidates[ci], forward_positions[ri], forward_positions, available_enemies);
+    }
+  }
+
+  // ---- 上位K点に絞ってハンガリアン行列を縮小 ----
+  // ロボット間でmax取りしてK点を選ぶことで全ロボットの選好を担保する
+  constexpr size_t MIN_TOP_K = 20;
+  const size_t top_k = std::min(n_cands, std::max(MIN_TOP_K, 4 * n_robots));
+
+  std::vector<size_t> top_indices(n_cands);
+  std::iota(top_indices.begin(), top_indices.end(), 0u);
+  if (n_cands > top_k) {
+    std::partial_sort(
+      top_indices.begin(), top_indices.begin() + static_cast<ptrdiff_t>(top_k), top_indices.end(),
+      [&](size_t a, size_t b) {
+        double max_a = 0.0, max_b = 0.0;
+        for (size_t ri = 0; ri < n_robots; ++ri) {
+          max_a = std::max(max_a, raw_scores[ri][a]);
+          max_b = std::max(max_b, raw_scores[ri][b]);
+        }
+        return max_a > max_b;
+      });
+    top_indices.resize(top_k);
+  }
+
+  // ---- パス2: 上位K点にヒステリシスボーナスを適用してスコア行列を構築 ----
+  const size_t n_top = top_indices.size();
+  std::vector<std::vector<double>> score_matrix(n_robots, std::vector<double>(n_top));
 
   for (size_t ri = 0; ri < n_robots; ++ri) {
-    const Point & robot_pos = forward_positions[ri];
     const uint8_t robot_id = robots[ri].id;
+    const auto last_it = last_targets_.find(robot_id);
 
-    for (size_t ci = 0; ci < n_cands; ++ci) {
-      double s = scorePoint(candidates[ci], robot_pos, forward_positions, available_enemies);
+    for (size_t ki = 0; ki < n_top; ++ki) {
+      const size_t ci = top_indices[ki];
+      double s = raw_scores[ri][ci];
 
-      // ---- ヒステリシス引力（前回目標付近のスコアを引き上げ） ----
-      // BONUS * exp(-dist²/(2σ²)) で前回目標付近を優遇
-      if (last_targets_.count(robot_id)) {
-        const double dist = (candidates[ci] - last_targets_.at(robot_id)).norm();
+      // ヒステリシス引力: BONUS * exp(-dist²/(2σ²)) で前回目標付近を優遇
+      if (last_it != last_targets_.end()) {
+        const double dist = (candidates[ci] - last_it->second).norm();
         constexpr double HYSTERESIS_BONUS = 0.3;
         constexpr double HYSTERESIS_SIGMA = 1.0;
         s *= 1.0 + HYSTERESIS_BONUS *
                      std::exp(-dist * dist / (2.0 * HYSTERESIS_SIGMA * HYSTERESIS_SIGMA));
       }
+      score_matrix[ri][ki] = s;
 
-      score_matrix[ri][ci] = s;
-
-      // 可視化（スコアを色付き円で表示）
       if (ri == 0 && visualizer) {
         visualizer->drawCircle(candidates[ci], s * 0.2, "lime", 3, 0.4);
       }
     }
   }
 
-  // ---- スコアの正規化（最大スコアで割る） ----
   double global_max = 1e-9;
   for (const auto & row : score_matrix) {
     for (double v : row) global_max = std::max(global_max, v);
   }
 
-  // ---- 最適割当（コスト = 1 - normalized_score） ----
   auto solution = getOptimalAssignmentsWithCost(
-    n_robots, n_cands, [&](int ri, int ci) { return 1.0 - score_matrix[ri][ci] / global_max; });
+    n_robots, n_top, [&](int ri, int ki) { return 1.0 - score_matrix[ri][ki] / global_max; });
 
   // ---- 目標点の適用とヒステリシス更新 ----
   for (size_t i = 0; i < n_robots; ++i) {
-    const int ci = solution[i];
+    const int ki = solution[i];
     const uint8_t robot_id = robots[i].id;
 
-    if (ci < 0 || static_cast<size_t>(ci) >= n_cands) {
+    if (ki < 0 || static_cast<size_t>(ki) >= n_top) {
       RCLCPP_WARN(
         rclcpp::get_logger("ForwardSession"),
-        "Invalid assignment index (%d) for robot %d. Skipping.", ci, robot_id);
+        "Invalid assignment index (%d) for robot %d. Skipping.", ki, robot_id);
       continue;
     }
 
+    const size_t ci = top_indices[ki];
     const Point & target = candidates[ci];
 
-    // ヒステリシス: 新目標が旧目標より15%以上スコア改善した場合のみ更新
+    // ヒステリシス: 生スコアで15%以上改善しない限り目標を切り替えない
     bool should_update = true;
-    if (last_targets_.count(robot_id)) {
-      // 現在の旧目標の非ヒステリシス補正済みスコア（元スコアで比較）
-      const Point & old_target = last_targets_.at(robot_id);
-      const double old_score =
-        scorePoint(old_target, forward_positions[i], forward_positions, available_enemies);
-      const double new_score =
-        scorePoint(target, forward_positions[i], forward_positions, available_enemies);
+    auto last_it = last_targets_.find(robot_id);
+    if (last_it != last_targets_.end()) {
+      auto score_it = last_scores_.find(robot_id);
+      const double old_raw_score = (score_it != last_scores_.end()) ? score_it->second : 0.0;
       constexpr double MIN_IMPROVEMENT = 0.15;
-      // 旧目標よりも大幅に改善した場合のみ切り替え
-      // （ヒステリシスなしの生スコアで比較してチラつきを防ぐ）
-      if (new_score < old_score * (1.0 + MIN_IMPROVEMENT)) {
+      if (raw_scores[i][ci] < old_raw_score * (1.0 + MIN_IMPROVEMENT)) {
         should_update = false;
       }
     }
 
-    const Point & final_target = should_update ? target : last_targets_.at(robot_id);
+    Point final_target = target;
+    if (!should_update) {
+      final_target = last_it->second;  // last_it有効: should_update=falseはlast_it!=end()の場合のみ
+    }
+
     if (should_update) {
       last_targets_[robot_id] = target;
+      last_scores_[robot_id] = raw_scores[i][ci];
     }
 
     forward_skills[i]->setParameter("front_point", final_target);
     forward_skills[i]->setParameter("back_point", final_target);
 
-    // 選択された目標点を強調表示
     if (visualizer) {
       visualizer->drawCircle(final_target, 0.25, "magenta", 8, 0.9);
-      if (last_targets_.count(robot_id) && !should_update) {
-        // ヒステリシスで旧目標を保持中の場合は旧目標→新候補へ線を引く
+      if (!should_update) {
         visualizer->drawLine(final_target, target, "orange", 3);
       }
     }
   }
 
-  // ---- スキル実行 ----
   std::vector<crane_msgs::msg::RobotCommand> robot_commands;
   for (auto & skill : forward_skills) {
     skill->run();


### PR DESCRIPTION
## 概要

ForwardSessionのロボット割当を、従来の固定ライン方式からスコアマップ＋ヒステリシス方式に刷新し、より柔軟で最適なポジショニングを実現する。

## 背景

従来の固定ライン方式では、ロボットの配置がライン定義に強く依存しており、動的な試合状況に応じた最適な配置が困難だった。スコアマップ方式を導入することで、各ロボットが取り得るポジションをスコア付けし、ハンガリアン法で全体最適な割当を行う。

## 変更内容

- `crane_sessions/forward_session.hpp` - スコアマップ・ヒステリシス関連のデータ構造を追加
- `crane_sessions/src/forward_session.cpp` - スコア計算とハンガリアン割当を実装、ヒステリシスによる割当安定化を追加
- `crane_robot_skills/src/forward.cpp` - ForwardSessionの新インターフェースに対応

## コミット構成

1. `c9a87e5` feat: ForwardSessionを固定ライン方式からスコアマップ+ヒステリシス方式に刷新
2. `453321a` refactor: ForwardSessionのスコア計算とハンガリアン割当を最適化