### PR TITLE
fix(crane_robot_skills): FreeKickerのコーナー自陣返し・ALIGN振動・Approach刷新を修正

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/free_kicker.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/free_kicker.hpp
@@ -42,6 +42,11 @@ public:
     return static_cast<FreeKickerState>(SkillBaseWithState::getCurrentState());
   }
 
+  /// 直近の試行で実際にボールが意図方向へ高速発射されたか。
+  /// FINISH 状態到達時点で確定する: ball_speed > FK_KICK_DETECT_VEL かつ
+  /// 意図方向との cos が FK_KICK_DIRECTION_COS_THRESHOLD を超えていれば true、
+  /// FK_KICK_TIMEOUT_SEC タイムアウトで FINISH した場合は false。
+  /// 試行ごと(ENTRY_POINT 自己遷移時) に false にリセットされる。
   bool kickActuallyLaunched() const { return kick_actually_launched_; }
 
 private:
@@ -66,13 +71,15 @@ private:
   bool last_chose_shoot_ = false;
   std::optional<uint8_t> last_pass_receiver_id_;
 
+  double chip_distance_ = 2.5;
+
   bool kick_started_ = false;
   std::chrono::steady_clock::time_point kick_started_time_{};
 
   std::optional<std::chrono::steady_clock::time_point> approach_entry_time_;
   std::optional<std::chrono::steady_clock::time_point> align_entry_time_;
 
-  int align_stable_count_ = 0;
+  Point align_target_locked_{Point::Zero()};
 
   bool kick_actually_launched_ = false;
 };

--- a/crane_robot_skills/src/free_kicker.cpp
+++ b/crane_robot_skills/src/free_kicker.cpp
@@ -18,12 +18,10 @@ namespace
 constexpr double FK_KICK_DETECT_VEL = 0.7;
 constexpr double FK_KICK_DIRECTION_COS_THRESHOLD = 0.7;
 constexpr double FK_APPROACH_PHASE_TIMEOUT = 6.0;
-constexpr double FK_ALIGN_PHASE_TIMEOUT = 4.0;
+constexpr double FK_ALIGN_WAIT_SEC = 1.0;
 constexpr double FK_KICK_TIMEOUT_SEC = 3.0;
 constexpr double FK_MIN_PASS_ACCEPT_SCORE = 0.4;
 constexpr double FK_PASS_HYSTERESIS_RATIO = 0.85;
-constexpr double FK_APPROACH_ANGLE_TOLERANCE_RAD = 10.0 * M_PI / 180.0;
-constexpr double FK_APPROACH_SPEED_TOLERANCE = 0.3;
 }  // namespace
 
 std::string FreeKicker::getStateName(int s)
@@ -36,26 +34,22 @@ void FreeKicker::resetInternalState()
   kick_started_ = false;
   target_locked_ = false;
   use_chip_ = false;
+  chip_distance_ = getParameter<double>("target_chip_distance");
   last_chose_shoot_ = false;
   last_pass_receiver_id_ = std::nullopt;
-  align_stable_count_ = 0;
   approach_entry_time_ = std::nullopt;
   align_entry_time_ = std::nullopt;
