### PR TITLE
feat(crane_web_debugger): robot cardsを削除しHUD・Detailを強化

### DIFF
--- a/crane_web_debugger/web/index.html
+++ b/crane_web_debugger/web/index.html
@@ -98,58 +98,6 @@
       transition: none;
     }
 
-    /* Robot cards */
-    #robot-cards-grid {
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      gap: 4px;
-      margin-bottom: var(--md-sys-spacing-sm);
-    }
-
-    .robot-card {
-      background-color: var(--md-sys-color-surface-container-high);
-      border: 1px solid var(--md-sys-color-outline-variant);
-      border-radius: var(--md-sys-shape-sm);
-      padding: 4px 2px;
-      text-align: center;
-      cursor: pointer;
-      transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard),
-                  border-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
-      min-width: 0;
-    }
-
-    .robot-card:hover {
-      background-color: var(--md-sys-color-surface-container-highest);
-      border-color: var(--md-sys-color-primary);
-    }
-
-    .robot-card.active {
-      background-color: var(--md-sys-color-primary-container);
-      border-color: var(--md-sys-color-primary);
-    }
-
-    .robot-card .robot-id {
-      font-size: 0.85rem;
-      font-weight: 700;
-      color: var(--md-sys-color-on-surface);
-      line-height: 1.2;
-    }
-
-    .robot-card .robot-planner {
-      font-size: 0.55rem;
-      color: var(--md-sys-color-on-surface-variant);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      line-height: 1.2;
-    }
-
-    .robot-card .robot-mode {
-      font-size: 0.55rem;
-      color: var(--md-sys-color-primary);
-      line-height: 1.2;
-    }
-
     #btn-move-mode.active {
       background-color: var(--md-sys-color-warning);
       color: var(--md-sys-color-on-warning);
@@ -444,6 +392,7 @@
       display: none;
       padding: 6px 8px;
       font-size: 0.75rem;
+      overflow-y: auto;
     }
 
     #robot-detail-inline.visible { display: block; }
@@ -452,7 +401,31 @@
       font-weight: 700;
       font-size: 0.85rem;
       color: var(--md-sys-color-primary);
-      margin-bottom: 4px;
+      margin-bottom: 6px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    #robot-detail-inline .rd-telem-link {
+      color: var(--md-sys-color-on-surface-variant);
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      opacity: 0.7;
+    }
+
+    #robot-detail-inline .rd-telem-link:hover { opacity: 1; }
+
+    #robot-detail-inline .rd-section-title {
+      font-size: 0.62rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--md-sys-color-on-surface-variant);
+      margin: 6px 0 2px;
+      padding-bottom: 2px;
+      border-bottom: 1px solid var(--md-sys-color-outline-variant);
     }
 
     #robot-detail-inline table {
@@ -468,7 +441,6 @@
     }
 
     #robot-detail-inline td:first-child {
-      color: var(--md-sys-color-on-surface-variant);
       white-space: nowrap;
       width: 5.5em;
     }
@@ -477,19 +449,30 @@
       color: var(--md-sys-color-on-surface);
     }
 
