### PR TITLE
feat(crane): SingleBallPlacementのグローバルタイムアウト・リトライ機構と相手プレイスメント中の敵PA回避を追加

### DIFF
--- a/crane_robot_skills/include/crane_robot_skills/single_ball_placement.hpp
+++ b/crane_robot_skills/include/crane_robot_skills/single_ball_placement.hpp
@@ -52,6 +52,18 @@ private:
 
   mutable std::optional<rclcpp::Time> last_ball_sensor_active_time_;
 
+  std::optional<rclcpp::Time> robot_outside_field_since_;
+
+  std::optional<rclcpp::Time> approach_since_;
+
+  void onPostUpdate() override;
+
+  bool isOutsideFieldTimeout() const;
+
+  bool isApproachTimeout() const;
+
+  bool checkAndLogTimeout(const char * state_name);
+
   Point getPlacementTarget() const
   {
     Point p;

--- a/crane_robot_skills/src/single_ball_placement.cpp
+++ b/crane_robot_skills/src/single_ball_placement.cpp
@@ -26,6 +26,9 @@ void SingleBallPlacement::initialize()
   // マイナスするとコート内も判定される
   setParameter("コート端判定のオフセット", 0.0);
 
+  setParameter("outside_field_timeout", 10.0);
+  setParameter("approach_timeout", 10.0);
+
   addStateFunction(static_cast<int>(SingleBallPlacementStates::ENTRY_POINT), [this]() {
     command->stopHere();
     return Status::RUNNING;
@@ -135,6 +138,11 @@ void SingleBallPlacement::initialize()
       }
     });
 
