### PR TITLE
feat: crane_web_debugger の Docker 開発時ホットリロードを有効化

### DIFF
--- a/crane_web_debugger/web_server/app.py
+++ b/crane_web_debugger/web_server/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 
 import uvicorn
@@ -21,6 +22,11 @@ def create_app(web_root: Path) -> FastAPI:
     return app
 
 
+# uvicorn の "app:app" import-string 起動 (--reload) に対応するためのモジュールレベル変数。
+# 環境変数 WEB_ROOT でルートディレクトリを指定できる（デフォルト: /app/web）。
+app = create_app(Path(os.environ.get("WEB_ROOT", "/app/web")))
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="crane web debugger HTTP server")
     parser.add_argument("--host", default="0.0.0.0")
@@ -31,8 +37,9 @@ def _parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = _parse_args()
-    app = create_app(args.web_root)
-    uvicorn.run(app, host=args.host, port=args.port, log_level="warning")
+    uvicorn.run(
+        create_app(args.web_root), host=args.host, port=args.port, log_level="warning"
+    )
 
 
 if __name__ == "__main__":

--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -7,6 +7,24 @@ services:
     network_mode: host
     environment:
       - HTTP_PORT=8090
+      - WEB_ROOT=/app/web
+    volumes:
+      - ../../crane_web_debugger/web:/app/web:ro
+      - ../../crane_web_debugger/web_server/app.py:/app/app.py:ro
+    command:
+      - uvicorn
+      - "app:app"
+      - --host
+      - "0.0.0.0"
+      - --port
+      - "8090"
+      - --reload
+      - --reload-include
+      - "app.py"
+      - --app-dir
+      - /app
+      - --log-level
+      - warning
     restart: unless-stopped
 
   ball-calibration:


### PR DESCRIPTION
## 概要

`crane_web_debugger` の開発ワークフロー改善。ソース変更のたびに `docker compose build` が必要だった問題を解消し、ブラウザリロードまたは uvicorn 自動再起動で変更を反映できるようにする。

## 背景・根本原因

`docker/dev/docker-compose.yaml` の `web-debugger` サービスに `volumes` 設定がなく、`web/` と `web_server/app.py` が Dockerfile の `COPY` によってイメージへ焼き込まれていた。そのため、フロントエンドの微小な変更でも再ビルドが必須となっていた。

## 変更内容

- `docker/dev/docker-compose.yaml`
  - `crane_web_debugger/web/` → `/app/web` に read-only マウントを追加
  - `crane_web_debugger/web_server/app.py` → `/app/app.py` に read-only マウントを追加
  - uvicorn を `--reload --reload-include app.py` 付きで起動するよう `command` を上書き（静的ファイル変更では不要なリロードが走らないよう `reload-include` で絞り込み）
  - `WEB_ROOT` 環境変数を追加

- `crane_web_debugger/web_server/app.py`
  - モジュールトップレベルで `app = create_app(...)` を生成し、uvicorn の `"app:app"` import-string 形式（`--reload` に必要）に対応
  - `WEB_ROOT` 環境変数でルートディレクトリを指定可能に（デフォルト: `/app/web`）
  - 従来の `python3 app.py --web-root ...` 起動との後方互換を維持（Dockerfile の `CMD` は変更なし）

## 開発フローの変化

| 変更内容 | 変更前 | 変更後 |
|---|---|---|
| `web/*.html/.js/.css` 編集 | `docker compose build` + `up -d` | ブラウザで Ctrl+F5 |
| `web_server/app.py` 編集 | `docker compose build` + `up -d` | uvicorn 自動リロード |
| `requirements.txt` 更新 | `docker compose build` + `up -d` | 同左（変わらず） |