### PR TITLE
feat: crane_web_debugger に Game Control / Sim Control 機能を追加

### DIFF
--- a/crane_web_debugger/CMakeLists.txt
+++ b/crane_web_debugger/CMakeLists.txt
@@ -28,9 +28,12 @@ ament_auto_add_executable(crane_websocket_server
 # Find dependencies for WebSocket server
 find_package(OpenSSL REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
+find_package(Protobuf REQUIRED)
+
+include_directories(${robocup_ssl_msgs_INCLUDE_DIRS})
 
 # Link libraries for WebSocket server
-target_link_libraries(crane_websocket_server ${Boost_LIBRARIES})
+target_link_libraries(crane_websocket_server ${Boost_LIBRARIES} ${robocup_ssl_msgs_LIBRARIES})
 if(TARGET OpenSSL::SSL)
   target_link_libraries(crane_websocket_server OpenSSL::SSL OpenSSL::Crypto)
 else()

--- a/crane_web_debugger/package.xml
+++ b/crane_web_debugger/package.xml
@@ -16,6 +16,7 @@
   <depend>libssl-dev</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>rclcpp</depend>
+  <depend>robocup_ssl_msgs</depend>
   <depend>std_msgs</depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>crane_lint_common</test_depend>

--- a/crane_web_debugger/src/websocket_server.cpp
+++ b/crane_web_debugger/src/websocket_server.cpp
@@ -8,6 +8,8 @@
 #include <openssl/buffer.h>
 #include <openssl/evp.h>
 #include <openssl/sha.h>
+#include <robocup_ssl_msgs/ssl_gc_common.pb.h>
+#include <robocup_ssl_msgs/ssl_simulation_control.pb.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 
@@ -15,6 +17,7 @@
 #include <boost/asio.hpp>
 #include <cctype>
 #include <chrono>
+#include <cmath>
 #include <crane_msgs/msg/human_annotation.hpp>
 #include <crane_msgs/msg/ping_status_array.hpp>
 #include <crane_msgs/msg/play_situation.hpp>
@@ -39,6 +42,66 @@
 #include <thread>
 
 using json = nlohmann::json;
+
+// ---- SSL Simulation Protocol UDP sender ----
+class SslSimulationSender
+{
+public:
+  SslSimulationSender()
+  : socket_(io_ctx_, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0))
+  {
+    setEndpoint("127.0.0.1", 10300);
+  }
+
+  void setEndpoint(const std::string & host, int port)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    boost::asio::ip::udp::resolver resolver(io_ctx_);
+    auto endpoints = resolver.resolve(host, std::to_string(port));
+    endpoint_ = *endpoints.begin();
+  }
+
+  void sendTeleportBall(float x, float y, float vx = 0.0f, float vy = 0.0f)
+  {
+    robocup_ssl::SimulatorCommand cmd;
+    auto * ball = cmd.mutable_control()->mutable_teleport_ball();
+    ball->set_x(x);
+    ball->set_y(y);
+    ball->set_vx(vx);
+    ball->set_vy(vy);
+    sendCmd(cmd);
+  }
+
+  void sendTeleportRobot(int id, bool yellow, float x, float y, float orientation_rad, bool present)
+  {
+    robocup_ssl::SimulatorCommand cmd;
+    auto * robot = cmd.mutable_control()->add_teleport_robot();
+    robot->mutable_id()->set_id(static_cast<uint32_t>(id));
+    robot->mutable_id()->set_team(yellow ? robocup_ssl::YELLOW : robocup_ssl::BLUE);
+    robot->set_x(x);
+    robot->set_y(y);
+    robot->set_orientation(orientation_rad);
+    robot->set_present(present);
+    sendCmd(cmd);
+  }
+
+private:
+  void sendCmd(const robocup_ssl::SimulatorCommand & cmd)
+  {
+    std::string data;
+    if (!cmd.SerializeToString(&data)) return;
+    std::lock_guard<std::mutex> lock(mutex_);
+    try {
+      socket_.send_to(boost::asio::buffer(data), endpoint_);
+    } catch (...) {
+    }
+  }
+
+  boost::asio::io_context io_ctx_;
+  boost::asio::ip::udp::socket socket_;
+  boost::asio::ip::udp::endpoint endpoint_;
+  std::mutex mutex_;
+};
 
 // Simple WebSocket frame implementation
 struct WebSocketFrame
