### PR TITLE
feat(docker): docker/devのシミュレータをprofileで切替可能にする

### DIFF
--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -9,15 +9,21 @@
 リポジトリルートから以下のコマンドを実行します。
 
 ```bash
-# シミュレーション環境(デフォルト) + ssl-log-recorder自動起動
+# シミュレーション環境(デフォルト: ER-Force) + ssl-log-recorder自動起動
 ./scripts/docker-dev.sh
+
+# シミュレーション環境(grSim)
+./scripts/docker-dev.sh --sim grsim
+
+# シミュレーション環境(ER-Force、明示指定)
+./scripts/docker-dev.sh --sim erforce
 
 # 実機環境 + ssl-log-recorder自動起動
 ./scripts/docker-dev.sh real
 
 # バックグラウンド起動
 ./scripts/docker-dev.sh -d
-./scripts/docker-dev.sh real -d
+./scripts/docker-dev.sh --sim grsim -d
 
 # robot-manager なしで起動
 ./scripts/docker-dev.sh --no-debug
@@ -54,8 +60,11 @@
 ### Docker Composeコマンドでの直接起動
 
 ```bash
-# シミュレーション環境
-docker compose -f docker/dev/docker-compose.yaml --profile sim up
+# シミュレーション環境(ER-Force)
+docker compose -f docker/dev/docker-compose.yaml --profile sim-erforce up
+
+# シミュレーション環境(grSim)
+docker compose -f docker/dev/docker-compose.yaml --profile sim-grsim up
 
 # 実機環境
 VISION_PORT=10006 docker compose -f docker/dev/docker-compose.yaml up
@@ -66,10 +75,11 @@ docker compose -f docker/dev/docker-compose.yaml down
 
 ## sim/real の差分
 
-| 項目 | sim | real |
-|------|-----|------|
-| Vision ポート | 10020 | 10006 |
-| ssl-status-board | 有効 | 無効 |
+| 項目 | sim (ER-Force) | sim (grSim) | real |
+|------|----------------|-------------|------|
+| Vision ポート | 10020 | 10020 | 10006 |
+| ssl-status-board | 有効 | 有効 | 無効 |
+| profile | `sim-erforce` | `sim-grsim` | なし |
 
 環境変数 `VISION_PORT` とDocker Composeの `profiles` 機能を使用して切り替えています。
 
@@ -81,6 +91,8 @@ docker compose -f docker/dev/docker-compose.yaml down
 - **autoref-tigers**: Tigers Mannheimのオートレフェリー
 - **voicevox**: 音声合成エンジン
 - **robot-manager**: ROS非依存のロボット管理Webアプリ（Start/Stop/Status）
+- **erforce-sim**: ER-Forceシミュレータ（`sim-erforce` profile時のみ）
+- **grsim**: grSimシミュレータ（`sim-grsim` profile時のみ）
 
 ## 設定ファイル
 

--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -48,7 +48,21 @@ services:
       --ibis-referee-port 11003
     restart: "no"
     profiles:
-      - sim
+      - sim-erforce
+
+  grsim:
+    image: ghcr.io/ibis-ssl/grsim:latest
+    container_name: grsim
+    network_mode: host
+    command: |
+      grSim --headless -platform offscreen
+    volumes:
+      - ./grsim.xml:/home/default/.grsim.xml:rw
+    tty: true
+    stdin_open: true
+    restart: "no"
+    profiles:
+      - sim-grsim
 
   ssl-game-controller:
     image: robocupssl/ssl-game-controller:latest
@@ -83,7 +97,8 @@ services:
       - 224.5.23.1:11003
     network_mode: host
     profiles:
-      - sim
+      - sim-erforce
+      - sim-grsim
 
   autoref-tigers:
     image: tigersmannheim/auto-referee:1.2.0

