### PR TITLE
feat(crane_robot_skills): KickOldスキルを復活させ既存スキルの回り込みアルゴリズムを旧実装に切替

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/attacker.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/attacker.hpp
@@ -11,7 +11,7 @@
 #include <crane_geometry/boost_geometry.hpp>
 #include <crane_geometry/interval.hpp>
 #include <crane_robot_skills/goal_kick.hpp>
-#include <crane_robot_skills/kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/receive.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
@@ -64,7 +64,7 @@ public:
 
   int forced_pass_receiver_id = -1;
 
-  Kick kick_skill;
+  KickOld kick_skill;
 
   GoalKick goal_kick_skill;
 
@@ -74,7 +74,7 @@ protected:
   void onPostUpdate() override;
 
 private:
-  void configurePassKick(const Point & target, Kick & kick_skill);
+  void configurePassKick(const Point & target, KickOld & kick_skill);
 
   // KICK状態の進捗タイムアウト用
   std::chrono::steady_clock::time_point kick_state_entry_time{};

--- a/crane_robot_skills/include/crane_robot_skills/goal_kick.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/goal_kick.hpp
@@ -8,7 +8,7 @@
 #define CRANE_ROBOT_SKILLS__GOAL_KICK_HPP_
 
 #include <crane_geometry/vector2d_adapter.hpp>
-#include <crane_robot_skills/kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
 
@@ -26,7 +26,7 @@ public:
 
   Status update() override;
 
-  Kick kick_skill;
+  KickOld kick_skill;
 
   static double getBestAngleToShootFromPoint(
     double minimum_angle_accuracy, const Point from_point,

--- a/crane_robot_skills/include/crane_robot_skills/goalie.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/goalie.hpp
@@ -9,7 +9,7 @@
 
 #include <chrono>
 #include <crane_geometry/vector2d_adapter.hpp>
-#include <crane_robot_skills/kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
 #include <string>
@@ -35,7 +35,7 @@ public:
 
   std::string phase;
 
-  Kick kick_skill;
+  KickOld kick_skill;
 
   std::optional<Point> prev_wait_point;
 

--- a/crane_robot_skills/include/crane_robot_skills/kick_old.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/kick_old.hpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_ROBOT_SKILLS__KICK_OLD_HPP_
+#define CRANE_ROBOT_SKILLS__KICK_OLD_HPP_
+
+#include <crane_geometry/vector2d_adapter.hpp>
+#include <crane_robot_skills/skill_base.hpp>
+#include <memory>
+
+namespace crane::skills
+{
+// 983f026a（2025-09-14）以前の回り込みアルゴリズム（move_direction ベース 2 フェーズ）
+enum class KickOldState {
+  ENTRY_POINT,
+  AROUND_BALL_AND_KICK,
+};
+
+class KickOld : public SkillBaseWithState
+{
+private:
+  static std::string getStateName(int s);
+
+public:
+  template <typename... Args>
+  explicit KickOld(Args &&... args)
+  : SkillBaseWithState(
+      static_cast<int>(KickOldState::ENTRY_POINT), &KickOld::getStateName, "kick_old",
+      std::forward<Args>(args)...)
+  {
+    initialize();
+  }
+
+  auto getBallExitPointFromField(const double offset = 0.3) -> Point;
+
+private:
+  void initialize();
+
+  void kickWithChip();
+
+  void kickStraight();
+};
+}  // namespace crane::skills
+#endif  // CRANE_ROBOT_SKILLS__KICK_OLD_HPP_

--- a/crane_robot_skills/include/crane_robot_skills/penalty_kick.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/penalty_kick.hpp
@@ -9,7 +9,7 @@
 
 #include <crane_geometry/interval.hpp>
 #include <crane_geometry/vector2d_adapter.hpp>
-#include <crane_robot_skills/kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
 #include <utility>
@@ -45,7 +45,7 @@ public:
     return static_cast<PenaltyKickState>(SkillBaseWithState::getCurrentState());
   }
 
-  Kick kick_skill;
+  KickOld kick_skill;
 
   std::optional<Point> start_ball_point = std::nullopt;
 };

--- a/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
@@ -9,7 +9,7 @@
 
 #include <algorithm>
 #include <crane_geometry/vector2d_adapter.hpp>
-#include <crane_robot_skills/kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
 #include <string>
@@ -33,7 +33,7 @@ public:
 
   Status update() override;
 
-  Kick kick_skill;
+  KickOld kick_skill;
 
 private:
   bool kicked = false;

--- a/crane_robot_skills/include/crane_robot_skills/skills.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/skills.hpp
@@ -19,6 +19,7 @@
 #include <crane_robot_skills/goalie.hpp>
 #include <crane_robot_skills/idle.hpp>
 #include <crane_robot_skills/kick.hpp>
+#include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/marker.hpp>
 #include <crane_robot_skills/receive.hpp>
 #include <crane_robot_skills/second_threat_defender.hpp>