@@ -513,6 +576,14 @@ private:
         handleDeactivateRobotTest(connection);
       } else if (type == "robot_test_target") {
         handleRobotTestTarget(connection, request);
+      } else if (type == "sim_teleport_ball") {
+        handleSimTeleportBall(connection, request);
+      } else if (type == "sim_teleport_robot") {
+        handleSimTeleportRobot(connection, request);
+      } else if (type == "sim_remove_robot") {
+        handleSimRemoveRobot(connection, request);
+      } else if (type == "sim_set_endpoint") {
+        handleSimSetEndpoint(connection, request);
       } else {
         json error_response = {{"type", "error"}, {"message", "Unknown request type: " + type}};
         connection->sendMessage(error_response.dump());
@@ -1195,6 +1266,61 @@ private:
     connection->sendMessage(result.dump());
   }
 
+  void handleSimTeleportBall(std::shared_ptr<WebSocketConnection> connection, const json & request)
+  {
+    float x = static_cast<float>(request.value("x", 0.0));
+    float y = static_cast<float>(request.value("y", 0.0));
+    float vx = static_cast<float>(request.value("vx", 0.0));
+    float vy = static_cast<float>(request.value("vy", 0.0));
+    sim_sender_.sendTeleportBall(x, y, vx, vy);
+    RCLCPP_DEBUG(this->get_logger(), "Sim teleport ball to (%.2f, %.2f)", x, y);
+    json result = {{"type", "sim_result"}, {"success", true}};
+    connection->sendMessage(result.dump());
+  }
+
+  void handleSimTeleportRobot(std::shared_ptr<WebSocketConnection> connection, const json & request)
+  {
+    int id = request.value("id", 0);
+    std::string team = request.value("team", "blue");
+    bool yellow = (team == "yellow");
+    float x = static_cast<float>(request.value("x", 0.0));
+    float y = static_cast<float>(request.value("y", 0.0));
+    float orientation_deg = static_cast<float>(request.value("orientation_deg", 0.0));
+    float orientation_rad = orientation_deg * static_cast<float>(M_PI) / 180.0f;
+    bool present = request.value("present", true);
+    sim_sender_.sendTeleportRobot(id, yellow, x, y, orientation_rad, present);
+    RCLCPP_DEBUG(
+      this->get_logger(), "Sim teleport robot %s #%d to (%.2f, %.2f)", team.c_str(), id, x, y);
+    json result = {{"type", "sim_result"}, {"success", true}};
+    connection->sendMessage(result.dump());
+  }
+
+  void handleSimRemoveRobot(std::shared_ptr<WebSocketConnection> connection, const json & request)
+  {
+    int id = request.value("id", 0);
+    std::string team = request.value("team", "blue");
+    bool yellow = (team == "yellow");
+    sim_sender_.sendTeleportRobot(id, yellow, 0.0f, 0.0f, 0.0f, false);
+    json result = {{"type", "sim_result"}, {"success", true}};
+    connection->sendMessage(result.dump());
+  }
+
+  void handleSimSetEndpoint(std::shared_ptr<WebSocketConnection> connection, const json & request)
+  {
+    std::string host = request.value("host", "127.0.0.1");
+    int port = request.value("port", 10300);
+    try {
+      sim_sender_.setEndpoint(host, port);
+      RCLCPP_INFO(this->get_logger(), "Sim endpoint updated to %s:%d", host.c_str(), port);
+      json result = {
+        {"type", "sim_endpoint_set"}, {"success", true}, {"host", host}, {"port", port}};
+      connection->sendMessage(result.dump());
+    } catch (const std::exception & e) {
+      json error = {{"type", "error"}, {"message", std::string("Invalid endpoint: ") + e.what()}};
+      connection->sendMessage(error.dump());
+    }
+  }
+
   void handleRobotControl(std::shared_ptr<WebSocketConnection> connection, const json & request)
   {
     int robot_id = request.value("robot_id", -1);
@@ -1339,6 +1465,9 @@ private:
   std::vector<crane_visualization_interfaces::msg::SvgUpdates::SharedPtr> pending_svg_updates_;
   std::mutex svg_updates_mutex_;
   rclcpp::TimerBase::SharedPtr svg_updates_timer_;
+
+  // Simulation control UDP sender
+  SslSimulationSender sim_sender_;
 };
 
 int main(int argc, char ** argv)

--- a/crane_web_debugger/web/viewer.html
+++ b/crane_web_debugger/web/viewer.html
@@ -247,6 +247,93 @@
       margin-top: 6px;
       font-size: 0.75rem;
     }