--- a/docker/dev/grsim.xml
+++ b/docker/dev/grsim.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<VarXML>
+  <Var name="Geometry" type="list">
+    <Var name="Game" type="list">
+      <Var name="Division" type="stringenum">Division A
+        <Var name="Division A" type="string">Division A</Var>
+        <Var name="Division B" type="string">Division B</Var>
+      </Var>
+      <Var name="Robots Count" type="int">8</Var>
+      <Var name="Color Robot Blue" type="string">#0000ff</Var>
+      <Var name="Color Robot Yellow" type="string">#ffff00</Var>
+    </Var>
+    <Var name="Field" type="list">
+      <Var name="Division A" type="list">
+        <Var name="Line Thickness" type="double">0.010000</Var>
+        <Var name="Length" type="double">12.000000</Var>
+        <Var name="Width" type="double">9.000000</Var>
+        <Var name="Radius" type="double">0.500000</Var>
+        <Var name="Free Kick Distance From Defense Area" type="double">0.700000</Var>
+        <Var name="Penalty width" type="double">3.600000</Var>
+        <Var name="Penalty depth" type="double">1.800000</Var>
+        <Var name="Penalty point" type="double">8.000000</Var>
+        <Var name="Margin" type="double">0.300000</Var>
+        <Var name="Referee margin" type="double">0.000000</Var>
+        <Var name="Wall thickness" type="double">0.050000</Var>
+        <Var name="Goal thickness" type="double">0.020000</Var>
+        <Var name="Goal depth" type="double">0.180000</Var>
+        <Var name="Goal width" type="double">1.800000</Var>
+        <Var name="Goal height" type="double">0.160000</Var>
+      </Var>
+      <Var name="Division B" type="list">
+        <Var name="Line Thickness" type="double">0.010000</Var>
+        <Var name="Length" type="double">9.000000</Var>
+        <Var name="Width" type="double">6.000000</Var>
+        <Var name="Radius" type="double">0.500000</Var>
+        <Var name="Free Kick Distance From Defense Area" type="double">0.700000</Var>
+        <Var name="Penalty width" type="double">2.000000</Var>
+        <Var name="Penalty depth" type="double">1.000000</Var>
+        <Var name="Penalty point" type="double">6.000000</Var>
+        <Var name="Margin" type="double">0.300000</Var>
+        <Var name="Referee margin" type="double">0.000000</Var>
+        <Var name="Wall thickness" type="double">0.050000</Var>
+        <Var name="Goal thickness" type="double">0.020000</Var>
+        <Var name="Goal depth" type="double">0.180000</Var>
+        <Var name="Goal width" type="double">1.000000</Var>
+        <Var name="Goal height" type="double">0.160000</Var>
+      </Var>
+    </Var>
+    <Var name="Yellow Team" type="stringenum">Parsian</Var>
+    <Var name="Blue Team" type="stringenum">Parsian</Var>
+    <Var name="Cameras" type="list">
+      <Var name="Height of all cameras" type="double">4.000000</Var>
+      <Var name="Focal length" type="double">390.000000</Var>
+      <Var name="Camera scaling limit" type="double">0.900000</Var>
+    </Var>
+    <Var name="Ball" type="list">
+      <Var name="Radius" type="double">0.021500</Var>
+    </Var>
+  </Var>
+  <Var name="Physics" type="list">
+    <Var name="World" type="list">
+      <Var name="Desired FPS" type="double">60.000000</Var>
+      <Var name="Synchronize ODE with OpenGL" type="bool">false</Var>
+      <Var name="ODE time step" type="double">0.016667</Var>
+      <Var name="Gravity" type="double">9.810000</Var>
+      <Var name="Auto reset turn-over" type="bool">true</Var>
+    </Var>
+    <Var name="Ball" type="list">
+      <Var name="Ball mass" type="double">0.043000</Var>
+      <Var name="Ball-ground friction" type="double">0.050000</Var>
+      <Var name="Ball-ground slip" type="double">1.000000</Var>
+      <Var name="Ball-ground bounce factor" type="double">0.500000</Var>
+      <Var name="Ball-ground bounce min velocity" type="double">0.100000</Var>
+      <Var name="Ball linear damping" type="double">0.004000</Var>
+      <Var name="Ball angular damping" type="double">0.004000</Var>
+      <Var name="Project airborne balls" type="bool">true</Var>
+      <Var name="Models" type="list">
+        <Var name="Straight-two-phase sliding acceleration" type="double">-14.000000</Var>
+        <Var name="Straight-two-phase rolling acceleration" type="double">-0.700000</Var>
+        <Var name="Straight-two-phase switch factor k" type="double">0.700000</Var>
+        <Var name="Chip-fixed-loss damping in xy-direction for first hop" type="double">0.600000</Var>
+        <Var name="Chip-fixed-loss damping in xy-direction for other hops" type="double">0.960000</Var>
+        <Var name="Chip-fixed-loss damping in z-direction" type="double">0.420000</Var>
+      </Var>
+    </Var>
+  </Var>
+  <Var name="Communication" type="list">
+    <Var name="Vision multicast address" type="string">224.5.23.2</Var>
+    <Var name="Vision multicast port" type="int">10020</Var>
+    <Var name="Command listen port" type="int">20011</Var>
+    <Var name="Blue Team status send port" type="int">30011</Var>
+    <Var name="Yellow Team status send port" type="int">30012</Var>
+    <Var name="Simulation control port" type="int">10300</Var>
+    <Var name="Blue team control port" type="int">10301</Var>
+    <Var name="Yellow team control port" type="int">10302</Var>
+    <Var name="Sending delay (milliseconds)" type="int">100</Var>
+    <Var name="Send geometry every X frames" type="int">120</Var>
+    <Var name="Binary Feedback" type="list">
+      <Var name="Enable Binary Feedback" type="bool">true</Var>
+      <Var name="Binary Feedback Address" type="string">127.0.0.1</Var>
+      <Var name="Binary Feedback Port Base" type="int">50100</Var>
+      <Var name="Select Team from Referee" type="bool">true</Var>
+      <Var name="Referee Multicast Address" type="string">224.5.23.1</Var>
+      <Var name="Referee Multicast Port" type="int">11003</Var>
+      <Var name="Our Team Name" type="string">ibis</Var>
+    </Var>
+    <Var name="Gaussian noise" type="list">
+      <Var name="Noise" type="bool">false</Var>
+      <Var name="Deviation for x values" type="double">3.000000</Var>
+      <Var name="Deviation for y values" type="double">3.000000</Var>
+      <Var name="Deviation for angle values" type="double">2.000000</Var>
+      <Var name="Vanishing" type="bool">false</Var>
+    </Var>
+    <Var name="Vanishing probability" type="list">
+      <Var name="Blue team" type="double">0.000000</Var>
+      <Var name="Yellow team" type="double">0.000000</Var>
+      <Var name="Ball" type="double">0.000000</Var>
+    </Var>
+  </Var>
+</VarXML>

