### PR TITLE
fix(world_model_publisher): Tracker欠落時の短期LOST判定を抑制

### DIFF
--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -60,7 +60,7 @@ limitations under the License.
   <!-- ============================================================ -->
   <!-- ロボット性能パラメータ -->
   <!-- ============================================================ -->
-  <arg name="max_vel" default="8.0" description="ロボットの最大速度 [m/s]"/>
+  <arg name="max_vel" default="4.0" description="ロボットの最大速度 [m/s]"/>
 
   <!-- Slack時間計算パラメータ -->
   <arg name="slack.robot_max_acceleration" default="2.5" description="slack時間計算に用いるロボットの最大加速度 [m/s^2]"/>
@@ -81,7 +81,7 @@ limitations under the License.
   <arg name="robot_acceleration.velocity_threshold" default="1.0" description="高速域・低速域のしきい値 [m/s]"/>
 
   <!-- 経路計画用の減速度パラメータ（実行側の90%以下に設定して計画と実行の不一致によるオーバーシュートを防止） -->
-  <arg name="planning_deceleration" default="1.5" description="減速計算用の減速度 [m/s^2]"/>
+  <arg name="planning_deceleration" default="1.0" description="減速計算用の減速度 [m/s^2]"/>
   <!-- 経路計画用の加速度パラメータ（加速フェーズ専用、減速度より高い値を設定可能） -->
   <arg name="planning_acceleration" default="3.0" description="加速フェーズの計画用加速度 [m/s^2]"/>
 

--- a/crane_bringup/launch/crane.launch.xml
+++ b/crane_bringup/launch/crane.launch.xml
@@ -47,7 +47,7 @@ limitations under the License.
   <!-- sim=falseの場合（公式ポート） -->
   <let name="vision_port_final" value="10006" if="$(eval &quot;'$(var vision_port)' == '' and '$(var sim)' == 'false'&quot;)"/>
   <let name="referee_port_final" value="10003" if="$(eval &quot;'$(var referee_port)' == '' and '$(var sim)' == 'false'&quot;)"/>
-  <let name="tracker_port_final" value="10010" if="$(eval &quot;'$(var tracker_port)' == '' and '$(var sim)' == 'false'&quot;)"/>
+  <let name="tracker_port_final" value="11010" if="$(eval &quot;'$(var tracker_port)' == '' and '$(var sim)' == 'false'&quot;)"/>
 
   <!-- ユーザー指定がある場合はそれを使用 -->
   <let name="vision_port_final" value="$(var vision_port)" unless="$(eval &quot;'$(var vision_port)' == ''&quot;)"/>

--- a/crane_robot_skills/include/crane_robot_skills/attacker.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/attacker.hpp
@@ -11,7 +11,7 @@
 #include <crane_geometry/boost_geometry.hpp>
 #include <crane_geometry/interval.hpp>
 #include <crane_robot_skills/goal_kick.hpp>
-#include <crane_robot_skills/kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/receive.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
@@ -64,7 +64,7 @@ public:
 
   int forced_pass_receiver_id = -1;
 
-  Kick kick_skill;
+  KickOld kick_skill;
 
   GoalKick goal_kick_skill;
 
@@ -74,7 +74,7 @@ protected:
   void onPostUpdate() override;
 
 private:
-  void configurePassKick(const Point & target, Kick & kick_skill);
+  void configurePassKick(const Point & target, KickOld & kick_skill);
 
   // KICK状態の進捗タイムアウト用
   std::chrono::steady_clock::time_point kick_state_entry_time{};

--- a/crane_robot_skills/include/crane_robot_skills/goal_kick.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/goal_kick.hpp
@@ -8,7 +8,7 @@
 #define CRANE_ROBOT_SKILLS__GOAL_KICK_HPP_
 
 #include <crane_geometry/vector2d_adapter.hpp>
-#include <crane_robot_skills/kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
 
@@ -26,7 +26,7 @@ public:
 
   Status update() override;
 