+  addTransition(
+    static_cast<int>(SingleBallPlacementStates::PULL_BACK_FROM_EDGE_PREPARE),
+    static_cast<int>(SingleBallPlacementStates::ENTRY_POINT),
+    [this]() { return checkAndLogTimeout("PULL_BACK_FROM_EDGE_PREPARE"); });
+
   // PULL_BACK_FROM_EDGE_TOUCH
   addStateFunction(
     static_cast<int>(SingleBallPlacementStates::PULL_BACK_FROM_EDGE_TOUCH), [this]() {
@@ -186,6 +194,11 @@ void SingleBallPlacement::initialize()
     static_cast<int>(SingleBallPlacementStates::PULL_BACK_FROM_EDGE_TOUCH),
     static_cast<int>(SingleBallPlacementStates::PULL_BACK_FROM_EDGE_PREPARE),
     [this]() { return skill_status == Status::FAILURE; });
+
+  addTransition(
+    static_cast<int>(SingleBallPlacementStates::PULL_BACK_FROM_EDGE_TOUCH),
+    static_cast<int>(SingleBallPlacementStates::ENTRY_POINT),
+    [this]() { return checkAndLogTimeout("PULL_BACK_FROM_EDGE_TOUCH"); });
 
   // PULL_BACK_FROM_EDGE_PULL
   addStateFunction(static_cast<int>(SingleBallPlacementStates::PULL_BACK_FROM_EDGE_PULL), [this]() {
@@ -273,6 +286,11 @@ void SingleBallPlacement::initialize()
     static_cast<int>(SingleBallPlacementStates::ENTRY_POINT),
     [this]() { return isBallTrulyLostFromDribbler(0.2); });
 
+  addTransition(
+    static_cast<int>(SingleBallPlacementStates::PULL_BACK_FROM_EDGE_PULL),
+    static_cast<int>(SingleBallPlacementStates::ENTRY_POINT),
+    [this]() { return checkAndLogTimeout("PULL_BACK_FROM_EDGE_PULL"); });
+
   addStateFunction(static_cast<int>(SingleBallPlacementStates::GO_OVER_BALL), [this]() {
     command->setMaxVelocity("SingleBallPlacementStates::GO_OVER_BALL", 1.5);
     auto placement_target = getPlacementTarget();
@@ -335,9 +353,19 @@ void SingleBallPlacement::initialize()
   });
 
   addTransition(
+    static_cast<int>(SingleBallPlacementStates::PASS_TO_TARGET),
+    static_cast<int>(SingleBallPlacementStates::ENTRY_POINT),
+    [this]() { return checkAndLogTimeout("PASS_TO_TARGET"); });
+
+  addTransition(
     static_cast<int>(SingleBallPlacementStates::GO_OVER_BALL),
     static_cast<int>(SingleBallPlacementStates::CONTACT_BALL),
     [this]() { return skill_status == Status::SUCCESS; });
+
+  addTransition(
+    static_cast<int>(SingleBallPlacementStates::GO_OVER_BALL),
+    static_cast<int>(SingleBallPlacementStates::ENTRY_POINT),
+    [this]() { return checkAndLogTimeout("GO_OVER_BALL"); });
 
   addStateFunction(static_cast<int>(SingleBallPlacementStates::CONTACT_BALL), [this]() {
     command->disablePlacementAvoidance();
@@ -391,6 +419,11 @@ void SingleBallPlacement::initialize()
       }
       return isBallTrulyLostFromDribbler(0.3);
     });
+
+  addTransition(
+    static_cast<int>(SingleBallPlacementStates::CONTACT_BALL),
+    static_cast<int>(SingleBallPlacementStates::ENTRY_POINT),
+    [this]() { return checkAndLogTimeout("CONTACT_BALL"); });
 
   addStateFunction(static_cast<int>(SingleBallPlacementStates::MOVE_TO_TARGET), [this]() {
     auto placement_target = getPlacementTarget();
@@ -483,6 +516,11 @@ void SingleBallPlacement::initialize()
   //   SingleBallPlacementStates::PULL_BACK_FROM_EDGE_PREPARE,
   //   [this]() { return skill_status == Status::FAILURE; });
 
+  addTransition(
+    static_cast<int>(SingleBallPlacementStates::MOVE_TO_TARGET),
+    static_cast<int>(SingleBallPlacementStates::ENTRY_POINT),
+    [this]() { return checkAndLogTimeout("MOVE_TO_TARGET"); });
+
   addStateFunction(static_cast<int>(SingleBallPlacementStates::SLEEP), [this]() {
     if (not sleep) {
       sleep = std::make_shared<Sleep>(command);
@@ -540,5 +578,67 @@ void SingleBallPlacement::initialize()
       return ((world_model()->ball().pos - placement_target).norm() > 0.15) &&
              world_model()->getMsg().ball_info.detected;
     });
+}
+
+void SingleBallPlacement::onPostUpdate()
+{
+  auto now = rclcpp::Clock(RCL_ROS_TIME).now();
+  const double offset = getParameter<double>("コート端判定のオフセット");
+
+  bool outside = !world_model()->point_checker.isFieldInside(robot()->pose.pos, offset);
+  if (outside) {
+    if (!robot_outside_field_since_) robot_outside_field_since_ = now;
+  } else {
+    robot_outside_field_since_ = std::nullopt;
+  }
+
+  auto s = static_cast<SingleBallPlacementStates>(state_machine_.getCurrentState());
+  bool is_approach =
+    s != SingleBallPlacementStates::ENTRY_POINT && s != SingleBallPlacementStates::RECEIVE_BALL &&
+    s != SingleBallPlacementStates::SLEEP && s != SingleBallPlacementStates::LEAVE_BALL &&
+    s != SingleBallPlacementStates::PULL_BACK_FROM_EDGE_OVER_SLEEP &&
+    s != SingleBallPlacementStates::PULL_BACK_FROM_EDGE_OVER_LEAVE;
+  if (is_approach) {
+    if (!approach_since_) approach_since_ = now;
+  } else {
+    approach_since_ = std::nullopt;
+  }
+}
+
+bool SingleBallPlacement::isOutsideFieldTimeout() const
+{
+  if (!robot_outside_field_since_) return false;
+  auto now = rclcpp::Clock(RCL_ROS_TIME).now();
+  return (now - *robot_outside_field_since_).seconds() >
+         getParameter<double>("outside_field_timeout");
+}
+
+bool SingleBallPlacement::isApproachTimeout() const
+{
+  if (!approach_since_) return false;
+  auto now = rclcpp::Clock(RCL_ROS_TIME).now();
+  return (now - *approach_since_).seconds() > getParameter<double>("approach_timeout");
+}
+
+bool SingleBallPlacement::checkAndLogTimeout(const char * state_name)
+{
+  if (isOutsideFieldTimeout()) {
+    auto clock = rclcpp::Clock(RCL_ROS_TIME).make_shared();
+    RCLCPP_WARN(
+      rclcpp::get_logger("SingleBallPlacement"),
+      "[%s] Robot outside field for %.1fs → ENTRY_POINT (retry)", state_name,
+      (rclcpp::Clock(RCL_ROS_TIME).now() - *robot_outside_field_since_).seconds());
+    robot_outside_field_since_ = std::nullopt;
+    return true;
+  }
+  if (isApproachTimeout()) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("SingleBallPlacement"),
+      "[%s] Approach time exceeded %.1fs → ENTRY_POINT (retry)", state_name,
+      (rclcpp::Clock(RCL_ROS_TIME).now() - *approach_since_).seconds());
+    approach_since_ = std::nullopt;
+    return true;
+  }
+  return false;
 }
 }  // namespace crane::skills

