### PR TITLE
feat(crane_sessions): BallPlacementをRotatingSingleSkillSession化し履歴記録機能を追加

### DIFF
--- a/crane_session_coordinator/config/ball_placement_history.yaml
+++ b/crane_session_coordinator/config/ball_placement_history.yaml
@@ -1,0 +1,2 @@
+next_seq: 1
+robots: {}

--- a/crane_sessions/include/crane_sessions/ball_placement_skill_session.hpp
+++ b/crane_sessions/include/crane_sessions/ball_placement_skill_session.hpp
@@ -9,45 +9,49 @@
 
 #include <crane_msg_wrappers/world_model_wrapper.hpp>
 #include <crane_robot_skills/single_ball_placement.hpp>
-#include <crane_sessions/session_base.hpp>
+#include <crane_sessions/rotating_single_skill_session.hpp>
+#include <filesystem>
 #include <memory>
+#include <optional>
 #include <rclcpp/rclcpp.hpp>
-#include <utility>
-#include <vector>
 
 #include "visibility_control.h"
 
 namespace crane
 {
-class BallPlacementSkillSession : public SessionBase
+class BallPlacementSkillSession : public RotatingSingleSkillSession<skills::SingleBallPlacement>
 {
 public:
-  std::shared_ptr<skills::SingleBallPlacement> skill = nullptr;
-
   COMPOSITION_PUBLIC explicit BallPlacementSkillSession(
     WorldModelWrapper::SharedPtr & world_model, rclcpp::Node &)
-  : SessionBase("ball_placement_skill", world_model)
+  : RotatingSingleSkillSession("ball_placement_skill", world_model)
   {
-  }
-
-  auto calculatePositionCommand(const std::vector<RobotIdentifier> & robots)
-    -> std::pair<Status, std::vector<crane_msgs::msg::RobotCommand>> override;
-
-  auto getRobotSuitabilityFunc() const
-    -> std::function<double(const std::shared_ptr<RobotInfo> &)> override
-  {
-    auto wm = world_model;
-    return [wm](const std::shared_ptr<RobotInfo> & robot) {
-      if (robot->id == wm->getOurGoalieId()) {
-        return GOALIE_EXCLUSION_COST;  // ゴールキーパーは除外
-      }
-      // 「一番近いロボット」を直感通りに選ぶため線形距離を使用
-      return robot->getDistance(wm->ball().pos);
-    };
   }
 
 protected:
-  void onRobotsChanged() override { skill.reset(); }
+  auto createSkill(uint8_t robot_id) -> std::shared_ptr<skills::SingleBallPlacement> override;
+
+  std::filesystem::path resolveHistoryFilePath() const override;
+
+  std::optional<bool> determineAssignmentResult(
+    const crane_msgs::msg::PlaySituation & current_play_situation) override;
+
+  void onSkillStarted() override;
+
+  void onBeforeSkillRun() override;
+
+  void onRobotsChangedHook() override;
+
+private:
+  /// 試行開始時点の味方チームの ball_placement_failures 値。
+  /// determineAssignmentResult からの参照後にリセットするため mutable 不要。
+  std::optional<std::uint32_t> initial_ball_placement_failures_;
+
+  std::uint32_t getCurrentBallPlacementFailures() const;
+
+  /// PlaySituation / Referee から明示的な成否を抽出する。
+  std::optional<bool> extractPlacementResult(
+    const crane_msgs::msg::PlaySituation & current_play_situation) const;
 };
 }  // namespace crane
 #endif  // CRANE_SESSIONS__BALL_PLACEMENT_SKILL_SESSION_HPP_

--- a/crane_sessions/package.xml
+++ b/crane_sessions/package.xml
@@ -23,6 +23,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>rclcpp_components</depend>
+  <depend>robocup_ssl_msgs</depend>
   <depend>speak_ros_interfaces</depend>
   <depend>std_msgs</depend>
   <depend>yaml-cpp</depend>