--- a/scripts/docker-dev.sh
+++ b/scripts/docker-dev.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # Docker開発環境の起動スクリプト
 # Usage:
-#   ./scripts/docker-dev.sh [sim|real] [--no-debug] [docker-compose-args...]
+#   ./scripts/docker-dev.sh [sim|real] [--sim erforce|grsim] [--no-debug] [docker-compose-args...]
 #
 # Examples:
-#   ./scripts/docker-dev.sh           # sim環境 + ssl-log-recorder
-#   ./scripts/docker-dev.sh -d        # sim環境(バックグラウンド)
-#   ./scripts/docker-dev.sh --no-debug  # robot-managerなし
-#   ./scripts/docker-dev.sh down      # 停止
+#   ./scripts/docker-dev.sh                     # sim環境(ER-Force) + ssl-log-recorder
+#   ./scripts/docker-dev.sh --sim grsim         # sim環境(grSim)
+#   ./scripts/docker-dev.sh -d                  # sim環境(バックグラウンド)
+#   ./scripts/docker-dev.sh --no-debug          # robot-managerなし
+#   ./scripts/docker-dev.sh down                # 停止
 
 set -e
 
@@ -20,6 +21,7 @@ COMPOSE_FILE="docker/dev/docker-compose.yaml"
 
 # 引数解析
 MODE="sim"
+SIM="erforce"
 ENABLE_ROBOT_MANAGER=true
 DOCKER_ARGS=()
 
@@ -32,6 +34,14 @@ while [[ $# -gt 0 ]]; do
     sim)
         MODE="sim"
         shift
+        ;;
+    --sim)
+        SIM="$2"
+        if [[ $SIM != "erforce" && $SIM != "grsim" ]]; then
+            echo "エラー: --sim には erforce または grsim を指定してください" >&2
+            exit 1
+        fi
+        shift 2
         ;;
     --no-debug)
         ENABLE_ROBOT_MANAGER=false
@@ -84,6 +94,9 @@ COMPOSE_COMMAND="$(detect_compose_command)"
 
 echo "=== Docker開発環境 ==="
 echo "モード: $MODE"
+if [[ $MODE == "sim" ]]; then
+    echo "シミュレータ: $SIM"
+fi
 echo "robot-manager: $ENABLE_ROBOT_MANAGER"
 echo "compose command: $COMPOSE_COMMAND"
 echo "Compose file: $COMPOSE_FILE"
@@ -96,7 +109,7 @@ fi
 
 if [[ $MODE == "sim" ]]; then
     # シミュレーション環境(status-board有効)
-    docker compose -f "$COMPOSE_FILE" --profile sim "${DOCKER_ARGS[@]}"
+    docker compose -f "$COMPOSE_FILE" --profile "sim-${SIM}" "${DOCKER_ARGS[@]}"
 else
     # 実機環境(Visionポート変更、status-board無効)
     VISION_PORT=10006 REFEREE_PORT=10003 TRACKER_PORT=10010 docker compose -f "$COMPOSE_FILE" "${DOCKER_ARGS[@]}"


### PR DESCRIPTION
## 概要

`docker/dev` の起動時にシミュレータ（ER-Force / grSim）を Docker Compose profile で切替できるようにします。

## 背景・根本原因

PR #1306 で grSim から ER-Force へ移行したが、ER-Force で問題が起きた際や過去設定での動作確認をする際に grSim へ戻す手段がなかった。
`--sim grsim` 引数を1つ追加するだけで切替できる構成とし、退避路を確保する。

## 変更内容

- `erforce-sim` の profile を `sim` → `sim-erforce` に変更（破壊的変更: `--profile sim` 直叩きは `--profile sim-erforce` へ移行要）
- `grsim` サービスを `sim-grsim` profile で追加
- `ssl-status-board` を `[sim-erforce, sim-grsim]` で両シミュレータに対応
- `docker/dev/grsim.xml` を git 履歴から実ファイルとして復元
- `docker-dev.sh` に `--sim erforce|grsim` 引数を追加（デフォルト: `erforce`）
- README を更新（使い方・差分表・サービス一覧）

## 使い方

```bash
./scripts/docker-dev.sh              # ER-Force（従来と同じ）
./scripts/docker-dev.sh --sim grsim  # grSim に切替
```