+
+    /* Game control panel */
+    .gc-row {
+      display: flex;
+      gap: 3px;
+      margin-bottom: 3px;
+    }
+
+    .gc-btn {
+      flex: 1;
+      min-width: 0;
+      font-size: 0.66rem !important;
+      padding: 3px 2px !important;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .gc-btn--halt {
+      background-color: var(--md-sys-color-error) !important;
+      color: var(--md-sys-color-on-error) !important;
+    }
+
+    .gc-btn--yellow {
+      background-color: #d4a700 !important;
+      color: #000 !important;
+      border-color: #d4a700 !important;
+    }
+
+    .gc-btn--blue {
+      background-color: #1d4ed8 !important;
+      color: #fff !important;
+      border-color: #1d4ed8 !important;
+    }
+
+    .gc-score-row {
+      display: flex;
+      align-items: center;
+      gap: 3px;
+      margin-bottom: 6px;
+    }
+
+    #gc-score {
+      font-size: 1.0rem;
+      font-weight: 700;
+      color: var(--md-sys-color-primary);
+      text-align: center;
+      flex: 1;
+    }
+
+    .gc-team-label {
+      font-size: 0.62rem;
+      color: var(--md-sys-color-on-surface-variant);
+      margin: 3px 0 2px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    /* Sim control panel */
+    #btn-sim-edit.active {
+      background-color: var(--md-sys-color-tertiary-container);
+      color: var(--md-sys-color-on-tertiary-container);
+    }
+
+    .btn-place-ball.active {
+      outline: 2px solid #fff;
+      outline-offset: 1px;
+    }
+
+    .sim-selected-label {
+      font-size: 0.72rem;
+      color: var(--md-sys-color-on-surface-variant);
+      padding: 3px 0;
+    }
+
+    .m3-text-input {
+      background: var(--md-sys-color-surface-container-high);
+      border: 1px solid var(--md-sys-color-outline-variant);
+      border-radius: var(--md-sys-shape-xs, 4px);
+      color: var(--md-sys-color-on-surface);
+      outline: none;
+      font-family: inherit;
+    }
+
+    .m3-text-input:focus {
+      border-color: var(--md-sys-color-primary);
+    }
   </style>
 </head>
 <body>
@@ -329,6 +416,87 @@
             </div>
             <div id="layer-list">
               <!-- Populated by viewer.js -->
