### PR TITLE
feat: ボール消失時のフォールバック推定を実装 (#1326)

### DIFF
--- a/crane_msgs/msg/BallInfo.msg
+++ b/crane_msgs/msg/BallInfo.msg
@@ -24,3 +24,16 @@ BallPhysicsConfig physics_config
 
 # ボール予測トレース（予実管理用）
 crane_msgs/BallPredictionTrace[<=1] ball_prediction_trace
+
+# --- Fallback 推定情報（メイン値は書き換えない） ---
+uint8 FALLBACK_NONE = 0
+uint8 FALLBACK_LAST_KNOWN = 1
+uint8 FALLBACK_BALL_SENSOR = 2
+uint8 FALLBACK_OCCLUSION_SHADOW = 3
+uint8 fallback_source
+
+bool fallback_available
+geometry_msgs/Vector3 fallback_position
+float32 fallback_confidence
+builtin_interfaces/Time fallback_stamp
+uint32 fallback_occluder_robot_id

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -27,8 +27,10 @@
 #include <deque>
 #include <functional>
 #include <limits>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <rclcpp/rclcpp.hpp>
 #include <robocup_ssl_msgs/msg/referee.hpp>
@@ -104,6 +106,14 @@ struct TrackerBallState
   bool detected{false};
 };
 
+// ボールセンサヒント（外部から通知される味方ロボットのボールセンサ情報）
+struct BallSensorHint
+{
+  uint32_t robot_id{0};
+  Eigen::Vector2d position{Eigen::Vector2d::Zero()};
+  rclcpp::Time stamp{};
+};
+
 class WorldModelDataProvider
 {
 public:
@@ -149,6 +159,17 @@ public:
   [[nodiscard]] auto getLastVisionTCapture() const -> double { return last_t_capture_; }
   [[nodiscard]] auto getLastVisionTSent() const -> double { return last_t_sent_; }
   auto setOurTeamColor(TeamColor color) -> void { our_team_color_ = color; }
+
+  /// 味方ロボットのボールセンサ反応を通知する（フォールバック推定に使用）
+  auto setBallSensorHint(uint32_t robot_id, Eigen::Vector2d pos, rclcpp::Time stamp) -> void
+  {
+    // 複数台反応している場合は最新のものを採用（同時刻なら robot_id 小さい方を優先）
+    if (
+      !ball_sensor_hint_ || stamp > ball_sensor_hint_->stamp ||
+      (stamp == ball_sensor_hint_->stamp && robot_id < ball_sensor_hint_->robot_id)) {
+      ball_sensor_hint_ = BallSensorHint{robot_id, pos, stamp};
+    }
+  }
 
   [[nodiscard]] auto getLatestPlaySituation() const -> const crane_msgs::msg::PlaySituation &
   {
@@ -208,6 +229,14 @@ private:
   // ボール状態管理（Vision/Tracker分離）
   VisionBallState vision_ball_state_;
   TrackerBallState tracker_ball_state_;
+
+  // フォールバック推定用
+  Eigen::Vector3d last_known_ball_position_{Eigen::Vector3d::Zero()};
+  rclcpp::Time last_known_ball_stamp_{};
+  bool last_known_ball_valid_{false};
+  std::optional<uint32_t> last_known_ball_camera_id_;
+  std::optional<BallSensorHint> ball_sensor_hint_;
+  std::map<uint32_t, Eigen::Vector3d> camera_positions_;  // camera_id → world position (m)
 
   rclcpp::TimerBase::SharedPtr udp_timer;
   rclcpp::TimerBase::SharedPtr status_check_timer_;
@@ -296,9 +325,11 @@ private:
     const crane_msgs::msg::RobotInfo & feedback_robot) -> crane_msgs::msg::RobotInfo;
 
   // ボール状態更新メソッド（Vision/Tracker分離）
-  auto updateVisionBallState(const robocup_ssl::SSL_DetectionBall & ssl_ball) -> void;
+  auto updateVisionBallState(const robocup_ssl::SSL_DetectionBall & ssl_ball, uint32_t camera_id)
+    -> void;
   auto updateTrackerBallState(const robocup_ssl_msgs::msg::TrackedBall & tracked_ball) -> void;
   auto integrateBallInfo() -> void;
+  auto estimateFallbackBall(const rclcpp::Time & now) -> void;
 
   // 半面練習モード: 自陣ゴールに最も近いボールのインデックスを返す
   template <typename BallContainer, typename PosExtractor>

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -284,7 +284,9 @@ auto WorldModelDataProvider::on_udp_timer() -> void
                 return std::make_pair(b.x() / 1000.0, b.y() / 1000.0);
               });
             }
