### PR TITLE
fix(crane_web_debugger): viewerのロボット選択と描画の不一致を修正

### DIFF
--- a/crane_web_debugger/web/viewer/main.js
+++ b/crane_web_debugger/web/viewer/main.js
@@ -568,6 +568,7 @@ class CraneViewer {
         let closest = null;
         let minDist = ROBOT_HIT_RADIUS_M * 2; // ホバー検出半径は選択より広め
         for (const [id, robot] of Object.entries(this.robotsOurs)) {
+            if (!robot.available_vision && !robot.available_tracker) continue;
             const d = Math.hypot(robot.x - fieldX, robot.y - fieldY);
             if (d < minDist) { minDist = d; closest = Number(id); }
         }
@@ -652,6 +653,9 @@ class CraneViewer {
     _nearestRobot(robotMap, fieldX, fieldY) {
         let id = null, dist = ROBOT_HIT_RADIUS_M;
         for (const [k, r] of Object.entries(robotMap)) {
+            // availability フラグがない（相手チーム等）場合はフィルタしない
+            const hasFlags = r.available_vision !== undefined || r.available_tracker !== undefined;
+            if (hasFlags && !r.available_vision && !r.available_tracker) continue;
             const d = Math.hypot(r.x - fieldX, r.y - fieldY);
             if (d < dist) { dist = d; id = Number(k); }
         }

--- a/crane_web_debugger/web/viewer/renderer/RobotHud.js
+++ b/crane_web_debugger/web/viewer/renderer/RobotHud.js
@@ -38,6 +38,7 @@ export class RobotHud {
         const zoom = viewer.zoomLevel ?? 1.0;
 
         for (const [idStr, robot] of Object.entries(viewer.robotsOurs)) {
+            if (!robot.available_vision && !robot.available_tracker) continue;
             const id = Number(idStr);
             const cx = robot.x * 1000;
             const cy = -robot.y * 1000;


### PR DESCRIPTION
## 概要

crane viewer でクリック選択が画面上の表示と一致しない不具合を修正します。

## 背景・根本原因

- **描画側**: `visualization_manager.cpp` の SVG レイヤーは、`vision_detection_stamp` が直近 1 秒以内のロボット（= 現在 vision に映っているもの）のみを描画します。
- **選択側**: クライアント (`main.js`) は WebSocket で受け取った `robots_ours` を **全件** ヒットテスト対象にしており、`available_vision` / `available_tracker` フラグを無視していました。

その結果、vision を失って画面から消えたロボットの「古い座標」が当たり判定に残留し、そこへのクリックを横取りしていました。逆に、その近くにいる可視ロボットは距離計算で負けて選択できなくなっていました。

PR #1347 で robot cards が廃止されキャンバス空間ヒットテストに一本化されたことで、この問題が顕在化しました。

## 変更内容

- `main.js (_nearestRobot)`: `available_vision` と `available_tracker` が両方 `false` のロボットをスキップ（相手チームはフラグ未設定のため従来通り全件対象）
- `main.js (_updateHover)`: 同条件でホバー・ツールチップ対象から除外
- `RobotHud.js (draw)`: 同条件で halo / arrow / LED / FSM / warning badge の描画をスキップ（幽霊ロボットへの HUD 描画を抑制）