--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -358,7 +358,7 @@ void Attacker::onPostUpdate()
   }
 }
 
-void Attacker::configurePassKick(const Point & target, Kick & kick_skill)
+void Attacker::configurePassKick(const Point & target, KickOld & kick_skill)
 {
   auto pass_analysis = getPassAnalysis(
     world_model()->ball().pos, target, world_model()->theirs().robotsWhere().available().get());

--- a/crane_robot_skills/src/kick_old.cpp
+++ b/crane_robot_skills/src/kick_old.cpp
@@ -1,0 +1,201 @@
+// Copyright (c) 2024 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <crane_robot_skills/kick_old.hpp>
+#include <magic_enum/magic_enum.hpp>
+
+#include "../include/crane_robot_skills/single_ball_placement.hpp"
+
+namespace crane::skills
+{
+std::string KickOld::getStateName(int s)
+{
+  return std::string(magic_enum::enum_name(static_cast<KickOldState>(s)));
+}
+
+void KickOld::initialize()
+{
+  using S = KickOldState;
+  auto s = [](S state) { return static_cast<int>(state); };
+
+  command->usePositionMode();
+  setParameter("target", Point(0, 0));
+  setParameter("kick_power", 0.7f);
+  setParameter("use_target_kick_speed", false);
+  setParameter("target_kick_speed", 2.0);
+  setParameter("use_target_chip_distance", false);
+  setParameter("target_chip_distance", 2.0);
+  setParameter("chip_kick", false);
+  setParameter("with_dribble", false);
+  setParameter("dribble_power", 0.3f);
+  setParameter("angle_threshold_deg", 15.0f);
+  setParameter("around_interval", 0.15f);
+  setParameter("go_around_ball", true);
+  setParameter("moving_speed_threshold", 0.2);
+  setParameter("kicked_speed_threshold", 1.5);
+
+  addStateFunction(s(S::ENTRY_POINT), [this]() {
+    visualizer->text()
+      .position(robot()->pose.pos.x() - 0.5, robot()->pose.pos.y() + 0.5)
+      .text("KickOld::ENTRY_POINT")
+      .fill("white")
+      .fontSize(100)
+      .build();
+    return Status::RUNNING;
+  });
+
+  addTransition(s(S::ENTRY_POINT), s(S::AROUND_BALL_AND_KICK), [this]() { return true; });
+
+  addStateFunction(s(S::AROUND_BALL_AND_KICK), [this]() {
+    auto target = getParameter<Point>("target");
+    Point ball_pos = world_model()->ball().pos;
+    visualizer->line()
+      .start(ball_pos)
+      .end(ball_pos + (target - ball_pos).normalized() * 1.0)
+      .stroke("blue")
+      .strokeWidth(10)
+      .build();
+
+    constexpr double SWITCH_DISTANCE = 0.5;
+    visualizer->circle()
+      .center(ball_pos)
+      .radius(SWITCH_DISTANCE)
+      .stroke("yellow")
+      .strokeWidth(10)
+      .build();
+
+    if (robot()->getDistance(ball_pos) > SWITCH_DISTANCE) {
+      visualizer->text()
+        .position(robot()->pose.pos.x() - 0.5, robot()->pose.pos.y() + 0.5)
+        .text("KickOld::AROUND_BALL(遠い)")
+        .fill("white")
+        .fontSize(100)
+        .build();
+      // 遠距離フェーズ: ボール後方の固定点へ向かいつつ角度を合わせる
+      command->setTargetPosition(ball_pos + (ball_pos - target).normalized() * 0.3)
+        .lookAtFrom(target, ball_pos);
+      return Status::RUNNING;
+    } else {
+      visualizer->text()
+        .position(robot()->pose.pos.x() - 0.5, robot()->pose.pos.y() + 0.5)
+        .text("KickOld::AROUND_BALL（近い）")
+        .fill("white")
+        .fontSize(100)
+        .build();
+
+      // 近距離フェーズ: ロボット相対の move_direction ベクトルで回り込む
+      auto calculateRatio =
+        [](const double distance, const double min_distance, const double max_distance) {
+          return (distance - min_distance) / (max_distance - min_distance);
+        };
+
+      using boost::math::constants::degree;
+      double ratio =
+        1.5 +
+        std::clamp(
+          -calculateRatio(robot()->getDistance(world_model()->ball().pos), 0.2, 1.5), -0.5, 0.);
+
+      double move_direction = getAngle(target - robot()->pose.pos) +
+                              (getAngleDiff(
+                                getAngle(world_model()->ball().pos - robot()->pose.pos),
+                                getAngle(target - robot()->pose.pos))) *
+                                ratio;
+      Vector2 move_vec = getNormVec(move_direction);
+      double move_vec_gain = [&]() {
+        if (
+          getAngleDiff(getAngle(target - ball_pos), robot()->pose.theta) < 2.5 * degree<double>()) {
+          return 0.4;
+        } else {
+          return 0.2;
+        }
+      }();
+
+      Vector2 ball_away_vec = (robot()->pose.pos - world_model()->ball().pos).normalized();
+      double ball_away_gain = 0.0;
+      if (
+        robot()->getDistance(world_model()->ball().pos) < 0.2 &&
+        getAngleDiff(
+          getAngle(target - ball_pos), getAngle(world_model()->ball().pos - robot()->pose.pos)) >
+          10. * degree<double>()) {
+        ball_away_gain = 0.0;
+      }
+
+      command->lookAtFrom(target, ball_pos)
+        .setDribblerTargetPosition(
+          robot()->pose.pos + move_vec * move_vec_gain + world_model()->ball().vel * 0.5 +
+          ball_away_vec * ball_away_gain)
+        .disableCollisionAvoidance()
+        .disableBallAvoidance();
+
+      if (
+        std::abs(
+          getAngleDiff(getAngle(target - ball_pos), getAngle(ball_pos - robot()->pose.pos))) <
+        20. * degree<double>()) {
+        if (getParameter<bool>("chip_kick")) {
+          kickWithChip();
+        } else {
+          kickStraight();
+        }
+      } else {
+        command->kickStraight(0.0);
+      }
+
+      if (getParameter<bool>("with_dribble")) {
+        command->withDribble(getParameter<double>("dribble_power"));
+      } else {
+        command->withDribble(0.0);
+      }
+      return Status::RUNNING;
+    }
+  });
+
+  addTransition(s(S::AROUND_BALL_AND_KICK), s(S::ENTRY_POINT), [this]() {
+    return world_model()->ball().isMoving(getParameter<double>("kicked_speed_threshold")) &&
+           world_model()->ball().isMovingAwayFrom(robot()->pose.pos, 30.);
+  });
+}
+
+auto KickOld::getBallExitPointFromField(const double offset) -> Point
+{
+  Segment ball_line{
+    world_model()->ball().pos,
+    world_model()->ball().pos + world_model()->ball().vel.normalized() * 10.0};
+
+  const double X = world_model()->fieldSize().x() / 2.0 - offset;
+  const double Y = world_model()->fieldSize().y() / 2.0 - offset;
+
+  std::vector<Segment> segments;
+  segments.emplace_back(Point(X, Y), Point(X, -Y));
+  segments.emplace_back(Point(-X, Y), Point(-X, -Y));
+  segments.emplace_back(Point(X, Y), Point(-X, Y));
+  segments.emplace_back(Point(X, -Y), Point(-X, -Y));
+
+  for (const auto & seg : segments) {
+    if (auto intersections = getIntersections(ball_line, seg); not intersections.empty()) {
+      return intersections.front();
+    }
+  }
+  return world_model()->ball().pos;
+}
+
+auto KickOld::kickWithChip() -> void
+{
+  if (getParameter<bool>("use_target_chip_distance")) {
+    command->setKickWithChipTargetDistance(getParameter<double>("target_chip_distance"));
+  } else {
+    command->kickWithChip(getParameter<double>("kick_power"));
+  }
+}
+
+auto KickOld::kickStraight() -> void
+{
+  if (getParameter<bool>("use_target_kick_speed")) {
+    command->setKickStraightTargetSpeed(getParameter<double>("target_kick_speed"));
+  } else {
+    command->kickStraight(getParameter<double>("kick_power"));
+  }
+}
+}  // namespace crane::skills


### PR DESCRIPTION
## 概要

2025-09-14（commit 983f026a）以前の Kick 回り込みアルゴリズム（move_direction ベース 2 フェーズ）を `KickOld` クラスとして復活させ、各スキルの `kick_skill` を旧実装に切替える。

## 背景・根本原因

zunoh 戦（2026-04-25）の試合会場で旧実装の安定動作を確認した。現行 `Kick` は 2025-09-14 以降の新アルゴリズムだが、試合環境では旧アルゴリズムの方が信頼性が高かったため復活させる。現 `Kick` 実装はそのまま残し、並列して保持する。

## 変更内容

- `crane_robot_skills/include/crane_robot_skills/kick_old.hpp` 新規追加  
  - 状態: `ENTRY_POINT` → `AROUND_BALL_AND_KICK` の 2 フェーズ  
  - Receive 依存・REDIRECT 系状態は含まない  
  - パラメータ I/F は `Kick` と同一キーを保持  
- `crane_robot_skills/src/kick_old.cpp` 新規追加  
- `skills.hpp` に `kick_old.hpp` の include を追加  
- `Attacker` / `Goalie` / `GoalKick` / `PenaltyKick` / `SimpleKickOff` の `kick_skill` メンバ型を `Kick` → `KickOld` に変更  
- `Attacker::configurePassKick` の引数型を `KickOld &` に変更

## 後続 PR で対応予定

- SimpleKickOff の GoalKick 化
- Attacker FORCED_PASS 削除
- SkillBase デフォルトキック無効化