### PR TITLE
feat(crane_robot_skills): FreeKickerスキル分離でOUR_FREE_KICKを専用ロジックへ

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/free_kicker.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/free_kicker.hpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_ROBOT_SKILLS__FREE_KICKER_HPP_
+#define CRANE_ROBOT_SKILLS__FREE_KICKER_HPP_
+
+#include <chrono>
+#include <crane_geometry/boost_geometry.hpp>
+#include <crane_robot_skills/skill_base.hpp>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace crane::skills
+{
+enum class FreeKickerState {
+  ENTRY_POINT,
+  APPROACH,
+  ALIGN,
+  KICK,
+  FINISH,
+};
+
+class FreeKicker : public SkillBaseWithState
+{
+public:
+  template <typename... Args>
+  explicit FreeKicker(Args &&... args)
+  : SkillBaseWithState(
+      static_cast<int>(FreeKickerState::ENTRY_POINT), &FreeKicker::getStateName, "free_kicker",
+      std::forward<Args>(args)...)
+  {
+    initialize();
+  }
+
+  FreeKickerState getCurrentState() const
+  {
+    return static_cast<FreeKickerState>(SkillBaseWithState::getCurrentState());
+  }
+
+private:
+  void initialize();
+  static std::string getStateName(int s);
+
+  void resetInternalState();
+
+  // ターゲット選定
+  Point selectKickTarget();
+  bool tryShoot(Point & out_target);
+  std::optional<Point> selectPassTarget();
+  double calculatePassScore(
+    const Point & target, const std::vector<std::shared_ptr<RobotInfo>> & enemies,
+    double best_enemy_slack) const;
+  Point computeFallbackTarget();
+
+  Point kick_target_{Point::Zero()};
+  Point standoff_{Point::Zero()};
+  bool target_locked_ = false;
+  bool use_chip_ = false;
+  bool last_chose_shoot_ = false;
+  std::optional<uint8_t> last_pass_receiver_id_;
+
+  bool kick_started_ = false;
+  std::chrono::steady_clock::time_point kick_started_time_{};
+
+  std::optional<std::chrono::steady_clock::time_point> approach_entry_time_;
+  std::optional<std::chrono::steady_clock::time_point> align_entry_time_;
+
+  int align_stable_count_ = 0;
+};
+}  // namespace crane::skills
+#endif  // CRANE_ROBOT_SKILLS__FREE_KICKER_HPP_

