### PR TITLE
feat: erforce-simのゲームルールとリアリズム設定を更新

### DIFF
--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -41,8 +41,8 @@ services:
     entrypoint: ["tini", "--"]
     command: >
       ./bin/simulator-cli
-      -g 2020B
-      --realism None
+      -g 2023
+      --realism Realistic
       --ibis-use-referee
       --ibis-feedback-team-name ibis
       --ibis-referee-port 11003


### PR DESCRIPTION
## 概要
erforce-sim サービスのシミュレーション設定を最新の試合条件に合わせて更新します。

## 背景・根本原因
ゲームルールが古い `2020B` のままとなっており、リアリズム設定も `None` であったため、
実環境に近いシミュレーションができていなかった。

## 変更内容
- ゲームルールを `-g 2020B` から `-g 2023` に更新
- リアリズム設定を `--realism None` から `--realism Realistic` に変更