### PR TITLE
fix(crane_robot_skills): FreeKickerのAPPROACHでPA回避が無効化される問題を修正

### DIFF
--- a/crane_robot_skills/src/free_kicker.cpp
+++ b/crane_robot_skills/src/free_kicker.cpp
@@ -88,7 +88,6 @@ void FreeKicker::initialize()
       .lookAtFrom(kick_target_, ball_pos)
       .disableBallAvoidance()
       .disablePlacementAvoidance()
-      .disableGoalAreaAvoidance()
       .disableFieldBoundary()
       .dribble(0.0)
       .setOmegaLimit(10.0);


### PR DESCRIPTION
## 概要
FreeKickerスキルがAPPROACHフェーズでペナルティエリア(PA)を横切ってボールへアプローチしてしまうバグを修正する。

## 背景・根本原因
PR #1360 でAPPROACHフェーズが刷新された際、目標位置への直進性を確保する目的で複数の回避処理を一括無効化する変更が加えられた。その中の `disableGoalAreaAvoidance()` 呼び出しによりPA回避が切られ、フリーキックのアプローチ時にロボットがPAを横断する挙動が観測されていた。

加えて `RobotCommandWrapper::latest_msg.local_planner_config.disable_goal_area_avoidance` フラグは `SkillInterface::prepareFrame()` でも `RobotCommandWrapper::usePositionMode()` でもクリアされないため、APPROACHで立てたフラグが ALIGN / KICK フェーズにも持ち越され、フリーキック試行の最後までPA回避が無効のまま動作する潜在問題もあった。

ルール上フリーキックは原則PA外で行われるため、PA回避はデフォルト(有効)のまま運用するのが安全。

## 変更内容
- `crane_robot_skills/src/free_kicker.cpp` の APPROACH 状態から `.disableGoalAreaAvoidance()` を1行削除
- これによりAPPROACH/ALIGN/KICK 全フェーズで `disable_goal_area_avoidance` がデフォルト値 `false`(PA回避ON) のまま動作
- ALIGN/KICK 側は元から `disableGoalAreaAvoidance()` を呼んでいないため変更不要。誰も `disable` を呼ばなくなったことでフラグ持ち越しの実害も解消
