### PR TITLE
fix: ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA ファール防止のため相手PA離隔マージンを拡大

### DIFF
--- a/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
@@ -10,6 +10,7 @@
 #include <rvo2_vendor/RVO/RVO.h>
 
 #include <crane_comm/parameter_with_event.hpp>
+#include <crane_msg_wrappers/play_situation_wrapper.hpp>
 #include <crane_msg_wrappers/velocity_plan_tracker.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 #include <crane_msgs/msg/robot_commands.hpp>
@@ -61,23 +62,6 @@ public:
     -> crane_msgs::msg::RobotCommands override;
 
   auto overrideTargetPosition(crane_msgs::msg::RobotCommands & msg) -> void;
-
-  // セットプレイ中（INPLAY/HALT以外）かどうかを判定する。
-  // STOP_PRE_*（値60-66）、FREE_KICK、BALL_PLACEMENT等が該当し、
-  // これらの状態では敵ペナルティエリアへの離隔マージンを拡大する。
-  static auto needsExpandedPenaltyAreaOffset(uint8_t cmd) -> bool
-  {
-    using PS = crane_msgs::msg::PlaySituation;
-    switch (cmd) {
-      case PS::INPLAY:
-      case PS::HALT:
-      case PS::HALF_TIME:
-      case PS::POST_GAME:
-        return false;
-      default:
-        return true;
-    }
-  }
 
 private:
   struct PreprocessContext
@@ -175,7 +159,7 @@ private:
 
   // ペナルティエリア回避パラメータ
   double PENALTY_AREA_OFFSET = 0.1;       // ペナルティエリア判定マージン [m]（グローバル回避用）
-  double PENALTY_AREA_OFFSET_STOP = 0.3;  // ペナルティエリア判定マージン [m]（STOP時）
+  double PENALTY_AREA_OFFSET_STOP = 0.4;  // ペナルティエリア判定マージン [m]（STOP時）
   double PENALTY_AREA_SURROUNDING_OFFSET = 0.2;         // 角回避の余白 [m]
   bool PENALTY_AREA_FORCE_WAYPOINT_ON_CROSSING = true;  // 横断時に強制迂回
   float PENALTY_AREA_TIME_HORIZON_OBST = 0.5f;          // RVO2障害物回避の時間ホライズン [s]

--- a/crane_robot_skills/src/ball_nearby_positioner.cpp
+++ b/crane_robot_skills/src/ball_nearby_positioner.cpp
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#include <crane_msgs/msg/play_situation.hpp>
+#include <crane_msg_wrappers/play_situation_wrapper.hpp>
 #include <crane_robot_skills/ball_nearby_positioner.hpp>
 
 namespace crane::skills