--- a/crane_robot_skills/src/free_kicker.cpp
+++ b/crane_robot_skills/src/free_kicker.cpp
@@ -1,0 +1,372 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <crane_geometry/geometry_operations.hpp>
+#include <crane_physics/pass.hpp>
+#include <crane_robot_skills/free_kicker.hpp>
+#include <crane_robot_skills/goal_kick.hpp>
+#include <magic_enum/magic_enum.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+namespace crane::skills
+{
+namespace
+{
+constexpr double FK_KICK_DETECT_VEL = 0.7;
+constexpr double FK_KICK_DIRECTION_COS_THRESHOLD = 0.7;
+constexpr double FK_APPROACH_PHASE_TIMEOUT = 6.0;
+constexpr double FK_ALIGN_PHASE_TIMEOUT = 4.0;
+constexpr double FK_KICK_TIMEOUT_SEC = 3.0;
+constexpr double FK_MIN_PASS_ACCEPT_SCORE = 0.4;
+constexpr double FK_PASS_HYSTERESIS_RATIO = 0.85;
+constexpr double FK_APPROACH_ANGLE_TOLERANCE_RAD = 10.0 * M_PI / 180.0;
+constexpr double FK_APPROACH_SPEED_TOLERANCE = 0.3;
+}  // namespace
+
+std::string FreeKicker::getStateName(int s)
+{
+  return std::string(magic_enum::enum_name(static_cast<FreeKickerState>(s)));
+}
+
+void FreeKicker::resetInternalState()
+{
+  kick_started_ = false;
+  target_locked_ = false;
+  use_chip_ = false;
+  last_chose_shoot_ = false;
+  last_pass_receiver_id_ = std::nullopt;
+  align_stable_count_ = 0;
+  approach_entry_time_ = std::nullopt;
+  align_entry_time_ = std::nullopt;
+}
+
+void FreeKicker::initialize()
+{
+  setParameter("approach_max_velocity", 1.5);
+  setParameter("align_max_velocity", 0.6);
+  setParameter("kick_max_velocity", 1.2);
+  setParameter("approach_distance", 0.25);
+  setParameter("align_distance", 0.12);
+  setParameter("approach_position_tolerance", 0.10);
+  setParameter("align_position_tolerance", 0.05);
+  setParameter("align_speed_tolerance", 0.10);
+  setParameter("align_omega_tolerance", 0.20);
+  setParameter("align_stable_frames", 5);
+  setParameter("target_kick_speed", 5.0);
+  setParameter("target_chip_distance", 2.5);
+  setParameter("shoot_min_angle_rad", 6.0 * M_PI / 180.0);
+  setParameter("pass_obstacle_distance", 0.2);
+  setParameter("pass_min_distance", 1.5);
+  setParameter("pass_max_distance", 6.0);
+  setParameter("enemy_slack_threshold", 0.3);
+  setParameter("ball_nearby_radius", 1.0);
+  setParameter("ball_nearby_speed", 0.5);
+  setParameter("pass_defensive_half_penalty", 0.1);
+  setParameter("pass_chip_bypass_distance", 1.5);
+
+  using S = FreeKickerState;
+  auto s = [](S st) { return static_cast<int>(st); };
+
+  // ENTRY_POINT: 自己遷移で内部状態リセット後、必ず APPROACH へ
+  addTransition(s(S::ENTRY_POINT), s(S::ENTRY_POINT), [this]() -> bool {
+    resetInternalState();
+    return false;
+  });
+  addTransition(s(S::ENTRY_POINT), s(S::APPROACH), []() -> bool { return true; });
+
+  addStateFunction(s(S::APPROACH), [this]() -> Status {
+    if (!approach_entry_time_.has_value()) {
+      approach_entry_time_ = std::chrono::steady_clock::now();
+    }
+    if (!target_locked_) {
+      kick_target_ = selectKickTarget();
+    }
+
+    const Point ball_pos = world_model()->ball().pos;
+    const double approach_dist = getParameter<double>("approach_distance");
+    standoff_ = computeAroundBallApproachTargetDynamic(
+      ball_pos, kick_target_, robot()->pose.pos, approach_dist, approach_dist * 1.5);
+
+    double max_vel = getParameter<double>("approach_max_velocity");
+    if ((robot()->pose.pos - ball_pos).norm() < getParameter<double>("ball_nearby_radius")) {
+      max_vel = std::min(max_vel, getParameter<double>("ball_nearby_speed"));
+    }
+    command->setTargetPosition(standoff_)
+      .lookAtFrom(kick_target_, ball_pos)
+      .setMaxVelocity("FreeKicker::APPROACH", max_vel);
+
+    return Status::RUNNING;
+  });
+  addTransition(s(S::APPROACH), s(S::ALIGN), [this]() -> bool {
+    const Point ball_pos = world_model()->ball().pos;
+    double pos_error = (robot()->pose.pos - standoff_).norm();
+    double angle_error =
+      std::abs(normalizeAngle(robot()->pose.theta - getAngle(kick_target_ - ball_pos)));
+    double speed = robot()->vel.linear.norm();
+
+    return pos_error < getParameter<double>("approach_position_tolerance") &&
+           angle_error < FK_APPROACH_ANGLE_TOLERANCE_RAD && speed < FK_APPROACH_SPEED_TOLERANCE;
+  });
+  addTransition(s(S::APPROACH), s(S::ENTRY_POINT), [this]() -> bool {
+    using std::chrono::duration;
+    using std::chrono::duration_cast;
+    using std::chrono::steady_clock;
+    return approach_entry_time_.has_value() &&
+           duration_cast<duration<double>>(steady_clock::now() - *approach_entry_time_).count() >
+             FK_APPROACH_PHASE_TIMEOUT;
+  });
+
+  addStateFunction(s(S::ALIGN), [this]() -> Status {
+    if (!align_entry_time_.has_value()) {
+      target_locked_ = true;
+      align_entry_time_ = std::chrono::steady_clock::now();
+      align_stable_count_ = 0;
+    }
+
+    const Point ball_pos = world_model()->ball().pos;
+    const Point press_point =
+      ball_pos - (kick_target_ - ball_pos).normalized() * getParameter<double>("align_distance");
+
+    command->setTargetPosition(press_point)
+      .lookAtFrom(kick_target_, ball_pos)
+      .setMaxVelocity("FreeKicker::ALIGN", getParameter<double>("align_max_velocity"))
+      .disableBallAvoidance();
+
+    double pos_error = (robot()->pose.pos - press_point).norm();
+    double speed = robot()->vel.linear.norm();
+    double omega = std::abs(robot()->vel.omega);
+
+    bool stable = pos_error < getParameter<double>("align_position_tolerance") &&
+                  speed < getParameter<double>("align_speed_tolerance") &&
+                  omega < getParameter<double>("align_omega_tolerance");
+
+    if (stable) {
+      align_stable_count_++;
+    } else {
+      align_stable_count_ = 0;
+    }
+
+    return Status::RUNNING;
+  });
+  addTransition(s(S::ALIGN), s(S::KICK), [this]() -> bool {
+    return align_stable_count_ >= getParameter<int>("align_stable_frames");
+  });
+  addTransition(s(S::ALIGN), s(S::ENTRY_POINT), [this]() -> bool {
+    using std::chrono::duration;
+    using std::chrono::duration_cast;
+    using std::chrono::steady_clock;
+    return align_entry_time_.has_value() &&
+           duration_cast<duration<double>>(steady_clock::now() - *align_entry_time_).count() >
+             FK_ALIGN_PHASE_TIMEOUT;
+  });
+
+  addStateFunction(s(S::KICK), [this]() -> Status {
+    if (!kick_started_) {
+      kick_started_ = true;
+      kick_started_time_ = std::chrono::steady_clock::now();
+    }
+
+    command
+      ->setTargetPosition(
+        world_model()->ball().pos + (kick_target_ - world_model()->ball().pos).normalized() * 0.1)
+      .lookAtFrom(kick_target_, robot()->pose.pos)
+      .setMaxVelocity("FreeKicker::KICK", getParameter<double>("kick_max_velocity"))
+      .disableBallAvoidance();
+    // 衝突回避は有効のまま（KickOld と異なる、フィールド外押し出し防止の肝）
+
+    if (use_chip_) {
+      command->setKickWithChipTargetDistance(getParameter<double>("target_chip_distance"));
+      command->kickWithChip(1.0);
+    } else {
+      command->setKickStraightTargetSpeed(getParameter<double>("target_kick_speed"));
+      command->kickStraight(1.0);
+    }
+
+    return Status::RUNNING;
+  });
+  // KICK → ENTRY_POINT のリトライ遷移は意図的に設けない（ダブルタッチ防止）
+  addTransition(s(S::KICK), s(S::FINISH), [this]() -> bool {
+    if (!kick_started_) return false;
+
+    using std::chrono::duration;
+    using std::chrono::duration_cast;
+    using std::chrono::steady_clock;
+    double elapsed =
+      duration_cast<duration<double>>(steady_clock::now() - kick_started_time_).count();
+    if (elapsed > FK_KICK_TIMEOUT_SEC) return true;
+
+    double ball_speed = world_model()->ball().vel.norm();
+    if (ball_speed > FK_KICK_DETECT_VEL) {
+      Vector2 ball_vel_dir = world_model()->ball().vel.normalized();
+      Vector2 intended_dir = (kick_target_ - world_model()->ball().pos).normalized();
+      return ball_vel_dir.dot(intended_dir) > FK_KICK_DIRECTION_COS_THRESHOLD;
+    }
+    return false;
+  });
+
+  addStateFunction(s(S::FINISH), [this]() -> Status {
+    command->stopHere();
+    return Status::SUCCESS;
+  });
+}
+
+Point FreeKicker::selectKickTarget()
+{
+  use_chip_ = false;
+
+  Point shoot_target;
+  if (tryShoot(shoot_target)) {
+    return shoot_target;
+  }
+
+  if (auto pass_target = selectPassTarget(); pass_target.has_value()) {
+    return pass_target.value();
+  }
+
+  return computeFallbackTarget();
+}
+
+bool FreeKicker::tryShoot(Point & out_target)
+{
+  const Point ball_pos = world_model()->ball().pos;
+  auto [best_angle, goal_angle_width] =
+    world_model()->getLargestAttackGoalAngleRangeFromPoint(ball_pos);
+
+  // ヒステリシス: 前回シュートを選んだ場合は閾値を少し下げる
+  double threshold = getParameter<double>("shoot_min_angle_rad");
+  if (last_chose_shoot_) {
+    threshold -= 0.5 * M_PI / 180.0;
+  }
+
+  if (goal_angle_width > threshold) {
+    last_chose_shoot_ = true;
+    double shoot_angle =
+      GoalKick::getBestAngleToShootFromPoint(3.0, ball_pos, world_model(), visualizer);
+    out_target = ball_pos + Vector2(std::cos(shoot_angle), std::sin(shoot_angle)) * 10.0;
+    return true;
+  }
+
+  last_chose_shoot_ = false;
+  return false;
+}
+
+std::optional<Point> FreeKicker::selectPassTarget()
+{
+  const auto & wm = world_model();
+  const Point ball_pos = wm->ball().pos;
+  const auto enemies = wm->theirs().robotsWhere().available().get();
+
+  double best_enemy_slack = -100.0;
+  for (const auto & s : wm->getMsg().game_analysis.their_slack) {
+    best_enemy_slack = std::max(best_enemy_slack, static_cast<double>(s.min.slack_time));
+  }
+
+  auto teammates = wm->ours().robotsWhere().available().excludeGoalie().get();
+
+  double best_score = FK_MIN_PASS_ACCEPT_SCORE;
+  std::optional<uint8_t> best_id;
+  Point best_pos = Point::Zero();
+
+  for (const auto & teammate : teammates) {
+    if (teammate->id == robot()->id) continue;
+
+    double score = calculatePassScore(teammate->pose.pos, enemies, best_enemy_slack);
+
+    if (last_pass_receiver_id_ && teammate->id == last_pass_receiver_id_.value()) {
+      score /= FK_PASS_HYSTERESIS_RATIO;
+    }
+
+    if (score > best_score) {
+      best_score = score;
+      best_id = teammate->id;
+      best_pos = teammate->pose.pos;
+    }
+  }
+
+  if (best_id) {
+    last_pass_receiver_id_ = best_id;
+    use_chip_ =
+      getPassAnalysis(ball_pos, best_pos, enemies, getParameter<double>("pass_obstacle_distance"))
+        .need_chip;
+    return best_pos;
+  }
+
+  return std::nullopt;
+}
+
+double FreeKicker::calculatePassScore(
+  const Point & target, const std::vector<std::shared_ptr<RobotInfo>> & enemies,
+  double best_enemy_slack) const
+{
+  const auto & wm = world_model();
+  const Point ball_pos = wm->ball().pos;
+  const double pass_distance = (target - ball_pos).norm();
+  const double pass_min = getParameter<double>("pass_min_distance");
+  const double pass_max = getParameter<double>("pass_max_distance");
+
+  if (pass_distance < pass_min || pass_distance > pass_max) return 0.0;
+
+  double score = 1.0;
+
+  if (target.x() * wm->getAttackSideSign() > 0.0) {
+    score *= 1.5;
+  } else {
+    score *= getParameter<double>("pass_defensive_half_penalty");
+  }
+
+  // ボール近傍の敵はチップキックで飛び越せるためブロッカーから除外
+  const double chip_bypass_dist = getParameter<double>("pass_chip_bypass_distance");
+  std::vector<std::shared_ptr<RobotInfo>> far_enemies;
+  for (const auto & e : enemies) {
+    if ((e->pose.pos - ball_pos).norm() >= chip_bypass_dist) {
+      far_enemies.push_back(e);
+    }
+  }
+  Segment pass_line{ball_pos, target};
+  if (
+    auto nearest_enemy = wm->getNearestRobotWithDistanceFromSegment(pass_line, far_enemies);
+    nearest_enemy.has_value()) {
+    if (nearest_enemy->distance < getParameter<double>("pass_obstacle_distance")) return 0.0;
+    score *= std::clamp(nearest_enemy->distance / 2.0, 0.0, 1.5);
+  }
+
+  auto [best_angle, recv_goal_w] = wm->getLargestAttackGoalAngleRangeFromPoint(target);
+  score += std::clamp(recv_goal_w / (M_PI / 12.0), 0.0, 0.5);
+
+  const Point attack_goal = wm->getAttackGoalCenter();
+  double dist_ball_to_goal = (ball_pos - attack_goal).norm();
+  double dist_target_to_goal = (target - attack_goal).norm();
+  double normed = (dist_target_to_goal - wm->fieldSize().x() * 0.5) / (wm->fieldSize().x() * 0.5);
+  score *= std::clamp(1.0 - normed, 0.3, 1.5);
+  // パスによりボールが敵ゴールから遠ざかる場合はペナルティ
+  if (dist_target_to_goal > dist_ball_to_goal) {
+    score *= std::clamp(dist_ball_to_goal / dist_target_to_goal, 0.3, 1.0);
+  }
+
+  // 敵の到達が受け手より enemy_slack_threshold 秒以上速い場合は減点
+  // (受け手への到達時間の代理値として pass_distance / 2.0 を使用)
+  if (best_enemy_slack > -(pass_distance / 2.0) + getParameter<double>("enemy_slack_threshold")) {
+    score *= 0.3;
+  }
+
+  return score;
+}
+
+Point FreeKicker::computeFallbackTarget()
+{
+  const Point ball_pos = world_model()->ball().pos;
+  double sign = world_model()->getAttackSideSign();
+  double field_half_x = world_model()->fieldSize().x() * 0.5;
+  double field_half_y = world_model()->fieldSize().y() * 0.5;
+
+  Point fallback;
+  fallback.x() = sign * field_half_x * 0.4;
+  fallback.y() = std::clamp(ball_pos.y(), -field_half_y * 0.3, field_half_y * 0.3);
+
+  use_chip_ = true;
+  return fallback;
+}
+}  // namespace crane::skills

