### PR TITLE
fix(crane_web_debugger): robot_testで存在しないロボットが表示される問題を修正

### DIFF
--- a/crane_web_debugger/web/robot_test.js
+++ b/crane_web_debugger/web/robot_test.js
@@ -167,15 +167,16 @@ class FieldRenderer {
 
         // 味方ロボット描画
         for (const [id, robot] of Object.entries(c.robotsOurs)) {
+            if (!robot.available_vision && !robot.available_tracker) continue;
             const color = c.isYellow ? '#FFD700' : '#4488FF';
             this._drawRobot(ctx, robot, Number(id), color, c.selectedRobotId);
         }
 
         // 選択ハイライト（破線円）
-        if (c.selectedRobotId !== null && c.robotsOurs[c.selectedRobotId]) {
-            const robot = c.robotsOurs[c.selectedRobotId];
-            const svgX = robot.x * 1000;
-            const svgY = -robot.y * 1000;
+        const selRobot = c.selectedRobotId !== null ? c.robotsOurs[c.selectedRobotId] : null;
+        if (selRobot && (selRobot.available_vision || selRobot.available_tracker)) {
+            const svgX = selRobot.x * 1000;
+            const svgY = -selRobot.y * 1000;
             ctx.save();
             ctx.strokeStyle = '#00ffff';
             ctx.lineWidth = 20;
@@ -621,6 +622,7 @@ class RobotTestController {
         let closest = null;
         let minDist = ROBOT_HIT_RADIUS_M;
         for (const [id, robot] of Object.entries(this.robotsOurs)) {
+            if (!robot.available_vision && !robot.available_tracker) continue;
             const dx = robot.x - fieldX;
             const dy = robot.y - fieldY;
             const dist = Math.sqrt(dx * dx + dy * dy);


### PR DESCRIPTION
## 概要

Robot Test ページでフィールド上に存在しない（Vision/Tracker 未検出の）味方ロボットが描画・選択できてしまう問題を修正する。

## 背景・根本原因

`crane_world_model_publisher` は `robot_info_ours` を常に `MAX_ROBOT_COUNT`（=16）スロット分発行しており、検出状態は各スロットの `available_vision`/`available_tracker` フラグで示される。しかし `robot_test.js` はこのフラグを参照せず全スロットを描画・ヒットテスト対象としていたため、未検出ロボットが画面に出現していた。

viewer（`viewer/main.js:571`）では既に同フィルタが実装済みで、`robot_test.js` 内の `_updateHover()` も実装済みだが、描画ループとクリック選択のみが抜けていた。

## 変更内容

- 味方ロボットの描画ループに `available_vision || available_tracker` フィルタを追加
- 選択ハイライト（破線円）の描画条件を検出済みロボットのみに変更
- `findRobotAtPosition()` のヒットテストに同フィルタを追加

変更は `crane_web_debugger/web/robot_test.js` のみ（JS のみ、C++ ビルド不要）。