@@ -84,12 +84,7 @@ auto BallNearByPositioner::update() -> Status
 
   auto avoidEnemyPenaltyArea = [&](Point & point) {
     const auto cmd = world_model()->getMsg().play_situation.command.value;
-    using PS = crane_msgs::msg::PlaySituation;
-    // INPLAY/HALT/HALF_TIME/POST_GAME以外（セットプレイ中）は拡大マージンを使用
-    // rvo2_planner の needsExpandedPenaltyAreaOffset() と同等の判定
-    const bool is_setplay =
-      (cmd != PS::INPLAY && cmd != PS::HALT && cmd != PS::HALF_TIME && cmd != PS::POST_GAME);
-    const double penalty_offset = is_setplay ? 0.2 : 0.15;
+    const double penalty_offset = needsExpandedPenaltyAreaOffset(cmd) ? 0.35 : 0.15;
 
     if (world_model()->point_checker.isEnemyPenaltyArea(point, penalty_offset)) {
       const auto their_penalty_area = world_model()->getTheirPenaltyArea();

--- a/crane_sessions/include/crane_sessions/forward_session.hpp
+++ b/crane_sessions/include/crane_sessions/forward_session.hpp
@@ -8,6 +8,7 @@
 #define CRANE_SESSIONS__FORWARD_SESSION_HPP_
 
 #include <algorithm>
+#include <crane_msg_wrappers/play_situation_wrapper.hpp>
 #include <crane_msg_wrappers/position_command_wrapper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 #include <crane_physics/penalty_aware_distance.hpp>

--- a/crane_sessions/src/forward_session.cpp
+++ b/crane_sessions/src/forward_session.cpp
@@ -22,7 +22,8 @@ auto ForwardSession::computeCandidatePoints() const -> std::vector<Point>
 {
   const double goal_line_x = world_model->fieldSize().x() * 0.5;
   const double field_half_width = world_model->fieldSize().y() * 0.5;
-  constexpr double PA_MARGIN = 0.3;
+  const double PA_MARGIN =
+    needsExpandedPenaltyAreaOffset(world_model->getMsg().play_situation.command.value) ? 0.4 : 0.3;
   constexpr double FIELD_MARGIN = 0.2;
   constexpr double ATTACK_HALFLINE_THRESHOLD = 0.3;
   constexpr double GRID_STEP = 0.5;

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/play_situation_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/play_situation_wrapper.hpp
@@ -32,5 +32,21 @@ auto getSituationCommandText(uint32_t id) -> std::string;
 auto getSituationCommandNamedInt(uint32_t id) -> crane_msgs::msg::NamedInt;
 
 auto getSituationCommandTextList() -> std::vector<std::string>;
+
+// STOP/セットプレイ中（INPLAY/HALT/HALF_TIME/POST_GAME以外）に相手PAへの拡大マージンが必要か
+// SSL Rule 5.2.4: STOP・フリーキック中は攻撃側ロボットが相手PAから0.2m以上離れていなければならない
+inline auto needsExpandedPenaltyAreaOffset(uint8_t cmd) -> bool
+{
+  using PS = crane_msgs::msg::PlaySituation;
+  switch (cmd) {
+    case PS::INPLAY:
+    case PS::HALT:
+    case PS::HALF_TIME:
+    case PS::POST_GAME:
+      return false;
+    default:
+      return true;
+  }
+}
 }  // namespace crane
 #endif  // CRANE_MSG_WRAPPERS__PLAY_SITUATION_WRAPPER_HPP_


### PR DESCRIPTION
## 概要

STOP/セットプレイ中に攻撃側ロボットが相手ペナルティエリアに近づきすぎて発生するATTACKER_TOO_CLOSE_TO_DEFENSE_AREAファールを防止するため、各コンポーネントの相手PA離隔マージンを拡大する。

## 背景・根本原因

rosbag解析 (`rosbag2_2026_04_17-21_34_53`, t=272s) にてbot5が相手PAから0.026m（ルール違反）まで接近するファールを確認。

SSL Rule 5.2.4: STOP・フリーキック中、攻撃側ロボットは相手PAから**0.2m以上**離れなければならない。

原因となっていた設定値:
- `ball_nearby_positioner`: setplay時マージン `0.2m`（バッファなし）
- `forward_session`: 候補点フィルタ `0.3m` 固定 + 格子0.5m刻みで実効0.22〜0.28m着地
- `rvo2_planner`: STOP時マージン `0.3m` + 0.05mステップ押し出しで制御ドリフトに脆弱

## 変更内容

- `play_situation_wrapper.hpp`: `needsExpandedPenaltyAreaOffset()` 共通ヘルパを追加（STOP/セットプレイ判定を一元化）
- `ball_nearby_positioner.cpp`: setplay時の相手PA離隔を `0.2m → 0.35m` に拡大
- `forward_session.cpp`: 候補点フィルタ `PA_MARGIN` を動的化（setplay時 `0.4m` / INPLAY `0.3m`）
- `rvo2_planner.hpp`: `PENALTY_AREA_OFFSET_STOP` を `0.3m → 0.4m` に拡大、共通ヘルパを参照