--- a/crane_session_coordinator/config/unified_session_config.yaml
+++ b/crane_session_coordinator/config/unified_session_config.yaml
@@ -40,7 +40,7 @@ situations:
     sessions:
       - name: goalie_skill
         max_robots: 1
-      - name: attacker_skill
+      - name: free_kicker_skill
         max_robots: 1
       - name: pass_receive
         max_robots: 1

--- a/crane_sessions/include/crane_sessions/free_kicker_skill_session.hpp
+++ b/crane_sessions/include/crane_sessions/free_kicker_skill_session.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_SESSIONS__FREE_KICKER_SKILL_SESSION_HPP_
+#define CRANE_SESSIONS__FREE_KICKER_SKILL_SESSION_HPP_
+
+#include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_robot_skills/free_kicker.hpp>
+#include <crane_sessions/single_skill_session.hpp>
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+
+#include "visibility_control.h"
+
+namespace crane
+{
+class FreeKickerSkillSession : public SingleSkillSession<skills::FreeKicker>
+{
+public:
+  COMPOSITION_PUBLIC explicit FreeKickerSkillSession(
+    WorldModelWrapper::SharedPtr & world_model, rclcpp::Node &)
+  : SingleSkillSession("free_kicker_skill", world_model)
+  {
+  }
+
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    auto wm = world_model;
+    return [wm](const std::shared_ptr<RobotInfo> & robot) {
+      if (robot->id == wm->getOurGoalieId()) {
+        return GOALIE_EXCLUSION_COST;
+      }
+      // ボール最寄りのロボットをフリーキッカーとして割り当てる
+      return robot->getSquareDistance(wm->ball().pos);
+    };
+  }
+
+protected:
+  auto createSkill(uint8_t robot_id) -> std::shared_ptr<skills::FreeKicker> override
+  {
+    return std::make_shared<skills::FreeKicker>(robot_id, world_model);
+  }
+};
+}  // namespace crane
+#endif  // CRANE_SESSIONS__FREE_KICKER_SKILL_SESSION_HPP_

