### PR TITLE
feat(crane_sessions): FreeKickerにローテ＋履歴ベースのロボット選定を追加

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/free_kicker.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/free_kicker.hpp
@@ -42,6 +42,8 @@ public:
     return static_cast<FreeKickerState>(SkillBaseWithState::getCurrentState());
   }
 
+  bool kickActuallyLaunched() const { return kick_actually_launched_; }
+
 private:
   void initialize();
   static std::string getStateName(int s);
@@ -71,6 +73,8 @@ private:
   std::optional<std::chrono::steady_clock::time_point> align_entry_time_;
 
   int align_stable_count_ = 0;
+
+  bool kick_actually_launched_ = false;
 };
 }  // namespace crane::skills
 #endif  // CRANE_ROBOT_SKILLS__FREE_KICKER_HPP_

--- a/crane_robot_skills/src/free_kicker.cpp
+++ b/crane_robot_skills/src/free_kicker.cpp
@@ -41,6 +41,7 @@ void FreeKicker::resetInternalState()
   align_stable_count_ = 0;
   approach_entry_time_ = std::nullopt;
   align_entry_time_ = std::nullopt;
+  kick_actually_launched_ = false;
 }
 
 void FreeKicker::initialize()
@@ -196,13 +197,19 @@ void FreeKicker::initialize()
     using std::chrono::steady_clock;
     double elapsed =
       duration_cast<duration<double>>(steady_clock::now() - kick_started_time_).count();
-    if (elapsed > FK_KICK_TIMEOUT_SEC) return true;
+    if (elapsed > FK_KICK_TIMEOUT_SEC) {
+      kick_actually_launched_ = false;
+      return true;
+    }
 
     double ball_speed = world_model()->ball().vel.norm();
     if (ball_speed > FK_KICK_DETECT_VEL) {
       Vector2 ball_vel_dir = world_model()->ball().vel.normalized();
       Vector2 intended_dir = (kick_target_ - world_model()->ball().pos).normalized();
-      return ball_vel_dir.dot(intended_dir) > FK_KICK_DIRECTION_COS_THRESHOLD;
+      if (ball_vel_dir.dot(intended_dir) > FK_KICK_DIRECTION_COS_THRESHOLD) {
+        kick_actually_launched_ = true;
+        return true;
+      }
     }
     return false;
   });

--- a/crane_session_coordinator/config/free_kicker_history.yaml
+++ b/crane_session_coordinator/config/free_kicker_history.yaml
@@ -1,0 +1,2 @@
+next_seq: 1
+robots: {}

--- a/crane_sessions/include/crane_sessions/free_kicker_skill_session.hpp
+++ b/crane_sessions/include/crane_sessions/free_kicker_skill_session.hpp
@@ -9,41 +9,51 @@
 
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 #include <crane_robot_skills/free_kicker.hpp>
-#include <crane_sessions/single_skill_session.hpp>
+#include <crane_sessions/rotating_single_skill_session.hpp>
+#include <cstddef>
+#include <filesystem>
 #include <memory>
