### PR TITLE
chore(crane): 通信・観測層のログ整理とTracker短期LOST判定の抑制

### DIFF
--- a/consai_ros2/robocup_ssl_comm/include/robocup_ssl_comm/game_controller_component.hpp
+++ b/consai_ros2/robocup_ssl_comm/include/robocup_ssl_comm/game_controller_component.hpp
@@ -17,6 +17,7 @@
 
 #include <robocup_ssl_msgs/ssl_gc_referee_message.pb.h>
 
+#include <atomic>
 #include <crane_comm/unicast.hpp>
 #include <memory>
 #include <mutex>
@@ -46,12 +47,15 @@ private:
   std::unique_ptr<crane::AsyncUdpReceiver> receiver;
 
   rclcpp::TimerBase::SharedPtr timer;
+  rclcpp::TimerBase::SharedPtr status_timer_;
   rclcpp::Publisher<robocup_ssl_msgs::msg::Referee>::SharedPtr pub_referee;
   rclcpp::Publisher<robocup_ssl_msgs::msg::GameEvent>::SharedPtr pub_game_event;
 
   std::mutex latest_mutex_;
   std::optional<robocup_ssl::Referee> latest_packet_;
   std::vector<robocup_ssl_msgs::msg::GameEvent> previous_game_events_;
+
+  std::atomic<bool> packet_received_{false};
 };
 
 }  // namespace robocup_ssl_comm

--- a/consai_ros2/robocup_ssl_comm/src/game_controller_component.cpp
+++ b/consai_ros2/robocup_ssl_comm/src/game_controller_component.cpp
@@ -41,6 +41,11 @@ GameController::GameController(const rclcpp::NodeOptions & options)
       if (packet.ParseFromArray(buf.data(), static_cast<int>(size))) {
         std::lock_guard<std::mutex> lock(latest_mutex_);
         latest_packet_ = std::move(packet);
+        packet_received_.store(true, std::memory_order_relaxed);
+      } else {
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 5000,
+          "Refereeパケットのパース失敗 (size=%zu) — protoバージョン不整合の可能性", size);
       }
     }
   });
@@ -50,6 +55,15 @@ GameController::GameController(const rclcpp::NodeOptions & options)
   pub_referee = create_publisher<robocup_ssl_msgs::msg::Referee>("referee", 10);
   pub_game_event = create_publisher<robocup_ssl_msgs::msg::GameEvent>("game_event", 10);
   timer = rclcpp::create_timer(this, get_clock(), 25ms, std::bind(&GameController::on_timer, this));
+
+  status_timer_ = rclcpp::create_timer(this, get_clock(), 1000ms, [this, address, port]() {
+    if (!packet_received_.exchange(false, std::memory_order_relaxed)) {
+      RCLCPP_WARN(get_logger(), "Referee受信が直近1秒間ありません (%s:%d)", address.c_str(), port);
+    }
+  });
+
+  RCLCPP_INFO(
+    get_logger(), "game_controller initialized - listening on %s:%d", address.c_str(), port);
 }
 
 GameController::~GameController() = default;

--- a/crane_latency_estimator/include/crane_latency_estimator/latency_estimator.hpp
+++ b/crane_latency_estimator/include/crane_latency_estimator/latency_estimator.hpp
@@ -69,9 +69,6 @@ private:
   double min_cmd_stddev_rad_{0.05};
   double estimation_interval_sec_{1.0};
   double ema_alpha_{0.3};
-  double log_interval_sec_{1.0};
-
-  rclcpp::Time last_log_time_;
 };
 
 }  // namespace crane

--- a/crane_latency_estimator/src/latency_estimator.cpp
+++ b/crane_latency_estimator/src/latency_estimator.cpp
@@ -8,7 +8,6 @@
 #include <chrono>
 #include <cmath>
 #include <crane_latency_estimator/latency_estimator.hpp>