-    /* Sparkline row */
-    .sparkline-row {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      padding: 4px 8px;
-      border-top: 1px solid var(--md-sys-color-outline-variant);
+    /* severity colors */
+    #robot-detail-inline .rd-warn  { color: var(--md-sys-color-warning,  #F9A825) !important; }
+    #robot-detail-inline .rd-crit  { color: var(--md-sys-color-error,    #B3261E) !important; font-weight: 600; }
+    #robot-detail-inline .rd-ok    { color: var(--md-sys-color-on-surface); }
+
+    /* availability chips */
+    .rd-chip {
+      display: inline-block;
+      font-size: 0.6rem;
+      padding: 1px 5px;
+      border-radius: 10px;
+      margin-right: 2px;
+      font-weight: 600;
     }
 
-    .sparkline-label {
-      font-size: 0.6rem;
-      color: var(--md-sys-color-on-surface-variant);
-      min-width: 4em;
+    .rd-chip--ok {
+      background: var(--md-sys-color-tertiary-container, #FFD8E4);
+      color: var(--md-sys-color-on-tertiary-container, #31111D);
+    }
+
+    .rd-chip--ng {
+      background: var(--md-sys-color-surface-container-highest, #E6E0E9);
+      color: var(--md-sys-color-on-surface-variant, #49454F);
+      opacity: 0.6;
     }
   </style>
 </head>
@@ -529,12 +512,6 @@
             <span class="info-label">Stage</span>
             <span class="info-value" id="game-stage">-</span>
           </div>
-        </div>
-
-        <!-- Robot cards -->
-        <div class="m3-section-title">Robots</div>
-        <div id="robot-cards-grid">
-          <!-- Populated by viewer/main.js -->
         </div>
 
         <!-- Game Control -->
@@ -709,7 +686,6 @@
         <div id="robot-detail-inline">
           <!-- Populated by main.js -->
         </div>
-        <div id="robot-sparklines"></div>
       </div>
 
       <!-- Log Panel -->
@@ -741,19 +717,6 @@
       <div id="time-scrubber-container" style="height:100%;"></div>
     </div>
 
-  </div>
-
-  <!-- Robot detail dialog -->
-  <div class="m3-dialog-scrim" id="robot-detail-scrim" onclick="window.__closeRobotDialog?.()"></div>
-  <div class="m3-dialog" id="robot-detail-modal" style="max-width:340px;">
-    <div class="m3-dialog__header">
-      <span class="m3-dialog__title" id="robot-detail-title">Robot</span>
-      <button class="m3-icon-btn m3-icon-btn--sm" onclick="window.__closeRobotDialog?.()">
-        <span class="material-symbols-outlined">close</span>
-      </button>
-    </div>
-    <div class="m3-dialog__body" id="robot-detail-body" style="font-size:0.8rem;">
-    </div>
   </div>
 
   <script type="module" src="viewer/main.js"></script>

--- a/crane_web_debugger/web/viewer/main.js
+++ b/crane_web_debugger/web/viewer/main.js
@@ -1,4 +1,9 @@
-import { CONTROL_MODE_SHORT, CONTROL_MODE_LONG, ROBOT_HIT_RADIUS_M, BALL_HIT_RADIUS_M } from './renderer/constants.js';
+import { ROBOT_HIT_RADIUS_M, BALL_HIT_RADIUS_M } from './renderer/constants.js';
+import {
+    formatPlannerName, getFsmState, getControlModeLong,
+    formatLatencyRich, formatVoltage, formatTemperature,
+    formatKickState, formatErrorBadge, availabilityChips,
+} from './renderer/formatters.js';
 import { SvgPrimitiveParser } from './renderer/SvgPrimitiveParser.js';
 import { CanvasRenderer } from './renderer/CanvasRenderer.js';
 import { FieldLayer } from './renderer/FieldLayer.js';
@@ -6,7 +11,7 @@ import { ThemeTokens } from './renderer/ThemeTokens.js';
 import { GameControlClient } from './ws/GameControlClient.js';
 import { DockLayout } from './ui/DockLayout.js';
 import { LogPanel } from './ui/LogPanel.js';
-import { Sparkline, MetricRing } from './ui/Sparkline.js';
+import { MetricRing } from './ui/Sparkline.js';
 import { RingBuffer, indexBy, applyLayerUpdate } from './replay/RingBuffer.js';
 import { TimeScrubber } from './ui/TimeScrubber.js';
 
@@ -51,10 +56,9 @@ class CraneViewer {
         this._keysDown = new Set();
         this._keyboardLoopRunning = false;
         this.robotFeedback = {};
+        this._feedbackTimestamp = {};  // { robot_id: Date.now() } - 警告バッジのstale判定用
         this.latencyEstimation = {};   // { robot_id: { source: { latency_ms, correlation, ... } } }
         this._robotMetrics = new Map(); // id -> { posX, posY, vel }
-        this._sparklines = null;        // [Sparkline] for current detail panel
-        this._sparklineRaf = null;
         this._detailRobotId = null;
         this._replayMode = false;
         this.ringBuffer = new RingBuffer();
@@ -316,8 +320,13 @@ class CraneViewer {
 
     handleRobotFeedback(data) {
         if (data.feedback) {
-            for (const fb of data.feedback) this.robotFeedback[fb.robot_id] = fb;
+            const now = Date.now();
+            for (const fb of data.feedback) {
+                this.robotFeedback[fb.robot_id] = fb;
+                this._feedbackTimestamp[fb.robot_id] = now;
+            }
         }
+        if (this._detailRobotId !== null) this.scheduleRobotUpdate();
     }
 
     handleGameInfo(data) {
@@ -332,7 +341,6 @@ class CraneViewer {
         if (this.robotUpdateTimer) return;
         this.robotUpdateTimer = setTimeout(() => {
             this.robotUpdateTimer = null;
-            this.renderRobotCards();
             if (this._detailRobotId !== null) {
                 const robot = this.robotsOurs[this._detailRobotId];
                 const cmd = this.controlTargets[this._detailRobotId];
@@ -350,24 +358,11 @@ class CraneViewer {
         if (banner) banner.classList.toggle('visible', !connected);
     }
 
-    renderRobotCards() {
-        const container = document.getElementById('robot-cards-grid');
-        if (!container) return;
-        const ids = Object.keys(this.robotsOurs).map(Number).sort((a, b) => a - b);
-        if (ids.length === 0) {
-            container.innerHTML = '<div style="font-size:0.7rem;color:var(--md-sys-color-on-surface-variant);text-align:center;grid-column:span 4;padding:8px;">No robot data</div>';
-            return;
-        }
-        container.innerHTML = '';
-        for (const id of ids) {
-            const cmd = this.controlTargets[id];
-            const modeName = cmd ? (CONTROL_MODE_SHORT[cmd.control_mode] ?? `M${cmd.control_mode}`) : '--';
-            const plannerName = cmd?.planner_name || '--';
-            const card = document.createElement('div');
-            card.className = 'robot-card';
-            card.innerHTML = `<div class="robot-id">${id}</div><div class="robot-mode">${modeName}</div><div class="robot-planner" title="${plannerName}">${plannerName}</div>`;
-            card.addEventListener('click', () => this.showRobotDetail(id));
-            container.appendChild(card);
+    toggleRobotDetail(id) {
+        if (this._detailRobotId === id) {
+            this.closeRobotDetail();
+        } else {
+            this.showRobotDetail(id);
         }
     }
 
@@ -382,104 +377,101 @@ class CraneViewer {
         this._detailRobotId = id;
         this._renderDetailPanel(id, robot, cmd);
         panel.classList.add('visible');
-
-        this._startSparklineLoop(id);
+        this.renderer?.invalidate();
     }
 
     _renderDetailPanel(id, robot, cmd) {
         const panel = document.getElementById('robot-detail-inline');
         if (!panel) return;
-        const modeName = cmd ? (CONTROL_MODE_LONG[cmd.control_mode] ?? `MODE_${cmd.control_mode}`) : '--';
-        let targetHtml = '';
-        if (cmd?.position_target_mode) {
-            targetHtml = `<tr><td>Target Pos</td><td>(${cmd.position_target_mode.target_x?.toFixed(2)}, ${cmd.position_target_mode.target_y?.toFixed(2)})</td></tr>`;
-        } else if (cmd?.simple_velocity_target_mode) {
-            targetHtml = `<tr><td>Target Vel</td><td>(${cmd.simple_velocity_target_mode.target_vx?.toFixed(2)}, ${cmd.simple_velocity_target_mode.target_vy?.toFixed(2)})</td></tr>`;
-        }
-        const latEst = this.latencyEstimation[id] ?? {};
-        const latRows = ['world_model', 'robot_feedback'].flatMap(src => {
-            const e = latEst[src];
-            if (!e) return [];
-            const ms  = e.latency_ms != null ? `${e.latency_ms.toFixed(1)} ms` : 'N/A';
-            const corr = `${(e.correlation * 100).toFixed(1)}%`;
-            const label = src === 'world_model' ? 'WM latency' : 'HW latency';
-            return [`<tr><td>${label}</td><td>${ms} <span style="opacity:0.6;font-size:0.85em">(r=${corr})</span></td></tr>`];
-        }).join('');
 
-        panel.innerHTML = `
-            <div class="rd-title">Robot ${id}</div>
+        // --- Command section ---
+        let commandHtml = '';
+        if (cmd) {
+            let targetHtml = '';
+            if (cmd.position_target_mode) {
+                targetHtml = `<tr><td>Target Pos</td><td>(${cmd.position_target_mode.target_x?.toFixed(2)}, ${cmd.position_target_mode.target_y?.toFixed(2)})</td></tr>`;
+            } else if (cmd.simple_velocity_target_mode) {
+                targetHtml = `<tr><td>Target Vel</td><td>(${cmd.simple_velocity_target_mode.target_vx?.toFixed(2)}, ${cmd.simple_velocity_target_mode.target_vy?.toFixed(2)})</td></tr>`;
+            }
+            commandHtml = `
+                <div class="rd-section-title">Command</div>
+                <table><tbody>
+                    <tr><td>Mode</td><td>${getControlModeLong(cmd)}</td></tr>
+                    <tr><td>Planner</td><td>${formatPlannerName(cmd.planner_name)}</td></tr>
+                    <tr><td>FSM</td><td>${getFsmState(cmd) ?? '--'}</td></tr>
+                    ${targetHtml}
+                    <tr><td>Target θ</td><td>${cmd.target_theta?.toFixed(3) ?? '--'}</td></tr>
+                </tbody></table>`;
+        }
+
+        // --- State section ---
+        const chips = availabilityChips(robot);
+        const chipHtml = ['vision', 'feedback', 'tracker'].map(k =>
+            `<span class="rd-chip ${chips[k] ? 'rd-chip--ok' : 'rd-chip--ng'}">${k}</span>`
+        ).join('');
+        const stateHtml = `
+            <div class="rd-section-title">State</div>
             <table><tbody>
-                <tr><td>Mode</td><td>${modeName}</td></tr>
-                <tr><td>Planner</td><td>${cmd?.planner_name || '--'}</td></tr>
-                <tr><td>FSM</td><td>${cmd?.planning_factors?.[0]?.name || '--'}</td></tr>
                 <tr><td>Pos</td><td>(${robot.x?.toFixed(3)}, ${robot.y?.toFixed(3)}) m</td></tr>
                 <tr><td>θ</td><td>${robot.theta?.toFixed(3)} rad</td></tr>
                 <tr><td>Vel</td><td>(${robot.vx?.toFixed(3)}, ${robot.vy?.toFixed(3)}) m/s</td></tr>
                 <tr><td>ω</td><td>${robot.omega?.toFixed(3)} rad/s</td></tr>
-                ${targetHtml}
-                <tr><td>Target θ</td><td>${cmd?.target_theta?.toFixed(3) ?? '--'}</td></tr>
-                ${latRows}
-            </tbody></table>
-            <div style="margin-top:4px;">
-                <a href="/robot_telemetry.html?id=${id}" class="m3-btn m3-btn--outlined m3-btn--sm" style="font-size:0.65rem;padding:2px 8px;">
-                    <span class="material-symbols-outlined icon-sm">show_chart</span> Telemetry
+                ${robot.acceleration_x != null ? `<tr><td>Accel</td><td>(${robot.acceleration_x?.toFixed(2)}, ${robot.acceleration_y?.toFixed(2)}, ${robot.acceleration_theta?.toFixed(2)})</td></tr>` : ''}
+                <tr><td>Avail</td><td>${chipHtml}</td></tr>
+            </tbody></table>`;
+
+        // --- Feedback section ---
+        let feedbackHtml = '';
+        const fb = this.robotFeedback[id];
+        if (fb) {
+            const volt = formatVoltage(fb.voltage);
+            const temp = formatTemperature(fb.temperatures);
+            const err = formatErrorBadge(fb);
+            const tempTitle = fb.temperatures ? fb.temperatures.map((t, i) => `[${i}] ${t.toFixed(0)}°C`).join(' ') : '';
+            feedbackHtml = `
+                <div class="rd-section-title">Feedback</div>
+                <table><tbody>
+                    <tr><td>Voltage</td><td class="rd-${volt.severity}">${volt.text}</td></tr>
+                    <tr><td>Temp</td><td class="rd-${temp.severity}" title="${tempTitle}">${temp.text}</td></tr>
+                    <tr><td>Packet</td><td class="${(fb.packet_frequency_hz ?? 0) < 80 ? 'rd-warn' : ''}">${fb.packet_frequency_hz?.toFixed(0) ?? 'N/A'} Hz</td></tr>
+                    <tr><td>Kick</td><td>${formatKickState(fb.kick_state)}</td></tr>
+                    <tr><td>Ball</td><td>${fb.ball_sensor ? '●' : '○'}</td></tr>
+                    <tr><td>Error</td><td class="${err ? 'rd-crit' : ''}">${err ? `id=${fb.error_id} ${fb.error_info ?? ''}` : 'none'}</td></tr>
+                    ${fb.motor_current ? `<tr><td>Motor I</td><td>[${fb.motor_current.map(v => v.toFixed(1)).join(', ')}]</td></tr>` : ''}
+                </tbody></table>`;
+        }
+
+        // --- Latency section ---
+        const latEst = this.latencyEstimation[id] ?? {};
+        const latRows = ['world_model', 'robot_feedback'].flatMap(src => {
+            const e = latEst[src];
+            if (!e) return [];
+            const label = src === 'world_model' ? 'WM' : 'HW';
+            const high = e.latency_ms > 100;
+            return [`<tr><td>${label}</td><td class="${high ? 'rd-warn' : ''}">${formatLatencyRich(e)}</td></tr>`];
+        }).join('');
+        const latencyHtml = latRows ? `
+            <div class="rd-section-title">Latency</div>
+            <table><tbody>${latRows}</tbody></table>` : '';
+
+        panel.innerHTML = `
+            <div class="rd-title">Robot ${id}
+                <a href="/robot_telemetry.html?id=${id}" target="_blank" class="rd-telem-link" title="Telemetry を別タブで開く">
+                    <span class="material-symbols-outlined icon-sm">open_in_new</span>
                 </a>
             </div>
+            ${commandHtml}
+            ${stateHtml}
+            ${feedbackHtml}
+            ${latencyHtml}
         `;
-    }
-
-    _startSparklineLoop(id) {
-        this._stopSparklineLoop();
-        const container = document.getElementById('robot-sparklines');
-        if (!container) return;
-        container.innerHTML = '';
-
-        const tokens = this.themeTokens.get() ?? {};
-        const sparkData = [
-            { label: 'Pos X', color: tokens.hudAccent ?? '#D0BCFF' },
-            { label: 'Pos Y', color: tokens.teamYellow ?? '#C49000' },
-            { label: '|Vel|', color: tokens.moveOverlay ?? '#B5EAD7' },
-        ];
-
-        this._sparklines = sparkData.map(({ label, color }) => {
-            const row = document.createElement('div');
-            row.className = 'sparkline-row';
-            const lbl = document.createElement('span');
-            lbl.className = 'sparkline-label';
-            lbl.textContent = label;
-            row.appendChild(lbl);
-            container.appendChild(row);
-            return new Sparkline(row, { width: 100, height: 22, color });
-        });
-
-        const keys = ['posX', 'posY', 'vel'];
-        const loop = () => {
-            if (this._detailRobotId !== id) return;
-            const metrics = this._robotMetrics.get(id);
-            const tokens2 = this.themeTokens.get() ?? {};
-            if (metrics) {
-                keys.forEach((key, i) => {
-                    this._sparklines[i].setSeries([{ color: sparkData[i].color, data: metrics[key].latest(60) }]);
-                    this._sparklines[i].render(tokens2);
-                });
-            }
-            this._sparklineRaf = requestAnimationFrame(loop);
-        };
-        this._sparklineRaf = requestAnimationFrame(loop);
-    }
-
-    _stopSparklineLoop() {
-        if (this._sparklineRaf) { cancelAnimationFrame(this._sparklineRaf); this._sparklineRaf = null; }
-        this._sparklines = null;
-        this._detailRobotId = null;
     }
 
     closeRobotDetail() {
         const panel = document.getElementById('robot-detail-inline');
         panel?.classList.remove('visible');
-        const container = document.getElementById('robot-sparklines');
-        if (container) container.innerHTML = '';
-        this._stopSparklineLoop();
+        this._detailRobotId = null;
+        this.renderer?.invalidate();
     }
 
     updateLayerList() {
@@ -995,6 +987,14 @@ class CraneViewer {
                     this.gcClient.newCommand('BALL_PLACEMENT', team);
                 } else if (this.simEditMode) {
                     this.simSelectAt(fp.x, fp.y);
+                } else if (!e.shiftKey && !this.moveMode) {
+                    // 通常クリック: ロボットをクリックで Detail トグル、空所クリックで閉じる
+                    const hitId = this.findRobotAtPosition(fp.x, fp.y);
+                    if (hitId !== null) {
+                        this.toggleRobotDetail(hitId);
+                    } else {
+                        this.closeRobotDetail();
+                    }
                 }
             }
         });
@@ -1023,6 +1023,7 @@ class CraneViewer {
                 if (this.placeBallPending) { this.cancelBallPlacement(); return; }
                 if (this.simEditMode) { this.toggleSimEditMode(); return; }
                 if (this.moveMode) { this.deactivateMoveMode(); return; }
+                if (this._detailRobotId !== null) { this.closeRobotDetail(); return; }
                 if (this._multiSelect.size > 0) { this._multiSelect.clear(); this.renderer?.invalidate(); return; }
                 // モード外の Escape → 確認ダイアログ付き HALT
                 this._requestHalt();

--- a/crane_web_debugger/web/viewer/renderer/RobotHud.js
+++ b/crane_web_debugger/web/viewer/renderer/RobotHud.js
@@ -1,3 +1,5 @@
+import { formatPlannerName, getFsmState, formatLatencyMs, formatLatencyRich } from './formatters.js';
+
 const HALO_RADIUS = 120;         // mm
 const ARROW_LEN = 150;
 const ARROW_HEAD_LEN = 40;
@@ -6,15 +8,34 @@ const ARROW_LINE_W = 18;
 const FSM_Y = 170;               // mm below center in SVG space (+Y = down)
 const PLANNER_Y = 260;
 const LATENCY_Y = 360;
+const HW_LATENCY_Y = 460;        // mm below center
 const DRIBBLER_R = 15;
 const DRIBBLER_Y = 30;           // mm below center (front LED position)
+
+// ズーム閾値
+const ZOOM_MEDIUM = 1.5;
+const ZOOM_HIGH = 2.0;
+
+// 警告閾値
+const VOLTAGE_CRIT = 21.0;
+const VOLTAGE_WARN = 22.5;
+const TEMP_CRIT = 75;
+const TEMP_WARN = 60;
+const FEEDBACK_STALE_MS = 500;
+
+// 警告バッジサイズ (mm)
+const BADGE_R = 32;
+const BADGE_OFFSET_X = 95;
+const BADGE_OFFSET_Y = -95;
 
 export class RobotHud {
     // ctx は CanvasRenderer._render() 内の変換済みコンテキスト（SVG 座標系、1 unit = 1mm）
     draw(ctx, viewer, tokens) {
         const primary = viewer.selectedRobotId;
+        const detail = viewer._detailRobotId;
         const multi = viewer._multiSelect;
         const hover = viewer._hoveredRobotId;
+        const zoom = viewer.zoomLevel ?? 1.0;
 
         for (const [idStr, robot] of Object.entries(viewer.robotsOurs)) {
             const id = Number(idStr);
@@ -22,21 +43,35 @@ export class RobotHud {
             const cy = -robot.y * 1000;
             const theta = robot.theta ?? 0;
             const cmd = viewer.controlTargets[id];
-            this._drawHalo(ctx, cx, cy, id, primary, multi, hover, tokens);
+            this._drawHalo(ctx, cx, cy, id, primary, detail, multi, hover, tokens);
             this._drawArrow(ctx, cx, cy, theta, cmd, tokens);
             this._drawDribblerLed(ctx, cx, cy, id, viewer, tokens);
             const latEst = viewer.latencyEstimation?.[id];
-            if (cmd) this._drawLabels(ctx, cx, cy, cmd, tokens, latEst);
+            if (cmd || latEst) this._drawLabels(ctx, cx, cy, cmd, tokens, latEst, zoom);
+            this._drawWarningBadges(ctx, cx, cy, id, viewer, tokens);
         }
     }
 
-    _drawHalo(ctx, cx, cy, id, primary, multi, hover, tokens) {
+    _drawHalo(ctx, cx, cy, id, primary, detail, multi, hover, tokens) {
         const accent = tokens.selectionHalo ?? tokens.hudAccent ?? '#D0BCFF';
+        const detailColor = tokens.tertiary ?? '#7D5260';
         if (id === primary) {
+            // moveMode 選択: 実線・太
             ctx.save();
             ctx.strokeStyle = accent;
             ctx.globalAlpha = 0.8;
             ctx.lineWidth = 24;
+            ctx.setLineDash([]);
+            ctx.beginPath();
+            ctx.arc(cx, cy, HALO_RADIUS, 0, Math.PI * 2);
+            ctx.stroke();
+            ctx.restore();
+        } else if (id === detail) {
+            // Detail パネル選択: 実線・細、別色
+            ctx.save();
+            ctx.strokeStyle = detailColor;
+            ctx.globalAlpha = 0.75;
+            ctx.lineWidth = 14;
             ctx.setLineDash([]);
             ctx.beginPath();
             ctx.arc(cx, cy, HALO_RADIUS, 0, Math.PI * 2);
@@ -107,11 +142,11 @@ export class RobotHud {
         ctx.restore();
     }
 
-    _drawLabels(ctx, cx, cy, cmd, tokens, latEst) {
-        const fsm = cmd.planning_factors?.[0]?.name ?? '';
-        const planner = cmd.planner_name ?? '';
+    _drawLabels(ctx, cx, cy, cmd, tokens, latEst, zoomLevel) {
+        const fsm = getFsmState(cmd) ?? '';
+        const planner = cmd?.planner_name ?? '';
         const wmEst = latEst?.world_model;
-        if (!fsm && !planner && !wmEst) return;
+        const hwEst = latEst?.robot_feedback;
 
         ctx.save();
         ctx.textAlign = 'center';
@@ -125,18 +160,95 @@ export class RobotHud {
             ctx.fillText(fsm, cx, cy + FSM_Y);
         }
         if (planner) {
-            const name = planner.length > 20 ? '…' + planner.slice(-19) : planner;
             ctx.font = '64px sans-serif';
             ctx.fillStyle = tokens.noDataText ?? '#8C929A';
             ctx.textBaseline = 'top';
-            ctx.fillText(name, cx, cy + PLANNER_Y);
+            ctx.fillText(formatPlannerName(planner), cx, cy + PLANNER_Y);
         }
+
+        // WM latency は常時表示
         if (wmEst?.latency_ms != null) {
-            const latStr = `${wmEst.latency_ms.toFixed(0)}ms`;
+            const latColor = wmEst.latency_ms > 100
+                ? (tokens.error ?? '#B3261E')
+                : (tokens.tertiaryContainer ?? '#F4DFF0');
             ctx.font = '56px sans-serif';
-            ctx.fillStyle = tokens.tertiaryContainer ?? '#F4DFF0';
+            ctx.fillStyle = latColor;
             ctx.textBaseline = 'top';
-            ctx.fillText(latStr, cx, cy + LATENCY_Y);
+
+            if (zoomLevel >= ZOOM_HIGH) {
+                // ズーム大: WM/HW + correlation 値
+                const wmLabel = `WM: ${formatLatencyRich(wmEst)}`;
+                ctx.fillText(wmLabel, cx, cy + LATENCY_Y);
+                if (hwEst?.latency_ms != null) {
+                    const hwColor = hwEst.latency_ms > 100
+                        ? (tokens.error ?? '#B3261E')
+                        : (tokens.tertiaryContainer ?? '#F4DFF0');
+                    ctx.fillStyle = hwColor;
+                    ctx.fillText(`HW: ${formatLatencyRich(hwEst)}`, cx, cy + HW_LATENCY_Y);
+                }
+            } else if (zoomLevel >= ZOOM_MEDIUM) {
+                // ズーム中: WM/HW のみ (ms)
+                ctx.fillText(`WM: ${formatLatencyMs(wmEst)}`, cx, cy + LATENCY_Y);
+                if (hwEst?.latency_ms != null) {
+                    const hwColor = hwEst.latency_ms > 100
+                        ? (tokens.error ?? '#B3261E')
+                        : (tokens.tertiaryContainer ?? '#F4DFF0');
+                    ctx.fillStyle = hwColor;
+                    ctx.fillText(`HW: ${formatLatencyMs(hwEst)}`, cx, cy + HW_LATENCY_Y);
+                }
+            } else {
+                // 通常: WM のみ (ms)
+                ctx.fillText(formatLatencyMs(wmEst), cx, cy + LATENCY_Y);
+            }
+        }
+        ctx.restore();
+    }
+
+    _drawWarningBadges(ctx, cx, cy, id, viewer, tokens) {
+        const fb = viewer.robotFeedback?.[id];
+        const badges = [];
+
+        // feedback stale チェック
+        const fbTs = viewer._feedbackTimestamp?.[id] ?? 0;
+        const stale = fb && (Date.now() - fbTs > FEEDBACK_STALE_MS);
+
+        if (fb && !stale) {
+            if (fb.error_id != null && fb.error_id !== 0) {
+                badges.push({ label: '!', color: tokens.error ?? '#B3261E' });
+            }
+            const v = fb.voltage;
+            if (v != null && v <= VOLTAGE_CRIT) {
+                badges.push({ label: 'V', color: tokens.inversePrimary ?? '#6650A4' });
+            } else if (v != null && v <= VOLTAGE_WARN) {
+                badges.push({ label: 'V', color: tokens.warning ?? '#F9A825' });
+            }
+            const temps = fb.temperatures;
+            if (temps && temps.length > 0) {
+                const maxT = Math.max(...temps);
+                if (maxT >= TEMP_CRIT) {
+                    badges.push({ label: 'T', color: tokens.warning ?? '#F9A825' });
+                }
+            }
+        }
+
+        if (badges.length === 0) return;
+
+        ctx.save();
+        ctx.setLineDash([]);
+        for (let i = 0; i < badges.length; i++) {
+            const bx = cx + BADGE_OFFSET_X + i * (BADGE_R * 2 + 8);
+            const by = cy + BADGE_OFFSET_Y;
+            ctx.fillStyle = badges[i].color;
+            ctx.globalAlpha = 0.9;
+            ctx.beginPath();
+            ctx.arc(bx, by, BADGE_R, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = '#FFFFFF';
+            ctx.globalAlpha = 1.0;
+            ctx.font = `bold ${BADGE_R * 1.2}px sans-serif`;
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(badges[i].label, bx, by);
         }
         ctx.restore();
     }

--- a/crane_web_debugger/web/viewer/renderer/formatters.js
+++ b/crane_web_debugger/web/viewer/renderer/formatters.js
@@ -1,0 +1,68 @@
+import { CONTROL_MODE_SHORT, CONTROL_MODE_LONG } from './constants.js';
+
+export function formatPlannerName(name, maxLen = 20) {
+    if (!name) return '--';
+    return name.length > maxLen ? '…' + name.slice(-(maxLen - 1)) : name;
+}
+
+export function getFsmState(cmd) {
+    return cmd?.planning_factors?.[0]?.name ?? null;
+}
+
+export function getControlModeShort(cmd) {
+    if (!cmd) return '--';
+    return CONTROL_MODE_SHORT[cmd.control_mode] ?? `M${cmd.control_mode}`;
+}
+
+export function getControlModeLong(cmd) {
+    if (!cmd) return '--';
+    return CONTROL_MODE_LONG[cmd.control_mode] ?? `MODE_${cmd.control_mode}`;
+}
+
+export function formatLatencyRich(latEst) {
+    if (!latEst || latEst.latency_ms == null) return 'N/A';
+    const ms = latEst.latency_ms.toFixed(0);
+    const corr = latEst.correlation != null ? ` (r=${(latEst.correlation).toFixed(2)})` : '';
+    return `${ms}ms${corr}`;
+}
+
+export function formatLatencyMs(latEst) {
+    if (!latEst || latEst.latency_ms == null) return 'N/A';
+    return `${latEst.latency_ms.toFixed(0)}ms`;
+}
+
+// severity: 'ok' | 'warn' | 'crit'
+export function formatVoltage(v, warnV = 22.5, critV = 21.0) {
+    if (v == null) return { text: 'N/A', severity: 'ok' };
+    const text = `${v.toFixed(1)} V`;
+    if (v <= critV) return { text, severity: 'crit' };
+    if (v <= warnV) return { text, severity: 'warn' };
+    return { text, severity: 'ok' };
+}
+
+export function formatTemperature(temps) {
+    if (!temps || temps.length === 0) return { max: null, text: 'N/A', severity: 'ok' };
+    const max = Math.max(...temps);
+    const text = `max ${max.toFixed(0)} °C`;
+    if (max >= 75) return { max, text, severity: 'crit' };
+    if (max >= 60) return { max, text, severity: 'warn' };
+    return { max, text, severity: 'ok' };
+}
+
+export function formatKickState(state) {
+    const map = { 0: 'READY', 1: 'CHARGING', 2: 'FIRING', 3: 'CHARGED' };
+    return map[state] ?? `STATE_${state}`;
+}
+
+export function formatErrorBadge(fb) {
+    if (!fb || fb.error_id === 0 || fb.error_id == null) return null;
+    return { text: `E${fb.error_id}`, severity: 'crit' };
+}
+
+export function availabilityChips(robot) {
+    return {
+        vision: robot?.available_vision ?? false,
+        feedback: robot?.available_feedback ?? false,
+        tracker: robot?.available_tracker ?? false,
+    };
+}


### PR DESCRIPTION
## 概要

Crane Viewer の左ドックにある robot cards を廃止し、フィールド中心のワークフローへ再設計します。
HUD に警告バッジとレイテンシのズーム連動表示を追加し、Detail パネルをフィードバック情報まで含む多セクション構成に強化しました。

## 背景・根本原因

robot cards は ID・control_mode 略号・planner 名の 3 項目しか表示しておらず、情報量が薄い割に画面領域を占有していました。また Detail を開く唯一の入口がカードクリックのみという UX 上の問題もありました。

## 変更内容

### 削除
- 左ドックの robot cards（DOM・CSS・`renderRobotCards()` メソッド）
- sparkline（`_startSparklineLoop` / `_stopSparklineLoop` / `#robot-sparklines`）
- デッドコード（`#robot-detail-modal` / `#robot-detail-scrim` / `__closeRobotDialog`）

### クリック導線（新規）
- フィールド上の自軍ロボット通常クリック → Detail トグル
- 空所クリック / Esc → Detail クローズ
- `toggleRobotDetail(id)` メソッド新設

### HUD 強化（`RobotHud.js`）
- Detail で開いているロボットに tertiary 色の別色ハロー表示
- 警告バッジ（`_drawWarningBadges`）: error_id 非0 → `!`、電圧低下 → `V`、過温 → `T`
- レイテンシ表示のズーム連動:
  - 通常: WM のみ (ms)
  - ズーム ≥ 1.5: WM / HW 2 行
  - ズーム ≥ 2.0: WM / HW + correlation 値
- control_mode 略号は HUD から削除（Detail のみ表示）

### Detail パネル強化
- 4 セクション構成（Command / State / Feedback / Latency）
- **Feedback セクション新規追加**: voltage・temperature・packet freq・kick state・ball sensor・error id・motor current（severity 色付き）
- **State セクション拡充**: acceleration、available_*/vision/tracker チップ追加
- Telemetry リンクを別タブ（`target="_blank"`）で開くよう変更
- latency 100ms 超で警告色

### 共通フォーマッタ（`viewer/renderer/formatters.js` 新設）
`formatPlannerName` / `getFsmState` / `getControlModeShort` / `getControlModeLong` /
`formatLatencyRich` / `formatLatencyMs` / `formatVoltage` / `formatTemperature` /
`formatKickState` / `formatErrorBadge` / `availabilityChips` を一元化し、
HUD・Detail・Tooltip に散在していた重複ロジックを除去