+            </div>
+          </div>
+        </details>
+
+        <!-- Game Control -->
+        <div class="m3-section-title">Game Control</div>
+        <details class="m3-expansion" id="gc-accordion" open>
+          <summary>
+            <span class="material-symbols-outlined icon-sm m3-text-primary">sports</span>
+            Game Controller
+            <span class="m3-connection-dot" id="gc-connection-dot" style="margin-left:auto;flex-shrink:0;"></span>
+          </summary>
+          <div class="m3-expansion__body">
+            <div style="font-size:0.68rem;color:var(--md-sys-color-on-surface-variant);margin-bottom:4px;">
+              Stage: <span id="gc-stage">-</span> &nbsp;|&nbsp; Cmd: <span id="gc-command">-</span>
+            </div>
+            <!-- Score -->
+            <div class="gc-score-row">
+              <button class="m3-btn m3-btn--sm gc-btn gc-btn--yellow" onclick="window.craneViewer?.gcClient.updateGoals('YELLOW',-1)" title="Yellow score -1">－</button>
+              <button class="m3-btn m3-btn--sm gc-btn gc-btn--yellow" onclick="window.craneViewer?.gcClient.updateGoals('YELLOW',1)" title="Yellow score +1">＋</button>
+              <span id="gc-score">0 : 0</span>
+              <button class="m3-btn m3-btn--sm gc-btn gc-btn--blue" onclick="window.craneViewer?.gcClient.updateGoals('BLUE',-1)" title="Blue score -1">－</button>
+              <button class="m3-btn m3-btn--sm gc-btn gc-btn--blue" onclick="window.craneViewer?.gcClient.updateGoals('BLUE',1)" title="Blue score +1">＋</button>
+            </div>
+            <!-- Main commands -->
+            <div class="gc-row">
+              <button class="m3-btn m3-btn--sm m3-btn--filled gc-btn gc-btn--halt" onclick="window.craneViewer?.gcClient.newCommand('HALT')">HALT</button>
+              <button class="m3-btn m3-btn--sm m3-btn--tonal gc-btn" onclick="window.craneViewer?.gcClient.newCommand('STOP')">STOP</button>
+              <button class="m3-btn m3-btn--sm m3-btn--outlined gc-btn" onclick="window.craneViewer?.gcClient.newCommand('FORCE_START')">FORCE</button>
+              <button class="m3-btn m3-btn--sm m3-btn--tonal gc-btn" onclick="window.craneViewer?.gcClient.newCommand('NORMAL_START')">START</button>
+            </div>
+            <!-- Yellow team commands -->
+            <div class="gc-team-label">Yellow</div>
+            <div class="gc-row">
+              <button class="m3-btn m3-btn--sm gc-btn gc-btn--yellow" onclick="window.craneViewer?.gcClient.newCommand('DIRECT','YELLOW')">FREE KICK</button>
+              <button class="m3-btn m3-btn--sm gc-btn gc-btn--yellow" onclick="window.craneViewer?.gcClient.newCommand('KICKOFF','YELLOW')">KICKOFF</button>
+              <button class="m3-btn m3-btn--sm gc-btn gc-btn--yellow btn-place-ball" id="btn-place-ball-yellow" onclick="window.craneViewer?.activateBallPlacement('YELLOW')">PLACE</button>
+            </div>
+            <!-- Blue team commands -->
+            <div class="gc-team-label">Blue</div>
+            <div class="gc-row">
+              <button class="m3-btn m3-btn--sm gc-btn gc-btn--blue" onclick="window.craneViewer?.gcClient.newCommand('DIRECT','BLUE')">FREE KICK</button>
+              <button class="m3-btn m3-btn--sm gc-btn gc-btn--blue" onclick="window.craneViewer?.gcClient.newCommand('KICKOFF','BLUE')">KICKOFF</button>
+              <button class="m3-btn m3-btn--sm gc-btn gc-btn--blue btn-place-ball" id="btn-place-ball-blue" onclick="window.craneViewer?.activateBallPlacement('BLUE')">PLACE</button>
+            </div>
+            <!-- Cards -->
+            <div class="gc-team-label">Cards</div>
+            <div class="gc-row">
+              <button class="m3-btn m3-btn--sm m3-btn--outlined gc-btn" style="color:#d4a700;border-color:#d4a700;" onclick="window.craneViewer?.gcClient.addYellowCard('YELLOW')" title="Yellow card for Yellow">Y🟨</button>
+              <button class="m3-btn m3-btn--sm m3-btn--outlined gc-btn" style="color:#ef4444;border-color:#ef4444;" onclick="window.craneViewer?.gcClient.addRedCard('YELLOW')" title="Red card for Yellow">Y🟥</button>
+              <button class="m3-btn m3-btn--sm m3-btn--outlined gc-btn" style="color:#d4a700;border-color:#d4a700;" onclick="window.craneViewer?.gcClient.addYellowCard('BLUE')" title="Yellow card for Blue">B🟨</button>
+              <button class="m3-btn m3-btn--sm m3-btn--outlined gc-btn" style="color:#ef4444;border-color:#ef4444;" onclick="window.craneViewer?.gcClient.addRedCard('BLUE')" title="Red card for Blue">B🟥</button>
+            </div>
+            <!-- Next Stage -->
+            <div class="gc-row" style="margin-top:2px;">
+              <button class="m3-btn m3-btn--sm m3-btn--outlined gc-btn" style="flex:1;" onclick="window.craneViewer?.gcClient.nextStage()">Next Stage ▶</button>
+            </div>
+          </div>
+        </details>
+
+        <!-- Simulation Control -->
+        <div class="m3-section-title">Sim Control</div>
+        <details class="m3-expansion" id="sim-accordion">
+          <summary>
+            <span class="material-symbols-outlined icon-sm m3-text-primary">precision_manufacturing</span>
+            Simulation Control
+          </summary>
+          <div class="m3-expansion__body">
+            <div class="gc-row">
+              <button class="m3-btn m3-btn--sm m3-btn--tonal gc-btn" id="btn-sim-edit" onclick="window.craneViewer?.toggleSimEditMode()">Sim Edit</button>
+              <button class="m3-btn m3-btn--sm m3-btn--outlined gc-btn" onclick="window.craneViewer?.resetBallToCenter()">Reset Ball</button>
+            </div>
+            <div class="sim-selected-label">Selected: <span id="sim-selected-label">mode off</span></div>
+            <div style="font-size:0.68rem;color:var(--md-sys-color-on-surface-variant);margin-top:4px;margin-bottom:2px;">Sim endpoint (UDP)</div>
+            <div style="display:flex;gap:3px;align-items:center;">
+              <input type="text" id="sim-host-input" value="127.0.0.1" class="m3-text-input" style="flex:2;font-size:0.68rem;padding:3px 5px;">
+              <input type="number" id="sim-port-input" value="10300" class="m3-text-input" style="flex:1;font-size:0.68rem;padding:3px 5px;min-width:0;">
+              <button class="m3-btn m3-btn--sm m3-btn--outlined gc-btn" style="flex:0 0 auto;padding:3px 8px !important;" onclick="window.craneViewer?.applySimEndpoint()">Set</button>
+            </div>
+            <div style="font-size:0.62rem;color:var(--md-sys-color-on-surface-variant);margin-top:3px;">
+              Click: select &nbsp;|&nbsp; Dblclick/Enter: teleport &nbsp;|&nbsp; Esc: cancel
             </div>
           </div>
         </details>

--- a/crane_web_debugger/web/viewer.js
+++ b/crane_web_debugger/web/viewer.js
@@ -1,11 +1,79 @@
 'use strict';
 