+#include <optional>
 #include <rclcpp/rclcpp.hpp>
 
 #include "visibility_control.h"
 
 namespace crane
 {
-class FreeKickerSkillSession : public SingleSkillSession<skills::FreeKicker>
+class FreeKickerSkillSession : public RotatingSingleSkillSession<skills::FreeKicker>
 {
 public:
   COMPOSITION_PUBLIC explicit FreeKickerSkillSession(
     WorldModelWrapper::SharedPtr & world_model, rclcpp::Node &)
-  : SingleSkillSession("free_kicker_skill", world_model)
+  : RotatingSingleSkillSession("free_kicker_skill", world_model)
   {
-  }
-
-  auto getRobotSuitabilityFunc() const
-    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
-  {
-    auto wm = world_model;
-    return [wm](const std::shared_ptr<RobotInfo> & robot) {
-      if (robot->id == wm->getOurGoalieId()) {
-        return GOALIE_EXCLUSION_COST;
-      }
-      // ボール最寄りのロボットをフリーキッカーとして割り当てる
-      return robot->getSquareDistance(wm->ball().pos);
-    };
   }
 
 protected:
-  auto createSkill(uint8_t robot_id) -> std::shared_ptr<skills::FreeKicker> override
-  {
-    return std::make_shared<skills::FreeKicker>(robot_id, world_model);
-  }
+  auto createSkill(uint8_t robot_id) -> std::shared_ptr<skills::FreeKicker> override;
+
+  std::filesystem::path resolveHistoryFilePath() const override;
+
+  /// FreeKick の成否は以下の優先順で判定する:
+  /// 1. 試行中に NO_PROGRESS_IN_GAME / 自チームの BOT_DRIBBLED_BALL_TOO_FAR /
+  ///    自チームの ATTACKER_DOUBLE_TOUCHED_BALL が新規発生 → 失敗
+  /// 2. スキルが FINISH に到達 → skill->kickActuallyLaunched() の真偽そのまま
+  ///    (タイムアウトで FINISH した空振りは false=失敗)
+  /// 3. それ以外（FINISH 未到達で割当解除） → 失敗扱い
+  std::optional<bool> determineAssignmentResult(
+    const crane_msgs::msg::PlaySituation & current_play_situation) override;
+
+  void onSkillStarted() override;
+  void onRobotsChangedHook() override;
+
+private:
+  /// 試行開始時点での referee_raw.game_events のサイズ。
+  /// 「試行中に発生したイベント」だけを判定対象にするためのスナップショット。
+  std::optional<std::size_t> initial_game_events_size_;
+
+  /// 試行開始以降に追加された game events のうち、FreeKick 失敗を示すものがあるか。
+  bool hasOurFailureGameEvent(
+    const crane_msgs::msg::PlaySituation & current_play_situation, std::size_t start_index) const;
 };
 }  // namespace crane
 #endif  // CRANE_SESSIONS__FREE_KICKER_SKILL_SESSION_HPP_

