### PR TITLE
fix: HALT時にキーパーがペナルティエリア回避で動く問題を修正

### DIFF
--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -385,6 +385,9 @@ auto RVO2Planner::applyPenaltyAreaBrakingConstraint(
   PreprocessContext & ctx, const Box & area, const crane_msgs::msg::RobotCommand & command) const
   -> void
 {
+  if (world_model->getMsg().play_situation.command.value == crane_msgs::msg::PlaySituation::HALT) {
+    return;
+  }
   const double penalty_area_offset =
     needsExpandedPenaltyAreaOffset(world_model->getMsg().play_situation.command.value)
       ? PENALTY_AREA_OFFSET_STOP
@@ -753,7 +756,9 @@ auto RVO2Planner::adjustForFieldBoundary(
 auto RVO2Planner::adjustForPenaltyAreaAvoidance(
   Point & target_pos, const Point & current_pos, crane_msgs::msg::RobotCommand & command) -> void
 {
-  if (not command.local_planner_config.disable_goal_area_avoidance) {
+  if (
+    not command.local_planner_config.disable_goal_area_avoidance &&
+    world_model->getMsg().play_situation.command.value != crane_msgs::msg::PlaySituation::HALT) {
     const double penalty_area_offset =
       needsExpandedPenaltyAreaOffset(world_model->getMsg().play_situation.command.value)
         ? PENALTY_AREA_OFFSET_STOP

--- a/crane_sessions/src/waiter_session.cpp
+++ b/crane_sessions/src/waiter_session.cpp
@@ -16,6 +16,8 @@ WaiterSession::calculatePositionCommand(const std::vector<RobotIdentifier> & rob
     auto command =
       std::make_shared<crane::PositionCommandWrapper>("waiter_planner", robot_id.id, world_model);
     command->stopHere();
+    command->disableAnyAreaAvoidance();
+    command->disableCollisionAvoidance();
     robot_commands.emplace_back(command->getMsg());
   }
   return {SessionBase::Status::RUNNING, robot_commands};


### PR DESCRIPTION
## 概要

HALTレフェリーコマンド中に、キーパーが自陣ペナルティエリア外へ向かって動いてしまう問題を修正する。

## 背景・根本原因

2026-04-05のリファクタ（ea9b4262）でRVO前段処理をパイプライン化した際、`overrideTargetPosition` に存在していたHALTガードが機能しなくなりデッドコード化した。

その結果、以下の処理がHALT時にも走り続けていた：

- **`adjustForPenaltyAreaAvoidance`**: `stopHere()` で `target == current` でも「ゴールから5cm離す方向」を初期目標として脱出ループを起動する
- **`applyPenaltyAreaBrakingConstraint`**: PA内のロボットに 0.5 m/s の脱出速度を加算する

また、HALT時は `goalie_skill` セッションが起動しないため、`goalie.cpp` 内で `disableGoalAreaAvoidance()` を呼ぶ経路も通らなかった。

## 変更内容

二重防御で対処：

- **`crane_sessions/src/waiter_session.cpp`（一次防御）**: `stopHere()` に加えて `disableAnyAreaAvoidance()` / `disableCollisionAvoidance()` を呼び出し、LocalPlannerConfig レベルで全回避を無効化する
- **`crane_local_planner/src/rvo2_planner.cpp`（二次防御・根本修正）**:
  - `adjustForPenaltyAreaAvoidance`: 条件に `play_situation != HALT` を追加
  - `applyPenaltyAreaBrakingConstraint`: 冒頭に HALT 早期リターンを追加（将来 HALT に別セッションが追加された場合の保険にもなる）