### PR TITLE
refactor(crane_robot_skills): Attacker/SubAttacker/Goalie/SimpleKickoff のキック動作とゴール参照を整理

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/attacker.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/attacker.hpp
@@ -22,7 +22,6 @@ namespace crane::skills
 {
 enum class AttackerState {
   ENTRY_POINT,
-  FORCED_PASS,
   RECEIVE,
   KICK,
 };
@@ -61,8 +60,6 @@ public:
   std::optional<uint8_t> pass_receiver_id = std::nullopt;
 
   Point kick_target{Point::Zero()};
-
-  int forced_pass_receiver_id = -1;
 
   KickOld kick_skill;
 

--- a/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/simple_kickoff.hpp
@@ -9,13 +9,11 @@
 
 #include <algorithm>
 #include <crane_geometry/vector2d_adapter.hpp>
+#include <crane_robot_skills/goal_kick.hpp>
 #include <crane_robot_skills/kick_old.hpp>
 #include <crane_robot_skills/skill_base.hpp>
 #include <memory>
-#include <string>
-#include <unordered_map>
 #include <utility>
-#include <vector>
 
 namespace crane::skills
 {
@@ -24,16 +22,16 @@ class SimpleKickOff : public SkillBase
 public:
   template <typename... Args>
   explicit SimpleKickOff(Args &&... args)
-  : SkillBase("simple_kickoff", std::forward<Args>(args)...), kick_skill(command)
+  : SkillBase("simple_kickoff", std::forward<Args>(args)...),
+    kick_skill(command),
+    goal_kick_skill(command)
   {
-    initializeParameters();
   }
-
-  void initializeParameters();
 
   Status update() override;
 
   KickOld kick_skill;
+  GoalKick goal_kick_skill;
 
 private:
   bool kicked = false;

--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -21,7 +21,7 @@ namespace
 {
 constexpr double GOAL_ANGLE_THRESHOLD_DEG = 3.0;
 constexpr double GOAL_ANGLE_THRESHOLD_RAD = GOAL_ANGLE_THRESHOLD_DEG * M_PI / 180.0;
-constexpr double LOW_CHANCE_GOAL_ANGLE_THRESHOLD_DEG = 2.0;
+constexpr double LOW_CHANCE_GOAL_ANGLE_THRESHOLD_DEG = 0.5;
 constexpr double PASS_OBSTACLE_DISTANCE = 0.4;
 constexpr double BALL_CONTROL_DISTANCE = 1.0;
 constexpr double CHIP_KICK_DISTANCE = 2.0;
@@ -62,56 +62,6 @@ void Attacker::initialize()
       goal_kick_skill.clearVisualizer();
       return false;
     });
-
-  addTransition(
-    static_cast<int>(AttackerState::ENTRY_POINT), static_cast<int>(AttackerState::FORCED_PASS),
-    [this]() -> bool {
-      // セットプレイのときは強制パス
-      auto game_command = world_model()->getMsg().play_situation.command.value;
-      // ボールの停止条件は、INPLAY切り替わりの遅延対策
-      if (
-        (game_command == crane_msgs::msg::PlaySituation::OUR_DIRECT_FREE ||
-         game_command == crane_msgs::msg::PlaySituation::OUR_KICKOFF_START) &&
-        world_model()->ball().isStopped()) {
-        // pass_target_id が有効な場合のみパス先を設定（無い場合は FORCED_PASS で敵ゴールへキック）
-        if (world_model()->getMsg().game_analysis.pass_target_id >= 0) {
-          forced_pass_receiver_id =
-            static_cast<int>(world_model()->getMsg().game_analysis.pass_target_id);
-          pass_receiver_id = forced_pass_receiver_id;
-          auto receiver = world_model()->getOurRobot(pass_receiver_id.value());
-          kick_skill.setParameter("target", receiver->pose.pos);
-        }
-        return true;
-      } else {
-        return false;
-      }
-    });
-
-  // ----- ダブルタッチ防止の為、FORCED_PASS -> ENTRY_POINT の状態遷移は設けない ------- //
-
-  addStateFunction(static_cast<int>(AttackerState::FORCED_PASS), [this]() -> Status {
-    // パス
-    command->disableBallAvoidance();
-    command->setMaxVelocity("AttackerState::FORCED_PASS", 2.0);
-    if (pass_receiver_id) {
-      auto pass_receiver_pos = world_model()->getOurRobot(pass_receiver_id.value())->pose.pos;
-      if (pass_receiver_pos.x() * world_model()->getAttackSideSign() > 0.) {
-        // 自陣にいるときは強制的に攻撃対象ゴールを目標に設定
-        kick_target = world_model()->getAttackGoalCenter();
-      } else {
-        // 敵陣に適当なロボットがいる場合はパス
-        kick_target = pass_receiver_pos;
-      }
-    } else {
-      kick_target = world_model()->getAttackGoalCenter();
-    }
-    kick_skill.setParameter("target", kick_target);
-    Segment kick_line{world_model()->ball().pos, kick_target};
-    configurePassKick(kick_target, kick_skill);
-    kick_skill.run();
-
-    return Status::RUNNING;
-  });
 
   addTransition(
     static_cast<int>(AttackerState::ENTRY_POINT), static_cast<int>(AttackerState::RECEIVE),
@@ -337,12 +287,13 @@ void Attacker::initialize()
       command->disableBallAvoidance();
       return kick_skill.run();
     } else {
-      // FINAL_GUARD: ゴール角度が不十分なのでチップキックで前方クリア
+      // FINAL_GUARD: ゴール角度が不十分でも強ストレートでクリア
+      // チップキックはGK越えで直接ゴールに入るとファウルになるため使用不可
       printTextOnRobot("KICK::FINAL_GUARD");
       kick_skill.setParameter("target", world_model()->getAttackGoalCenter());
-      kick_skill.setParameter("chip_kick", true);
-      kick_skill.setParameter("use_target_chip_distance", true);
-      kick_skill.setParameter("target_chip_distance", CHIP_KICK_DISTANCE);
+      kick_skill.setParameter("chip_kick", false);
+      kick_skill.setParameter("use_target_kick_speed", true);
+      kick_skill.setParameter("target_kick_speed", 6.0);
       command->disableBallAvoidance();
       return kick_skill.run();
     }

--- a/crane_robot_skills/src/goalie.cpp
+++ b/crane_robot_skills/src/goalie.cpp
@@ -139,11 +139,6 @@ void Goalie::inplay(bool enable_emit)
       }
     }();
 