--- a/crane_sessions/include/crane_sessions/rotating_single_skill_session.hpp
+++ b/crane_sessions/include/crane_sessions/rotating_single_skill_session.hpp
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_SESSIONS__ROTATING_SINGLE_SKILL_SESSION_HPP_
+#define CRANE_SESSIONS__ROTATING_SINGLE_SKILL_SESSION_HPP_
+
+#include <crane_sessions/rotation_suitability.hpp>
+#include <crane_sessions/session_base.hpp>
+#include <crane_sessions/skill_assignment_history.hpp>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <rclcpp/rclcpp.hpp>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace crane
+{
+/// 単一スキルにロボットを割り当て、履歴に基づきローテーションさせる Session の共通基底。
+///
+/// 派生クラス（例: BallPlacementSkillSession, FreeKickerSkillSession）が以下を実装する:
+/// - createSkill(): スキルインスタンスを生成
+/// - resolveHistoryFilePath(): 履歴ファイルパスを返す（スキルごとに別ファイル）
+/// - determineAssignmentResult(): セッション終了時の成否判定
+///
+/// 共通化されているもの:
+/// - スキル lifecycle（生成・active_robot_id 追跡・直近 Status 記録）
+/// - 履歴ファイルの遅延ロードと成否記録
+/// - getRobotSuitabilityFunc(): rotation_suitability.hpp の共通ロジックを使う
+template <typename SkillType>
+class RotatingSingleSkillSession : public SessionBase
+{
+public:
+  std::shared_ptr<SkillType> skill = nullptr;
+
+  using SessionBase::SessionBase;
+
+  auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
+    -> std::pair<Status, std::vector<crane_msgs::msg::RobotCommand>> override
+  {
+    if (robots.empty()) {
+      return {Status::RUNNING, {}};
+    }
+    if (not skill) {
+      skill = createSkill(robots.front().id);
+      visualizer->layer = "skill/" + skill->name;
+      active_robot_id_ = robots.front().id;
+      onSkillStarted();
+    }
+    onBeforeSkillRun();
+    auto status = static_cast<Status>(skill->run());
+    last_skill_status_ = status;
+    return {status, {skill->getRobotCommand()}};
+  }
+
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    ensureHistoryLoaded();
+
+    RotationSuitabilityConfig config;
+    config.success_weight =
+      this->template getSessionParameter<double>("success_weight", config.success_weight);
+    config.failure_weight =
+      this->template getSessionParameter<double>("failure_weight", config.failure_weight);
+    config.distance_weight =
+      this->template getSessionParameter<double>("distance_weight", config.distance_weight);
+    config.rotation_weight =
+      this->template getSessionParameter<double>("rotation_weight", config.rotation_weight);
+    config.top_n_candidates =
+      this->template getSessionParameter<int>("top_n_candidates", config.top_n_candidates);
+
+    return makeRotationSuitabilityFunc(this->world_model, history_, config);
+  }
+
+protected:
+  /// スキルインスタンスを生成するファクトリメソッド（派生クラスで実装）。
+  virtual auto createSkill(uint8_t robot_id) -> std::shared_ptr<SkillType> = 0;
+
+  /// 履歴ファイルパスを解決する（派生クラスで実装、スキルごとに別ファイル）。
+  virtual std::filesystem::path resolveHistoryFilePath() const = 0;
+
+  /// セッションが Active 集合から外れた際の成否判定（派生クラスで実装）。
+  /// - std::nullopt: 履歴更新なし（明示的シグナルなし）
+  /// - true: 成功記録
+  /// - false: 失敗記録
+  ///
+  /// 呼び出し時点で getActiveRobotId() / getLastSkillStatus() が参照可能。
+  virtual std::optional<bool> determineAssignmentResult(
+    const crane_msgs::msg::PlaySituation & current_play_situation) = 0;
+
+  /// 初回 calculate 時にスキル生成直後に呼ばれる任意フック。
+  /// 試行開始時点のスナップショット（例: ボールプレイスメントの failures カウント）を
+  /// 派生クラスがキャプチャするのに使う。
+  virtual void onSkillStarted() {}
+
+  /// 各 calculate 呼び出しで skill->run() の直前に呼ばれる任意フック。
+  /// 動的なスキルパラメータ更新（例: placement_x/y のセット）に使う。
+  virtual void onBeforeSkillRun() {}
+
+  /// onRobotsChanged() の派生クラス固有処理用フック。
+  virtual void onRobotsChangedHook() {}
+
+  /// 直近の skill->run() の Status（determineAssignmentResult から参照する用）。
+  Status getLastSkillStatus() const { return last_skill_status_; }
+
+  /// 現在割り当て中のロボットID（determineAssignmentResult から参照する用）。
+  std::optional<uint8_t> getActiveRobotId() const { return active_robot_id_; }
+
+  /// 履歴を遅延初期化する。
+  void ensureHistoryLoaded() const
+  {
+    if (history_) {
+      return;
+    }
+    history_ = std::make_shared<SkillAssignmentHistory>(resolveHistoryFilePath());
+  }
+
+  void onRobotsChanged() override
+  {
+    skill.reset();
+    active_robot_id_.reset();
+    last_skill_status_ = Status::RUNNING;
+    onRobotsChangedHook();
+  }
+
+  void onDeactivated(const crane_msgs::msg::PlaySituation & current_play_situation) override
+  {
+    if (!active_robot_id_.has_value()) {
+      return;
+    }
+    const auto robot_id = *active_robot_id_;
+
+    // determineAssignmentResult は active_robot_id_ / last_skill_status_ を参照しうるため
+    // リセットより前に呼ぶ。派生クラスもこの順序を前提に実装すること。
+    const auto result = determineAssignmentResult(current_play_situation);
+
+    active_robot_id_.reset();
+    skill.reset();
+    last_skill_status_ = Status::RUNNING;
+
+    if (!result.has_value()) {
+      RCLCPP_INFO(
+        rclcpp::get_logger("RotatingSingleSkillSession"),
+        "[%s] ロボット %d "
+        "の試行終了を検知したが、明示的な成否シグナルがないため履歴更新をスキップ",
+        this->name.c_str(), static_cast<int>(robot_id));
+      return;
+    }
+
+    ensureHistoryLoaded();
+    const bool success = *result;
+    const bool saved =
+      success ? history_->recordSuccess(robot_id) : history_->recordFailure(robot_id);
+    const char * result_text = success ? "成功" : "失敗";
+    if (saved) {
+      RCLCPP_INFO(
+        rclcpp::get_logger("RotatingSingleSkillSession"), "[%s] ロボット %d の%sを記録",
+        this->name.c_str(), static_cast<int>(robot_id), result_text);
+    } else {
+      RCLCPP_WARN(
+        rclcpp::get_logger("RotatingSingleSkillSession"), "[%s] ロボット %d の%s履歴の保存に失敗",
+        this->name.c_str(), static_cast<int>(robot_id), result_text);
+    }
+  }
+
+private:
+  mutable std::shared_ptr<SkillAssignmentHistory> history_;
+  std::optional<uint8_t> active_robot_id_;
+  Status last_skill_status_ = Status::RUNNING;
+};
+
+}  // namespace crane
+#endif  // CRANE_SESSIONS__ROTATING_SINGLE_SKILL_SESSION_HPP_

