### PR TITLE
feat(crane_web_debugger): session injection UIを追加

### DIFF
--- a/crane_web_debugger/CMakeLists.txt
+++ b/crane_web_debugger/CMakeLists.txt
@@ -29,11 +29,12 @@ ament_auto_add_executable(crane_websocket_server
 find_package(OpenSSL REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(Protobuf REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 include_directories(${robocup_ssl_msgs_INCLUDE_DIRS})
 
 # Link libraries for WebSocket server
-target_link_libraries(crane_websocket_server ${Boost_LIBRARIES} ${robocup_ssl_msgs_LIBRARIES})
+target_link_libraries(crane_websocket_server ${Boost_LIBRARIES} ${robocup_ssl_msgs_LIBRARIES} ${YAML_CPP_LIBRARIES})
 if(TARGET OpenSSL::SSL)
   target_link_libraries(crane_websocket_server OpenSSL::SSL OpenSSL::Crypto)
 else()

--- a/crane_web_debugger/package.xml
+++ b/crane_web_debugger/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>crane_msgs</depend>
   <depend>crane_visualization_interfaces</depend>
   <depend>diagnostic_msgs</depend>
@@ -18,6 +19,7 @@
   <depend>rclcpp</depend>
   <depend>robocup_ssl_msgs</depend>
   <depend>std_msgs</depend>
+  <exec_depend>crane_session_coordinator</exec_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>crane_lint_common</test_depend>
 

--- a/crane_web_debugger/src/websocket_server.cpp
+++ b/crane_web_debugger/src/websocket_server.cpp
@@ -12,8 +12,10 @@
 #include <robocup_ssl_msgs/ssl_simulation_control.pb.h>
 #include <sys/socket.h>
 #include <sys/time.h>
+#include <yaml-cpp/yaml.h>
 
 #include <algorithm>
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <boost/asio.hpp>
 #include <cctype>
 #include <chrono>
@@ -29,6 +31,7 @@
 #include <crane_msgs/msg/world_model.hpp>
 #include <crane_visualization_interfaces/msg/svg_snapshot.hpp>
 #include <crane_visualization_interfaces/msg/svg_updates.hpp>
+#include <deque>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <filesystem>
 #include <fstream>
@@ -357,6 +360,20 @@ public:
       this->create_publisher<crane_msgs::msg::RobotCommands>("/control_targets", 10);
     session_injection_pub_ =
       this->create_publisher<std_msgs::msg::String>("/session_injection", 10);
+    session_injection_sub_ = this->create_subscription<std_msgs::msg::String>(
+      "/session_injection", 10, [this](const std_msgs::msg::String::SharedPtr msg) {
+        {
+          std::lock_guard<std::mutex> lock(injection_mutex_);
+          current_injection_ = msg->data;
+          auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::system_clock::now().time_since_epoch())
+                      .count();
+          injection_history_.push_front({msg->data, ms});
+          while (injection_history_.size() > 5) injection_history_.pop_back();
+        }
+        broadcastSessionInjectionCurrent();
+      });
+    loadSituationNames();
     robot_test_target_pub_ =
       this->create_publisher<crane_msgs::msg::RobotCommand>("/robot_test/target", 10);
 
@@ -552,6 +569,23 @@ private:
     // 接続確立時にPiステータスを取得・送信
     pollAllPiStatus();
 
+    // 接続確立時にsituation一覧と現在のinjection状態を送信
+    handleListSituations(connection);
+    {
+      json history_json = json::array();
+      std::string current;
+      {
+        std::lock_guard<std::mutex> lock(injection_mutex_);
+        current = current_injection_;
+        for (const auto & [n, ts] : injection_history_) {
+          history_json.push_back({{"name", n}, {"timestamp_ms", ts}});
+        }
+      }
+      json state_msg = {
+        {"type", "session_injection_current"}, {"name", current}, {"history", history_json}};
+      connection->sendMessage(state_msg.dump());
+    }
+
     // Message processing loop
     while (connection->isConnected() && running_) {
       std::string message = connection->receiveMessage();
@@ -605,6 +639,17 @@ private:
         handleSimRemoveRobot(connection, request);
       } else if (type == "sim_set_endpoint") {
         handleSimSetEndpoint(connection, request);
+      } else if (type == "list_situations") {
+        handleListSituations(connection);
+      } else if (type == "session_inject") {
+        handleSessionInject(connection, request);
+      } else if (type == "session_clear") {
+        std_msgs::msg::String injection_msg;
+        injection_msg.data = "HALT";
+        session_injection_pub_->publish(injection_msg);
+        RCLCPP_INFO(this->get_logger(), "Session injection cleared (HALT)");
+        json result = {{"type", "session_inject_result"}, {"success", true}, {"name", "HALT"}};
+        connection->sendMessage(result.dump());
       } else {
         json error_response = {{"type", "error"}, {"message", "Unknown request type: " + type}};
         connection->sendMessage(error_response.dump());
@@ -1187,6 +1232,66 @@ private:
     }
   }
 
+  void loadSituationNames()
+  {
+    try {
+      auto share_dir = ament_index_cpp::get_package_share_directory("crane_session_coordinator");
+      std::string config_path = share_dir + "/config/unified_session_config.yaml";
+      YAML::Node config = YAML::LoadFile(config_path);
+      std::lock_guard<std::mutex> lock(injection_mutex_);
+      cached_situation_names_.clear();
+      if (config["situations"]) {
+        for (auto it = config["situations"].begin(); it != config["situations"].end(); ++it) {
+          cached_situation_names_.push_back(it->first.as<std::string>());
+        }
+      }
+      RCLCPP_INFO(
+        this->get_logger(), "Loaded %zu situations from config", cached_situation_names_.size());
+    } catch (const std::exception & e) {
+      RCLCPP_WARN(this->get_logger(), "Failed to load situation names: %s", e.what());
+    }
+  }
+
+  void handleListSituations(std::shared_ptr<WebSocketConnection> connection)
+  {
+    json items = json::array();
+    {
+      std::lock_guard<std::mutex> lock(injection_mutex_);
+      for (const auto & name : cached_situation_names_) {
+        items.push_back(name);
+      }
+    }
+    json response = {{"type", "situations_list"}, {"items", items}};
+    connection->sendMessage(response.dump());
+  }
+
+  void handleSessionInject(std::shared_ptr<WebSocketConnection> connection, const json & request)
+  {
+    std::string name = request.value("name", "HALT");
+    std_msgs::msg::String injection_msg;
+    injection_msg.data = name;
+    session_injection_pub_->publish(injection_msg);
+    RCLCPP_INFO(this->get_logger(), "Session injected: %s", name.c_str());
+    json result = {{"type", "session_inject_result"}, {"success", true}, {"name", name}};
+    connection->sendMessage(result.dump());
+  }
+
+  void broadcastSessionInjectionCurrent()
+  {
+    json history_json = json::array();
+    std::string current;
+    {
+      std::lock_guard<std::mutex> lock(injection_mutex_);
+      current = current_injection_;
+      for (const auto & [n, ts] : injection_history_) {
+        history_json.push_back({{"name", n}, {"timestamp_ms", ts}});
+      }
+    }
+    json msg = {
+      {"type", "session_injection_current"}, {"name", current}, {"history", history_json}};
+    broadcastToAll(msg.dump());
+  }
+
   void handleActivateMoveMode(std::shared_ptr<WebSocketConnection> connection)
   {
     std_msgs::msg::String injection_msg;
@@ -1449,6 +1554,11 @@ private:
   rclcpp::Publisher<crane_msgs::msg::HumanAnnotation>::SharedPtr annotation_pub_;
   rclcpp::Publisher<crane_msgs::msg::RobotCommands>::SharedPtr move_command_pub_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr session_injection_pub_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr session_injection_sub_;
+  std::vector<std::string> cached_situation_names_;
+  std::string current_injection_{"HALT"};
+  std::deque<std::pair<std::string, int64_t>> injection_history_;
+  std::mutex injection_mutex_;
   rclcpp::Publisher<crane_msgs::msg::RobotCommand>::SharedPtr robot_test_target_pub_;
 
   // Cached world model state for move commands

--- a/crane_web_debugger/web/index.html
+++ b/crane_web_debugger/web/index.html
@@ -617,6 +617,35 @@
           </div>
         </details>
 
+        <!-- Session Control -->
+        <div class="m3-section-title">Session Control</div>
+        <details class="m3-expansion" id="session-accordion">
+          <summary>
+            <span class="material-symbols-outlined icon-sm m3-text-primary">flowsheet</span>
+            Session Injection
+          </summary>
+          <div class="m3-expansion__body">
+            <div style="font-size:0.68rem;color:var(--md-sys-color-on-surface-variant);margin-bottom:4px;">
+              Current: <span id="session-current" style="font-weight:600;color:var(--md-sys-color-primary);">-</span>
+            </div>
+            <div style="display:flex;gap:3px;align-items:center;margin-bottom:3px;">
+              <select id="session-select" class="m3-text-input" style="flex:2;font-size:0.68rem;padding:3px 5px;"></select>
+              <button class="m3-btn m3-btn--sm m3-btn--tonal gc-btn" data-action="session-inject-select">Inject</button>
+            </div>
+            <div style="display:flex;gap:3px;align-items:center;margin-bottom:3px;">
+              <input type="text" id="session-custom-input" placeholder="custom name"
+                     class="m3-text-input" style="flex:2;font-size:0.68rem;padding:3px 5px;">
+              <button class="m3-btn m3-btn--sm m3-btn--outlined gc-btn" data-action="session-inject-custom">Send</button>
+            </div>
+            <div class="gc-row">
+              <button class="m3-btn m3-btn--sm m3-btn--filled gc-btn gc-btn--halt"
+                      data-action="session-clear" style="flex:1;">Clear Injection (HALT)</button>
+            </div>
+            <div style="font-size:0.62rem;color:var(--md-sys-color-on-surface-variant);margin-top:4px;">Recent:</div>
+            <ul id="session-history" style="font-size:0.65rem;margin:2px 0 0;padding-left:14px;max-height:64px;overflow-y:auto;list-style:disc;"></ul>
+          </div>
+        </details>
+
       </div>
     </aside>
 

--- a/crane_web_debugger/web/viewer/main.js
+++ b/crane_web_debugger/web/viewer/main.js
@@ -133,6 +133,42 @@ class CraneViewer {
             case 'robot_feedback':     this.handleRobotFeedback(data); break;
             case 'game_info':          this.handleGameInfo(data); break;
             case 'latency_estimation': this.handleLatencyEstimation(data); break;
+            case 'situations_list':          this.handleSituationsList(data); break;
+            case 'session_injection_current': this.handleSessionInjectionCurrent(data); break;
+        }
+    }
+
+    handleSituationsList(data) {
+        const sel = document.getElementById('session-select');
+        if (!sel) return;
+        const current = sel.value;
+        sel.innerHTML = '';
+        for (const name of (data.items || [])) {
+            const opt = document.createElement('option');
+            opt.value = name;
+            opt.textContent = name;
+            if (name === current) opt.selected = true;
+            sel.appendChild(opt);
+        }
+        if (!sel.options.length) {
+            const opt = document.createElement('option');
+            opt.value = '';
+            opt.textContent = 'No situations loaded';
+            sel.appendChild(opt);
+        }
+    }
+
+    handleSessionInjectionCurrent(data) {
+        const currentEl = document.getElementById('session-current');
+        if (currentEl) currentEl.textContent = data.name || '-';
+        const historyEl = document.getElementById('session-history');
+        if (!historyEl) return;
+        historyEl.innerHTML = '';
+        for (const entry of (data.history || [])) {
+            const li = document.createElement('li');
+            const t = new Date(entry.timestamp_ms).toLocaleTimeString();
+            li.textContent = `${t}  ${entry.name}`;
+            historyEl.appendChild(li);
         }
     }
 
@@ -855,6 +891,25 @@ class CraneViewer {
                 case 'sim-set-endpoint':
                     this.applySimEndpoint();
                     this.logPanel?.appendLog('action', 'Sim', 'endpoint updated');
+                    break;
+                case 'session-inject-select': {
+                    const name = document.getElementById('session-select')?.value;
+                    if (!name) break;
+                    this.websocket?.send(JSON.stringify({type: 'session_inject', name}));
+                    this.logPanel?.appendLog('action', 'Session', `inject ${name}`);
+                    break;
+                }
+                case 'session-inject-custom': {
+                    const inp = document.getElementById('session-custom-input');
+                    const name = (inp?.value || '').trim();
+                    if (!name) break;
+                    this.websocket?.send(JSON.stringify({type: 'session_inject', name}));
+                    this.logPanel?.appendLog('action', 'Session', `inject(custom) ${name}`);
+                    break;
+                }
+                case 'session-clear':
+                    this.websocket?.send(JSON.stringify({type: 'session_clear'}));
+                    this.logPanel?.appendLog('action', 'Session', 'clear → HALT');
                     break;
             }
         });