--- a/crane_sessions/src/free_kicker_skill_session.cpp
+++ b/crane_sessions/src/free_kicker_skill_session.cpp
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <crane_sessions/free_kicker_skill_session.hpp>
+
+namespace crane
+{
+}  // namespace crane

--- a/crane_sessions/src/session_factory.cpp
+++ b/crane_sessions/src/session_factory.cpp
@@ -19,6 +19,7 @@
 #include <crane_sessions/emplace_robot_session.hpp>
 #include <crane_sessions/formation_session.hpp>
 #include <crane_sessions/forward_session.hpp>
+#include <crane_sessions/free_kicker_skill_session.hpp>
 #include <crane_sessions/goalie_skill_session.hpp>
 #include <crane_sessions/latency_measurement_session.hpp>
 #include <crane_sessions/marker_session.hpp>
@@ -79,6 +80,7 @@ auto getSessionFactoryMap() -> const std::unordered_map<std::string, SessionFact
     PLANNER_ENTRY("total_defense", TotalDefenseSession),
     PLANNER_ENTRY("emplace_robot", EmplaceRobotSession),
     PLANNER_ENTRY("forward", ForwardSession),
+    PLANNER_ENTRY("free_kicker_skill", FreeKickerSkillSession),
     PLANNER_ENTRY("second_threat_defender", SecondThreatDefenderSession),
     PLANNER_ENTRY("ball_calibration_data_collector", BallCalibrationDataCollectorSession),
     PLANNER_ENTRY("center_stop_kick", CenterStopKickSession),


