### PR TITLE
feat(crane_local_planner): update_rate_hz<=0でコールバック駆動モードを追加

### DIFF
--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -146,7 +146,7 @@ limitations under the License.
       <param name="max_vel" value="$(var max_vel)"/>
       <param name="planning_deceleration" value="$(var planning_deceleration)"/>
       <param name="planning_acceleration" value="$(var planning_acceleration)"/>
-      <param name="update_rate_hz" value="120.0"/>
+      <param name="update_rate_hz" value="0.0"/>
       <param name="straight_kick_power_array" value="[0.0, 0.3, 0.6, 1.0]"/>
       <param name="straight_kick_speed_array" value="[0.0, 2.0, 4.0, 7.5]"/>
       <param name="chip_kick_power_array" value="[0.0, 0.5, 0.8]"/>

--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -133,7 +133,7 @@ limitations under the License.
       <param name="planning_acceleration" value="$(var planning_acceleration)"/>
       <param name="rvo_radius" value="0.15"/>
       <param name="velocity_damping_gain" value="0.0"/>
-      <param name="update_rate_hz" value="120.0"/>
+      <param name="update_rate_hz" value="0.0"/>
       <!-- KickerModel統合：YAML設定ファイルから読み込み -->
       <param name="kicker_physics_config" value="$(find-pkg-share crane_world_model_publisher)/config/kicker_physics.yaml"/>
     </node>

--- a/crane_local_planner/include/crane_local_planner/local_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/local_planner.hpp
@@ -82,8 +82,7 @@ public:
     const bool callback_driven = update_rate_hz <= 0.0;
 
     control_targets_sub = this->create_subscription<crane_msgs::msg::RobotCommands>(
-      "/control_targets", 10,
-      [this, callback_driven](const crane_msgs::msg::RobotCommands & msg) {
+      "/control_targets", 10, [this, callback_driven](const crane_msgs::msg::RobotCommands & msg) {
         latest_commands_ = msg;
         if (callback_driven) {
           processLatestCommands();

--- a/crane_local_planner/include/crane_local_planner/local_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/local_planner.hpp
@@ -77,15 +77,30 @@ public:
       theta_offset = 0.;
     }
 
-    control_targets_sub = this->create_subscription<crane_msgs::msg::RobotCommands>(
-      "/control_targets", 10,
-      [this](const crane_msgs::msg::RobotCommands & msg) { latest_commands_ = msg; });
-
     declare_parameter("update_rate_hz", 60.0);
     const auto update_rate_hz = get_parameter("update_rate_hz").as_double();
-    update_timer_ = create_wall_timer(
-      std::chrono::microseconds(static_cast<int64_t>(1e6 / update_rate_hz)),
-      [this]() { processLatestCommands(); });
+    const bool callback_driven = update_rate_hz <= 0.0;
+
+    control_targets_sub = this->create_subscription<crane_msgs::msg::RobotCommands>(
+      "/control_targets", 10,
+      [this, callback_driven](const crane_msgs::msg::RobotCommands & msg) {
+        latest_commands_ = msg;
+        if (callback_driven) {
+          processLatestCommands();
+        }
+      });
+
+    if (callback_driven) {
+      RCLCPP_INFO(
+        get_logger(),
+        "update_rate_hz=%.3f (<=0): timer disabled, driving processLatestCommands() from "
+        "/control_targets callback.",
+        update_rate_hz);
+    } else {
+      update_timer_ = create_wall_timer(
+        std::chrono::microseconds(static_cast<int64_t>(1e6 / update_rate_hz)),
+        [this]() { processLatestCommands(); });
+    }
   }
 
   auto processLatestCommands() -> void;


### PR DESCRIPTION
## 概要

`crane_local_planner` の `update_rate_hz` パラメータが 0 以下のとき、タイマーではなく上流コマンド `/control_targets` の受信コールバックで `processLatestCommands()` を駆動するモードを追加します。

## 背景・根本原因

- 上流の発行レートとタイマーレートがずれると同一メッセージの多重処理や取りこぼしが発生していた
- `update_rate_hz = 0` のときゼロ除算で未定義動作になるバグがあった

## 変更内容

- `local_planner.hpp`: `update_rate_hz <= 0.0` のときタイマーを生成せず、`/control_targets` 受信コールバック内で直接 `processLatestCommands()` を呼ぶよう分岐を追加。正値の場合は従来通りタイマー駆動。
- `crane.launch.xml`: シミュレータ・実機両方の `update_rate_hz` を `0.0` に変更し、デフォルトをコールバック駆動に設定。