### PR TITLE
refactor(crane): Defender/Formationセッション簡潔化とRVO2のPA処理整理

### DIFF
--- a/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
@@ -128,8 +128,6 @@ private:
     Point & target_pos, const Point & current_pos,
     const crane_msgs::msg::RobotCommand & command) const -> void;
 
-  auto initializePenaltyAreaObstacles() -> void;
-
   std::unique_ptr<RVO::RVOSimulator> rvo_sim;
 
   crane_msgs::msg::RobotCommands pre_commands;
@@ -162,10 +160,6 @@ private:
   double PENALTY_AREA_OFFSET_STOP = 0.4;  // ペナルティエリア判定マージン [m]（STOP時）
   double PENALTY_AREA_SURROUNDING_OFFSET = 0.2;         // 角回避の余白 [m]
   bool PENALTY_AREA_FORCE_WAYPOINT_ON_CROSSING = true;  // 横断時に強制迂回
-  float PENALTY_AREA_TIME_HORIZON_OBST = 0.5f;          // RVO2障害物回避の時間ホライズン [s]
-
-  bool penalty_area_obstacles_initialized = false;
-
   // 加速度は減速度の何倍にするかという係数
   ParameterWithEvent<double> acceleration_factor;
 

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -108,10 +108,6 @@ RVO2Planner::RVO2Planner(rclcpp::Node & node)
     "penalty_area_force_waypoint_on_crossing", PENALTY_AREA_FORCE_WAYPOINT_ON_CROSSING);
   PENALTY_AREA_FORCE_WAYPOINT_ON_CROSSING =
     node.get_parameter("penalty_area_force_waypoint_on_crossing").as_bool();
-  node.declare_parameter("penalty_area_time_horizon_obst", PENALTY_AREA_TIME_HORIZON_OBST);
-  PENALTY_AREA_TIME_HORIZON_OBST =
-    static_cast<float>(node.get_parameter("penalty_area_time_horizon_obst").as_double());
-
   node.declare_parameter("enable_velocity_plan_trace", false);
   enable_velocity_plan_trace = node.get_parameter("enable_velocity_plan_trace").as_bool();
 
@@ -128,34 +124,6 @@ RVO2Planner::RVO2Planner(rclcpp::Node & node)
   sub_feedback_array = node.create_subscription<crane_msgs::msg::RobotFeedbackArray>(
     "/robot_feedback", 1,
     [this](const crane_msgs::msg::RobotFeedbackArray & msg) { latest_feedback = msg; });
-}
-
-auto RVO2Planner::initializePenaltyAreaObstacles() -> void
-{
-  // ペナルティエリアをRVO2のポリゴン障害物として登録する。
-  // processObstacles()呼び出し後は変更不可なので、フィールド情報確定後に一度だけ呼ぶ。
-  // 頂点は反時計回り（RVO2の仕様）で指定する。
-  const Box our_area = world_model->getOurPenaltyArea();
-  const Box their_area = world_model->getTheirPenaltyArea();
-  auto addBoxObstacle = [&](const Box & box) {
-    const float xmin = static_cast<float>(box.min_corner().x());
-    const float xmax = static_cast<float>(box.max_corner().x());
-    const float ymin = static_cast<float>(box.min_corner().y());
-    const float ymax = static_cast<float>(box.max_corner().y());
-    // 反時計回り: 左下 → 右下 → 右上 → 左上
-    rvo_sim->addObstacle({{xmin, ymin}, {xmax, ymin}, {xmax, ymax}, {xmin, ymax}});
-  };
-  addBoxObstacle(our_area);
-  addBoxObstacle(their_area);
-  rvo_sim->processObstacles();
-  penalty_area_obstacles_initialized = true;
-  RCLCPP_INFO(
-    rclcpp::get_logger("rvo2_local_planner"),
-    "Penalty area obstacles initialized (our: [%.2f,%.2f]x[%.2f,%.2f], "
-    "their: [%.2f,%.2f]x[%.2f,%.2f])",
-    our_area.min_corner().x(), our_area.max_corner().x(), our_area.min_corner().y(),
-    our_area.max_corner().y(), their_area.min_corner().x(), their_area.max_corner().x(),
-    their_area.min_corner().y(), their_area.max_corner().y());
 }
 
 auto RVO2Planner::getCurrentEstimatedPosition(uint8_t robot_id, const Point & fallback) const
