### PR TITLE
feat(crane_session_coordinator): セッションごとのロボットID固定割当とヒートローテを実装

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/skill_base.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/skill_base.hpp
@@ -105,8 +105,13 @@ public:
   : SkillInterface(std::forward<Args>(args)...)
   {
     this->name = name;
-    // commandはdelegating constructor内で空のnameで生成されるため、ここで正しいnameを設定する
-    this->command->name = name;
+    // 共有command（合成スキル）の場合は親スキル名を上書きしない。
+    // PracticeMode の kick_allowed_skills 判定が command->name に依存するため、
+    // 例えば Attacker(command) → 内部で KickOld(command) と合成しても
+    // command->name は親の "attacker" のまま保持する必要がある。
+    if (this->command->name.empty()) {
+      this->command->name = name;
+    }
     if (visualizer->layer == "skill/") {
       visualizer->layer = "skill/" + name;
     }
@@ -184,6 +189,9 @@ protected:
     msg.current_pose.x = robot()->pose.pos.x();
     msg.current_pose.y = robot()->pose.pos.y();
     msg.current_pose.theta = robot()->pose.theta;
+    // 各スキルが明示的にkick系メソッドを呼ばない限りキックしない不変条件を保証する
+    msg.chip_enable = false;
+    msg.kick_power = 0.0f;
   }
 
   void finalizeFrame(Status status)

--- a/crane_session_coordinator/config/unified_session_config.yaml
+++ b/crane_session_coordinator/config/unified_session_config.yaml
@@ -10,7 +10,7 @@ situations:
       - name: goalie_skill
         max_robots: 1
       - name: emplace_robot
-        max_robots: 1
+        max_robots: 20
       - name: attacker_skill
         max_robots: 1
       - name: defender
@@ -33,6 +33,22 @@ situations:
     sessions:
       - name: ball_placement_skill
         max_robots: 1
+        # 候補ロボット選択の重み。詳細は BallPlacementSkillSession を参照。
+        # スコア = clamped > 0 ? clamped + W_D * distance
+        #        : W_R * rotation_rank + W_D * distance     (clamped == 0 のローテ帯)
+        # ただし clamped = max(0, W_F * failures - W_S * successes)
+        # W_D: ボールからの距離に掛ける重み。小さいほど近いロボットを優先。
+        # W_F: 失敗回数に掛ける重み。大きいほど失敗履歴のあるロボットを避ける。
+        # rotation_rank は上位 top_n 台内で last_seq 昇順の順位 (0=最古=最優先)。
+        # 上位 top_n 台のみが対象。それ以外は実質除外される。
+        # history_file_path を指定しなければ
+        # crane_session_coordinator/config/ball_placement_history.yaml が使われる。
+        params:
+          success_weight: 1.0
+          failure_weight: 3.0
+          distance_weight: 0.01
+          rotation_weight: 0.05
+          top_n_candidates: 3
       - name: ball_placement_avoidance
         max_robots: 20
   OUR_FREE_KICK:
@@ -42,6 +58,12 @@ situations:
         max_robots: 1
       - name: free_kicker_skill
         max_robots: 1
+        # params:
+        #   success_weight: 1.0
+        #   failure_weight: 3.0
+        #   distance_weight: 0.01
+        #   rotation_weight: 0.05
+        #   top_n_candidates: 3
       - name: pass_receive
         max_robots: 1
       - name: defender
@@ -75,7 +97,7 @@ situations:
     description: STOP
     sessions:
       - name: emplace_robot
-        max_robots: 1
+        max_robots: 20
       - name: goalie_skill
         max_robots: 1
       - name: defender
@@ -187,29 +209,48 @@ situations:
         max_robots: 20
   HALF_FIELD_PRACTICE:
     description: 半面練習モード（FW逆方向攻撃・キック禁止・移動制限あり・レフェリー信号基準）
+    # fixed_robots: [...] を指定すると allocator が自動で固定候補として扱う。
+    # fixed_robots の数が max_robots より少ない場合、残りは動的割当で補完される。
+    # attacker_heat_rotation は candidate_robots: [...] を候補プールとして使う。
+    # fixed_robots を指定しない場合は WARN を出しつつ候補内で動的選択する。
     practice_mode:
       enabled: true
       kick_prohibition: true
       reverse_attack: true
       use_normal_speed: true