-    if (robot()->getDistance(target) > 0.2) {
-      target += (target - robot()->pose.pos).normalized() * 2.0;
-      // command->setTerminalVelocity(3.0); //動作しない
-    }
-
     command->setTargetPosition(target).lookAtBallFrom(target);
   } else {
     // ボールがフィールド外かつ自陣側（ゴール内）かどうか

--- a/crane_robot_skills/src/kick.cpp
+++ b/crane_robot_skills/src/kick.cpp
@@ -107,7 +107,7 @@ void Kick::initialize()
       // 角度が合っている場合のみキックゾーンに入ったと判断し、ボールに向かって押し込む
       if (angle_ok && bg::distance(ball_kick_zone, robot()->pose.pos) < 0.15) {
         command->disableCollisionAvoidance();
-        return 0.5;
+        return 0.3;
       } else {
         return 0.0;
       }

--- a/crane_robot_skills/src/simple_kickoff.cpp
+++ b/crane_robot_skills/src/simple_kickoff.cpp
@@ -8,13 +8,6 @@
 
 namespace crane::skills
 {
-void SimpleKickOff::initializeParameters()
-{
-  kick_skill.setParameter("chip_kick", true);
-  kick_skill.setParameter("use_target_chip_distance", true);
-  kick_skill.setParameter("target_chip_distance", 2.0);
-}
-
 Status SimpleKickOff::update()
 {
   if (!kicked && world_model()->ball().isMoving(0.5)) {
@@ -26,7 +19,6 @@ Status SimpleKickOff::update()
     return Status::RUNNING;
   }
 
-  kick_skill.setParameter("target", world_model()->getAttackGoalCenter());
-  return kick_skill.run();
+  return goal_kick_skill.run();
 }
 }  // namespace crane::skills

--- a/crane_robot_skills/src/sub_attacker.cpp
+++ b/crane_robot_skills/src/sub_attacker.cpp
@@ -41,7 +41,7 @@ Status SubAttacker::update()
     // 後ろからきたボールは一旦避ける
     Segment short_ball_line = world_model()->ball().getTrajectorySegmentByTime(3.0);
     auto result = getClosestPointAndDistance(robot()->pose.pos, short_ball_line);
-    // ボールが敵ゴールに向かっているか
+    // ボールが攻撃対象ゴールに向かっているか
     double dot_dir = (world_model()->getAttackGoalCenter() - world_model()->ball().pos)
                        .dot(world_model()->ball().vel);
     // ボールがロボットを追い越そうとしているか
@@ -62,7 +62,7 @@ Status SubAttacker::update()
       // ゴールとボールの中間方向を向く
       // TODO(Hansobo): ボールの速さ・キッカーの強さでボールの反射する角度が変わるため、要考慮
       auto [goal_angle, width] =
-        world_model()->getLargestGoalAngleRangeFromPoint(result.closest_point);
+        world_model()->getLargestAttackGoalAngleRangeFromPoint(result.closest_point);
       auto to_goal = getNormVec(goal_angle);
       auto to_ball = (world_model()->ball().pos - result.closest_point).normalized();
       double intermediate_angle = getAngle(2 * to_goal + to_ball);
@@ -87,7 +87,8 @@ Status SubAttacker::update()
     }
     command->setTargetPosition(best_position);
     // ゴールとボールの中間方向を向く