--- a/crane_sessions/src/ball_placement_skill_session.cpp
+++ b/crane_sessions/src/ball_placement_skill_session.cpp
@@ -4,29 +4,88 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <crane_sessions/ball_placement_skill_session.hpp>
+#include <robocup_ssl_msgs/msg/game_event_type.hpp>
 
 namespace crane
 {
-auto BallPlacementSkillSession::calculatePositionCommand(
-  const std::vector<RobotIdentifier> & robots)
-  -> std::pair<SessionBase::Status, std::vector<crane_msgs::msg::RobotCommand>>
+auto BallPlacementSkillSession::createSkill(uint8_t robot_id)
+  -> std::shared_ptr<skills::SingleBallPlacement>
 {
-  // GlobalRobotAllocator対応: robotsが変更されたらスキルを再生成
-  if (robots.empty()) {
-    return {SessionBase::Status::RUNNING, {}};
-  }
-  if (not skill) {
-    skill = std::make_shared<skills::SingleBallPlacement>(
-      "ball_placement_skill_planner", robots.front().id, world_model);
+  return std::make_shared<skills::SingleBallPlacement>(
+    "ball_placement_skill_planner", robot_id, world_model);
+}
+
+std::filesystem::path BallPlacementSkillSession::resolveHistoryFilePath() const
+{
+  const auto override_path = getSessionParameter<std::string>("history_file_path", "");
+  if (!override_path.empty()) {
+    return override_path;
   }
 
+  // unified_session_config.yaml と同様に package_share_directory/config から解決する。
+  // その上で symlink-install 環境では実体パスへ解決し、src 側のファイルを直接更新する。
+  const auto config_path =
+    std::filesystem::path(
+      ament_index_cpp::get_package_share_directory("crane_session_coordinator")) /
+    "config" / "ball_placement_history.yaml";
+  try {
+    return std::filesystem::weakly_canonical(config_path);
+  } catch (const std::exception &) {
+    return config_path;
+  }
+}
+
+std::optional<bool> BallPlacementSkillSession::determineAssignmentResult(
+  const crane_msgs::msg::PlaySituation & current_play_situation)
+{
+  const auto explicit_result = extractPlacementResult(current_play_situation);
+  if (explicit_result.has_value()) {
+    initial_ball_placement_failures_.reset();
+    return explicit_result;
+  }
+
+  const auto start_failures = initial_ball_placement_failures_.value_or(0);
+  initial_ball_placement_failures_.reset();
+  if (current_play_situation.our_team_info.ball_placement_failures > start_failures) {
+    return false;
+  }
+  return std::nullopt;
+}
+
+void BallPlacementSkillSession::onSkillStarted()
+{
+  initial_ball_placement_failures_ = getCurrentBallPlacementFailures();
+}
+
+void BallPlacementSkillSession::onBeforeSkillRun()
+{
   if (auto target = world_model->getBallPlacementTarget(); target.has_value()) {
     skill->setParameter("placement_x", target->x());
     skill->setParameter("placement_y", target->y());
   }
-  auto status = skill->run();
-  return {static_cast<SessionBase::Status>(status), {skill->getRobotCommand()}};
+}
+
+void BallPlacementSkillSession::onRobotsChangedHook() { initial_ball_placement_failures_.reset(); }
+
+std::uint32_t BallPlacementSkillSession::getCurrentBallPlacementFailures() const
+{
+  return world_model->getMsg().play_situation.our_team_info.ball_placement_failures;
+}
+
+std::optional<bool> BallPlacementSkillSession::extractPlacementResult(
+  const crane_msgs::msg::PlaySituation & current_play_situation) const
+{
+  std::optional<bool> result;
+  for (const auto & game_event : current_play_situation.referee_raw.game_events) {
+    if (game_event.type.value == robocup_ssl_msgs::msg::GameEventType::PLACEMENT_SUCCEEDED) {
+      result = true;
+    } else if (game_event.type.value == robocup_ssl_msgs::msg::GameEventType::PLACEMENT_FAILED) {
+      result = false;
+    }
+  }
+  return result;
 }
 
 }  // namespace crane


### PR DESCRIPTION
## Summary

0425ブランチで実機検証された、BallPlacement の **ロボットID 履歴記録（Referee 結果ベース）** を反映する。0425→develop段階的反映の **第6弾（最終）**。

### crane_sessions/ball_placement_skill_session

- 既存の \`SessionBase\` 派生から \`RotatingSingleSkillSession\` 派生に変更し、共通のローテーション・履歴記録基盤を活用
- \`createSkill()\` で \`SingleBallPlacement\` インスタンスを生成
- \`resolveHistoryFilePath()\` で \`crane_session_coordinator/config/ball_placement_history.yaml\` を解決（symlink-install 環境では \`weakly_canonical\` で実体パスへ解決し、src 側を直接更新可能）
- \`determineAssignmentResult()\` を override して、AutoRef/Referee の game event（\`PLACEMENT_SUCCEEDED\` / \`PLACEMENT_FAILED\`）または \`PlaySituation\` コマンドからプレイスメント成否を抽出
- \`onSkillStarted\` / \`onBeforeSkillRun\` / \`onRobotsChangedHook\` で試行開始時点の \`ball_placement_failures\` を保存し、\`determineAssignmentResult\` からのフォールバック判定に使用

### crane_session_coordinator/config/ball_placement_history.yaml （新規）

- **空テンプレート**（\`next_seq: 1, robots: {}\`）として追加。実行時に \`SkillAssignmentHistory\` が成否を書き込む（\`free_kicker_history.yaml\` と同形式）
- 0425 上の差分には試合中の実データ（\`next_seq: 11\` 等）が入っていたが、本PRでは空テンプレートに置き換えてコミット

### crane_sessions/package.xml

- \`robocup_ssl_msgs\` を依存に追加（\`GameEventType\` を参照するため）

## 0425 差分から取り込まなかったもの

- \`crane_sessions/include/crane_sessions/session_base.hpp\` — \`setFixedRobots\` / \`getFixedRobots\` / \`onDeactivated(PlaySituation)\` などは既に develop (#1362) 側で同等のメソッドが追加済み。0425上の差分は重複定義のため取り込み不要
- \`crane_sessions/src/session_factory.cpp\` — 0425上の差分は \`attacker_heat_rotation\` の重複登録（マージ事故）のみ。develop 側を維持

## 関連 0425 コミット

- \`962052f1\` [feat] BallPlacement履歴をレフェリー結果で記録
- \`21dafc16\` [refactor] 固定割当を通常セッションに統合（の一部）
