### PR TITLE
fix: ボールプレイスメント時にフィールド外への立入を許可

### DIFF
--- a/crane_robot_skills/src/single_ball_placement.cpp
+++ b/crane_robot_skills/src/single_ball_placement.cpp
@@ -283,17 +283,11 @@ void SingleBallPlacement::initialize()
     Point approach = computeAroundBallApproachTargetDynamic(
       ball_pos, placement_target, robot()->pose.pos, INTERVAL, MAX_INTERVAL);
 
-    // フィールド境界内にクランプ（壁際での回り込みスタックを防ぐ）
-    constexpr double field_margin = 0.05;  // 5cmマージン
-    const double max_x = world_model()->fieldSize().x() * 0.5 - field_margin;
-    const double max_y = world_model()->fieldSize().y() * 0.5 - field_margin;
-    approach.x() = std::clamp(approach.x(), -max_x, max_x);
-    approach.y() = std::clamp(approach.y(), -max_y, max_y);
-
     command->setTargetPosition(approach, 0.0);
     command->lookAtFrom(placement_target, ball_pos);
     command->disablePlacementAvoidance();
     command->disableGoalAreaAvoidance();
+    command->disableFieldBoundary();
     command->dribble(0.0);
     command->setOmegaLimit(10.0);
 
@@ -327,6 +321,7 @@ void SingleBallPlacement::initialize()
   addStateFunction(static_cast<int>(SingleBallPlacementStates::PASS_TO_TARGET), [this]() {
     command->disablePlacementAvoidance();
     command->disableBallAvoidance();
+    command->disableFieldBoundary();
     command->setMaxVelocity("SingleBallPlacementStates::PASS_TO_TARGET", 0.2);
     command->setMaxAcceleration("SingleBallPlacementStates::PASS_TO_TARGET", 1.0);
     auto placement_target = getPlacementTarget();
@@ -347,6 +342,7 @@ void SingleBallPlacement::initialize()
   addStateFunction(static_cast<int>(SingleBallPlacementStates::CONTACT_BALL), [this]() {
     command->disablePlacementAvoidance();
     command->disableBallAvoidance();
+    command->disableFieldBoundary();
     command->setMaxVelocity("SingleBallPlacementStates::CONTACT_BALL", 0.2);
     command->setMaxAcceleration("SingleBallPlacementStates::CONTACT_BALL", 1.0);
     auto placement_target = getPlacementTarget();


### PR DESCRIPTION
## 概要

ボールプレイスメント実行中、壁際にボールが出た際にロボットがスタックする問題を修正。

## 背景・根本原因

`SingleBallPlacement::GO_OVER_BALL` ステートで、回り込み用の approach 点を「フィールド内にクランプ」する処理があり、さらに `disableFieldBoundary()` が呼ばれていなかった。
そのため RVO2Planner のフィールド境界制約（`max_y = fieldSize/2 + 0.2`）が有効なままとなり、ボールが場外 14cm 以上にある状況では裏への回り込みが不可能になっていた。

rosbag `2026-04-19 22:45:05` の最終 `BALL_PLACEMENT_YELLOW`（t=396.35, ball=(2.10, 4.45), target=(2.87, 3.11)）でこの現象を確認。Robot 4 が約13秒 (2.4, 4.46) 付近で停止した。

SSL ルール上、ボールプレイスメント実行中はキッカーのフィールド外走行が許容される。

## 変更内容

- `GO_OVER_BALL`: approach のフィールド内クランプブロック（5cm マージン）を削除
- `GO_OVER_BALL`: `command->disableFieldBoundary()` を追加
- `CONTACT_BALL`: `command->disableFieldBoundary()` を追加
- `PASS_TO_TARGET`: `command->disableFieldBoundary()` を追加

`PULL_BACK_FROM_EDGE_*` / `MOVE_TO_TARGET` / `LEAVE_BALL` / `SLEEP` は既に `disableAnyAreaAvoidance()` を呼んでいるため変更不要。