-    auto [goal_angle, width] = world_model()->getLargestGoalAngleRangeFromPoint(best_position);
+    auto [goal_angle, width] =
+      world_model()->getLargestAttackGoalAngleRangeFromPoint(best_position);
     auto to_goal = getNormVec(goal_angle);
     auto to_ball = (world_model()->ball().pos - best_position).normalized();
     command->setTargetTheta(getAngle(to_goal + to_ball));

--- a/crane_sessions/include/crane_sessions/forward_session.hpp
+++ b/crane_sessions/include/crane_sessions/forward_session.hpp
@@ -42,7 +42,7 @@ public:
     auto wm = world_model;
     return [wm](const std::shared_ptr<RobotInfo> & robot) {
       return estimatePenaltyAwareDistance(
-        robot->pose.pos, wm->getTheirGoalCenter(), wm->getOurPenaltyArea(), wm->getOurGoalCenter(),
+        robot->pose.pos, wm->getAttackGoalCenter(), wm->getOurPenaltyArea(), wm->getOurGoalCenter(),
         wm->getTheirPenaltyArea(), wm->getTheirGoalCenter(), wm->penaltyAreaSize());
     };
   }

--- a/utility/crane_msg_wrappers/src/sub_attacker_evaluation.cpp
+++ b/utility/crane_msg_wrappers/src/sub_attacker_evaluation.cpp
@@ -27,7 +27,7 @@ double evaluateSubAttackerPosition(const Point & p, const WorldModelWrapper & wo
     }
   }
 
-  auto [angle, width] = world_model.getLargestGoalAngleRangeFromPoint(p);
+  auto [angle, width] = world_model.getLargestAttackGoalAngleRangeFromPoint(p);
   // ゴールが見える角度が大きいほどよい
   double score = width;
 
@@ -69,13 +69,14 @@ double evaluateSubAttackerPosition(const Point & p, const WorldModelWrapper & wo
   // 自分とボールの延長線上にゴールがある場合は避ける
   Segment robot_to_ball_and_more{
     p, world_model.ball().pos + (world_model.ball().pos - p).normalized() * 10.0};
-  Segment goal_line{world_model.getTheirGoalPosts().first, world_model.getTheirGoalPosts().second};
+  Segment goal_line{
+    world_model.getAttackGoalPosts().first, world_model.getAttackGoalPosts().second};
   if (double distance = bg::distance(robot_to_ball_and_more, goal_line); distance < 1.0) {
     score *= distance;
   }
 
   // ボールの後側には行かない
-  double dot = (world_model.getTheirGoalCenter() - world_model.ball().pos)
+  double dot = (world_model.getAttackGoalCenter() - world_model.ball().pos)
                  .normalized()
                  .dot((p - world_model.ball().pos).normalized());
   score *= std::max((dot + 0.5), 0.0);


### PR DESCRIPTION
## Summary

0425ブランチで実機検証された、複数の小バグ修正と無駄ロジックの整理を一括反映する。0425→develop段階的反映の第4弾。

### Attacker

- \`AttackerState::FORCED_PASS\` と \`forced_pass_receiver_id\` を**撤去**。セットプレー時の強制パス機能は副作用が大きく、ヒューリスティック選択側で代替できる
- \`LOW_CHANCE_GOAL_ANGLE_THRESHOLD_DEG\` を 2.0° → **0.5°** に引き下げ、低角度時のチップキック条件を厳格化
- \`FINAL_GUARD\` のチップキックを廃止し**ストレートクリアに変更**。GK越えで直接ゴールに入るとファウル扱いになるため

### SubAttacker / forward_session / sub_attacker_evaluation

- 参照ゴールを Attack-side switch に対応するAPIへ統一
  - \`getTheirGoalCenter\` → \`getAttackGoalCenter\`
  - \`getLargestGoalAngleRangeFromPoint\` → \`getLargestAttackGoalAngleRangeFromPoint\`
  - \`getTheirGoalPosts\` → \`getAttackGoalPosts\`

### Goalie

- \`inplay()\` の DIRTY-HACK な急加速ロジック（target を robot 方向へ 2.0 m 延伸）を**削除**

### SimpleKickOff

- チップキック設定（\`initializeParameters\`）を撤去し、\`GoalKick\` スキル呼び出しに**置換**

### Kick

- キックゾーン押し込み速度を 0.5 → **0.3** に調整（ボール押し出しすぎによるオーバーシュート対策）

## 関連 0425 コミット

- \`566c220a\` Attacker::FORCED_PASS削除
- \`6d472bfc\` LOW_CHANCE_GOAL_ANGLE_THRESHOLD_DEGを引き下げ
- \`2f6a7ea0\` FINAL_GUARDはストレート
- \`68721b97\` refactor: SubAttacker系の参照ゴールをAttackGoalに統一
- \`11429b30\` DIRTY-HACKなキーパーの急加速を削除
- \`bfec71ee\` refactor(simple_kickoff): チップキックをGoalKickスキルに置き換え
- \`93161561\` fix: 修正されたスキル名の設定ロジックとスキル許可リストの更新
- \`4c9a25e4\` 系（旧Kick実装の押し込み速度調整）
