### PR TITLE
fix(crane_bag): rosx_introspection 2.x の API 変更に追随してCIビルドを修正

### DIFF
--- a/crane_bag/src/bag/bag_reader.cpp
+++ b/crane_bag/src/bag/bag_reader.cpp
@@ -123,7 +123,7 @@ BagData BagReader::read(
   // --- rosx_introspection パーサを構築 ---
   // readSummary() のスキーマID対応は bagによっては不正確なため、
   // メッセージイテレーション中に view.schema から直接登録する。
-  RosMsgParser::ParsersCollection<RosMsgParser::FastCDR_Deserializer> parsers;
+  RosMsgParser::ParsersCollection<RosMsgParser::ROS2_Deserializer> parsers;
   std::unordered_set<std::string> registered_topics;
 
   // --- 時間範囲フィルタを設定 ---
@@ -159,8 +159,8 @@ BagData BagReader::read(
     size_t raw_size = view.message.dataSize;
     if (raw_size == 0) continue;
 
-    // FastCDR_Deserializer が DDS_CDR モードで encapsulation header（00 01 00 00）を
-    // 自前で読み込む。スキップせずそのまま渡す。
+    // ROS2_Deserializer (CDR) が encapsulation header（00 01 00 00）を自前で読み込む。
+    // スキップせずそのまま渡す。
     RosMsgParser::Span<const uint8_t> buf(raw, raw_size);
 
     int64_t ts = static_cast<int64_t>(view.message.logTime);

--- a/crane_bag/src/bag/msg_extractors.cpp
+++ b/crane_bag/src/bag/msg_extractors.cpp
@@ -33,12 +33,14 @@ struct FlatValueMap
       auto pos = path.find('/', 1);
       return pos != std::string::npos ? path.substr(0, pos) : path;
     };
-    if (!flat.value.empty())
-      prefix = find_prefix(flat.value[0].first.toStdString());
-    else if (!flat.name.empty())
-      prefix = find_prefix(flat.name[0].first.toStdString());
-    for (const auto & [fv, var] : flat.value) numeric[fv.toStdString()] = var.convert<double>();
-    for (const auto & [fv, s] : flat.name) text[fv.toStdString()] = s;
+    if (!flat.value.empty()) prefix = find_prefix(flat.value[0].first.toStdString());
+    for (const auto & [fv, var] : flat.value) {
+      if (var.getTypeID() == RosMsgParser::STRING) {
+        text[fv.toStdString()] = var.extract<std::string>();
+      } else {
+        numeric[fv.toStdString()] = var.convert<double>();
+      }
+    }
   }
 
   // 完全パスで各型の値を返す

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -968,15 +968,12 @@ auto WorldModelDataProvider::integrateBallInfo() -> void
   }
 
   // Tracker情報の更新（常にTrackerの生データを保持）
+  // Tracker はカメラ統合済みなので特定カメラに帰属しない → occlusion 推定には使えない
   if (tracker_ball_state_.detected) {
     ball_info_.tracker.stamp = tracker_ball_state_.last_detect_time;
     ball_info_.tracker.pos.x = tracker_ball_state_.position.x();
     ball_info_.tracker.pos.y = tracker_ball_state_.position.y();
     ball_info_.tracker.pos.z = tracker_ball_state_.position.z();
-  }
-
-  // Tracker はカメラ統合済みなので特定カメラに帰属しない → occlusion 推定には使えない
-  if (tracker_ball_state_.detected) {
     last_known_ball_position_ = tracker_ball_state_.position;
     last_known_ball_stamp_ = now;
     last_known_ball_valid_ = true;


### PR DESCRIPTION
## 概要

`rosx_introspection` が apt で 1.x から 2.3.0 に更新されたことにより、CI が `crane_bag` のコンパイルエラーで失敗していたため修正。

## 背景・根本原因

- **参照ラン**: [docker build #24567022637](https://github.com/ibis-ssl/crane/actions/runs/24567022637) / [full build test #24567022604](https://github.com/ibis-ssl/crane/actions/runs/24567022604)
- `rosx_introspection` 2.x でクラス名と FlatMessage 構造が変更された

| API (1.x) | API (2.3.0) |
|---|---|
| `RosMsgParser::FastCDR_Deserializer` | `NanoCDR_Deserializer` に改名 |
| `FlatMessage::name`（string 専用フィールド）| 廃止。string も `FlatMessage::value` に `Variant` として格納 |

## 変更内容

- `bag_reader.cpp`: `FastCDR_Deserializer` → `ROS2_Deserializer`（旧新両バージョンで有効な using alias）
- `msg_extractors.cpp`: `FlatMessage::name` 参照を削除し、`flat.value` を走査して `Variant::getTypeID() == STRING` で string/numeric を振り分けるよう変更