-  Kick kick_skill;
+  KickOld kick_skill;
 
   static double getBestAngleToShootFromPoint(
     double minimum_angle_accuracy, const Point from_point,

--- a/crane_robot_skills/include/crane_robot_skills/goalie.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/goalie.hpp
@@ -9,7 +9,7 @@
 
 #include <chrono>
 #include <crane_geometry/vector2d_adapter.hpp>
-#include <crane_robot_skills/kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
 #include <string>
@@ -35,7 +35,7 @@ public:
 
   std::string phase;
 
-  Kick kick_skill;
+  KickOld kick_skill;
 
   std::optional<Point> prev_wait_point;
 

--- a/crane_robot_skills/include/crane_robot_skills/kick_old.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/kick_old.hpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_ROBOT_SKILLS__KICK_OLD_HPP_
+#define CRANE_ROBOT_SKILLS__KICK_OLD_HPP_
+
+#include <crane_geometry/vector2d_adapter.hpp>
+#include <crane_robot_skills/receive.hpp>
+#include <crane_robot_skills/skill_base.hpp>
+#include <memory>
+
+namespace crane::skills
+{
+// 983f026a（2025-09-14）以前の回り込みアルゴリズム（move_direction ベース 2 フェーズ）
+enum class KickOldState {
+  ENTRY_POINT,
+  AROUND_BALL_AND_KICK,
+  REDIRECT_KICK,
+  POSITIVE_REDIRECT_KICK,
+};
+
+class KickOld : public SkillBaseWithState
+{
+private:
+  static std::string getStateName(int s);
+
+  Receive receive_skill;
+
+public:
+  template <typename... Args>
+  explicit KickOld(Args &&... args)
+  : SkillBaseWithState(
+      static_cast<int>(KickOldState::ENTRY_POINT), &KickOld::getStateName, "kick_old",
+      std::forward<Args>(args)...),
+    receive_skill(command)
+  {
+    initialize();
+  }
+
+  auto getBallExitPointFromField(const double offset = 0.3) -> Point;
+
+private:
+  void initialize();
+
+  void kickWithChip();
+
+  void kickStraight();
+};
+}  // namespace crane::skills
+#endif  // CRANE_ROBOT_SKILLS__KICK_OLD_HPP_

--- a/crane_robot_skills/include/crane_robot_skills/kick_old.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/kick_old.hpp
@@ -8,7 +8,6 @@
 #define CRANE_ROBOT_SKILLS__KICK_OLD_HPP_
 
 #include <crane_geometry/vector2d_adapter.hpp>
-#include <crane_robot_skills/receive.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
 
@@ -18,8 +17,6 @@ namespace crane::skills
 enum class KickOldState {
   ENTRY_POINT,
   AROUND_BALL_AND_KICK,
-  REDIRECT_KICK,
-  POSITIVE_REDIRECT_KICK,
 };
 
 class KickOld : public SkillBaseWithState
@@ -27,15 +24,12 @@ class KickOld : public SkillBaseWithState
 private:
   static std::string getStateName(int s);
 
-  Receive receive_skill;
-
 public:
   template <typename... Args>
   explicit KickOld(Args &&... args)
   : SkillBaseWithState(
       static_cast<int>(KickOldState::ENTRY_POINT), &KickOld::getStateName, "kick_old",
-      std::forward<Args>(args)...),
-    receive_skill(command)
+      std::forward<Args>(args)...)
   {
     initialize();
   }

--- a/crane_robot_skills/include/crane_robot_skills/penalty_kick.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/penalty_kick.hpp
@@ -9,7 +9,7 @@
 
 #include <crane_geometry/interval.hpp>
 #include <crane_geometry/vector2d_adapter.hpp>
-#include <crane_robot_skills/kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
 #include <utility>
@@ -45,7 +45,7 @@ public:
     return static_cast<PenaltyKickState>(SkillBaseWithState::getCurrentState());
   }
 
-  Kick kick_skill;
+  KickOld kick_skill;
 
   std::optional<Point> start_ball_point = std::nullopt;
 };

--- a/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
@@ -9,8 +9,8 @@
 
 #include <algorithm>
 #include <crane_geometry/vector2d_adapter.hpp>
-#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/goal_kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
 #include <utility>
@@ -22,7 +22,9 @@ class SimpleKickOff : public SkillBase
 public:
   template <typename... Args>
   explicit SimpleKickOff(Args &&... args)
-  : SkillBase("simple_kickoff", std::forward<Args>(args)...), goal_kick_skill(command)
+  : SkillBase("simple_kickoff", std::forward<Args>(args)...),
+    kick_skill(command),
+    goal_kick_skill(command)
   {
   }
 

--- a/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
@@ -7,6 +7,9 @@
 #ifndef CRANE_ROBOT_SKILLS__SIMPLE_KICKOFF_HPP_
 #define CRANE_ROBOT_SKILLS__SIMPLE_KICKOFF_HPP_
 
+#include <algorithm>
+#include <crane_geometry/vector2d_adapter.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/goal_kick.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
@@ -25,6 +28,7 @@ public:
 
   Status update() override;
 
+  KickOld kick_skill;
   GoalKick goal_kick_skill;
 
 private:

--- a/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
@@ -7,15 +7,10 @@
 #ifndef CRANE_ROBOT_SKILLS__SIMPLE_KICKOFF_HPP_
 #define CRANE_ROBOT_SKILLS__SIMPLE_KICKOFF_HPP_
 
-#include <algorithm>
-#include <crane_geometry/vector2d_adapter.hpp>
-#include <crane_robot_skills/kick_old.hpp>
+#include <crane_robot_skills/goal_kick.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
-#include <string>
-#include <unordered_map>
 #include <utility>