-#include <cstdio>
 #include <numeric>
 #include <string>
 #include <vector>
@@ -26,7 +25,6 @@ LatencyEstimator::LatencyEstimator(const rclcpp::NodeOptions & options)
   min_cmd_stddev_rad_ = declare_parameter("min_cmd_stddev_rad", 0.05);
   estimation_interval_sec_ = declare_parameter("estimation_interval_sec", 1.0);
   ema_alpha_ = declare_parameter("ema_alpha", 0.3);
-  log_interval_sec_ = declare_parameter("log_interval_sec", 1.0);
 
   sub_commands_ = create_subscription<crane_msgs::msg::RobotCommands>(
     "/robot_commands", 10,
@@ -46,8 +44,6 @@ LatencyEstimator::LatencyEstimator(const rclcpp::NodeOptions & options)
   const auto interval_ms =
     std::chrono::milliseconds(static_cast<int>(estimation_interval_sec_ * 1000.0));
   estimation_timer_ = create_wall_timer(interval_ms, [this]() { onEstimationTimer(); });
-
-  last_log_time_ = now();
 }
 
 double LatencyEstimator::interpolate(const std::deque<std::pair<double, double>> & data, double t)
@@ -216,31 +212,6 @@ void LatencyEstimator::onEstimationTimer()
 
   if (!out.estimations.empty()) {
     pub_estimation_->publish(out);
-  }
-
-  if ((rclcpp::Time(out.header.stamp) - last_log_time_).seconds() >= log_interval_sec_) {
-    last_log_time_ = rclcpp::Time(out.header.stamp);
-    for (const auto & [robot_id, buf] : buffers_) {
-      if (buf.cmd.empty()) continue;
-      const double world_ms = buf.ema_world_ms;
-      const double fb_ms = buf.ema_fb_ms;
-      if (std::isnan(world_ms) && std::isnan(fb_ms)) {
-        RCLCPP_DEBUG(
-          get_logger(), "[id %u] no valid estimate (cmd buf=%zu)", robot_id, buf.cmd.size());
-      } else {
-        char line[128];
-        int pos = std::snprintf(line, sizeof(line), "[id %u]", robot_id);
-        if (!std::isnan(world_ms)) {
-          pos += std::snprintf(
-            line + pos, sizeof(line) - pos, " world=%.0fms(r=%.2f)", world_ms, buf.last_world_corr);
-        }
-        if (!std::isnan(fb_ms)) {
-          std::snprintf(
-            line + pos, sizeof(line) - pos, " fb=%.0fms(r=%.2f)", fb_ms, buf.last_fb_corr);
-        }
-        RCLCPP_INFO(get_logger(), "%s", line);
-      }
-    }
   }
 }
 

--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -202,6 +202,7 @@ private:
   FieldGeometry field_geometry_;
   bool has_vision_updated_;
   int feedback_stale_timeout_ms_{100};
+  double robot_vision_hold_sec_{0.15};
 
   // エラー継続時間を算出するためのトラッキング用構造体
   struct ErrorTracker

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -48,12 +48,14 @@ WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
   node.declare_parameter("tracker_port", 10010);
   node.declare_parameter("use_udp_detection", false);
   node.declare_parameter("feedback_stale_timeout_ms", feedback_stale_timeout_ms_);
+  node.declare_parameter("robot_vision_hold_sec", robot_vision_hold_sec_);
 
   config_.vision_address = node.get_parameter("vision_address").get_value<std::string>();
   config_.vision_port = node.get_parameter("vision_port").get_value<int>();
   config_.confidence_threshold = node.get_parameter("confidence_threshold").get_value<double>();
   use_udp_detection_ = node.get_parameter("use_udp_detection").get_value<bool>();
   feedback_stale_timeout_ms_ = node.get_parameter("feedback_stale_timeout_ms").get_value<int>();
+  robot_vision_hold_sec_ = node.get_parameter("robot_vision_hold_sec").get_value<double>();
 
   // Initialize UDP receivers
 