--- a/crane_sessions/include/crane_sessions/rotation_suitability.hpp
+++ b/crane_sessions/include/crane_sessions/rotation_suitability.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_SESSIONS__ROTATION_SUITABILITY_HPP_
+#define CRANE_SESSIONS__ROTATION_SUITABILITY_HPP_
+
+#include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_sessions/skill_assignment_history.hpp>
+#include <functional>
+#include <memory>
+
+namespace crane
+{
+/// ローテーション付き suitability 関数の重み・パラメータ。
+///
+/// スコア = clamped > 0 ? clamped + W_D * distance
+///        : W_R * rotation_rank + W_D * distance     (clamped == 0 のローテ帯)
+///   ただし clamped = max(0, W_F * failures - W_S * successes)
+///
+/// distance はボールからの直線距離（m）。
+/// rotation_rank は上位 top_n_candidates 台内で last_seq 昇順の順位 (0=最古=最優先)。
+struct RotationSuitabilityConfig
+{
+  double success_weight = 1.0;
+  double failure_weight = 2.0;
+  double distance_weight = 0.01;
+  double rotation_weight = 0.001;
+  int top_n_candidates = 3;
+};
+
+/// ローテーション付き suitability 関数を生成する。
+///
+/// - 距離昇順で上位 top_n_candidates 台のみ候補とし、それ以外は実用上選ばれない高コスト
+///   (NON_CANDIDATE_COST + distance) を返す。
+/// - 候補内で失敗履歴が支配的なら「失敗少 → 距離」順、そうでなければ
+///   「last_seq 古い → 距離」順で選ぶことでローテーションする。
+/// - ゴーリーは GOALIE_EXCLUSION_COST で除外。
+///
+/// `history` は遅延初期化された後の有効な shared_ptr を渡すこと。
+std::function<double(const std::shared_ptr<RobotInfo> &)> makeRotationSuitabilityFunc(
+  const WorldModelWrapper::SharedPtr & world_model, std::shared_ptr<SkillAssignmentHistory> history,
+  const RotationSuitabilityConfig & config);
+
+}  // namespace crane
+#endif  // CRANE_SESSIONS__ROTATION_SUITABILITY_HPP_

--- a/crane_sessions/include/crane_sessions/session_base.hpp
+++ b/crane_sessions/include/crane_sessions/session_base.hpp
@@ -13,6 +13,7 @@
 #include <crane_msg_wrappers/robot_command_wrapper.hpp>
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 #include <crane_msgs/msg/game_analysis.hpp>
+#include <crane_msgs/msg/play_situation.hpp>
 #include <crane_msgs/msg/robot_commands.hpp>
 #include <crane_physics/position_assignments.hpp>
 #include <crane_utils/stream.hpp>
@@ -176,6 +177,17 @@ public:
     return default_value;
   }
 