+      # スキル名は SkillInterface の command->name と完全一致比較される。
+      # 合成スキル(Attacker → 内部 KickOld/GoalKick 等)も親のスキル名で判定される。
       kick_allowed_skills:
-        - goalie_skill
+        - goalie
+        - attacker
         - defender
+        - free_kicker
     sessions:
       - name: goalie_skill
         max_robots: 1
-      - name: attacker_skill
+        fixed_robots: [0]
+      - name: attacker_heat_rotation
         max_robots: 1
+        # 候補プール。基本は同一ロボットを使い続け、最大モータ温度が
+        # rotation_trigger_celsius を超えた瞬間に候補内で最も冷えたロボットへ切替える。
+        candidate_robots: [1, 5, 9]
+        # しきい値（℃）。省略時は 60℃。
+        # params:
+        #   rotation_trigger_celsius: 65.0
       - name: defender
         max_robots: 3
+        fixed_robots: [2, 3, 4]
         params:
           reduced_robots: 1
       - name: pass_receive
         max_robots: 1
+        fixed_robots: [5]
       - name: sub_attacker_skill
         max_robots: 1
+        fixed_robots: [6]
       - name: marker
         max_robots: 2
+        fixed_robots: [7, 8]
       - name: forward
         max_robots: 20
 events:

--- a/crane_session_coordinator/include/crane_session_coordinator/configuration_manager.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/configuration_manager.hpp
@@ -8,6 +8,7 @@
 #define CRANE_SESSION_COORDINATOR__CONFIGURATION_MANAGER_HPP_
 
 #include <crane_msgs/msg/practice_mode.hpp>
+#include <cstdint>
 #include <filesystem>
 #include <optional>
 #include <rclcpp/rclcpp.hpp>
@@ -25,6 +26,11 @@ struct SessionSlot
   std::string session_name;
   int max_robots;
   std::unordered_map<std::string, SessionParameterType> params;