@@ -850,11 +852,16 @@ auto WorldModelDataProvider::processTrackedFrame(
   integrateBallInfo();
 
   // ロボット情報の処理
-  // 全チーム・全ロボットIDをリセット（trackerフレーム毎にvision/tracker両フラグをクリア）
+  // available_visionが継続してfalseになると、一時的なトラッカー欠落でもロボットがlost扱いになる。
+  // robot_vision_hold_sec_ 以内に検出されていたロボットは状態を維持し、超過後のみリセットする。
   for (int team_idx = 0; team_idx < 2; ++team_idx) {
     for (auto & robot : robot_info_[team_idx]) {
-      robot.available_vision = false;
-      robot.available_tracker = false;
+      if (!robot.available_vision) continue;
+      const double age = (now - rclcpp::Time(robot.vision.stamp)).seconds();
+      if (age < 0.0 || age > robot_vision_hold_sec_) {
+        robot.available_vision = false;
+        robot.available_tracker = false;
+      }
     }
   }
 

--- a/utility/crane_comm/include/crane_comm/unicast.hpp
+++ b/utility/crane_comm/include/crane_comm/unicast.hpp
@@ -110,10 +110,28 @@ public:
           boost::system::error_code join_ec;
           socket_.set_option(join_device, join_ec);
           if (!join_ec) {
+            RCLCPP_DEBUG(
+              rclcpp::get_logger("crane_comm"), "マルチキャスト参加成功: %s on %s (%s)",
+              addr.to_string().c_str(), if_name.c_str(), ip);
             joined_interfaces.insert(if_name);
+          } else {
+            RCLCPP_WARN(
+              rclcpp::get_logger("crane_comm"), "マルチキャスト参加失敗: %s on %s (%s): %s",
+              addr.to_string().c_str(), if_name.c_str(), ip, join_ec.message().c_str());
           }
         }
         freeifaddrs(interfaces);
+        if (joined_interfaces.empty()) {
+          RCLCPP_ERROR(
+            rclcpp::get_logger("crane_comm"),
+            "マルチキャストグループ %s の参加に全インターフェースで失敗しました — "
+            "パケットは受信できません",
+            addr.to_string().c_str());
+        } else {
+          RCLCPP_INFO(
+            rclcpp::get_logger("crane_comm"), "マルチキャスト %s に参加済みインターフェース: %zu個",
+            addr.to_string().c_str(), joined_interfaces.size());
+        }
       } catch (std::exception & e) {
         RCLCPP_ERROR(rclcpp::get_logger("crane_comm"), "%s", e.what());
       }


### PR DESCRIPTION
## Summary

0425ブランチで実機検証された、通信・観測層の可観測性強化とノイズログ整理を develop へ反映する。本PRは0425→develop段階的反映の第1弾。

- **crane_world_model_publisher**: トラッカー欠落時に短期間 vision 情報を保持する `robot_vision_hold_sec` パラメータ（既定 0.15s）を追加し、瞬断による誤LOSTを抑制
- **robocup_ssl_comm/game_controller_component**: Referee パケット受信状況を1秒間隔で監視し、未受信時に WARN 出力。パース失敗時にも WARN を出力
- **crane_comm/unicast**: マルチキャスト参加成功/失敗ログを INFO/WARN/ERROR で階層化し、全インターフェースで失敗した場合に ERROR を出力
- **crane_latency_estimator**: 1秒ごとの定期 INFO ログを削除（ノイズ削減、必要時は estimation トピック購読で十分）

## 関連 0425 コミット

- \`9ca5b647\` fix(world_model_publisher): Tracker欠落時の短期LOST判定を抑制
- \`10d09dba\` Refの受信状況をログに残す
- \`9013d20d\` chore(crane_latency_estimator): 継続的なログ出力を削除
- unicast.hpp 改修分