@@ -488,19 +456,10 @@ auto RVO2Planner::applyRVOInputStage(
   rvo_sim->setAgentPosition(command.robot_id, toRVO(ctx.current_pose_position));
   rvo_sim->setAgentPrefVelocity(command.robot_id, toRVO(ctx.target_vel));
   rvo_sim->setAgentMaxSpeed(command.robot_id, ctx.max_vel);
-  rvo_sim->setAgentTimeHorizonObst(
-    command.robot_id, command.local_planner_config.disable_goal_area_avoidance
-                        ? 0.0f
-                        : PENALTY_AREA_TIME_HORIZON_OBST);
 }
 
 auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> void
 {
-  // ペナルティエリアObstacleの遅延初期化（フィールド情報が確定してから一度だけ）
-  if (!penalty_area_obstacles_initialized && world_model->fieldSize().squaredNorm() > 0.01) {
-    initializePenaltyAreaObstacles();
-  }
-
   const auto referee_command = world_model->getMsg().play_situation.referee_raw.command.value;
   if (
     referee_command == robocup_ssl_msgs::msg::RefereeCommand::STOP &&
@@ -609,11 +568,21 @@ auto RVO2Planner::extractVelocityCommandsFromRVOSim(
     double distance = std::hypot(
       original_pos_mode.target_x - robot->pose.pos.x(),
       original_pos_mode.target_y - robot->pose.pos.y());
+
+    const auto referee_cmd = world_model->getMsg().play_situation.referee_raw.command.value;
+    const bool is_stop_state = referee_cmd == robocup_ssl_msgs::msg::RefereeCommand::STOP &&
+                               !world_model->isPracticeNormalSpeed();
+    constexpr double STOP_STATE_POSITION_TOLERANCE = 0.03;
+    double effective_tolerance = original_pos_mode.position_tolerance;
+    if (is_stop_state) {
+      effective_tolerance = std::max(effective_tolerance, STOP_STATE_POSITION_TOLERANCE);
+    }
+
     addOrUpdatePlanningFactor(command, "RVO2DistanceToTarget", formatPlanningDouble(distance));
     addOrUpdatePlanningFactor(
-      command, "RVO2PositionTolerance", formatPlanningDouble(original_pos_mode.position_tolerance));
+      command, "RVO2PositionTolerance", formatPlanningDouble(effective_tolerance));
     ZeroVelocityReason zero_velocity_reason = ZeroVelocityReason::NONE;
-    if (distance < original_pos_mode.position_tolerance) {
+    if (distance < effective_tolerance) {
       vel = Velocity::Zero();
       zero_velocity_reason = ZeroVelocityReason::POSITION_TOLERANCE;
     }

--- a/crane_sessions/src/defender_session.cpp
+++ b/crane_sessions/src/defender_session.cpp
@@ -30,25 +30,18 @@ DefenderSession::calculatePositionCommand(const std::vector<RobotIdentifier> & r
   }
 
   std::vector<Point> defense_points = [&]() {
-    // フィールド横幅の半分よりボールが遠ければ円弧守備に移行
-    if (
-      (world_model->ball().pos - world_model->getOurGoalCenter()).norm() <
-      world_model->fieldSize().y() * 0.5) {
-      // ball_lineが防御ラインと交差しない場合のフォールバック
-      // ボールがPA境界〜防御ライン間にいるとき、ball_line(ball→goal)が防御ラインの内側を向くため交差しない
-      auto defense_parameter = getDefenseLinePointParameter(ball_line, world_model);
-      Segment effective_ball_line = ball_line;
-      if (not defense_parameter) {
-        effective_ball_line = Segment{
-          world_model->getOurGoalCenter(),
-          ball.pos + (ball.pos - world_model->getOurGoalCenter()).normalized() * 2.0};
-        defense_parameter = getDefenseLinePointParameter(effective_ball_line, world_model);
-      }
-      return getDefenseLinePoints(
-        robots.size(), effective_ball_line, world_model, false, defense_parameter);
-    } else {
-      return getDefenseArcPoints(robots.size(), ball_line, world_model);
+    // ball_lineが防御ラインと交差しない場合のフォールバック
+    // ボールがPA境界〜防御ライン間にいるとき、ball_line(ball→goal)が防御ラインの内側を向くため交差しない
+    auto defense_parameter = getDefenseLinePointParameter(ball_line, world_model);
+    Segment effective_ball_line = ball_line;
+    if (not defense_parameter) {
+      effective_ball_line = Segment{
+        world_model->getOurGoalCenter(),
+        ball.pos + (ball.pos - world_model->getOurGoalCenter()).normalized() * 2.0};
+      defense_parameter = getDefenseLinePointParameter(effective_ball_line, world_model);
     }
+    return getDefenseLinePoints(
+      robots.size(), effective_ball_line, world_model, false, defense_parameter);
   }();
 
   if (not defense_points.empty()) {

--- a/crane_sessions/src/formation_session.cpp
+++ b/crane_sessions/src/formation_session.cpp
@@ -12,7 +12,7 @@ std::vector<Point> FormationSession::getWingFormationPoints(int robot_num)
 {
   std::vector<Point> formation_points;
 
-  formation_points.emplace_back(0.6, 0.0);
+  formation_points.emplace_back(0.7, 0.0);
   formation_points.emplace_back(1.5, 1.2);
   formation_points.emplace_back(1.5, -1.2);
   formation_points.emplace_back(0.6, 2.4);
@@ -97,7 +97,9 @@ FormationSession::calculatePositionCommand(const std::vector<RobotIdentifier> & 
       // フォーメーション特有の固定角度を設定
       command->setTargetTheta(target_theta);
       command->setMaxVelocity("フォーメーションはゆっくり", 1.0);
-    });
+      command->disableAnyAreaAvoidance();
+    },
+    0.03);
   return {SessionBase::Status::RUNNING, robot_commands};
 }
 }  // namespace crane


### PR DESCRIPTION
## Summary

0425ブランチで実機検証された、守備・隊形ロジックの簡潔化と RVO2 ローカルプランナのペナルティエリア処理の整理を反映する。0425→develop段階的反映の第3弾。

### crane_sessions/defender_session

- 「ボールが遠ければ円弧守備」分岐を撤去し、**常にディフェンスライン上で守備**に統一
- 実機運用上、円弧守備フェーズへの遷移が逆に隊形を不安定にしていた

### crane_sessions/formation_session

- ウィングフォーメーション最前列の x を 0.6 → 0.7 に微調整
- フォーメーション中は \`disableAnyAreaAvoidance()\` を有効化、\`position_tolerance\` を **3 cm** に拡大して停止しやすくする

### crane_local_planner/rvo2_planner

- ペナルティエリアをポリゴン障害物として RVO2 に登録する仕組み（\`initializePenaltyAreaObstacles\` 関数および \`penalty_area_time_horizon_obst\` パラメータ）を**撤去**
- PA 回避は従来どおり上位レイヤの waypoint 強制 / setMaxVelocity 方針に統一
- STOP 状態中の \`position_tolerance\` を最低 3 cm に拡大してロボットが完全停止しやすくなるよう調整

## 関連 0425 コミット

- \`f9aced64\` DefenderSessionで円弧守備機能を削除
- \`8b92f1d9\` フォーメーション中のエリア回避をOFF
- \`3039fde3\` フォーメーションのtoleranceを3cmに設定
- \`d27d568c\` STOP中の停止
- \`51768862\` ペナルティエリアの回避が強制されてしまうバグを修正