+  /// セッションに固定で割り当てるロボットID。空なら従来通りsuitabilityで動的割当。
+  std::vector<uint8_t> fixed_robots;
+  /// セッション側のロジック（例: 熱ローテーション）で使う候補IDプール。
+  /// 割当アルゴリズムには影響を与えず、Sessionが自身のsuitability関数等で参照する。
+  std::vector<uint8_t> candidate_robots;
 };
 
 /**

--- a/crane_session_coordinator/include/crane_session_coordinator/robot_allocator.hpp
+++ b/crane_session_coordinator/include/crane_session_coordinator/robot_allocator.hpp
@@ -8,6 +8,7 @@
 #define CRANE_SESSION_COORDINATOR__ROBOT_ALLOCATOR_HPP_
 
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_msgs/msg/play_situation.hpp>
 #include <crane_msgs/msg/robot_select_results.hpp>
 #include <crane_physics/allocation_cost.hpp>
 #include <crane_physics/robot_info.hpp>
@@ -34,10 +35,17 @@ struct SessionRequirement
   int priority;
   int max_robots;
   std::function<double(const std::shared_ptr<RobotInfo> &)> suitability_func;
+  /// 固定割当ID。空でないとき suitability を無視してこのIDを優先取得する。
+  std::vector<uint8_t> fixed_robots;
 
   SessionRequirement(
-    std::string n, int p, int max_r, std::function<double(const std::shared_ptr<RobotInfo> &)> func)
-  : name(std::move(n)), priority(p), max_robots(max_r), suitability_func(std::move(func))
+    std::string n, int p, int max_r, std::function<double(const std::shared_ptr<RobotInfo> &)> func,
+    std::vector<uint8_t> fixed = {})
+  : name(std::move(n)),
+    priority(p),
+    max_robots(max_r),
+    suitability_func(std::move(func)),
+    fixed_robots(std::move(fixed))
   {
   }
 };
@@ -62,7 +70,8 @@ public:
    */
   auto allocate(
     const std::string & session_name, std::vector<uint8_t> selectable_robot_ids,
-    WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node)
+    WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node,
+    const crane_msgs::msg::PlaySituation & current_play_situation)
     -> crane_msgs::msg::RobotSelectResults;
 
   /**

--- a/crane_session_coordinator/src/configuration_manager.cpp
+++ b/crane_session_coordinator/src/configuration_manager.cpp
@@ -107,6 +107,24 @@ auto ConfigurationManager::loadUnifiedConfig(const std::filesystem::path & confi
         ss << "\tNAME       : " << session_capacity.session_name << "\n";
         ss << "\tMAX_ROBOTS : " << session_capacity.max_robots << "\n";
 
+        // fixed_robots の読み込み（存在する場合のみ）
+        // 指定されたIDは suitability 評価をスキップして優先割当される
+        if (session_node["fixed_robots"]) {
+          for (const auto & id_node : session_node["fixed_robots"]) {
+            session_capacity.fixed_robots.push_back(static_cast<uint8_t>(id_node.as<int>()));
+          }
+          ss << "\tFIXED_ROBOTS : " << session_capacity.fixed_robots.size() << " entries\n";
+        }
+
+        // candidate_robots の読み込み（存在する場合のみ）
+        // allocator は参照しない。Session 側のロジック（例: 熱ローテ）が使う。
+        if (session_node["candidate_robots"]) {
+          for (const auto & id_node : session_node["candidate_robots"]) {
+            session_capacity.candidate_robots.push_back(static_cast<uint8_t>(id_node.as<int>()));
+          }
+          ss << "\tCANDIDATE_ROBOTS : " << session_capacity.candidate_robots.size() << " entries\n";
+        }
+
         // params の読み込み（存在する場合のみ）
         if (session_node["params"]) {
           for (const auto & param : session_node["params"]) {

--- a/crane_session_coordinator/src/crane_session_coordinator.cpp
+++ b/crane_session_coordinator/src/crane_session_coordinator.cpp
@@ -123,7 +123,7 @@ auto SessionCoordinatorComponent::assign(const std::string & event_name) -> void
     try {
       auto results = robot_allocator_->allocate(
         session_name, world_model->ours().robotsWhere().available().getIds(), world_model,
-        static_cast<rclcpp::Node &>(*this));
+        static_cast<rclcpp::Node &>(*this), play_situation);
 
       // 結果をパブリッシュ
       robot_select_results_pub->publish(results);

--- a/crane_session_coordinator/src/robot_allocator.cpp
+++ b/crane_session_coordinator/src/robot_allocator.cpp
@@ -27,7 +27,8 @@ RobotAllocator::RobotAllocator(
 
 auto RobotAllocator::allocate(
   const std::string & session_name, std::vector<uint8_t> selectable_robot_ids,
-  WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node)
+  WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node,
+  const crane_msgs::msg::PlaySituation & current_play_situation)
   -> crane_msgs::msg::RobotSelectResults
 {
   auto session_capacities_opt = config_manager_->getSessionCapacitiesForSituation(session_name);
@@ -59,6 +60,44 @@ auto RobotAllocator::allocate(
       session_capacity.session_name, world_model, node, prev_available_planners,
       session_capacity.params);
 
+    // fixed_robots が指定されていれば session 側の宣言有無に関わらず反映する。
+    // allocator は fixed_robots の存在をもって固定候補ありとみなし、
+    // 固定IDを優先確保しつつ不足分は動的割当にフォールバックする。
+    {
+      const bool yaml_has_fixed = !session_capacity.fixed_robots.empty();
+      if (yaml_has_fixed) {
+        session->setFixedRobots(session_capacity.fixed_robots);
+      } else if (session_capacity.session_name == "attacker_heat_rotation") {
+        RCLCPP_WARN(
+          rclcpp::get_logger("RobotAllocator"),
+          "Session '%s' has no fixed_robots: falling back to dynamic suitability allocation "
+          "within candidate_robots.",
+          session_capacity.session_name.c_str());
+      }
+    }
+
+    // 候補ロボットプール（派生クラスで setUseCandidateRobots(true)）と
+    // YAML の candidate_robots: の整合をチェックして反映する。
+    // allocator は候補プールには関与せず、Session 側のロジックのみが使用する。
+    {
+      const bool session_uses_candidate = session->usesCandidateRobots();
+      const bool yaml_has_candidate = !session_capacity.candidate_robots.empty();
+      if (session_uses_candidate && yaml_has_candidate) {
+        session->setCandidateRobots(session_capacity.candidate_robots);
+      } else if (session_uses_candidate && !yaml_has_candidate) {
+        RCLCPP_WARN(
+          rclcpp::get_logger("RobotAllocator"),
+          "Session '%s' declares candidate-robots mode but YAML has no candidate_robots:.",
+          session_capacity.session_name.c_str());
+      } else if (!session_uses_candidate && yaml_has_candidate) {
+        RCLCPP_WARN(
+          rclcpp::get_logger("RobotAllocator"),
+          "Session '%s' has candidate_robots in YAML but does not declare candidate-robots "
+          "mode (setUseCandidateRobots(true) not called); the YAML setting is ignored.",
+          session_capacity.session_name.c_str());
+      }
+    }
+
     // 適性関数を取得
     auto suitability_func = session->getRobotSuitabilityFunc();
 
@@ -69,7 +108,7 @@ auto RobotAllocator::allocate(
     requirements.emplace_back(
       session_capacity.session_name, priority++,
       effective_max,  // max_robots（動的に調整）
-      suitability_func);
+      suitability_func, session_capacity.fixed_robots);
   }
 
   // グリーディ方式でロボットを割当
@@ -127,6 +166,20 @@ auto RobotAllocator::allocate(
       result.selectable_robots = selectable_robot_ids;
       result.selected_robots = robot_ids;
       results.results.push_back(result);
+    }
+  }
+
+  const std::unordered_set<SessionBase *> active_session_ptrs([&]() {
+    std::unordered_set<SessionBase *> ptrs;
+    for (const auto & session : session_registry_->getAllPlanners()) {
+      ptrs.insert(session.get());
+    }
+    return ptrs;
+  }());
+
+  for (const auto & previous_session : prev_available_planners) {
+    if (active_session_ptrs.count(previous_session.get()) == 0) {
+      previous_session->onDeactivated(current_play_situation);
     }
   }
 
@@ -224,25 +277,60 @@ auto RobotAllocator::allocateRobotsGreedy(
       break;
     }
 
-    // 適性評価でロボットをスコアリング（ヒステリシスボーナスを適用して安定化）
-    std::vector<std::pair<uint8_t, double>> robot_scores;
-    for (const auto & robot_id : remaining_robots) {
-      auto robot = world_model->getOurRobot(robot_id);
-      double score = req.suitability_func(robot);
-      if (prev_state.wasAssignedTo(robot_id, req.name)) {
-        score -= config.hysteresis_bonus;
+    std::vector<uint8_t> assigned_robots;
+
+    // fixed_robots 指定時はそのIDを優先取得し、不足分は動的割当にフォールバックする
+    if (!req.fixed_robots.empty()) {
+      const std::unordered_set<uint8_t> remaining_set(
+        remaining_robots.begin(), remaining_robots.end());
+      for (const uint8_t id : req.fixed_robots) {
+        if (static_cast<int>(assigned_robots.size()) >= req.max_robots) {
+          break;
+        }
+        if (remaining_set.count(id) > 0) {
+          assigned_robots.push_back(id);
+        } else {
+          RCLCPP_WARN(
+            logger_, "Session「%s」の固定割当ID %d は利用不可のためスキップ", req.name.c_str(),
+            static_cast<int>(id));
+        }
       }
-      robot_scores.emplace_back(robot_id, score);
+
+      if (static_cast<int>(assigned_robots.size()) < req.max_robots) {
+        const int remaining_dynamic_slots =
+          req.max_robots - static_cast<int>(assigned_robots.size());
+        RCLCPP_DEBUG(
+          logger_, "Session「%s」は固定割当 %zu 台を確保。残り %d 台は動的割当を使用",
+          req.name.c_str(), assigned_robots.size(), remaining_dynamic_slots);
+      }
     }
 
-    std::ranges::sort(
-      robot_scores, [](const auto & a, const auto & b) { return a.second < b.second; });
+    if (static_cast<int>(assigned_robots.size()) < req.max_robots) {
+      // 適性評価でロボットをスコアリング（ヒステリシスボーナスを適用して安定化）
+      const std::unordered_set<uint8_t> assigned_set(
+        assigned_robots.begin(), assigned_robots.end());
+      std::vector<std::pair<uint8_t, double>> robot_scores;
+      for (const auto & robot_id : remaining_robots) {
+        if (assigned_set.count(robot_id) > 0) {
+          continue;
+        }
+        auto robot = world_model->getOurRobot(robot_id);
+        double score = req.suitability_func(robot);
+        if (prev_state.wasAssignedTo(robot_id, req.name)) {
+          score -= config.hysteresis_bonus;
+        }
+        robot_scores.emplace_back(robot_id, score);
+      }
 
-    int num_to_allocate = std::min(req.max_robots, static_cast<int>(remaining_robots.size()));
+      std::ranges::sort(
+        robot_scores, [](const auto & a, const auto & b) { return a.second < b.second; });
 
-    std::vector<uint8_t> assigned_robots;
-    for (int i = 0; i < num_to_allocate; ++i) {
-      assigned_robots.push_back(robot_scores[i].first);
+      const int num_to_allocate = std::min(
+        req.max_robots - static_cast<int>(assigned_robots.size()),
+        static_cast<int>(robot_scores.size()));
+      for (int i = 0; i < num_to_allocate; ++i) {
+        assigned_robots.push_back(robot_scores[i].first);
+      }
     }
 
     result[req.name] = assigned_robots;

--- a/crane_sessions/include/crane_sessions/attacker_heat_rotation_session.hpp
+++ b/crane_sessions/include/crane_sessions/attacker_heat_rotation_session.hpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_SESSIONS__ATTACKER_HEAT_ROTATION_SESSION_HPP_
+#define CRANE_SESSIONS__ATTACKER_HEAT_ROTATION_SESSION_HPP_
+
+#include <algorithm>
+#include <crane_msg_wrappers/world_model_wrapper.hpp>
+#include <crane_sessions/attacker_skill_session.hpp>
+#include <functional>
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <unordered_set>
+#include <vector>
+
+#include "visibility_control.h"
+
+namespace crane
+{
+/// 候補IDプール内でモーター温度ベースに1台を選ぶ Attacker 練習用セッション。
+///
+/// 候補IDは YAML の `candidate_robots: [1, 5, 9]` から受け取る
+/// （SessionBase::setCandidateRobots 経由）。
+/// 基本は同じロボットを使い続け、その最大モータ温度が閾値（params.rotation_trigger_celsius、
+/// 既定 60℃）を超えた瞬間に、候補内で最も冷えたロボットへ切り替える。
+/// allocator の `fixed_robots` 機構は使わず、suitability 関数の中で
+/// 「候補外排除」「現在割当の維持」「閾値超でローテ」を表現することで、
+/// ローテーションロジックをこのセッション内に閉じ込めている。
+class AttackerHeatRotationSession : public AttackerSkillSession
+{
+public:
+  /// ローテーションが発火するモータ温度の既定しきい値（℃）。
+  /// YAML の params: { rotation_trigger_celsius: ... } で上書き可。
+  static constexpr double DEFAULT_ROTATION_TRIGGER_CELSIUS = 60.0;
+
+  /// 候補外ロボットへの大きなペナルティ（実用上選ばれない値）。
+  static constexpr double NON_CANDIDATE_COST = 1e6;
+
+  /// 現在割当ロボットを「閾値未満の間は確実に維持する」ための負コスト。
+  /// 他候補は max_temp（実温度）を返すので、負値であれば必ず勝つ。
+  static constexpr double KEEP_CURRENT_COST = -1.0e3;
+
+  COMPOSITION_PUBLIC explicit AttackerHeatRotationSession(
+    WorldModelWrapper::SharedPtr & world_model, rclcpp::Node & node)
+  : AttackerSkillSession(world_model, node)
+  {
+    setUseCandidateRobots(true);
+  }
+
+  auto getRobotSuitabilityFunc() const
+    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
+  {
+    const std::unordered_set<uint8_t> candidates(
+      candidate_robots_.begin(), candidate_robots_.end());
+
+    // 前ティックの割当をキャプチャ。閾値判定の基準になる。
+    std::vector<uint8_t> currently_assigned;
+    currently_assigned.reserve(robots.size());
+    for (const auto & r : robots) {
+      currently_assigned.push_back(r.id);
+    }
+
+    const double trigger =
+      getSessionParameter<double>("rotation_trigger_celsius", DEFAULT_ROTATION_TRIGGER_CELSIUS);
+
+    return [candidates, currently_assigned, trigger](const std::shared_ptr<RobotInfo> & robot) {
+      // 候補外ロボットは事実上選ばれない高コストにする
+      if (!candidates.empty() && candidates.count(robot->id) == 0) {
+        return NON_CANDIDATE_COST;
+      }
+
+      double max_temp = 0.0;
+      for (auto t : robot->motor_temperatures) {
+        max_temp = std::max(max_temp, static_cast<double>(t));
+      }
+
+      const bool is_current =
+        std::find(currently_assigned.begin(), currently_assigned.end(), robot->id) !=
+        currently_assigned.end();
+
+      // 現在割当ロボットが閾値未満なら、温度に関係なく維持する。
+      // KEEP_CURRENT_COST は他候補が返す温度値（正）より必ず小さいため必ず選ばれる。
+      if (is_current && max_temp < trigger) {
+        return KEEP_CURRENT_COST;
+      }
+
+      // 現在割当が閾値を超えた、または非current。
+      // 温度を素直にコストとして返し、候補内で最も冷えたロボットに切替える。
+      return max_temp;
+    };
+  }
+};
+
+}  // namespace crane
+#endif  // CRANE_SESSIONS__ATTACKER_HEAT_ROTATION_SESSION_HPP_

--- a/crane_sessions/include/crane_sessions/session_base.hpp
+++ b/crane_sessions/include/crane_sessions/session_base.hpp
@@ -242,8 +242,8 @@ protected:
     const std::vector<RobotIdentifier> & robots, const std::vector<Point> & target_points,
     const std::string & command_name, const Point & look_at_point,
     const std::function<void(std::shared_ptr<PositionCommandWrapper> &)> & customize_command =
-      [](std::shared_ptr<PositionCommandWrapper> &) {})
-    -> std::vector<crane_msgs::msg::RobotCommand>
+      [](std::shared_ptr<PositionCommandWrapper> &) {},
+    double position_tolerance = -1.0) -> std::vector<crane_msgs::msg::RobotCommand>
   {
     if (robots.empty() || target_points.empty()) {
       return {};
@@ -267,7 +267,11 @@ protected:
       auto command =
         std::make_shared<PositionCommandWrapper>(command_name, robot_id->id, world_model);
 
-      command->setTargetPosition(target_point);
+      if (position_tolerance < 0.) {
+        command->setTargetPosition(target_point);
+      } else {
+        command->setTargetPosition(target_point, position_tolerance);
+      }
       command->setTargetTheta(getAngle(look_at_point - target_point));
 
       // カスタム設定を適用
@@ -285,6 +289,12 @@ protected:
 
   std::unordered_map<std::string, SessionParameterType> session_params_;
 
+  bool use_candidate_robots_ = false;
+
+  std::vector<uint8_t> fixed_robots_;
+
+  std::vector<uint8_t> candidate_robots_;
+
   virtual std::pair<Status, std::vector<crane_msgs::msg::RobotCommand>> calculatePositionCommand(
     const std::vector<RobotIdentifier> & robots) = 0;
 
@@ -294,9 +304,6 @@ protected:
 
 private:
   crane_msgs::msg::GameAnalysis game_analysis_;
-  std::vector<uint8_t> fixed_robots_;
-  std::vector<uint8_t> candidate_robots_;
-  bool use_candidate_robots_ = false;
 };
 
 }  // namespace crane

--- a/crane_sessions/src/session_factory.cpp
+++ b/crane_sessions/src/session_factory.cpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 
 // 全プランナーのインクルード（.cppファイルでのみ必要）
+#include <crane_sessions/attacker_heat_rotation_session.hpp>
 #include <crane_sessions/attacker_skill_session.hpp>
 #include <crane_sessions/ball_calibration_data_collector_session.hpp>
 #include <crane_sessions/ball_near_by_positioner_skill_session.hpp>
@@ -54,6 +55,7 @@ namespace
 auto getSessionFactoryMap() -> const std::unordered_map<std::string, SessionFactory> &
 {
   static const std::unordered_map<std::string, SessionFactory> factory_map{
+    PLANNER_ENTRY("attacker_heat_rotation", AttackerHeatRotationSession),
     PLANNER_ENTRY("attacker_skill", AttackerSkillSession),
     PLANNER_ENTRY("ball_nearby_positioner_skill", BallNearByPositionerSkillSession),
     PLANNER_ENTRY(


### PR DESCRIPTION
## Summary
- 0425ブランチからの分割PR。YAML の各セッションに `fixed_robots` / `candidate_robots` を指定してロボットIDを固定・候補管理できるようにする。
- ハーフコート練習中などで defender/forward 等のロールが意図せず入れ替わるのを防止。
- アタッカーのモータヒートに応じてローテーションする `AttackerHeatRotationSession` を追加。

## 含まれる変更

### fixed_robots 固定割当（`b0fa1c7d` + `21dafc16` 相当）
- `unified_session_config.yaml`: `sessions[].fixed_robots: [id,...]` / `candidate_robots: [id,...]` の指定を有効化
  - `fixed_robots` の数が `max_robots` 未満の場合は動的割当で補完
- `robot_allocator.cpp`: fixed / candidate 割当の分岐ロジックを追加
- `configuration_manager.hpp/.cpp`: `fixed_robots` / `candidate_robots` を YAML からパース
- `robot_allocator.hpp`: `allocate()` に `PlaySituation` 引数を追加（`onDeactivated` 呼び出し用）
- `crane_session_coordinator.cpp`: `allocate()` 呼び出しを 5 引数に更新

### AttackerHeatRotationSession（`e3cb8382` 相当）
- `attacker_heat_rotation_session.hpp` を新設
  - `candidate_robots` プール内でロボットを維持し、最大モータ温度が `rotation_trigger_celsius`（既定 60℃）を超えた瞬間に最も冷えたロボットへ切替
- `session_factory.cpp` に `"attacker_heat_rotation"` を登録

### SkillBase 修正（`93161561` 相当）
- `skill_base.hpp`: コンストラクタで `command->name` を「空のときのみ」設定（合成スキルの親スキル名を保持し `kick_allowed_skills` 判定を正確に）
- `skill_base.hpp`: `prepareFrame` で `chip_enable` / `kick_power` をゼロリセット（明示的にキックしない限りキックしない不変条件）

### session_base.hpp
- `fixed_robots_` / `candidate_robots_` / `use_candidate_robots_` を private → protected に移動
- `assignRobotsToPoints` に `position_tolerance` パラメータを追加

### YAML 設定更新
- `BALL_PLACEMENT`: `RotatingSingleSkillSession` 用の重みパラメータ（`success_weight` 等）を追加
- `STOP` / `NORMAL_GAME`: `emplace_robot` の `max_robots` を 1 → 20 に変更
- `HALF_FIELD_PRACTICE`:
  - `fixed_robots` / `candidate_robots` を各セッションに設定
  - `kick_allowed_skills` をスキル名（`goalie` / `attacker` / `defender` / `free_kicker`）に更新
  - `attacker_skill` → `attacker_heat_rotation` に切替

## 対応元コミット (origin/0425)
- `b0fa1c7d` feat: セッションごとにロボットID固定割当を可能にする
- `e3cb8382` refactor: 固定IDと候補プールを派生クラスの宣言ベースに整理（*_fixed_session 部分は 21dafc16 で廃止済み）
- `21dafc16` refactor: 固定割当を通常セッションに統合
- `93161561` fix: 修正されたスキル名の設定ロジックとスキル許可リストの更新

## Test plan
- [x] `colcon build --packages-up-to crane_sessions crane_robot_skills crane_session_coordinator` が通る
- [ ] `colcon test --packages-select crane_sessions crane_session_coordinator` が全PASS
- [ ] `unified_session_config.yaml` の `HALF_FIELD_PRACTICE` で起動し、`fixed_robots` 指定のIDが正しく割り当てられることを確認
- [ ] `attacker_heat_rotation` セッションでアタッカーのモータ温度が閾値を超えた際に候補内で切り替わることを確認
- [ ] `kick_allowed_skills` の `attacker` / `goalie` 等でフリーキック時のキック制限が正しく動作することを確認