+  void setFixedRobots(const std::vector<uint8_t> & ids) { fixed_robots_ = ids; }
+  const std::vector<uint8_t> & getFixedRobots() const { return fixed_robots_; }
+
+  void setUseCandidateRobots(bool flag) { use_candidate_robots_ = flag; }
+  bool usesCandidateRobots() const { return use_candidate_robots_; }
+
+  void setCandidateRobots(const std::vector<uint8_t> & ids) { candidate_robots_ = ids; }
+  const std::vector<uint8_t> & getCandidateRobots() const { return candidate_robots_; }
+
+  virtual void onDeactivated(const crane_msgs::msg::PlaySituation &) {}
+
   /**
    * @brief ロボット適性評価関数を取得（GlobalRobotAllocator用）
    *
@@ -282,6 +294,9 @@ protected:
 
 private:
   crane_msgs::msg::GameAnalysis game_analysis_;
+  std::vector<uint8_t> fixed_robots_;
+  std::vector<uint8_t> candidate_robots_;
+  bool use_candidate_robots_ = false;
 };
 
 }  // namespace crane

--- a/crane_sessions/include/crane_sessions/skill_assignment_history.hpp
+++ b/crane_sessions/include/crane_sessions/skill_assignment_history.hpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_SESSIONS__SKILL_ASSIGNMENT_HISTORY_HPP_
+#define CRANE_SESSIONS__SKILL_ASSIGNMENT_HISTORY_HPP_
+
+#include <cstdint>
+#include <filesystem>
+#include <unordered_map>
+
+namespace crane
+{
+/// 単一スキルへのロボット割当履歴を YAML ファイルに永続化する汎用ストア。
+///
+/// プロセス再起動を跨いで「どのロボットが何回成功/失敗したか」「最後に
+/// 選ばれたのは何順目か」を覚えておき、ローテーション付き suitability 関数
+/// (rotation_suitability.hpp) からロボット選定の根拠として参照される。
+///
+/// last_seq はゼロ帯（成功支配で clamp された複数ロボット）でローテーションを
+/// 行うためのグローバル順番付けで、success/failure を記録するたびに
+/// `next_seq_` を払い出してそのロボットに記録する。
+///
+/// データ構造自体はスキル非依存なので、ボールプレイスメント・フリーキック等
+/// 別スキルごとに別ファイルパスでインスタンス化して使う。
+class SkillAssignmentHistory
+{
+public:
+  struct Entry
+  {
+    int success = 0;
+    int failure = 0;
+    std::uint64_t last_seq = 0;
+  };
+
+  explicit SkillAssignmentHistory(const std::filesystem::path & file_path);
+
+  Entry get(std::uint8_t robot_id) const;
+
+  /// 成功を記録し、新しい seq を割り当ててファイルに書き出す。
+  bool recordSuccess(std::uint8_t robot_id);
+
+  /// 失敗を記録し、新しい seq を割り当ててファイルに書き出す。
+  bool recordFailure(std::uint8_t robot_id);
+
+  std::uint64_t nextSeq() const { return next_seq_; }
+
+private:
+  void load();
+  bool save() const;
+
+  std::filesystem::path file_path_;
+  std::unordered_map<std::uint8_t, Entry> entries_;
+  std::uint64_t next_seq_ = 1;
+};
+}  // namespace crane
+#endif  // CRANE_SESSIONS__SKILL_ASSIGNMENT_HISTORY_HPP_

--- a/crane_sessions/src/free_kicker_skill_session.cpp
+++ b/crane_sessions/src/free_kicker_skill_session.cpp
@@ -4,8 +4,90 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <crane_sessions/free_kicker_skill_session.hpp>
+#include <robocup_ssl_msgs/msg/game_event_type.hpp>
+#include <robocup_ssl_msgs/msg/team.hpp>
 
 namespace crane
 {
+auto FreeKickerSkillSession::createSkill(uint8_t robot_id) -> std::shared_ptr<skills::FreeKicker>
+{
+  return std::make_shared<skills::FreeKicker>(robot_id, world_model);
+}
+
+std::filesystem::path FreeKickerSkillSession::resolveHistoryFilePath() const
+{
+  const auto override_path = getSessionParameter<std::string>("history_file_path", "");
+  if (!override_path.empty()) {
+    return override_path;
+  }
+
+  const auto config_path =
+    std::filesystem::path(
+      ament_index_cpp::get_package_share_directory("crane_session_coordinator")) /
+    "config" / "free_kicker_history.yaml";
+  try {
+    return std::filesystem::weakly_canonical(config_path);
+  } catch (const std::exception &) {
+    return config_path;
+  }
+}
+
+std::optional<bool> FreeKickerSkillSession::determineAssignmentResult(
+  const crane_msgs::msg::PlaySituation & current_play_situation)
+{
+  const auto start_index = initial_game_events_size_.value_or(0);
+  initial_game_events_size_.reset();
+
+  if (hasOurFailureGameEvent(current_play_situation, start_index)) {
+    return false;
+  }
+
+  if (skill && skill->getCurrentState() == skills::FreeKickerState::FINISH) {
+    return skill->kickActuallyLaunched();
+  }
+
+  return false;
+}
+
+void FreeKickerSkillSession::onSkillStarted()
+{
+  initial_game_events_size_ = world_model->getMsg().play_situation.referee_raw.game_events.size();
+}
+
+void FreeKickerSkillSession::onRobotsChangedHook() { initial_game_events_size_.reset(); }
+
+bool FreeKickerSkillSession::hasOurFailureGameEvent(
+  const crane_msgs::msg::PlaySituation & current_play_situation, std::size_t start_index) const
+{
+  const auto & events = current_play_situation.referee_raw.game_events;
+  if (start_index > events.size()) {
+    // 何らかの理由でリストが縮んだ場合は判定不能 → 失敗扱いしない
+    return false;
+  }
+
+  const int our_team_value = world_model->isYellow() ? robocup_ssl_msgs::msg::Team::YELLOW
+                                                     : robocup_ssl_msgs::msg::Team::BLUE;
+
+  using GET = robocup_ssl_msgs::msg::GameEventType;
+  for (std::size_t i = start_index; i < events.size(); ++i) {
+    const auto & ge = events[i];
+    switch (ge.type.value) {
+      case GET::NO_PROGRESS_IN_GAME:
+        // ゲーム全体が膠着した: フリーキックで打開できなかった → 失敗
+        return true;
+      case GET::BOT_DRIBBLED_BALL_TOO_FAR:
+        if (ge.event.bot_dribbled_ball_too_far.by_team.value == our_team_value) return true;
+        break;
+      case GET::ATTACKER_DOUBLE_TOUCHED_BALL:
+        if (ge.event.attacker_double_touched_ball.by_team.value == our_team_value) return true;
+        break;
+      default:
+        break;
+    }
+  }
+  return false;
+}
+
 }  // namespace crane

--- a/crane_sessions/src/rotation_suitability.cpp
+++ b/crane_sessions/src/rotation_suitability.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <algorithm>
+#include <crane_sessions/rotation_suitability.hpp>
+#include <crane_sessions/session_base.hpp>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace crane
+{
+namespace
+{
+/// 候補外（ゴーリーや上位N台外）に乗せる大きなコスト。distance を加算して数値を分散させる。
+constexpr double NON_CANDIDATE_COST = 1e6;
+}  // namespace
+
+std::function<double(const std::shared_ptr<RobotInfo> &)> makeRotationSuitabilityFunc(
+  const WorldModelWrapper::SharedPtr & world_model, std::shared_ptr<SkillAssignmentHistory> history,
+  const RotationSuitabilityConfig & config)
+{
+  // 距離昇順で上位 N 台を事前計算する
+  // （suitability_func は1ロボットずつ呼ばれるため、ランキング情報を lambda にキャプチャしておく）
+  const auto goalie_id = world_model->getOurGoalieId();
+  const Point ball_pos = world_model->ball().pos;
+
+  std::vector<std::pair<std::uint8_t, double>> distances;
+  for (const auto & r : world_model->ours().robotsWhere().available().get()) {
+    if (r->id == goalie_id) continue;
+    distances.emplace_back(r->id, (r->pose.pos - ball_pos).norm());
+  }
+  std::ranges::sort(distances, [](const auto & a, const auto & b) { return a.second < b.second; });
+
+  // 上位 N 台のID集合と、その中での last_seq 順のランク（0=最古=最優先）
+  // 注: last_seq の絶対値を使うと長期的に W_R * last_seq が W_F を超えてしまい
+  // 失敗履歴のあるロボットに流れてしまう。順位なら最大でも (top_n - 1) で上限が効く。
+  std::unordered_set<std::uint8_t> top_ids;
+  std::vector<std::pair<std::uint8_t, std::uint64_t>> top_with_seq;
+  for (int i = 0; i < std::min<int>(config.top_n_candidates, distances.size()); ++i) {
+    const auto id = distances[i].first;
+    top_ids.insert(id);
+    top_with_seq.emplace_back(id, history->get(id).last_seq);
+  }
+  std::ranges::stable_sort(
+    top_with_seq, [](const auto & a, const auto & b) { return a.second < b.second; });
+  std::unordered_map<std::uint8_t, int> rotation_rank;
+  for (std::size_t i = 0; i < top_with_seq.size(); ++i) {
+    rotation_rank[top_with_seq[i].first] = static_cast<int>(i);
+  }
+
+  return [history, top_ids = std::move(top_ids), rotation_rank = std::move(rotation_rank), ball_pos,
+          goalie_id, config](const std::shared_ptr<RobotInfo> & robot) {
+    if (robot->id == goalie_id) {
+      return SessionBase::GOALIE_EXCLUSION_COST;
+    }
+
+    const double distance = (robot->pose.pos - ball_pos).norm();
+
+    // 上位 N 台外は実用上選ばれない高コスト。distance を加算して安定なランキングを与える。
+    if (top_ids.find(robot->id) == top_ids.end()) {
+      return NON_CANDIDATE_COST + distance;
+    }
+
+    const auto entry = history->get(robot->id);
+    const double raw = config.failure_weight * static_cast<double>(entry.failure) -
+                       config.success_weight * static_cast<double>(entry.success);
+    const double clamped = std::max(0.0, raw);
+
+    if (clamped > 0.0) {
+      // 失敗が支配的: 失敗少 → 距離 の順
+      return clamped + config.distance_weight * distance;
+    }
+    // 全員「優秀」ゾーン: 上位N内で last_seq が小さい(=最古) ロボットを優先 → ローテ
+    // rank は 0..(top_n-1) なので W_R * rank の上限は (top_n-1) * W_R で、W_F より小さく保てる
+    const auto it = rotation_rank.find(robot->id);
+    const int rank = (it != rotation_rank.end()) ? it->second : 0;
+    return config.rotation_weight * static_cast<double>(rank) + config.distance_weight * distance;
+  };
+}
+
+}  // namespace crane

--- a/crane_sessions/src/skill_assignment_history.cpp
+++ b/crane_sessions/src/skill_assignment_history.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <yaml-cpp/yaml.h>
+
+#include <cinttypes>
+#include <crane_sessions/skill_assignment_history.hpp>
+#include <fstream>
+#include <rclcpp/rclcpp.hpp>
+
+namespace crane
+{
+SkillAssignmentHistory::SkillAssignmentHistory(const std::filesystem::path & file_path)
+: file_path_(file_path)
+{
+  load();
+}
+
+SkillAssignmentHistory::Entry SkillAssignmentHistory::get(std::uint8_t robot_id) const
+{
+  auto it = entries_.find(robot_id);
+  if (it == entries_.end()) {
+    return Entry{};
+  }
+  return it->second;
+}
+
+bool SkillAssignmentHistory::recordSuccess(std::uint8_t robot_id)
+{
+  const auto previous_next_seq = next_seq_;
+  auto & e = entries_[robot_id];
+  const auto previous_entry = e;
+  e.success += 1;
+  e.last_seq = next_seq_++;
+  if (save()) {
+    return true;
+  }
+  e = previous_entry;
+  next_seq_ = previous_next_seq;
+  return false;
+}
+
+bool SkillAssignmentHistory::recordFailure(std::uint8_t robot_id)
+{
+  const auto previous_next_seq = next_seq_;
+  auto & e = entries_[robot_id];
+  const auto previous_entry = e;
+  e.failure += 1;
+  e.last_seq = next_seq_++;
+  if (save()) {
+    return true;
+  }
+  e = previous_entry;
+  next_seq_ = previous_next_seq;
+  return false;
+}
+
+void SkillAssignmentHistory::load()
+{
+  if (!std::filesystem::exists(file_path_)) {
+    RCLCPP_INFO(
+      rclcpp::get_logger("SkillAssignmentHistory"), "履歴ファイルが存在しないため新規開始: %s",
+      file_path_.c_str());
+    return;
+  }
+
+  try {
+    YAML::Node root = YAML::LoadFile(file_path_.string());
+    if (root["next_seq"]) {
+      next_seq_ = root["next_seq"].as<std::uint64_t>();
+    }
+    if (root["robots"]) {
+      for (const auto & kv : root["robots"]) {
+        const auto id = kv.first.as<int>();
+        Entry e;
+        if (kv.second["success"]) e.success = kv.second["success"].as<int>();
+        if (kv.second["failure"]) e.failure = kv.second["failure"].as<int>();
+        if (kv.second["last_seq"]) e.last_seq = kv.second["last_seq"].as<std::uint64_t>();
+        entries_[static_cast<std::uint8_t>(id)] = e;
+      }
+    }
+    RCLCPP_INFO(
+      rclcpp::get_logger("SkillAssignmentHistory"),
+      "履歴ファイル読み込み完了: %s (entries=%zu, next_seq=%" PRIu64 ")", file_path_.c_str(),
+      entries_.size(), static_cast<uint64_t>(next_seq_));
+  } catch (const std::exception & ex) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("SkillAssignmentHistory"),
+      "履歴ファイル読み込み失敗 (空状態で開始): %s, error=%s", file_path_.c_str(), ex.what());
+    entries_.clear();
+    next_seq_ = 1;
+  }
+}
+
+bool SkillAssignmentHistory::save() const
+{
+  try {
+    YAML::Node root;
+    root["next_seq"] = next_seq_;
+    YAML::Node robots;
+    for (const auto & [id, e] : entries_) {
+      YAML::Node entry;
+      entry["success"] = e.success;
+      entry["failure"] = e.failure;
+      entry["last_seq"] = e.last_seq;
+      robots[static_cast<int>(id)] = entry;
+    }
+    root["robots"] = robots;
+
+    // 親ディレクトリを作成
+    std::filesystem::create_directories(file_path_.parent_path());
+
+    // 一時ファイルに書いてから rename することで原子的に更新する
+    auto tmp_path = file_path_;
+    tmp_path += ".tmp";
+    {
+      std::ofstream ofs(tmp_path);
+      if (!ofs) {
+        RCLCPP_ERROR(
+          rclcpp::get_logger("SkillAssignmentHistory"), "履歴ファイル書き込み失敗 (open): %s",
+          tmp_path.c_str());
+        return false;
+      }
+      ofs << root;
+    }
+    std::filesystem::rename(tmp_path, file_path_);
+    RCLCPP_INFO(
+      rclcpp::get_logger("SkillAssignmentHistory"),
+      "履歴ファイル書き込み成功: %s (entries=%zu, next_seq=%" PRIu64 ")", file_path_.c_str(),
+      entries_.size(), static_cast<uint64_t>(next_seq_));
+    return true;
+  } catch (const std::exception & ex) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("SkillAssignmentHistory"), "履歴ファイル書き込み失敗: %s, error=%s",
+      file_path_.c_str(), ex.what());
+    return false;
+  }
+}
+}  // namespace crane


### PR DESCRIPTION
## Summary
- FreeKicker 分割PR 第2弾。`RotatingSingleSkillSession` 共通基底を新設し、`FreeKickerSkillSession` を `SingleSkillSession` から移行。
- 試行履歴（`free_kicker_history.yaml`）に基づいてロボットをローテーションし、成功率の高いロボットを優先割当できるようになる。
- フリーキックの成否はゲームイベント（`NO_PROGRESS_IN_GAME` / `BOT_DRIBBLED_BALL_TOO_FAR` / `ATTACKER_DOUBLE_TOUCHED_BALL`）で自動判定。

## 含まれる変更
- 新規: `crane_sessions/include/crane_sessions/rotating_single_skill_session.hpp` — テンプレート共通基底
- 新規: `crane_sessions/include/crane_sessions/rotation_suitability.{hpp,cpp}` — ローテ適性スコア計算
- 新規: `crane_sessions/include/crane_sessions/skill_assignment_history.{hpp,cpp}` — YAML永続化履歴管理
- 既存: `session_base.hpp` — `onDeactivated` フック追加、`fixed_robots` / `candidate_robots` メンバ追加
- 既存: `free_kicker_skill_session.{hpp,cpp}` — `RotatingSingleSkillSession` 継承へ完全書き換え
- 既存: `free_kicker.{hpp,cpp}` — `kickActuallyLaunched()` API 追加、KICK→FINISH 遷移の成否記録
- 新規: `crane_session_coordinator/config/free_kicker_history.yaml` — 初期設定

## 含まれない変更（後続PRで取り込み）
- ALIGN改善（`baaf9b2c`/`f08f81b9`：1秒タイマー化・ALIGN目標整合） → 段階3
- コーナーフリーキック自陣返し修正 / `getAttackSideSign()` 符号反転 (`1df297f6`) → 段階3
- Approach 設計刷新（`4792c7b8`/`87e91a1a`） → 段階3
- `BallPlacementSkillSession` の `RotatingSingleSkillSession` 移行 → 別PR

## 対応元コミット (origin/0425)
- `cd73d407` feat: フリーキックのロボット選定をローテ＋履歴ベースに（`FreeKicker` / `FreeKickerSkillSession` 部分のみ）
- `b545837d` feat: free_kicker_history.yaml 初期設定追加

## Test plan
- [x] `colcon build --packages-up-to crane_sessions crane_robot_skills crane_session_coordinator` が通る
- [ ] `colcon test --packages-select crane_robot_skills crane_sessions crane_session_coordinator` が全PASS
- [ ] シミュレータで OUR_FREE_KICK を複数回発火 → `free_kicker_history.yaml` に履歴が書き込まれることを確認
- [ ] 履歴に失敗記録のあるロボットが次の試行で後回しにされることをログで確認