+// ---- GameControlClient: ssl-game-controller WebSocket API (/api/control) クライアント ----
+class GameControlClient {
+    constructor() {
+        this.ws = null;
+        this.state = null;
+        this.onStateChange = null;
+        this._host = null;
+    }
+
+    connect(host) {
+        this._host = host;
+        const url = `ws://${host}:8081/api/control`;
+        try { this.ws = new WebSocket(url); } catch { this._reconnect(); return; }
+        this.ws.onopen = () => this._setIndicator(true);
+        this.ws.onmessage = (e) => {
+            try {
+                const msg = JSON.parse(e.data);
+                if (msg.matchState !== undefined) {
+                    this.state = msg.matchState;
+                    this.onStateChange?.(this.state);
+                }
+            } catch { /* ignore parse errors */ }
+        };
+        this.ws.onclose = () => { this._setIndicator(false); this._reconnect(); };
+        this.ws.onerror = () => this._setIndicator(false);
+    }
+
+    _reconnect() { setTimeout(() => this.connect(this._host), 5000); }
+
+    _setIndicator(ok) {
+        document.getElementById('gc-connection-dot')?.classList.toggle('connected', ok);
+    }
+
+    _sendChange(change) {
+        if (this.ws?.readyState === WebSocket.OPEN)
+            this.ws.send(JSON.stringify({ change }));
+    }
+
+    _sendInput(input) {
+        if (this.ws?.readyState === WebSocket.OPEN)
+            this.ws.send(JSON.stringify(input));
+    }
+
+    newCommand(type, forTeam = 'UNKNOWN') {
+        this._sendChange({ newCommandChange: { command: { type, forTeam } } });
+    }
+
+    setBallPlacementPos(x, y) {
+        this._sendChange({ setBallPlacementPosChange: { pos: { x, y } } });
+    }
+
+    addYellowCard(team) { this._sendChange({ addYellowCardChange: { forTeam: team } }); }
+    addRedCard(team) { this._sendChange({ addRedCardChange: { forTeam: team } }); }
+
+    updateGoals(team, delta) {
+        const current = this.state?.teamState?.[team]?.goals ?? 0;
+        this._sendChange({
+            updateTeamStateChange: { forTeam: team, goals: Math.max(0, current + delta) }
+        });
+    }
+
+    nextStage() {
+        const ca = this.state?.continueActions?.[0];
+        if (ca) this._sendInput({ continueAction: ca });
+    }
+}
+
 // ---- 定数 ----
 const CONTROL_MODE_SHORT = { 0: 'CAM', 1: 'POS', 2: 'VEL', 3: 'POL' };
 const CONTROL_MODE_LONG = {
     0: 'LOCAL_CAMERA', 1: 'POSITION_TARGET', 2: 'SIMPLE_VELOCITY', 3: 'POLAR_VELOCITY'
 };
 const ROBOT_HIT_RADIUS_M = 0.15;
+const BALL_HIT_RADIUS_M = 0.08;
 const VB_X = -6000, VB_Y = -4500, VB_W = 12000, VB_H = 9000;
 
 // ---- SVG属性regex生成ヘルパー ----
@@ -326,6 +394,31 @@ class CanvasRenderer {
             }
         }
 
+        // Sim edit mode: 選択オブジェクトのオーバーレイ
+        if (v.simEditMode && v.simSelectedObj) {
+            const obj = v.simSelectedObj;
+            ctx.save();
+            ctx.globalAlpha = 0.85;
+            ctx.lineWidth = 22;
+            ctx.setLineDash([45, 25]);
+            if (obj.type === 'ball') {
+                ctx.strokeStyle = '#ff8800';
+                ctx.beginPath();
+                ctx.arc(v.ballPos.x * 1000, -v.ballPos.y * 1000, ROBOT_HIT_RADIUS_M * 900, 0, Math.PI * 2);
+                ctx.stroke();
+            } else {
+                const source = (obj.yellow === v.isYellow) ? v.robotsOurs : v.robotsTheirs;
+                const robot = source[obj.id];
+                if (robot) {
+                    ctx.strokeStyle = '#00ff88';
+                    ctx.beginPath();
+                    ctx.arc(robot.x * 1000, -robot.y * 1000, ROBOT_HIT_RADIUS_M * 1000, 0, Math.PI * 2);
+                    ctx.stroke();
+                }
+            }
+            ctx.restore();
+        }
+
         ctx.restore();
 
         // データなし表示