### PR DESCRIPTION
## 概要

Crane Viewerの左ドックにSession Controlパネルを新設し、ROSトピック `/session_injection` を通じて任意のsituation名をインタラクティブに注入できるようにした。

## 背景・根本原因

開発・デバッグ中にセッション（戦術）を手動で切り替えたい場面で、これまでは `ros2 topic pub --once /session_injection std_msgs/String '{data: "..."}'` をターミナルから叩く必要があった。session injectionの受信基盤（`crane_session_coordinator`）とROS publisher（`websocket_server.cpp`）は既に実装済みだったが、Viewer UI側に任意のsituation名を送る手段がなかった。

## 変更内容

### `crane_web_debugger/src/websocket_server.cpp`
- 起動時に `crane_session_coordinator/config/unified_session_config.yaml` をyaml-cppでパース、situation名一覧をキャッシュ
- `/session_injection` トピックを自身でsubscribeし、受信のたびに全WSクライアントへ現在状態・履歴をbroadcast
- WSメッセージ `list_situations` / `session_inject` / `session_clear` の3種を新規対応
- 接続確立時にsituation一覧と現在のinjection状態を即送信

### `crane_web_debugger/web/index.html`
- 左ドックの「Sim Control」の下に「Session Control」アコーディオンを追加

### `crane_web_debugger/web/viewer/main.js`
- `situations_list` / `session_injection_current` のWSメッセージハンドラを追加
- `session-inject-select` / `session-inject-custom` / `session-clear` の3種の`data-action`を追加

### `crane_web_debugger/CMakeLists.txt` / `package.xml`
- yaml-cpp・ament_index_cpp依存を追加

## 動作

- ドロップダウンからYAML定義済みのsituation名（HALT/INPLAY/OUR_FREE_KICK等）を選んでInject
- 自由入力フィールドから任意の名前を送信
- 「Clear Injection (HALT)」でリセット
- 現在のINJECTION値と直近5件の履歴をリアルタイム表示
- 複数ブラウザタブ間でも同期