-#include <vector>
 
 namespace crane::skills
 {
@@ -24,16 +19,13 @@ class SimpleKickOff : public SkillBase
 public:
   template <typename... Args>
   explicit SimpleKickOff(Args &&... args)
-  : SkillBase("simple_kickoff", std::forward<Args>(args)...), kick_skill(command)
+  : SkillBase("simple_kickoff", std::forward<Args>(args)...), goal_kick_skill(command)
   {
-    initializeParameters();
   }
-
-  void initializeParameters();
 
   Status update() override;
 
-  KickOld kick_skill;
+  GoalKick goal_kick_skill;
 
 private:
   bool kicked = false;

--- a/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
@@ -9,7 +9,7 @@
 
 #include <algorithm>
 #include <crane_geometry/vector2d_adapter.hpp>
-#include <crane_robot_skills/kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
 #include <string>
@@ -33,7 +33,7 @@ public:
 
   Status update() override;
 
-  Kick kick_skill;
+  KickOld kick_skill;
 
 private:
   bool kicked = false;

--- a/crane_robot_skills/include/crane_robot_skills/skills.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/skills.hpp
@@ -19,6 +19,7 @@
 #include <crane_robot_skills/goalie.hpp>
 #include <crane_robot_skills/idle.hpp>
 #include <crane_robot_skills/kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/marker.hpp>
 #include <crane_robot_skills/receive.hpp>
 #include <crane_robot_skills/second_threat_defender.hpp>

--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -314,16 +314,14 @@ void Attacker::initialize()
       goal_kick_skill.setParameter("target_kick_speed", 6.0);
       goal_kick_skill.setParameter("dribble_power", 0.2);
       return goal_kick_skill.run();
-    }
-    // else if (pass_receiver_id.has_value()) {
-    //   // STANDARD_PASS
-    //   printTextOnRobot("KICK::STANDARD_PASS");
-    //   kick_target = world_model()->getOurRobot(pass_receiver_id.value())->pose.pos;
-    //   kick_skill.setParameter("target", kick_target);
-    //   configurePassKick(kick_target, kick_skill);
-    //   return kick_skill.run();
-    // }
-    else if (goal_angle_width > LOW_CHANCE_GOAL_ANGLE_THRESHOLD_DEG * M_PI / 180.0) {
+    } else if (pass_receiver_id.has_value()) {
+      // STANDARD_PASS
+      printTextOnRobot("KICK::STANDARD_PASS");
+      kick_target = world_model()->getOurRobot(pass_receiver_id.value())->pose.pos;
+      kick_skill.setParameter("target", kick_target);
+      configurePassKick(kick_target, kick_skill);
+      return kick_skill.run();
+    } else if (goal_angle_width > LOW_CHANCE_GOAL_ANGLE_THRESHOLD_DEG * M_PI / 180.0) {
       // LOW_CHANCE_GOAL_KICK
       printTextOnRobot("KICK::LOW_CHANCE_GOAL_KICK");
       return goal_kick_skill.run();

--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -314,14 +314,16 @@ void Attacker::initialize()
       goal_kick_skill.setParameter("target_kick_speed", 6.0);
       goal_kick_skill.setParameter("dribble_power", 0.2);
       return goal_kick_skill.run();
-    } else if (pass_receiver_id.has_value()) {
-      // STANDARD_PASS
-      printTextOnRobot("KICK::STANDARD_PASS");
-      kick_target = world_model()->getOurRobot(pass_receiver_id.value())->pose.pos;
-      kick_skill.setParameter("target", kick_target);
-      configurePassKick(kick_target, kick_skill);
-      return kick_skill.run();
-    } else if (goal_angle_width > LOW_CHANCE_GOAL_ANGLE_THRESHOLD_DEG * M_PI / 180.0) {
+    }
+    // else if (pass_receiver_id.has_value()) {
+    //   // STANDARD_PASS
+    //   printTextOnRobot("KICK::STANDARD_PASS");
+    //   kick_target = world_model()->getOurRobot(pass_receiver_id.value())->pose.pos;
+    //   kick_skill.setParameter("target", kick_target);
+    //   configurePassKick(kick_target, kick_skill);
+    //   return kick_skill.run();
+    // }
+    else if (goal_angle_width > LOW_CHANCE_GOAL_ANGLE_THRESHOLD_DEG * M_PI / 180.0) {
       // LOW_CHANCE_GOAL_KICK
       printTextOnRobot("KICK::LOW_CHANCE_GOAL_KICK");
       return goal_kick_skill.run();

--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -358,7 +358,7 @@ void Attacker::onPostUpdate()
   }
 }
 