@@ -484,7 +577,7 @@ class CanvasRenderer {
         // 逆ユーザーパン/ズーム
         const mmX = (svgX - v.panOffset.x) / v.zoomLevel;
         const mmY = (svgY - v.panOffset.y) / v.zoomLevel;
-        return { x: mmX / 1000, y: mmY / 1000 };
+        return { x: mmX / 1000, y: -mmY / 1000 };
     }
 
     // ピクセルデルタ → SVG座標デルタ（パン操作用）
@@ -514,12 +607,24 @@ class CraneViewer {
         this.flushIntervalMs = 50;
 
         this.robotsOurs = {};
+        this.robotsTheirs = {};
         this.controlTargets = {};
 
         this.moveMode = false;
         this.selectedRobotId = null;
         this.isYellow = false;
         this.onPositiveHalf = false;
+
+        // Sim / GC integration
+        this.ballPos = { x: 0, y: 0 };
+        this.simEditMode = false;
+        this.simSelectedObj = null; // null | {type:'ball'} | {type:'robot', id, yellow, theta}
+        this.placeBallPending = null; // null | 'YELLOW' | 'BLUE'
+        this.gcClient = new GameControlClient();
+        this._dragStartX = 0;
+        this._dragStartY = 0;
+        this._dragMoved = false;
+        this._lastMouseField = { x: 0, y: 0 };
 
         this.robotUpdateTimer = null;
         this.parser = new SvgPrimitiveParser();
@@ -534,6 +639,8 @@ class CraneViewer {
         this.setupWebSocket();
         this.setupEventListeners();
         this.updateConnectionStatus(false);
+        this.gcClient.connect(window.location.hostname);
+        this.gcClient.onStateChange = (state) => this.updateGcPanel(state);
     }
 
     setupWebSocket() {
@@ -666,12 +773,18 @@ class CraneViewer {
     handleWorldModel(data) {
         if (data.is_yellow !== undefined) this.isYellow = data.is_yellow;
         if (data.on_positive_half !== undefined) this.onPositiveHalf = data.on_positive_half;
+        if (data.ball) this.ballPos = { x: data.ball.x, y: data.ball.y };
         if (data.robots_ours) {
             this.robotsOurs = {};
             for (const robot of data.robots_ours) this.robotsOurs[robot.id] = robot;
         }
+        if (data.robots_theirs) {
+            this.robotsTheirs = {};
+            for (const robot of data.robots_theirs) this.robotsTheirs[robot.id] = robot;
+        }
         this.scheduleRobotUpdate();
         if (this.moveMode && this.selectedRobotId !== null) this.renderer?.invalidate();
+        if (this.simEditMode) this.renderer?.invalidate();
     }
 
     handleControlTargets(data) {
@@ -840,6 +953,133 @@ class CraneViewer {
         return closest;
     }
 
+    _nearestRobot(robotMap, fieldX, fieldY) {
+        let id = null, dist = ROBOT_HIT_RADIUS_M;
+        for (const [k, r] of Object.entries(robotMap)) {
+            const d = Math.hypot(r.x - fieldX, r.y - fieldY);
+            if (d < dist) { dist = d; id = Number(k); }
+        }
+        return id !== null ? { id, dist } : null;
+    }
+
+    simSelectAt(fieldX, fieldY) {
+        const candidates = [];
+        const ourHit = this._nearestRobot(this.robotsOurs, fieldX, fieldY);
+        const theirHit = this._nearestRobot(this.robotsTheirs, fieldX, fieldY);
+        const ballDist = Math.hypot(this.ballPos.x - fieldX, this.ballPos.y - fieldY);
+
+        if (ourHit) candidates.push({ kind: 'our', dist: ourHit.dist, id: ourHit.id });
+        if (ballDist < BALL_HIT_RADIUS_M) candidates.push({ kind: 'ball', dist: ballDist });
+        if (theirHit) candidates.push({ kind: 'their', dist: theirHit.dist, id: theirHit.id });
+
+        // 最短距離の候補を選ぶ。同距離は ball > our > their の優先度
+        candidates.sort((a, b) => {
+            if (Math.abs(a.dist - b.dist) > 1e-6) return a.dist - b.dist;
+            const rank = { ball: 0, our: 1, their: 2 };
+            return rank[a.kind] - rank[b.kind];
+        });
+
+        const best = candidates[0] ?? null;
+        if (!best) {
+            this.simSelectedObj = null;
+        } else if (best.kind === 'ball') {
+            this.simSelectedObj = { type: 'ball' };
+        } else if (best.kind === 'our') {
+            const r = this.robotsOurs[best.id];
+            this.simSelectedObj = { type: 'robot', id: best.id, yellow: this.isYellow, theta: r?.theta ?? 0 };
+        } else {
+            const r = this.robotsTheirs[best.id];
+            this.simSelectedObj = { type: 'robot', id: best.id, yellow: !this.isYellow, theta: r?.theta ?? 0 };
+        }
+        this._updateSimLabel();
+        this.renderer?.invalidate();
+    }
+
+    simTeleportTo(fieldX, fieldY) {
+        if (!this.simSelectedObj) return;
+        const obj = this.simSelectedObj;
+        if (obj.type === 'ball') {
+            this.websocket?.send(JSON.stringify({ type: 'sim_teleport_ball', x: fieldX, y: fieldY, vx: 0, vy: 0 }));
+        } else {
+            this.websocket?.send(JSON.stringify({
+                type: 'sim_teleport_robot',
+                id: obj.id,
+                team: obj.yellow ? 'yellow' : 'blue',
+                x: fieldX, y: fieldY,
+                orientation_deg: (obj.theta ?? 0) * 180 / Math.PI
+            }));
+        }
+    }
+
+    resetBallToCenter() {
+        this.websocket?.send(JSON.stringify({ type: 'sim_teleport_ball', x: 0, y: 0, vx: 0, vy: 0 }));
+    }
+
+    applySimEndpoint() {
+        const host = document.getElementById('sim-host-input')?.value || '127.0.0.1';
+        const port = parseInt(document.getElementById('sim-port-input')?.value || '10300', 10);
+        this.websocket?.send(JSON.stringify({ type: 'sim_set_endpoint', host, port }));
+    }
+
+    toggleSimEditMode() {
+        this.simEditMode = !this.simEditMode;
+        const btn = document.getElementById('btn-sim-edit');
+        const canvas = document.getElementById('field-canvas');
+        if (this.simEditMode) {
+            if (this.moveMode) this.deactivateMoveMode();
+            this.cancelBallPlacement();
+            this.simSelectedObj = null;
+            btn?.classList.add('active');
+            if (canvas) canvas.style.cursor = 'crosshair';
+        } else {
+            this.simSelectedObj = null;
+            btn?.classList.remove('active');
+            if (canvas) canvas.style.cursor = 'grab';
+        }
+        this._updateSimLabel();
+        this.renderer?.invalidate();
+    }
+
+    activateBallPlacement(team) {
+        if (this.simEditMode) this.toggleSimEditMode();
+        this.cancelBallPlacement();
+        this.placeBallPending = team;
+        const canvas = document.getElementById('field-canvas');
+        if (canvas) canvas.style.cursor = 'crosshair';
+        document.getElementById(`btn-place-ball-${team.toLowerCase()}`)?.classList.add('active');
+    }
+
+    cancelBallPlacement() {
+        if (!this.placeBallPending) return;
+        const team = this.placeBallPending;
+        this.placeBallPending = null;
+        document.getElementById('field-canvas').style.cursor =
+            this.simEditMode ? 'crosshair' : 'grab';
+        document.getElementById(`btn-place-ball-${team.toLowerCase()}`)?.classList.remove('active');
+    }
+
+    _updateSimLabel() {
+        const el = document.getElementById('sim-selected-label');
+        if (!el) return;
+        if (!this.simEditMode) { el.textContent = 'mode off'; return; }
+        if (!this.simSelectedObj) { el.textContent = 'click to select'; return; }
+        const obj = this.simSelectedObj;
+        el.textContent = obj.type === 'ball' ? 'Ball' : `${obj.yellow ? 'Yellow' : 'Blue'} #${obj.id}`;
+    }
+
+    updateGcPanel(state) {
+        if (!state) return;
+        const ts = state.teamState ?? {};
+        const y = ts['YELLOW'] ?? {};
+        const b = ts['BLUE'] ?? {};
+        const scoreEl = document.getElementById('gc-score');
+        if (scoreEl) scoreEl.textContent = `${y.goals ?? 0} : ${b.goals ?? 0}`;
+        const stageEl = document.getElementById('gc-stage');
+        if (stageEl) stageEl.textContent = (state.stage ?? '-').replace('NORMAL_', '').replace('_', ' ');
+        const cmdEl = document.getElementById('gc-command');
+        if (cmdEl) cmdEl.textContent = state.command?.type ?? '-';
+    }
+
     activateMoveMode() {
         this.moveMode = true;
         document.getElementById('btn-move-mode')?.classList.add('active');
@@ -906,6 +1146,9 @@ class CraneViewer {
 
         canvas.addEventListener('mousedown', (e) => {
             if (e.button !== 0) return;
+            this._dragStartX = e.clientX;
+            this._dragStartY = e.clientY;
+            this._dragMoved = false;
             if (e.shiftKey && this.moveMode) {
                 const fp = this.clientToFieldCoords(e.clientX, e.clientY);
                 const hitId = this.findRobotAtPosition(fp.x, fp.y);
@@ -920,11 +1163,14 @@ class CraneViewer {
             } else {
                 this.isPanning = true;
                 this.lastPanPoint = { x: e.clientX, y: e.clientY };
-                canvas.style.cursor = 'grabbing';
+                if (!this.simEditMode && !this.placeBallPending) canvas.style.cursor = 'grabbing';
             }
         });
 
         canvas.addEventListener('mousemove', (e) => {
+            const dx = e.clientX - this._dragStartX, dy = e.clientY - this._dragStartY;
+            if (Math.hypot(dx, dy) > 5) this._dragMoved = true;
+            this._lastMouseField = this.clientToFieldCoords(e.clientX, e.clientY);
             if (!this.isPanning) return;
             if (this.renderer) {
                 const d = this.renderer.pixelDeltaToSvgDelta(
@@ -938,14 +1184,47 @@ class CraneViewer {
             this.renderer?.invalidate();
         });
 
-        canvas.addEventListener('mouseup', () => {
+        canvas.addEventListener('mouseup', (e) => {
             this.isPanning = false;
-            canvas.style.cursor = 'grab';
+            if (!this.simEditMode && !this.placeBallPending) canvas.style.cursor = 'grab';
+            if (!this._dragMoved) {
+                const fp = this.clientToFieldCoords(e.clientX, e.clientY);
+                if (this.placeBallPending) {
+                    const team = this.placeBallPending;
+                    this.cancelBallPlacement();
+                    this.gcClient.setBallPlacementPos(fp.x, fp.y);
+                    this.gcClient.newCommand('BALL_PLACEMENT', team);
+                } else if (this.simEditMode) {
+                    this.simSelectAt(fp.x, fp.y);
+                }
+            }
         });
+
+        canvas.addEventListener('dblclick', (e) => {
+            if (!this.simEditMode || !this.simSelectedObj) return;
+            if (this._dragMoved) return;
+            const fp = this.clientToFieldCoords(e.clientX, e.clientY);
+            this.simTeleportTo(fp.x, fp.y);
+        });
+
         canvas.addEventListener('mouseleave', () => {
             this.isPanning = false;
-            canvas.style.cursor = 'default';
+            if (!this.simEditMode && !this.placeBallPending) canvas.style.cursor = 'default';
         });
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                if (this.placeBallPending) { this.cancelBallPlacement(); return; }
+                if (this.simEditMode) { this.toggleSimEditMode(); return; }
+                if (this.moveMode) { this.deactivateMoveMode(); return; }
+                this.gcClient.newCommand('HALT');
+                return;
+            }
+            if (e.key === 'Enter' && this.simEditMode && this.simSelectedObj) {
+                this.simTeleportTo(this._lastMouseField.x, this._lastMouseField.y);
+            }
+        });
+
         canvas.style.cursor = 'grab';
     }
 }


### PR DESCRIPTION
## 概要
crane_web_debugger の viewer にゲームコントローラ操作パネルとシミュレータ制御パネルを追加した。
ブラウザから直接 HALT/KICKOFF 等のコマンド送信、およびボール・ロボットのテレポートが行えるようになる。

## 背景・根本原因
試合運営のデバッグ時に、ブラウザの viewer 上からゲームコントローラへのコマンド発行と
シミュレータへのテレポート操作をワンストップで行えることが求められていた。

また今回の開発中に以下のバグを修正した：
- Sim Edit 選択ヒットテストが「自ロボット優先」の固定順で距離比較なしだったため、
  ボール付近でクリックしてもロボットが選ばれる問題を修正
  → 全候補（自ロボット・ボール・相手ロボット）の距離を比較して最近接を選択する方式に変更
- `clientToFieldCoords` の y 軸符号誤り（描画時の `-y*1000` 変換に対する逆変換の欠落）を修正

## 変更内容
- **viewer.html**: Game Control パネル（HALT/STOP/KICKOFF/FREE KICK/PLACE、スコア操作、カード）と
  Sim Control パネル（Sim Edit モード・Reset Ball・UDP endpoint 設定 UI）を追加
- **viewer.js**: `GameControlClient` クラスを追加（ssl-game-controller WebSocket API `/api/control`）、
  Sim Edit モード（クリックで選択、dblclick/Enter でテレポート、Esc でキャンセル）を実装、
  選択ロジック修正・y軸符号修正・dblclick ドラッグガード追加
- **websocket_server.cpp**: `SslSimulationSender` クラス追加（UDP で SSL Simulation Protocol 送信、
  既定エンドポイント `127.0.0.1:10300`）、`sim_teleport_ball` / `sim_teleport_robot` /
  `sim_remove_robot` / `sim_set_endpoint` WebSocket ハンドラを追加
- **CMakeLists.txt / package.xml**: `robocup_ssl_msgs` / Protobuf 依存を追加