### PR TITLE
fix: docker-dev.sh でビルド前に ball-calibration proto を自動同期

### DIFF
--- a/scripts/docker-dev.sh
+++ b/scripts/docker-dev.sh
@@ -107,6 +107,12 @@ if [[ $ENABLE_ROBOT_MANAGER == "false" ]] && [[ $COMPOSE_COMMAND == "up" ]]; the
     DOCKER_ARGS+=(--scale robot-manager=0)
 fi
 
+case "$COMPOSE_COMMAND" in
+build | up | create)
+    "$REPO_ROOT/docker/dev/ball-calibration/scripts/sync_proto.sh"
+    ;;
+esac
+
 if [[ $MODE == "sim" ]]; then
     # シミュレーション環境(status-board有効)
     docker compose -f "$COMPOSE_FILE" --profile "sim-${SIM}" "${DOCKER_ARGS[@]}"


### PR DESCRIPTION
## 概要

`./scripts/docker-dev.sh build` 実行時に `ball-calibration` サービスのビルドが失敗する問題を修正。

## 背景・根本原因

コミット `91a74645` (ball_calibration 再設計) で追加された `Dockerfile` が `COPY proto /tmp/ssl_proto` を必要とするが、`proto/` ディレクトリは `.gitignore` 対象で、`scripts/sync_proto.sh` を手動実行しないと生成されない。`docker-dev.sh` はこの同期を自動実行しないため、未同期の状態でビルドすると常に以下のエラーで失敗していた。

```
target ball-calibration: failed to solve: ... "/proto": not found
```

## 変更内容

- `scripts/docker-dev.sh` の `build` / `up` / `create` サブコマンド実行前に `docker/dev/ball-calibration/scripts/sync_proto.sh` を自動呼び出し
- `down` 等ビルドを伴わないサブコマンドでは実行しない