-void Attacker::configurePassKick(const Point & target, Kick & kick_skill)
+void Attacker::configurePassKick(const Point & target, KickOld & kick_skill)
 {
   auto pass_analysis = getPassAnalysis(
     world_model()->ball().pos, target, world_model()->theirs().robotsWhere().available().get());

--- a/crane_robot_skills/src/kick.cpp
+++ b/crane_robot_skills/src/kick.cpp
@@ -107,7 +107,7 @@ void Kick::initialize()
       // 角度が合っている場合のみキックゾーンに入ったと判断し、ボールに向かって押し込む
       if (angle_ok && bg::distance(ball_kick_zone, robot()->pose.pos) < 0.15) {
         command->disableCollisionAvoidance();
-        return 0.5;
+        return 0.3;
       } else {
         return 0.0;
       }

--- a/crane_robot_skills/src/kick_old.cpp
+++ b/crane_robot_skills/src/kick_old.cpp
@@ -1,0 +1,272 @@
+// Copyright (c) 2024 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <crane_robot_skills/kick_old.hpp>
+#include <magic_enum/magic_enum.hpp>
+
+#include "../include/crane_robot_skills/single_ball_placement.hpp"
+
+namespace crane::skills
+{
+std::string KickOld::getStateName(int s)
+{
+  return std::string(magic_enum::enum_name(static_cast<KickOldState>(s)));
+}
+
+void KickOld::initialize()
+{
+  using S = KickOldState;
+  auto s = [](S state) { return static_cast<int>(state); };
+
+  command->usePositionMode();
+  setParameter("target", Point(0, 0));
+  setParameter("kick_power", 0.7f);
+  setParameter("use_target_kick_speed", false);
+  setParameter("target_kick_speed", 2.0);
+  setParameter("use_target_chip_distance", false);
+  setParameter("target_chip_distance", 2.0);
+  setParameter("chip_kick", false);
+  setParameter("with_dribble", false);
+  setParameter("dribble_power", 0.3f);
+  setParameter("angle_threshold_deg", 15.0f);
+  setParameter("around_interval", 0.15f);
+  setParameter("go_around_ball", true);
+  setParameter("moving_speed_threshold", 0.2);
+  setParameter("kicked_speed_threshold", 1.5);
+
+  receive_skill.setParameter("dribble_power", 0.3);
+  receive_skill.setParameter("enable_software_bumper", false);
+  receive_skill.setParameter("policy", std::string("min_slack"));
+  receive_skill.setParameter("enable_active_receive", true);
+  receive_skill.setParameter("enable_redirect", true);
+  receive_skill.setParameter("redirect_target", Point(0, 0));
+  receive_skill.setParameter("redirect_kick_power", 0.3);
+
+  addStateFunction(s(S::ENTRY_POINT), [this]() {
+    visualizer->text()
+      .position(robot()->pose.pos.x() - 0.5, robot()->pose.pos.y() + 0.5)
+      .text("KickOld::ENTRY_POINT")
+      .fill("white")
+      .fontSize(100)
+      .build();
+    return Status::RUNNING;
+  });
+
+  addTransition(s(S::ENTRY_POINT), s(S::AROUND_BALL_AND_KICK), [this]() { return true; });
+
+  addStateFunction(s(S::POSITIVE_REDIRECT_KICK), [this]() {
+    visualizer->text()
+      .position(robot()->pose.pos.x() - 0.5, robot()->pose.pos.y() + 0.5)
+      .text("KickOld::POSITIVE_REDIRECT_KICK")
+      .fill("white")
+      .fontSize(100)
+      .build();
+    const auto & ball_pos = world_model()->ball().pos;
+    command->lookAtFrom(getParameter<Point>("target"), ball_pos);
+
+    const auto & ball_vel_normed = world_model()->ball().vel.normalized();
+    Segment ball_line = world_model()->ball().getTrajectorySegmentByDistance(10.);
+    auto [distance, closest_point] = getClosestPointAndDistance(ball_pos, ball_line);
+    if ((ball_pos - closest_point).dot(ball_vel_normed) > 0) {
+      auto target_pos = [&]() -> Point {
+        if (distance < 0.1) {
+          return ball_pos + ball_vel_normed;
+        } else {
+          return closest_point + ball_vel_normed * distance;
+        }
+      }();
+      command->setDribblerTargetPosition(target_pos);
+      command->kickStraight(0.3);
+      command->disableBallAvoidance();
+    } else {
+      command->setTargetPosition(
+        closest_point + (robot()->pose.pos - closest_point).normalized() * 0.3);
+    }
+
+    return Status::RUNNING;
+  });
+
+  addTransition(s(S::POSITIVE_REDIRECT_KICK), s(S::ENTRY_POINT), [this]() {
+    return !world_model()->ball().isMovingAwayFrom(robot()->pose.pos, 10.0) ||
+           !world_model()->ball().isMovingTowards(getParameter<Point>("target"), 30.0);
+  });
+
+  addStateFunction(s(S::REDIRECT_KICK), [this]() {
+    visualizer->text()
+      .position(robot()->pose.pos.x() - 0.5, robot()->pose.pos.y() + 0.5)
+      .text("KickOld::REDIRECT_KICK")
+      .fill("white")
+      .fontSize(100)
+      .build();
+    receive_skill.setParameter("target", getParameter<Point>("target"));
+    if (robot()->getDistance(world_model()->ball().pos) < 0.5) {
+      receive_skill.setParameter("policy", std::string("closest"));
+    } else {
+      receive_skill.setParameter("policy", std::string("min_slack"));
+    }
+    command->disableBallAvoidance();
+    return receive_skill.update();
+  });
+
+  addTransition(s(S::REDIRECT_KICK), s(S::AROUND_BALL_AND_KICK), [this]() {
+    return !world_model()->ball().isMoving(getParameter<double>("moving_speed_threshold"));
+  });
+
+  addTransition(s(S::REDIRECT_KICK), s(S::ENTRY_POINT), [this]() {
+    return world_model()->ball().isMoving(getParameter<double>("kicked_speed_threshold")) &&
+           world_model()->ball().isMovingAwayFrom(robot()->pose.pos, 30.);
+  });
+
+  addStateFunction(s(S::AROUND_BALL_AND_KICK), [this]() {
+    auto target = getParameter<Point>("target");
+    Point ball_pos = world_model()->ball().pos;
+    visualizer->line()
+      .start(ball_pos)
+      .end(ball_pos + (target - ball_pos).normalized() * 1.0)
+      .stroke("blue")
+      .strokeWidth(10)
+      .build();
+
+    constexpr double SWITCH_DISTANCE = 0.5;
+    visualizer->circle()
+      .center(ball_pos)
+      .radius(SWITCH_DISTANCE)
+      .stroke("yellow")
+      .strokeWidth(10)
+      .build();
+
+    if (robot()->getDistance(ball_pos) > SWITCH_DISTANCE) {
+      visualizer->text()
+        .position(robot()->pose.pos.x() - 0.5, robot()->pose.pos.y() + 0.5)
+        .text("KickOld::AROUND_BALL(遠い)")
+        .fill("white")
+        .fontSize(100)
+        .build();
+      // 遠距離フェーズ: ボール後方の固定点へ向かいつつ角度を合わせる
+      command->setTargetPosition(ball_pos + (ball_pos - target).normalized() * 0.3)
+        .lookAtFrom(target, ball_pos);
+      return Status::RUNNING;
+    } else {
+      visualizer->text()
+        .position(robot()->pose.pos.x() - 0.5, robot()->pose.pos.y() + 0.5)
+        .text("KickOld::AROUND_BALL（近い）")
+        .fill("white")
+        .fontSize(100)
+        .build();
+
+      // 近距離フェーズ: ロボット相対の move_direction ベクトルで回り込む
+      auto calculateRatio =
+        [](const double distance, const double min_distance, const double max_distance) {
+          return (distance - min_distance) / (max_distance - min_distance);
+        };
+
+      using boost::math::constants::degree;
+      double ratio =
+        1.5 +
+        std::clamp(
+          -calculateRatio(robot()->getDistance(world_model()->ball().pos), 0.2, 1.5), -0.5, 0.);
+
+      double move_direction = getAngle(target - robot()->pose.pos) +
+                              (getAngleDiff(
+                                getAngle(world_model()->ball().pos - robot()->pose.pos),
+                                getAngle(target - robot()->pose.pos))) *
+                                ratio;
+      Vector2 move_vec = getNormVec(move_direction);
+      double move_vec_gain = [&]() {
+        if (
+          getAngleDiff(getAngle(target - ball_pos), robot()->pose.theta) < 2.5 * degree<double>()) {
+          return 0.4;
+        } else {
+          return 0.2;
+        }
+      }();
+
+      Vector2 ball_away_vec = (robot()->pose.pos - world_model()->ball().pos).normalized();
+      double ball_away_gain = 0.0;
+      if (
+        robot()->getDistance(world_model()->ball().pos) < 0.2 &&
+        getAngleDiff(
+          getAngle(target - ball_pos), getAngle(world_model()->ball().pos - robot()->pose.pos)) >
+          10. * degree<double>()) {
+        ball_away_gain = 0.0;
+      }
+
+      command->lookAtFrom(target, ball_pos)
+        .setDribblerTargetPosition(
+          robot()->pose.pos + move_vec * move_vec_gain + world_model()->ball().vel * 0.5 +
+          ball_away_vec * ball_away_gain)
+        .disableCollisionAvoidance()
+        .disableBallAvoidance();
+
+      if (
+        std::abs(
+          getAngleDiff(getAngle(target - ball_pos), getAngle(ball_pos - robot()->pose.pos))) <
+        20. * degree<double>()) {
+        if (getParameter<bool>("chip_kick")) {
+          kickWithChip();
+        } else {
+          kickStraight();
+        }
+      } else {
+        command->kickStraight(0.0);
+      }
+
+      if (getParameter<bool>("with_dribble")) {
+        command->withDribble(getParameter<double>("dribble_power"));
+      } else {
+        command->withDribble(0.0);
+      }
+      return Status::RUNNING;
+    }
+  });
+
+  addTransition(s(S::AROUND_BALL_AND_KICK), s(S::ENTRY_POINT), [this]() {
+    return world_model()->ball().isMoving(getParameter<double>("kicked_speed_threshold")) &&
+           world_model()->ball().isMovingAwayFrom(robot()->pose.pos, 30.);
+  });
+}
+
+auto KickOld::getBallExitPointFromField(const double offset) -> Point
+{
+  Segment ball_line{
+    world_model()->ball().pos,
+    world_model()->ball().pos + world_model()->ball().vel.normalized() * 10.0};
+
+  const double X = world_model()->fieldSize().x() / 2.0 - offset;
+  const double Y = world_model()->fieldSize().y() / 2.0 - offset;
+
+  std::vector<Segment> segments;
+  segments.emplace_back(Point(X, Y), Point(X, -Y));
+  segments.emplace_back(Point(-X, Y), Point(-X, -Y));
+  segments.emplace_back(Point(X, Y), Point(-X, Y));
+  segments.emplace_back(Point(X, -Y), Point(-X, -Y));
+
+  for (const auto & seg : segments) {
+    if (auto intersections = getIntersections(ball_line, seg); not intersections.empty()) {
+      return intersections.front();
+    }
+  }
+  return world_model()->ball().pos;
+}
+
+auto KickOld::kickWithChip() -> void
+{
+  if (getParameter<bool>("use_target_chip_distance")) {
+    command->setKickWithChipTargetDistance(getParameter<double>("target_chip_distance"));
+  } else {
+    command->kickWithChip(getParameter<double>("kick_power"));
+  }
+}
+
+auto KickOld::kickStraight() -> void
+{
+  if (getParameter<bool>("use_target_kick_speed")) {
+    command->setKickStraightTargetSpeed(getParameter<double>("target_kick_speed"));
+  } else {
+    command->kickStraight(getParameter<double>("kick_power"));
+  }
+}
+}  // namespace crane::skills

--- a/crane_robot_skills/src/kick_old.cpp
+++ b/crane_robot_skills/src/kick_old.cpp
@@ -37,14 +37,6 @@ void KickOld::initialize()
   setParameter("moving_speed_threshold", 0.2);
   setParameter("kicked_speed_threshold", 1.5);
 
-  receive_skill.setParameter("dribble_power", 0.3);
-  receive_skill.setParameter("enable_software_bumper", false);
-  receive_skill.setParameter("policy", std::string("min_slack"));
-  receive_skill.setParameter("enable_active_receive", true);
-  receive_skill.setParameter("enable_redirect", true);
-  receive_skill.setParameter("redirect_target", Point(0, 0));
-  receive_skill.setParameter("redirect_kick_power", 0.3);
-
   addStateFunction(s(S::ENTRY_POINT), [this]() {
     visualizer->text()
       .position(robot()->pose.pos.x() - 0.5, robot()->pose.pos.y() + 0.5)
@@ -56,69 +48,6 @@ void KickOld::initialize()
   });
 
   addTransition(s(S::ENTRY_POINT), s(S::AROUND_BALL_AND_KICK), [this]() { return true; });
-
-  addStateFunction(s(S::POSITIVE_REDIRECT_KICK), [this]() {
-    visualizer->text()
-      .position(robot()->pose.pos.x() - 0.5, robot()->pose.pos.y() + 0.5)
-      .text("KickOld::POSITIVE_REDIRECT_KICK")
-      .fill("white")
-      .fontSize(100)
-      .build();
-    const auto & ball_pos = world_model()->ball().pos;
-    command->lookAtFrom(getParameter<Point>("target"), ball_pos);
-
-    const auto & ball_vel_normed = world_model()->ball().vel.normalized();
-    Segment ball_line = world_model()->ball().getTrajectorySegmentByDistance(10.);
-    auto [distance, closest_point] = getClosestPointAndDistance(ball_pos, ball_line);
-    if ((ball_pos - closest_point).dot(ball_vel_normed) > 0) {
-      auto target_pos = [&]() -> Point {
-        if (distance < 0.1) {
-          return ball_pos + ball_vel_normed;
-        } else {
-          return closest_point + ball_vel_normed * distance;
-        }
-      }();
-      command->setDribblerTargetPosition(target_pos);
-      command->kickStraight(0.3);
-      command->disableBallAvoidance();
-    } else {
-      command->setTargetPosition(
-        closest_point + (robot()->pose.pos - closest_point).normalized() * 0.3);
-    }
-
-    return Status::RUNNING;
-  });
-
-  addTransition(s(S::POSITIVE_REDIRECT_KICK), s(S::ENTRY_POINT), [this]() {
-    return !world_model()->ball().isMovingAwayFrom(robot()->pose.pos, 10.0) ||
-           !world_model()->ball().isMovingTowards(getParameter<Point>("target"), 30.0);
-  });
-
-  addStateFunction(s(S::REDIRECT_KICK), [this]() {
-    visualizer->text()
-      .position(robot()->pose.pos.x() - 0.5, robot()->pose.pos.y() + 0.5)
-      .text("KickOld::REDIRECT_KICK")
-      .fill("white")
-      .fontSize(100)
-      .build();
-    receive_skill.setParameter("target", getParameter<Point>("target"));
-    if (robot()->getDistance(world_model()->ball().pos) < 0.5) {
-      receive_skill.setParameter("policy", std::string("closest"));
-    } else {
-      receive_skill.setParameter("policy", std::string("min_slack"));
-    }
-    command->disableBallAvoidance();
-    return receive_skill.update();
-  });
-
-  addTransition(s(S::REDIRECT_KICK), s(S::AROUND_BALL_AND_KICK), [this]() {
-    return !world_model()->ball().isMoving(getParameter<double>("moving_speed_threshold"));
-  });
-
-  addTransition(s(S::REDIRECT_KICK), s(S::ENTRY_POINT), [this]() {
-    return world_model()->ball().isMoving(getParameter<double>("kicked_speed_threshold")) &&
-           world_model()->ball().isMovingAwayFrom(robot()->pose.pos, 30.);
-  });
 
   addStateFunction(s(S::AROUND_BALL_AND_KICK), [this]() {
     auto target = getParameter<Point>("target");

--- a/crane_robot_skills/src/simple_kickoff.cpp
+++ b/crane_robot_skills/src/simple_kickoff.cpp
@@ -8,13 +8,6 @@
 
 namespace crane::skills
 {
-void SimpleKickOff::initializeParameters()
-{
-  kick_skill.setParameter("chip_kick", true);
-  kick_skill.setParameter("use_target_chip_distance", true);
-  kick_skill.setParameter("target_chip_distance", 2.0);
-}
-
 Status SimpleKickOff::update()
 {
   if (!kicked && world_model()->ball().isMoving(0.5)) {
@@ -26,7 +19,6 @@ Status SimpleKickOff::update()
     return Status::RUNNING;
   }
 
-  kick_skill.setParameter("target", world_model()->getAttackGoalCenter());
-  return kick_skill.run();
+  return goal_kick_skill.run();
 }
 }  // namespace crane::skills

--- a/crane_session_coordinator/config/unified_session_config.yaml
+++ b/crane_session_coordinator/config/unified_session_config.yaml
@@ -14,9 +14,9 @@ situations:
       - name: attacker_skill
         max_robots: 1
       - name: defender
-        max_robots: 3
+        max_robots: 4
         params:
-          reduced_robots: 1
+          reduced_robots: 2
       - name: pass_receive
         max_robots: 1
       - name: sub_attacker_skill
@@ -25,7 +25,7 @@ situations:
         max_robots: 1
       - name: marker
         max_robots: 2
-      - name: forward
+      - name: waiter
         max_robots: 20
 
   OUR_BALL_PLACEMENT:
@@ -195,6 +195,7 @@ situations:
       kick_allowed_skills:
         - goalie_skill
         - defender
+        - attacker_skill
     sessions:
       - name: goalie_skill
         max_robots: 1

--- a/crane_sessions/src/formation_session.cpp
+++ b/crane_sessions/src/formation_session.cpp
@@ -12,7 +12,7 @@ std::vector<Point> FormationSession::getWingFormationPoints(int robot_num)
 {
   std::vector<Point> formation_points;
 
-  formation_points.emplace_back(0.6, 0.0);
+  formation_points.emplace_back(0.7, 0.0);
   formation_points.emplace_back(1.5, 1.2);
   formation_points.emplace_back(1.5, -1.2);
   formation_points.emplace_back(0.6, 2.4);

--- a/crane_web_debugger/src/websocket_server.cpp
+++ b/crane_web_debugger/src/websocket_server.cpp
@@ -1456,8 +1456,7 @@ private:
     connection->sendMessage(result.dump());
   }
 
-  void handleSetPlannerParam(
-    std::shared_ptr<WebSocketConnection> connection, const json & request)
+  void handleSetPlannerParam(std::shared_ptr<WebSocketConnection> connection, const json & request)
   {
     std::vector<rclcpp::Parameter> params;
     if (request.contains("velocity_damping_gain")) {
@@ -1477,13 +1476,12 @@ private:
       return;
     }
     local_planner_params_client_->set_parameters(
-      params, [this](std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>>
-                       future) {
+      params,
+      [this](std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>> future) {
         try {
           for (const auto & r : future.get()) {
             if (!r.successful) {
-              RCLCPP_WARN(
-                this->get_logger(), "set param failed: %s", r.reason.c_str());
+              RCLCPP_WARN(this->get_logger(), "set param failed: %s", r.reason.c_str());
             }
           }
         } catch (const std::exception & e) {

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -202,6 +202,7 @@ private:
   FieldGeometry field_geometry_;
   bool has_vision_updated_;
   int feedback_stale_timeout_ms_{100};
+  double robot_vision_hold_sec_{0.15};
 
   // エラー継続時間を算出するためのトラッキング用構造体
   struct ErrorTracker

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -48,12 +48,14 @@ WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
   node.declare_parameter("tracker_port", 10010);
   node.declare_parameter("use_udp_detection", false);
   node.declare_parameter("feedback_stale_timeout_ms", feedback_stale_timeout_ms_);
+  node.declare_parameter("robot_vision_hold_sec", robot_vision_hold_sec_);
 
   config_.vision_address = node.get_parameter("vision_address").get_value<std::string>();
   config_.vision_port = node.get_parameter("vision_port").get_value<int>();
   config_.confidence_threshold = node.get_parameter("confidence_threshold").get_value<double>();
   use_udp_detection_ = node.get_parameter("use_udp_detection").get_value<bool>();
   feedback_stale_timeout_ms_ = node.get_parameter("feedback_stale_timeout_ms").get_value<int>();
+  robot_vision_hold_sec_ = node.get_parameter("robot_vision_hold_sec").get_value<double>();
 
   // Initialize UDP receivers
 
@@ -850,11 +852,16 @@ auto WorldModelDataProvider::processTrackedFrame(
   integrateBallInfo();
 
   // ロボット情報の処理
-  // 全チーム・全ロボットIDをリセット（trackerフレーム毎にvision/tracker両フラグをクリア）
+  // available_visionが継続してfalseになると、一時的なトラッカー欠落でもロボットがlost扱いになる。
+  // robot_vision_hold_sec_ 以内に検出されていたロボットは状態を維持し、超過後のみリセットする。
   for (int team_idx = 0; team_idx < 2; ++team_idx) {
     for (auto & robot : robot_info_[team_idx]) {
-      robot.available_vision = false;
-      robot.available_tracker = false;
+      if (!robot.available_vision) continue;
+      const double age = (now - rclcpp::Time(robot.vision.stamp)).seconds();
+      if (age < 0.0 || age > robot_vision_hold_sec_) {
+        robot.available_vision = false;
+        robot.available_tracker = false;
+      }
     }
   }
 


### PR DESCRIPTION
## 背景・問題

zunoh戦 後半rosbag解析で判明した事象：ibis（YELLOW）が `ATTACKER_TOO_CLOSE_TO_DEFENSE_AREA` を3回取られた（t=156.88, 157.18, 183.23、すべてbot=1 at (-6.00, 1.10)）。

rosbag調査で、bot=1 は t=82.35付近で crane の WorldModel上で `detected=False`（`available_vision=false`）になり、姿勢が (-0.505, 4.144) で凍結・制御不能状態になっていた。一方、autorefはraw SSL-Visionを直接見るため、bot=1 を実フィールド上で検出し続けてファールを発火していた。

## 根本原因

`processTrackedFrame` の現実装では毎フレーム冒頭で**全ロボットの `available_vision`/`available_tracker` を一旦 `false` に落とし**、今回 TrackerWrapperPacket フレームに含まれるロボットだけ `true` に戻す。そのため：

- TrackerWrapperPacket（port 11010 の autoref Tracker output）からロボットが1フレームでも欠落すると即 `detected=False`
- autoref の Tracker output は lossy で一時的に特定ロボットを欠落させることがある
- crane には Kalman/再結合などの補正ロジックが無いため、欠落したフレームが積み重なるとロストしたまま

## 修正内容

`robot_vision_hold_sec`（デフォルト **0.15秒** = Tracker 60Hz で約9フレーム分）の保持タイムアウトを追加。

- 直近 `robot_vision_hold_sec` 以内に検出されていたロボットはフレームから消えても `available_vision` を維持
- 保持時間を超えた場合のみ `false` にリセット（長期lostは正しくlost扱い）
- ROS パラメータで調整可能（`robot_vision_hold_sec`）

## 変更ファイル

- `crane_world_model_publisher/src/world_model_data_provider.cpp` — `processTrackedFrame` リセットロジック変更
- `crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp` — `robot_vision_hold_sec_` メンバ変数追加

## テスト計画

- [ ] ビルド確認: `colcon build --packages-select crane_world_model_publisher` → 成功済み
- [ ] dev docker環境でのロボットトラッキング動作確認（一時的な検出欠落で `available_vision` が即 false にならないこと）
- [ ] 長期欠落（0.15秒超）では正しく `available_vision=false` になること

## スコープ外

- tracker port（10010/11010）の変更: 別途検討
- raw SSL-Vision でのロボット検出フォールバック: 別途検討
- 長期間（秒オーダー）連続欠落のケース: 本修正では救えない（運用対応）