+  align_target_locked_ = Point::Zero();
   kick_actually_launched_ = false;
 }
 
 void FreeKicker::initialize()
 {
   setParameter("approach_max_velocity", 1.5);
-  setParameter("align_max_velocity", 0.6);
-  setParameter("kick_max_velocity", 1.2);
-  setParameter("approach_distance", 0.25);
-  setParameter("align_distance", 0.12);
-  setParameter("approach_position_tolerance", 0.10);
-  setParameter("align_position_tolerance", 0.05);
-  setParameter("align_speed_tolerance", 0.10);
-  setParameter("align_omega_tolerance", 0.20);
-  setParameter("align_stable_frames", 5);
+  setParameter("align_max_velocity", 0.3);
+  setParameter("kick_max_velocity", 0.5);
+  setParameter("approach_distance", 0.15);
+  setParameter("approach_position_tolerance", 0.05);
   setParameter("target_kick_speed", 5.0);
   setParameter("target_chip_distance", 2.5);
   setParameter("shoot_min_angle_rad", 6.0 * M_PI / 180.0);
@@ -63,8 +57,6 @@ void FreeKicker::initialize()
   setParameter("pass_min_distance", 1.5);
   setParameter("pass_max_distance", 6.0);
   setParameter("enemy_slack_threshold", 0.3);
-  setParameter("ball_nearby_radius", 1.0);
-  setParameter("ball_nearby_speed", 0.5);
   setParameter("pass_defensive_half_penalty", 0.1);
   setParameter("pass_chip_bypass_distance", 1.5);
 
@@ -81,35 +73,30 @@ void FreeKicker::initialize()
   addStateFunction(s(S::APPROACH), [this]() -> Status {
     if (!approach_entry_time_.has_value()) {
       approach_entry_time_ = std::chrono::steady_clock::now();
-    }
-    if (!target_locked_) {
+      // standoff_ を安定させるため APPROACH 開始の 1 フレーム目でロック
       kick_target_ = selectKickTarget();
+      target_locked_ = true;
     }
 
     const Point ball_pos = world_model()->ball().pos;
-    const double approach_dist = getParameter<double>("approach_distance");
+    const double interval = getParameter<double>("approach_distance");
     standoff_ = computeAroundBallApproachTargetDynamic(
-      ball_pos, kick_target_, robot()->pose.pos, approach_dist, approach_dist * 1.5);
+      ball_pos, kick_target_, robot()->pose.pos, interval, interval * 4.0);
 
-    double max_vel = getParameter<double>("approach_max_velocity");
-    if ((robot()->pose.pos - ball_pos).norm() < getParameter<double>("ball_nearby_radius")) {
-      max_vel = std::min(max_vel, getParameter<double>("ball_nearby_speed"));
-    }
-    command->setTargetPosition(standoff_)
+    command->setMaxVelocity("FreeKicker::APPROACH", getParameter<double>("approach_max_velocity"))
+      .setTargetPosition(standoff_, 0.0)
       .lookAtFrom(kick_target_, ball_pos)
-      .setMaxVelocity("FreeKicker::APPROACH", max_vel);
+      .disableBallAvoidance()
+      .disablePlacementAvoidance()
+      .disableGoalAreaAvoidance()
+      .disableFieldBoundary()
+      .dribble(0.0)
+      .setOmegaLimit(10.0);
 
     return Status::RUNNING;
   });
   addTransition(s(S::APPROACH), s(S::ALIGN), [this]() -> bool {
-    const Point ball_pos = world_model()->ball().pos;
-    double pos_error = (robot()->pose.pos - standoff_).norm();
-    double angle_error =
-      std::abs(normalizeAngle(robot()->pose.theta - getAngle(kick_target_ - ball_pos)));
-    double speed = robot()->vel.linear.norm();
-
-    return pos_error < getParameter<double>("approach_position_tolerance") &&
-           angle_error < FK_APPROACH_ANGLE_TOLERANCE_RAD && speed < FK_APPROACH_SPEED_TOLERANCE;
+    return command->getTargetDistance() < getParameter<double>("approach_position_tolerance");
   });
   addTransition(s(S::APPROACH), s(S::ENTRY_POINT), [this]() -> bool {
     using std::chrono::duration;
@@ -124,44 +111,26 @@ void FreeKicker::initialize()
     if (!align_entry_time_.has_value()) {
       target_locked_ = true;
       align_entry_time_ = std::chrono::steady_clock::now();
-      align_stable_count_ = 0;
+      // APPROACH 最終地点と整合させるため、進入時のボール位置を基準に1回だけ計算してロック
+      const Point ball_pos = world_model()->ball().pos;
+      align_target_locked_ = ball_pos - (kick_target_ - ball_pos).normalized() *
+                                          getParameter<double>("approach_distance");
     }
 
-    const Point ball_pos = world_model()->ball().pos;
-    const Point press_point =
-      ball_pos - (kick_target_ - ball_pos).normalized() * getParameter<double>("align_distance");
-
-    command->setTargetPosition(press_point)
-      .lookAtFrom(kick_target_, ball_pos)
+    command->setTargetPosition(align_target_locked_)
+      .lookAtFrom(kick_target_, world_model()->ball().pos)
       .setMaxVelocity("FreeKicker::ALIGN", getParameter<double>("align_max_velocity"))
       .disableBallAvoidance();
-
-    double pos_error = (robot()->pose.pos - press_point).norm();
-    double speed = robot()->vel.linear.norm();
-    double omega = std::abs(robot()->vel.omega);
-
-    bool stable = pos_error < getParameter<double>("align_position_tolerance") &&
-                  speed < getParameter<double>("align_speed_tolerance") &&
-                  omega < getParameter<double>("align_omega_tolerance");
-
-    if (stable) {
-      align_stable_count_++;
-    } else {
-      align_stable_count_ = 0;
-    }
 
     return Status::RUNNING;
   });
   addTransition(s(S::ALIGN), s(S::KICK), [this]() -> bool {
-    return align_stable_count_ >= getParameter<int>("align_stable_frames");
-  });
-  addTransition(s(S::ALIGN), s(S::ENTRY_POINT), [this]() -> bool {
     using std::chrono::duration;
     using std::chrono::duration_cast;
     using std::chrono::steady_clock;
     return align_entry_time_.has_value() &&
-           duration_cast<duration<double>>(steady_clock::now() - *align_entry_time_).count() >
-             FK_ALIGN_PHASE_TIMEOUT;
+           duration_cast<duration<double>>(steady_clock::now() - *align_entry_time_).count() >=
+             FK_ALIGN_WAIT_SEC;
   });
 
   addStateFunction(s(S::KICK), [this]() -> Status {
@@ -179,16 +148,16 @@ void FreeKicker::initialize()
     // 衝突回避は有効のまま（KickOld と異なる、フィールド外押し出し防止の肝）
 
     if (use_chip_) {
-      command->setKickWithChipTargetDistance(getParameter<double>("target_chip_distance"));
-      command->kickWithChip(1.0);
+      command->setKickWithChipTargetDistance(chip_distance_);
     } else {
       command->setKickStraightTargetSpeed(getParameter<double>("target_kick_speed"));
-      command->kickStraight(1.0);
     }
 
     return Status::RUNNING;
   });
   // KICK → ENTRY_POINT のリトライ遷移は意図的に設けない（ダブルタッチ防止）