--- a/crane_sessions/include/crane_sessions/placement_avoidance_session.hpp
+++ b/crane_sessions/include/crane_sessions/placement_avoidance_session.hpp
@@ -59,6 +59,15 @@ public:
              placement_area_opt.value().radius + offset;
     };
 
+    const auto cmd_value = world_model->getMsg().play_situation.command.value;
+    const bool is_their_placement =
+      cmd_value == crane_msgs::msg::PlaySituation::THEIR_BALL_PLACEMENT;
+    const double pa_offset = needsExpandedPenaltyAreaOffset(cmd_value) ? 0.35 : 0.15;
+    auto isInEnemyPA = [&](const Point & p) -> bool {
+      if (!is_their_placement) return false;
+      return world_model->point_checker.isEnemyPenaltyArea(p, pa_offset);
+    };
+
     for (const auto & robot_id : robots) {
       auto robot = world_model->getOurRobot(robot_id.id);
       if (!robot) {
@@ -77,8 +86,10 @@ public:
         // 0.8m離れる
         target_position = closest_point + (current_position - closest_point).normalized() * 0.8;
 
-        if (not world_model->point_checker.isFieldInside(target_position, 0.2)) {
-          // 一番近いフィールド外のポイントがだめなので逆方向に0.8m離れる
+        if (
+          not world_model->point_checker.isFieldInside(target_position, 0.2) ||
+          isInEnemyPA(target_position)) {
+          // フィールド外または敵PAのポイントがだめなので逆方向に0.8m離れる
           target_position = closest_point + (closest_point - current_position).normalized() * 0.8;
 
           if (
@@ -97,7 +108,8 @@ public:
                 [&](const auto & target_candidate) {
                   return (
                     world_model->point_checker.isFieldInside(target_candidate, 0.2) &&
-                    not isInPlacementArea(target_candidate, 0.1));
+                    not isInPlacementArea(target_candidate, 0.1) &&
+                    not isInEnemyPA(target_candidate));
                 });
               target != target_candidates.end()) {
               target_position = *target;
@@ -111,7 +123,7 @@ public:
               }
               auto valid = std::ranges::find_if(radial_candidates, [&](const auto & c) {
                 return world_model->point_checker.isFieldInside(c, 0.2) &&
-                       not isInPlacementArea(c, 0.1);
+                       not isInPlacementArea(c, 0.1) && not isInEnemyPA(c);
               });
               if (valid != radial_candidates.end()) {
                 target_position = *valid;
@@ -132,7 +144,12 @@ public:
       }
 
       command->setTargetPosition(target_position);
-      command->disableGoalAreaAvoidance().lookAtBall();
+      if (is_their_placement) {
+        command->enableGoalAreaAvoidance();
+      } else {
+        command->disableGoalAreaAvoidance();
+      }
+      command->lookAtBall();
       robot_commands.push_back(command->getMsg());
     }
     return {Status::RUNNING, robot_commands};


### PR DESCRIPTION
## Summary

0425ブランチで実機検証された、ボールプレイスメントの自己復旧と相手プレイスメント時の安全性向上を反映する。0425→develop段階的反映の第5弾。

### crane_robot_skills/single_ball_placement

- 各アプローチ系状態（\`PULL_BACK_FROM_EDGE_PREPARE/TOUCH/PULL\`, \`GO_OVER_BALL\`, \`CONTACT_BALL\`, \`PASS_TO_TARGET\`, \`MOVE_TO_TARGET\`）から **ENTRY_POINT へのタイムアウト遷移** を追加
- **2種類のタイムアウト判定**:
  - \`outside_field_timeout\` (既定 **10 s**): ロボットがフィールド外に居続けたらリトライ
  - \`approach_timeout\` (既定 **10 s**): アプローチ系状態に居続けたらリトライ
- \`onPostUpdate()\` でロボット位置と現在状態を毎フレーム監視し、タイムアウト時刻を記録。\`checkAndLogTimeout()\` でリトライ時に WARN ログを出力
- \`ENTRY_POINT\` / \`RECEIVE_BALL\` / \`SLEEP\` / \`LEAVE_BALL\` 系の待機・離脱状態は approach 判定から除外

### crane_sessions/placement_avoidance_session

- 相手プレイスメント中（\`THEIR_BALL_PLACEMENT\`）に限り、回避点候補から **敵PAを除外**
- \`enableGoalAreaAvoidance()\` を有効化して敵PA侵入を防止
- \`needsExpandedPenaltyAreaOffset\` で得られるオフセット（0.35 m / 0.15 m）を適用

## 関連 0425 コミット

- \`11e663ff\` fix: SingleBallPlacementにグローバルタイムアウト・リトライ機構を追加
- \`a7db3eb6\` fix: 相手プレイスメント中に敵ペナルティーエリア回避を追加
