### PR TITLE
fix: Docker 開発環境の erforce-sim UDP マルチキャスト送信失敗を修正

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -6,6 +6,26 @@
 
 ### ローカルホストでマルチキャスト
 
+Docker 開発環境（`network_mode: host`）では、ホスト内で完結する UDP multicast
+（SSL Vision/Referee/Tracker、ROS 2 DDS など）を正しく疎通させるために、
+lo インターフェイスのマルチキャスト有効化と `224.0.0.0/4` のループバック向けルートが必要。
+
+一括で適用するヘルパーを用意している:
+
+```bash
+./scripts/setup-multicast.sh
+```
+
+このスクリプトは冪等で、以下を実行する（sudo パスワードの入力が必要）:
+
+- `sudo ip link set multicast on lo`
+- `sudo ip route replace 224.0.0.0/4 dev lo`
+
+**OS 再起動で失われる**ので、再起動後に `erforce-sim | Sending UDP datagram failed`
+や `ssl-game-controller | messageGen unresponsive` が出たら再実行すること。
+
+手動で個別に実行したい場合は:
+
 ```bash
 sudo ip link set multicast on lo
 ```

--- a/scripts/setup-multicast.sh
+++ b/scripts/setup-multicast.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# ホスト側でマルチキャストが通るように lo を有効化し 224.0.0.0/4 をループバックへ向ける。
+# network_mode: host で動く Docker コンテナ同士の multicast 通信（SSL Vision/Referee/Tracker など）を
+# ホスト内で完結させるための前提設定。OS 再起動で失われるので必要に応じて再実行する。
+#
+# 冪等: すでに設定済みならスキップ。
+set -euo pipefail
+
+need_multicast=false
+if ! ip link show lo | grep -q MULTICAST; then
+    need_multicast=true
+fi
+
+need_route=false
+if ! ip route show 224.0.0.0/4 | grep -q "dev lo"; then
+    need_route=true
+fi
+
+if [[ $need_multicast == false && $need_route == false ]]; then
+    echo "[setup-multicast] すでに設定済み (lo MULTICAST 有効 / 224.0.0.0/4 ルート済み)"
+    exit 0
+fi
+
+echo "[setup-multicast] マルチキャスト設定を適用します (sudo が必要)"
+if [[ $need_multicast == true ]]; then
+    echo "  - lo に MULTICAST フラグを設定"
+    sudo ip link set multicast on lo
+fi
+if [[ $need_route == true ]]; then
+    echo "  - 224.0.0.0/4 を lo に向ける"
+    sudo ip route replace 224.0.0.0/4 dev lo
+fi
+echo "[setup-multicast] 完了"


### PR DESCRIPTION
## 概要

Docker 開発環境（`./scripts/docker-dev.sh`）で erforce-sim / ssl-game-controller / autoref-tigers が連続エラーを出力する問題を修正した。ホストのマルチキャスト設定を行う冪等スクリプトと、ドキュメントの追記により対応する。

## 背景・根本原因

`docker/dev/docker-compose.yaml` のすべてのサービスが `network_mode: host` でマルチキャスト（224.5.23.x）を使って通信しているが、ホスト側の状態が以下の通りだった:

- `lo` インターフェイスに `MULTICAST` フラグなし
- `224.0.0.0/4` 向けのルートが未設定
- デフォルトルートが `wlp2s0`（WiFi）

この状態で erforce-sim が `sendto(224.5.23.x, ...)` を呼ぶと、カーネルが WiFi IF 経由で送出を試みて `ENETUNREACH` / `EINVAL` を返す。ER-Force 側のエラーメッセージは "maybe too large?" と表示されるが実際はサイズ起因ではない。

結果として以下の連鎖が発生していた:
- `erforce-sim`: `Sending UDP datagram failed (maybe too large?). Size was: 429/1324 byte(s).`
- `ssl-game-controller`: `processTick: Hook messageGen unresponsive!`
- `autoref-tigers`: `Non-consecutive cam frame for cam 0: 2247 -> 2253`

`docs/network.md` には `sudo ip link set multicast on lo` が記載されていたが、route 追加手順が未記載かつ自動化もされていなかった。

## 変更内容

- **`scripts/setup-multicast.sh`（新規）**: `lo` への MULTICAST フラグ付与と `224.0.0.0/4 dev lo` ルート追加を冪等に行うスクリプト。2 回目以降は sudo を呼ばず即終了。OS 再起動で失われるため再起動後の再実行が必要。
- **`docs/network.md`（追記）**: スクリプトの使い方・実行タイミング・OS 再起動で失われる旨を既存セクションに統合。

## 使い方

```bash
./scripts/setup-multicast.sh
```