+  // 同じ FINISH 遷移でも、ボールが意図方向に飛んだ場合は kick_actually_launched_=true、
+  // タイムアウトで諦めた場合は false にして外部 (Session) から判別できるようにする。
   addTransition(s(S::KICK), s(S::FINISH), [this]() -> bool {
     if (!kick_started_) return false;
 
@@ -273,13 +242,19 @@ std::optional<Point> FreeKicker::selectPassTarget()
 
   auto teammates = wm->ours().robotsWhere().available().excludeGoalie().get();
 
+  // 自陣ロボ（敵半面にいないロボット）はパス先候補から除外
+  const double our_sign = wm->getOurSideSign();
+  teammates.erase(
+    std::remove_if(
+      teammates.begin(), teammates.end(),
+      [&](const auto & r) { return r->id == robot()->id || r->pose.pos.x() * our_sign > 0.0; }),
+    teammates.end());
+
   double best_score = FK_MIN_PASS_ACCEPT_SCORE;
   std::optional<uint8_t> best_id;
   Point best_pos = Point::Zero();
 
   for (const auto & teammate : teammates) {
-    if (teammate->id == robot()->id) continue;
-
     double score = calculatePassScore(teammate->pose.pos, enemies, best_enemy_slack);
 
     if (last_pass_receiver_id_ && teammate->id == last_pass_receiver_id_.value()) {
@@ -295,9 +270,16 @@ std::optional<Point> FreeKicker::selectPassTarget()
 
   if (best_id) {
     last_pass_receiver_id_ = best_id;
-    use_chip_ =
-      getPassAnalysis(ball_pos, best_pos, enemies, getParameter<double>("pass_obstacle_distance"))
-        .need_chip;
+    auto pass_analysis =
+      getPassAnalysis(ball_pos, best_pos, enemies, getParameter<double>("pass_obstacle_distance"));
+    use_chip_ = true;
+    if (use_chip_) {
+      if (pass_analysis.required_chip_distance > 0.5) {
+        chip_distance_ = pass_analysis.required_chip_distance + 0.2;
+      } else {
+        chip_distance_ = 1.0;
+      }
+    }
     return best_pos;
   }
 
@@ -374,6 +356,8 @@ Point FreeKicker::computeFallbackTarget()
   fallback.y() = std::clamp(ball_pos.y(), -field_half_y * 0.3, field_half_y * 0.3);
 
   use_chip_ = true;
+  chip_distance_ =
+    std::clamp((fallback - ball_pos).norm(), 1.0, getParameter<double>("pass_max_distance"));
   return fallback;
 }
 }  // namespace crane::skills

--- a/crane_sessions/src/forward_session.cpp
+++ b/crane_sessions/src/forward_session.cpp
@@ -28,7 +28,7 @@ auto ForwardSession::computeCandidatePoints() const -> std::vector<Point>
   constexpr double ATTACK_HALFLINE_THRESHOLD = 0.3;
   constexpr double GRID_STEP = 0.5;
 
-  const double side_sign = -world_model->getAttackSideSign();
+  const double side_sign = world_model->getAttackSideSign();
   const double x_near = side_sign * 0.5;
   const double x_far = side_sign * (goal_line_x - 1.0);
   const double x_min = std::min(x_near, x_far);
@@ -60,9 +60,19 @@ auto ForwardSession::scorePoint(
   const auto & ball = world_model->ball();
   const auto their_goal_center = world_model->getAttackGoalCenter();
 
-  // 1. パス受取スコア（パスライン上の敵距離）
+  // 1. パス受取スコア（チップキック考慮済みパスライン上の敵距離）
+  //    ボール近傍 CHIP_KICK_CLEAR_RADIUS 以内の敵はチップで越せるため線分評価から除外する。
+  //    これによりコーナー等の長いパス線が、ボール直近の敵を理由に不当に減点されない。
+  constexpr double CHIP_KICK_CLEAR_RADIUS = 1.5;
+  RobotList chippable_filtered;
+  chippable_filtered.reserve(available_enemies.size());
+  for (const auto & enemy : available_enemies) {
+    if ((enemy->pose.pos - ball.pos).norm() > CHIP_KICK_CLEAR_RADIUS) {
+      chippable_filtered.push_back(enemy);
+    }
+  }
   auto nearest_enemy =
-    world_model->getNearestRobotWithDistanceFromSegment(Segment{ball.pos, p}, available_enemies);
+    world_model->getNearestRobotWithDistanceFromSegment(Segment{ball.pos, p}, chippable_filtered);
   if (nearest_enemy) {
     score *= std::clamp(nearest_enemy->distance, 0.2, 2.0) / 2.0;
   }

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
@@ -158,7 +158,7 @@ struct WorldModelWrapper : public DelayMonitorMixin<WorldModelWrapper>
   /// @note FW/アタッカー系のみ使用。DF/ゴーリーは getOurSideSign() を使うこと
   [[nodiscard]] auto getAttackSideSign() const
   {
-    return isPracticeReverseAttack() ? -getOurSideSign() : getOurSideSign();
+    return isPracticeReverseAttack() ? getOurSideSign() : -getOurSideSign();
   }
 
   auto addCallback(std::function<void(void)> && callback_func) -> void


### PR DESCRIPTION
## Summary
- 0425ブランチ FreeKicker 分割PR 第3弾（最終）。バグ修正・ALIGN改善・Approach刷新をまとめて取り込む。
- 敵コーナーフリーキックで自陣に蹴り戻すバグ（`getAttackSideSign()` 符号逆・チップキック二重呼び）を修正。
- ALIGN判定を1秒タイマーに簡略化してコーナー付近でも確実にKICKへ遷移。
- APPROACHをボールプレースメントと同じアルゴリズムに揃えて安定性を向上。

## 含まれる変更

### バグ修正（`1df297f6` 相当）
- `world_model_wrapper.hpp`: `getAttackSideSign()` の符号反転（逆定義されていた）
- `forward_session.cpp`: 上記のワークアラウンドとして付いていた符号否定を除去
- `free_kicker.cpp`: KICK状態の `setKickWithChipTargetDistance` + `kickWithChip` 二重呼びを `if/else` 排他化
- `free_kicker.hpp/.cpp`: `chip_distance_` メンバ追加、パス選定時に `required_chip_distance+0.2` で動的計算
- `free_kicker.cpp`: `selectPassTarget()` で自陣ロボを事前除外するフィルタ追加

### ALIGN改善（`baaf9b2c` + `f08f81b9`/`45647d2b` 相当）
- ALIGN目標をAPPROACH最終地点と同じ位置にロック（`align_target_locked_`）、遷移時の目標ジャンプ排除
- ALIGN判定を位置・速度・角速度の安定フレーム数から **1秒タイマー** に簡略化
- 削除: `align_stable_count_` / `align_stable_frames` / `align_position_tolerance` / `align_omega_tolerance` パラメータ

### Approach刷新（`4792c7b8` + `87e91a1a` 相当）
- `computeAroundBallApproachTargetDynamic` の回り込み距離を `interval * 4.0` に拡大
- `disableBallAvoidance` / `disablePlacementAvoidance` / `disableGoalAreaAvoidance` / `disableFieldBoundary` 追加
- 旧 `ball_nearby_speed` 制限を廃止し `approach_max_velocity` で一元管理

### パラメータ調整（`feb46094` 相当）
- `align_max_velocity`: 0.6 → 0.3、`kick_max_velocity`: 1.2 → 0.5、`approach_distance`: 0.25 → 0.15

### ForwardSession 改善（`17e8042c` 相当）
- パスライン評価でボール近傍 1.5m 以内の敵をチップで越せるとして除外。逆サイドへの長いパスが近傍の敵で不当に減点されなくなる。

## 対応元コミット (origin/0425)
- `1df297f6` fix: FreeKickerが敵コーナーフリーキックで自陣に蹴り戻すバグを修正
- `17e8042c` fix: ForwardSessionのパスライン評価にチップキック考慮を追加
- `baaf9b2c` fix: FreeKickerのALIGN目標をAPPROACH最終地点と整合させ振動を解消
- `f08f81b9` / `45647d2b` refactor: FreeKickerのALIGN判定を1秒タイマーに簡略化
- `60f41fc6` ビルド修正
- `feb46094` フリーキックパラメータ設定
- `4792c7b8` フリーキックのアプローチをバールプレイスメントと揃える
- `87e91a1a` パス

## 除外した 0425 コミット
- `6eecfb36`（KICKターゲット 0.2m、`ball_placement_history.yaml` 試合実データ混在） → 廃棄

## Test plan
- [x] `colcon build --packages-up-to crane_sessions crane_robot_skills crane_session_coordinator` が通る
- [ ] `colcon test --packages-select crane_robot_skills crane_sessions crane_session_coordinator` が全PASS
- [ ] シミュレータで **敵コーナーフリーキック** を発火 → 自陣に蹴り戻さないことを確認
- [ ] シミュレータで通常OUR_FREE_KICK → APPROACH→(1秒後)KICK遷移が安定することを確認
- [ ] `getAttackSideSign()` を呼んでいる他コードへの影響がないことを確認（ForwardSession以外にワークアラウンドが残っていないか）