-            updateVisionBallState(balls.at(static_cast<int>(idx)));
+            updateVisionBallState(
+              balls.at(static_cast<int>(idx)),
+              static_cast<uint32_t>(packet.detection().camera_id()));
             integrateBallInfo();
           }
           if (use_udp_detection_) {
@@ -576,7 +578,8 @@ auto WorldModelDataProvider::processDetectionFrame(
       idx = selectClosestBallToOurGoal(
         balls, [](const auto & b) { return std::make_pair(b.x() / 1000.0, b.y() / 1000.0); });
     }
-    updateVisionBallState(balls.at(static_cast<int>(idx)));
+    updateVisionBallState(
+      balls.at(static_cast<int>(idx)), static_cast<uint32_t>(detection.camera_id()));
   }
 
   // Vision/Tracker状態を統合してball_info_を更新
@@ -593,6 +596,19 @@ auto WorldModelDataProvider::processGeometryData(const robocup_ssl::SSL_Geometry
 {
   convertFieldGeometry(geometry);
 
+  // カメラ位置をキャッシュ（occlusion shadow 推定に使用）
+  for (int i = 0; i < geometry.calib_size(); ++i) {
+    const auto & calib = geometry.calib(i);
+    if (
+      calib.has_derived_camera_world_tx() && calib.has_derived_camera_world_ty() &&
+      calib.has_derived_camera_world_tz()) {
+      // mm → m 変換
+      camera_positions_[static_cast<uint32_t>(calib.camera_id())] = Eigen::Vector3d(
+        calib.derived_camera_world_tx() / 1000.0, calib.derived_camera_world_ty() / 1000.0,
+        calib.derived_camera_world_tz() / 1000.0);
+    }
+  }
+
   if (geometry_visualization_callback_) {
     geometry_visualization_callback_(geometry, false);  // half_court_mode = false
   }
@@ -600,8 +616,100 @@ auto WorldModelDataProvider::processGeometryData(const robocup_ssl::SSL_Geometry
   return true;
 }
 
-auto WorldModelDataProvider::updateVisionBallState(const robocup_ssl::SSL_DetectionBall & ssl_ball)
-  -> void
+auto WorldModelDataProvider::estimateFallbackBall(const rclcpp::Time & now) -> void
+{
+  constexpr double kBallSensorTimeoutSec = 0.2;
+  constexpr double kLastKnownTimeoutSec = 2.0;
+  // ロボット半径(0.09m) + ボール半径(0.0215m) の合計でオクルージョン判定
+  constexpr double kOcclusionShadowRadius = 0.09 + 0.0215;
+
+  auto setFallback = [&](
+                       uint8_t source, const Eigen::Vector2d & pos, float conf, uint32_t occluder,
+                       const rclcpp::Time & stamp) {
+    ball_info_.fallback_available = true;
+    ball_info_.fallback_source = source;
+    ball_info_.fallback_position.x = pos.x();
+    ball_info_.fallback_position.y = pos.y();
+    ball_info_.fallback_position.z = 0.0;
+    ball_info_.fallback_confidence = conf;
+    ball_info_.fallback_occluder_robot_id = occluder;
+    ball_info_.fallback_stamp = stamp;
+  };
+
+  auto clearFallback = [&]() {
+    ball_info_.fallback_available = false;
+    ball_info_.fallback_source = crane_msgs::msg::BallInfo::FALLBACK_NONE;
+    ball_info_.fallback_confidence = 0.0f;
+    ball_info_.fallback_occluder_robot_id = 0;
+    ball_info_.fallback_stamp = now;
+  };
+
+  // 優先度 1: 物理センサ反応は最も信頼度が高い
+  if (ball_sensor_hint_) {
+    if ((now - ball_sensor_hint_->stamp).seconds() <= kBallSensorTimeoutSec) {
+      setFallback(
+        crane_msgs::msg::BallInfo::FALLBACK_BALL_SENSOR, ball_sensor_hint_->position, 0.9f,
+        ball_sensor_hint_->robot_id, ball_sensor_hint_->stamp);
+      return;
+    }
+    ball_sensor_hint_ = std::nullopt;
+  }
+
+  if (!last_known_ball_valid_) {
+    clearFallback();
+    return;
+  }
+
+  double last_known_age = (now - last_known_ball_stamp_).seconds();
+
+  // 優先度 2: カメラの視線がロボットで遮られている場合、ボールは最終観測位置にある可能性が高い
+  if (last_known_ball_camera_id_ && last_known_age <= kLastKnownTimeoutSec) {
+    auto cam_it = camera_positions_.find(*last_known_ball_camera_id_);
+    if (cam_it != camera_positions_.end()) {
+      const Eigen::Vector3d & cam3d = cam_it->second;
+      Eigen::Vector2d cam_xy(cam3d.x(), cam3d.y());
+      Eigen::Vector2d ball_xy(last_known_ball_position_.x(), last_known_ball_position_.y());
+      Eigen::Vector2d ray = ball_xy - cam_xy;
+      double ray_len = ray.norm();
+
+      if (ray_len > 1e-6) {
+        Eigen::Vector2d ray_dir = ray / ray_len;
+        for (int team = 0; team < 2; ++team) {
+          for (const auto & robot_info : robot_info_[team]) {
+            if (!robot_info.available_vision && !robot_info.available_tracker) continue;
+            Eigen::Vector2d robot_xy(robot_info.pose.x, robot_info.pose.y);
+            double t = (robot_xy - cam_xy).dot(ray_dir) / ray_len;
+            if (t <= 0.0 || t >= 1.0) continue;
+            double dist_to_ray = (robot_xy - (cam_xy + t * ray)).norm();
+            if (dist_to_ray < kOcclusionShadowRadius) {
+              float conf =
+                static_cast<float>(std::max(0.3, 1.0 - last_known_age / kLastKnownTimeoutSec));
+              setFallback(
+                crane_msgs::msg::BallInfo::FALLBACK_OCCLUSION_SHADOW, ball_xy, conf,
+                static_cast<uint32_t>(robot_info.id), last_known_ball_stamp_);
+              return;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // 優先度 3: 最終観測位置（信頼度は時間とともに線形減衰）
+  if (last_known_age <= kLastKnownTimeoutSec) {
+    float conf = static_cast<float>(std::max(0.0, 1.0 - last_known_age / kLastKnownTimeoutSec));
+    setFallback(
+      crane_msgs::msg::BallInfo::FALLBACK_LAST_KNOWN,
+      Eigen::Vector2d(last_known_ball_position_.x(), last_known_ball_position_.y()), conf, 0,
+      last_known_ball_stamp_);
+    return;
+  }
+
+  clearFallback();
+}
+
+auto WorldModelDataProvider::updateVisionBallState(
+  const robocup_ssl::SSL_DetectionBall & ssl_ball, uint32_t camera_id) -> void
 {
   // 座標変換 (mm -> m)
   double x = ssl_ball.x() / 1000.0;
@@ -625,6 +733,12 @@ auto WorldModelDataProvider::updateVisionBallState(const robocup_ssl::SSL_Detect
   vision_ball_state_.raw_position.x = x;
   vision_ball_state_.raw_position.y = y;
   vision_ball_state_.raw_position.z = z;
+
+  // フォールバック用: 最終観測情報を記録
+  last_known_ball_position_ = Eigen::Vector3d(x, y, z);
+  last_known_ball_stamp_ = now;
+  last_known_ball_valid_ = true;
+  last_known_ball_camera_id_ = camera_id;
 
   RCLCPP_DEBUG(node.get_logger(), "Vision ball updated at (%.3f, %.3f, %.3f)", x, y, z);
 }
@@ -861,11 +975,29 @@ auto WorldModelDataProvider::integrateBallInfo() -> void
     ball_info_.tracker.pos.z = tracker_ball_state_.position.z();
   }
 
+  // Tracker はカメラ統合済みなので特定カメラに帰属しない → occlusion 推定には使えない
+  if (tracker_ball_state_.detected) {
+    last_known_ball_position_ = tracker_ball_state_.position;
+    last_known_ball_stamp_ = now;
+    last_known_ball_valid_ = true;
+    last_known_ball_camera_id_ = std::nullopt;
+  }
+
   // ボール状態の決定
   if (ball_info_.velocity_norm < 0.1) {
     ball_info_.state = crane_msgs::msg::BallInfo::STOPPED;
   } else {
     ball_info_.state = crane_msgs::msg::BallInfo::ROLLING;
+  }
+
+  if (!ball_info_.detected) {
+    estimateFallbackBall(now);
+  } else {
+    ball_info_.fallback_available = false;
+    ball_info_.fallback_source = crane_msgs::msg::BallInfo::FALLBACK_NONE;
+    ball_info_.fallback_confidence = 0.0f;
+    ball_info_.fallback_stamp = now;
+    ball_info_.fallback_occluder_robot_id = 0;
   }
 }
 

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -170,18 +170,14 @@ auto WorldModelPublisherComponent::postProcessWorldModel(WorldModelWrapperPtr wo
 
 auto WorldModelPublisherComponent::updateBallContact() -> void
 {
-  auto now = rclcpp::Clock(RCL_ROS_TIME).now();
-
-  // ローカルセンサーの情報でボール情報を更新
+  auto now = this->now();
   auto friend_robots = wrapper_->ours().robotsWhere().available().get();
   for (std::size_t i = 0; i < friend_robots.size(); i++) {
     auto robot = friend_robots[i];
-    // ビジョンがボールを見失っているときに
-    // ボールセンサが反応している間は、接触しているものとみなす。
     if (robot->getBallSensorAvailable(now) && not wrapper_->ball().detected) {
-      // ビジョンはボール見失っているけどロボットが保持しているので、
-      // ロボットの座標にボールがあることにする
-      wrapper_->overwriteBallPos(robot->kicker_center());
+      const auto kicker_pos = robot->kicker_center();
+      data_provider_->setBallSensorHint(
+        static_cast<uint32_t>(robot->id), Eigen::Vector2d(kicker_pos.x(), kicker_pos.y()), now);
     }
   }
 }

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
@@ -82,7 +82,11 @@ struct WorldModelWrapper : public DelayMonitorMixin<WorldModelWrapper>
 
   auto update(const crane_msgs::msg::GameAnalysis & msg) -> void { latest_msg.game_analysis = msg; }
 
-  auto overwriteBallPos(Point pos, double z = 0.0) -> void
+  // @deprecated メイン値を書き換えてはならない。
+  // ボールセンサ等の補完情報は BallInfo.fallback_* フィールドを使用すること。
+  // この関数は下位互換のために残されているが、新規コードからは呼び出さないこと。
+  [[deprecated("Use BallInfo fallback fields instead of overwriting main ball position")]] auto
+  overwriteBallPos(Point pos, double z = 0.0) -> void
   {
     ball_.pos = pos;
     ball_.pos_z = z;

--- a/utility/crane_physics/include/crane_physics/ball_info.hpp
+++ b/utility/crane_physics/include/crane_physics/ball_info.hpp
@@ -65,6 +65,21 @@ struct Ball
     FLYING,
   } state;
 
+  enum class FallbackSource : uint8_t {
+    NONE = 0,
+    LAST_KNOWN = 1,
+    BALL_SENSOR = 2,
+    OCCLUSION_SHADOW = 3,
+  };
+
+  struct FallbackEstimate
+  {
+    FallbackSource source{FallbackSource::NONE};
+    Point pos{Point::Zero()};
+    float confidence{0.0f};
+    uint32_t occluder_robot_id{0};
+  };
+
   Point pos;
 
   double pos_z;
@@ -74,6 +89,16 @@ struct Ball
   double vel_z;
 
   bool detected;
+
+  std::optional<FallbackEstimate> fallback;
+
+  /// フォールバック opt-in 用: 呼び出し側は main pos/detected を変えずにフォールバックを利用できる
+  [[nodiscard]] auto effectivePos() const -> Point
+  {
+    if (detected) return pos;
+    if (fallback && fallback->source != FallbackSource::NONE) return fallback->pos;
+    return pos;
+  }
 
   // 統合された物理モデル（必須、常に有効）
   // 注：shared_ptrを使用する理由：

--- a/utility/crane_physics/src/ball_info.cpp
+++ b/utility/crane_physics/src/ball_info.cpp
@@ -216,6 +216,22 @@ void Ball::toMsg(BallInfoMsg & msg) const
   msg.physics_config.height_threshold = config.height_threshold;
   msg.physics_config.speed_threshold = config.speed_threshold;
   msg.physics_config.stop_threshold = config.stop_threshold;
+
+  // Fallback 推定情報
+  if (fallback && fallback->source != FallbackSource::NONE) {
+    msg.fallback_available = true;
+    msg.fallback_source = static_cast<uint8_t>(fallback->source);
+    msg.fallback_position.x = fallback->pos.x();
+    msg.fallback_position.y = fallback->pos.y();
+    msg.fallback_position.z = 0.0;
+    msg.fallback_confidence = fallback->confidence;
+    msg.fallback_occluder_robot_id = fallback->occluder_robot_id;
+  } else {
+    msg.fallback_available = false;
+    msg.fallback_source = static_cast<uint8_t>(FallbackSource::NONE);
+    msg.fallback_confidence = 0.0f;
+    msg.fallback_occluder_robot_id = 0;
+  }
 }
 
 template <typename BallInfoMsg>
@@ -248,6 +264,18 @@ void Ball::fromMsg(const BallInfoMsg & msg)
 
   // BallPhysicsModel設定から物理モデルを設定
   updatePhysicsConfigFromMsg(msg.physics_config);
+
+  // Fallback 推定情報
+  if (msg.fallback_available && msg.fallback_source != BallInfoMsg::FALLBACK_NONE) {
+    FallbackEstimate fb;
+    fb.source = static_cast<FallbackSource>(msg.fallback_source);
+    fb.pos = Point(msg.fallback_position.x, msg.fallback_position.y);
+    fb.confidence = msg.fallback_confidence;
+    fb.occluder_robot_id = msg.fallback_occluder_robot_id;
+    fallback = fb;
+  } else {
+    fallback = std::nullopt;
+  }
 }
 
 // 明示的なテンプレートインスタンス化


### PR DESCRIPTION
## 概要

ボールが Vision/Tracker 両方で見失われた際のフォールバック推定を実装する。
メイン値（`BallInfo.position`）を書き換えず、別フィールド（`fallback_*`）に推定情報を格納し、
コンシューマーが明示的に opt-in して利用できる設計にする。

## 背景・根本原因

従来の `overwriteBallPos` はボールセンサ反応時にメイン位置を直接書き換えており、
Vision/Tracker 由来のクリーンな観測とセンサ推定が混在していた。
またロボットの陰によるカメラオクルージョンや最終観測位置の活用も不足していた。

## 変更内容

- **`BallInfo.msg`**: フォールバックフィールドを追加
  - `fallback_source` (NONE / LAST_KNOWN / BALL_SENSOR / OCCLUSION_SHADOW)
  - `fallback_available`, `fallback_position`, `fallback_confidence`, `fallback_stamp`, `fallback_occluder_robot_id`
- **`Ball` 構造体**: `FallbackEstimate` / `FallbackSource` を追加、`effectivePos()` を提供
- **`WorldModelDataProvider`**:
  - SSL geometry `calib` フィールドからカメラ位置（mm→m）をキャッシュ
  - `estimateFallbackBall(now)` を新設。優先度順に推定:
    1. **BALL_SENSOR**: 味方ロボットのボールセンサ反応 → kicker_center (confidence=0.9)
    2. **OCCLUSION_SHADOW**: カメラ視線上にロボットが遮蔽している場合
    3. **LAST_KNOWN**: 最終観測位置（2秒・時間減衰信頼度）
  - `setBallSensorHint()` を公開 API として追加
- **`updateBallContact`**: `overwriteBallPos` 呼び出しを削除し `setBallSensorHint` に変更
- **`overwriteBallPos`**: `[[deprecated]]` 属性付与（メイン値保護を明示）

## 既存動作への影響

既存スキル・プランナーは `ball.pos` / `ball.detected` のみ参照しており、デフォルトの動作は変わらない。
フォールバック情報は `ball.effectivePos()` または `ball.fallback` への明示的アクセスで opt-in できる。

Closes #1326