### PR DESCRIPTION
## Summary
- 0425ブランチに積まれていたFreeKicker関連変更のうち、スキル本体とSessionの基本形のみをdevelop向けに分離する第1段PR。
- AttackerスキルからフリーキックロジックをFreeKickerスキルとして切り出し、APPROACH→ALIGN→KICK→FINISH のステートマシンで制御。
- ゴール可視角に応じてシュート/パス/フォールバックを段階選択。

## 含まれる変更
- 新規: `crane_robot_skills/{include/crane_robot_skills/free_kicker.hpp, src/free_kicker.cpp}`
- 新規: `crane_sessions/{include/crane_sessions/free_kicker_skill_session.hpp, src/free_kicker_skill_session.cpp}`（`SingleSkillSession` ベース、ボール最寄り選定）
- 既存: `crane_sessions/src/session_factory.cpp` に `free_kicker_skill` 登録
- 既存: `crane_session_coordinator/config/unified_session_config.yaml` の `OUR_FREE_KICK` を `free_kicker_skill` に切替

## 含まれない変更（後続PRで取り込み）
- 履歴ベース・ローテ選定（`RotatingSingleSkillSession` 共通基底抽出 / cd73d407） → 段階2
- 敵コーナーフリーキック自陣返し修正・`getAttackSideSign()` 符号反転 (1df297f6) → 段階3
- Approach 設計刷新 (4792c7b8 / 87e91a1a) → 段階3
- HALF_FIELD_PRACTICE の `kick_allowed_skills` への `free_kicker` 追加 → 別系統PR

## 対応元コミット (origin/0425)
- `46bfed62` feat: FreeKickerスキル新規導入（FreeKicker分のみ・HALF_FIELD_PRACTICE変更とフォーマット周辺差分は除外）
- `9af0da77` セットプレーのキック処理更新(halftime)（KICKターゲット 0.1m 前方シフト）
- `18f51444` linter（`free_kicker.cpp` 部分のみ取り込み）

## Test plan
- [x] `colcon build --packages-up-to crane_sessions crane_robot_skills crane_session_coordinator` が通る
- [x] `colcon build --packages-select crane_robot_skills --cmake-args -DCRANE_UNITY_BUILD=OFF` が通る（include漏れチェック）
- [ ] `colcon test --packages-select crane_robot_skills crane_sessions crane_session_coordinator` が全PASS
- [ ] `make scenario-test TEST=STOP_ROBOT_SPEED` で回帰なし
- [ ] シミュレータ + ssl-game-controller で OUR_FREE_KICK を発火 → APPROACH→ALIGN→KICK 遷移とボール発射を目視確認
- [ ] 既知未修正: 敵コーナーフリーキック時の自陣返し（段階3で修正予定）