### PR TITLE
feat: 開発環境のautorefをER-Force版に切り替え

### DIFF
--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -129,7 +129,7 @@ services:
       - --vision-port
       - "${VISION_PORT:-10020}"
       - --tracker-port
-      - "${TRACKER_PORT:-11010}"
+      - "11010"
       - --gc-port
       - "${REFEREE_PORT:-11003}"
     network_mode: host

--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -123,18 +123,29 @@ services:
       - sim-erforce
       - sim-grsim
 
-  autoref-tigers:
-    image: tigersmannheim/auto-referee:1.2.0
+  autoref-erforce:
+    image: roboticserlangen/autoref:2025.1.0
     command:
-      - --active # active mode (connect to GC)
-      - --headless
-      - --visionAddress
-      - 224.5.23.2:${VISION_PORT:-10020}
-      - --refereeAddress
-      - 224.5.23.1:11003
-      - --trackerAddress
-      - 224.5.23.2:11010
+      - --vision-port
+      - "${VISION_PORT:-10020}"
+      - --tracker-port
+      - "${TRACKER_PORT:-11010}"
+      - --gc-port
+      - "${REFEREE_PORT:-11003}"
     network_mode: host
+
+  # autoref-tigers:
+  #   image: tigersmannheim/auto-referee:1.2.0
+  #   command:
+  #     - --active # active mode (connect to GC)
+  #     - --headless
+  #     - --visionAddress
+  #     - 224.5.23.2:${VISION_PORT:-10020}
+  #     - --refereeAddress
+  #     - 224.5.23.1:11003
+  #     - --trackerAddress
+  #     - 224.5.23.2:11010
+  #   network_mode: host
 
   ssl-log-recorder:
     image: robocupssl/ssl-log-recorder:latest


### PR DESCRIPTION
## 概要
`docker/dev/docker-compose.yaml` の AutoRef を Tigers 版から ER-Force 版に切り替えます。Tigers 版はコメントアウトで残し、必要に応じて戻せるようにしています。

## 背景・根本原因
Japan Open の運営環境（`japanopen_setup`）では `roboticserlangen/autoref:2025.1.0` を採用しています。開発・シミュレーション環境でも同じ AutoRef を使うことで、試合前に AutoRef の挙動差による想定外のペナルティ判定を事前確認できるようにします。

## 変更内容
- `autoref-tigers`（`tigersmannheim/auto-referee:1.2.0`）をコメントアウト
- `autoref-erforce`（`roboticserlangen/autoref:2025.1.0`）を追加
- Vision ポートは `${VISION_PORT:-10020}`、Referee ポートは `${REFEREE_PORT:-11003}` で環境変数参照に統一
- Tracker ポートは `11010` に固定（大会運営側 Tracker との切り分けのため、実機モードでも `TRACKER_PORT=10010` に上書きされないよう固定値を使用）