### PR TITLE
feat(crane_sender): 位置ターゲット+到着速度ベクトルモードを追加

### DIFF
--- a/crane_bag/src/bag/bag_types.hpp
+++ b/crane_bag/src/bag/bag_types.hpp
@@ -82,6 +82,7 @@ struct NamedString
 struct PositionTarget
 {
   float target_x = 0, target_y = 0;
+  float terminal_velocity_x = 0, terminal_velocity_y = 0;
 };
 
 struct PolarVelocityTarget

--- a/crane_bag/src/bag/msg_extractors.cpp
+++ b/crane_bag/src/bag/msg_extractors.cpp
@@ -213,6 +213,10 @@ RobotCommands extract_robot_commands(const RosMsgParser::FlatMessage & flat)
         m.get_f(FlatValueMap::arr_path(pos_prefix, j, "target_x"));
       cmd.position_target_mode[j].target_y =
         m.get_f(FlatValueMap::arr_path(pos_prefix, j, "target_y"));
+      cmd.position_target_mode[j].terminal_velocity_x =
+        m.get_f(FlatValueMap::arr_path(pos_prefix, j, "terminal_velocity_x"));
+      cmd.position_target_mode[j].terminal_velocity_y =
+        m.get_f(FlatValueMap::arr_path(pos_prefix, j, "terminal_velocity_y"));
     }
 
     const std::string vel_prefix = ap("polar_velocity_target_mode");

--- a/crane_msgs/msg/PositionTargetMode.msg
+++ b/crane_msgs/msg/PositionTargetMode.msg
@@ -5,3 +5,7 @@ float32 target_y
 float32 position_tolerance 0.0
 
 float32 speed_limit_at_target 0.0
+
+# 目標位置に到着した瞬間の速度ベクトル (グローバル座標, m/s)
+float32 terminal_velocity_x 0.0
+float32 terminal_velocity_y 0.0

--- a/crane_sender/include/crane_sender/robot_packet.h
+++ b/crane_sender/include/crane_sender/robot_packet.h
@@ -84,8 +84,27 @@ inline void PolarVelocityModeArgs_serialize(const PolarVelocityModeArgs * args, 
   forward(&data[2], &data[3], args->target_global_velocity_theta, 32.767);
 }
 
+typedef struct
+{
+  float terminal_velocity_x;
+  float terminal_velocity_y;
+} PositionTargetModeArgs;
+
+inline void PositionTargetModeArgs_init(PositionTargetModeArgs * args, const uint8_t * data)
+{
+  args->terminal_velocity_x = convertTwoByteToFloat(data[0], data[1], 32.767);
+  args->terminal_velocity_y = convertTwoByteToFloat(data[2], data[3], 32.767);
+}
+
+inline void PositionTargetModeArgs_serialize(const PositionTargetModeArgs * args, uint8_t * data)
+{
+  forward(&data[0], &data[1], args->terminal_velocity_x, 32.767);
+  forward(&data[2], &data[3], args->terminal_velocity_y, 32.767);
+}
+
 typedef enum {
   POLAR_VELOCITY_TARGET_MODE = 3,
+  POSITION_TARGET_WITH_TERMINAL_VELOCITY_MODE = 4,
 } ControlMode;
 
 typedef struct
@@ -110,6 +129,7 @@ typedef struct
 
   union {
     PolarVelocityModeArgs polar_velocity;
+    PositionTargetModeArgs position_target;
   } mode_args;
 
   float target_global_pos[2];
@@ -206,6 +226,10 @@ inline void RobotCommandSerializedV2_serialize(
       PolarVelocityModeArgs_serialize(
         &command->mode_args.polar_velocity, &serialized->data[CONTROL_MODE_ARGS]);
       break;
+    case POSITION_TARGET_WITH_TERMINAL_VELOCITY_MODE:
+      PositionTargetModeArgs_serialize(
+        &command->mode_args.position_target, &serialized->data[CONTROL_MODE_ARGS]);
+      break;
   }
   forward(
     &serialized->data[TARGET_GLOBAL_POS_X_HIGH], &serialized->data[TARGET_GLOBAL_POS_X_LOW],
@@ -256,6 +280,10 @@ inline RobotCommandV2 RobotCommandSerializedV2_deserialize(
     case POLAR_VELOCITY_TARGET_MODE:
       PolarVelocityModeArgs_init(
         &command.mode_args.polar_velocity, &serialized->data[CONTROL_MODE_ARGS]);
+      break;
+    case POSITION_TARGET_WITH_TERMINAL_VELOCITY_MODE:
+      PositionTargetModeArgs_init(
+        &command.mode_args.position_target, &serialized->data[CONTROL_MODE_ARGS]);
       break;
   }
   command.target_global_pos[0] = convertTwoByteToFloat(

--- a/crane_sender/src/ibis_sender_node.cpp
+++ b/crane_sender/src/ibis_sender_node.cpp
@@ -265,18 +265,22 @@ private:
     packet.latency_time_ms = static_cast<uint8_t>(command.latency_ms);
     packet.elapsed_time_ms_since_last_vision = command.elapsed_time_ms_since_last_vision;
 
-    packet.control_mode = POLAR_VELOCITY_TARGET_MODE;
-    packet.mode_args.polar_velocity.target_global_velocity_r = target_velocity_r;
-    packet.mode_args.polar_velocity.target_global_velocity_theta = target_velocity_theta;
-
     if (!command.position_target_mode.empty()) {
       const auto & pos_mode = command.position_target_mode.front();
+      packet.control_mode = POSITION_TARGET_WITH_TERMINAL_VELOCITY_MODE;
+      packet.mode_args.position_target.terminal_velocity_x = pos_mode.terminal_velocity_x;
+      packet.mode_args.position_target.terminal_velocity_y = pos_mode.terminal_velocity_y;
       packet.target_global_pos[0] = pos_mode.target_x;
       packet.target_global_pos[1] = pos_mode.target_y;
       packet.terminal_velocity = pos_mode.speed_limit_at_target;
     } else {
-      packet.target_global_pos[0] = 0.0f;
-      packet.target_global_pos[1] = 0.0f;
+      // POLAR_VELOCITY_TARGET_MODE は「位置ターゲット = 現在位置, 速度ベクトル = 目標速度」として
+      // POSITION_TARGET_WITH_TERMINAL_VELOCITY_MODE と統一的に解釈できる互換構成にする
+      packet.control_mode = POLAR_VELOCITY_TARGET_MODE;
+      packet.mode_args.polar_velocity.target_global_velocity_r = target_velocity_r;
+      packet.mode_args.polar_velocity.target_global_velocity_theta = target_velocity_theta;
+      packet.target_global_pos[0] = command.current_pose.x;
+      packet.target_global_pos[1] = command.current_pose.y;
       packet.terminal_velocity = 0.0f;
     }
 

--- a/crane_sender/test/test_robot_packet.cpp
+++ b/crane_sender/test/test_robot_packet.cpp
@@ -91,6 +91,33 @@ TEST(RobotPacket, EncodeDecode)
       packet.target_global_pos[1], deserialized_packet.target_global_pos[1], MAX_ERROR_32);
     EXPECT_NEAR(packet.terminal_velocity, deserialized_packet.terminal_velocity, MAX_ERROR_32);
   }
+
+  {
+    packet.target_global_pos[0] = dist_32(gen);
+    packet.target_global_pos[1] = dist_32(gen);
+    packet.terminal_velocity = dist_32(gen);
+
+    packet.control_mode = POSITION_TARGET_WITH_TERMINAL_VELOCITY_MODE;
+    packet.mode_args.position_target.terminal_velocity_x = dist_32(gen);
+    packet.mode_args.position_target.terminal_velocity_y = dist_32(gen);
+
+    RobotCommandSerializedV2 serialized_packet;
+    RobotCommandSerializedV2_serialize(&serialized_packet, &packet);
+
+    RobotCommandV2 deserialized_packet = RobotCommandSerializedV2_deserialize(&serialized_packet);
+    EXPECT_EQ(packet.control_mode, deserialized_packet.control_mode);
+    EXPECT_NEAR(
+      packet.mode_args.position_target.terminal_velocity_x,
+      deserialized_packet.mode_args.position_target.terminal_velocity_x, MAX_ERROR_32);
+    EXPECT_NEAR(
+      packet.mode_args.position_target.terminal_velocity_y,
+      deserialized_packet.mode_args.position_target.terminal_velocity_y, MAX_ERROR_32);
+    EXPECT_NEAR(
+      packet.target_global_pos[0], deserialized_packet.target_global_pos[0], MAX_ERROR_32);
+    EXPECT_NEAR(
+      packet.target_global_pos[1], deserialized_packet.target_global_pos[1], MAX_ERROR_32);
+    EXPECT_NEAR(packet.terminal_velocity, deserialized_packet.terminal_velocity, MAX_ERROR_32);
+  }
 }
 
 int main(int argc, char ** argv)

--- a/crane_web_debugger/src/websocket_server.cpp
+++ b/crane_web_debugger/src/websocket_server.cpp
@@ -835,7 +835,9 @@ private:
         {"target_x", pt.target_x},
         {"target_y", pt.target_y},
         {"position_tolerance", pt.position_tolerance},
-        {"speed_limit_at_target", pt.speed_limit_at_target}};
+        {"speed_limit_at_target", pt.speed_limit_at_target},
+        {"terminal_velocity_x", pt.terminal_velocity_x},
+        {"terminal_velocity_y", pt.terminal_velocity_y}};
     }
 
     json simple_velocity_json = nullptr;


### PR DESCRIPTION
## 概要
crane_sender のワイヤフォーマット (`robot_packet.h`) に新しい `ControlMode` `POSITION_TARGET_WITH_TERMINAL_VELOCITY_MODE` を追加し、上流の局所プランナが「位置ターゲット + その位置に到着する瞬間の速度ベクトル」を明示的にロボットへ伝えられるようにします。同時に既存の `POLAR_VELOCITY_TARGET_MODE` を「位置ターゲット = 現在位置, 速度ベクトル = 目標速度」と再解釈する互換構成を導入し、ファームウェア側で両モードを統一的に処理できるようにします。

## 背景・根本原因
- 現状の wire format には `POLAR_VELOCITY_TARGET_MODE` (極座標目標速度) しかなく、`target_global_pos[2]` と `terminal_velocity` は補助情報として送られるのみだった。
- 局所プランナは「目標位置とそこへの到着速度ベクトル」を一次情報として持っているが、それを直接ファームへ伝える wire 表現がなかった。
- 新モードでは到着速度ベクトル (vx, vy) を明示的に持たせ、ファーム側で「位置ターゲット + 到着速度」という統一インタフェースを実現できるようにする。

## 変更内容
- `crane_sender/include/crane_sender/robot_packet.h`
  - `ControlMode` enum に `POSITION_TARGET_WITH_TERMINAL_VELOCITY_MODE = 4` を追加
  - `PositionTargetModeArgs` (terminal_velocity_x/y) と init/serialize 関数を追加
  - `mode_args` union に `position_target` を追加し、serialize/deserialize の switch を拡張
- `crane_msgs/msg/PositionTargetMode.msg`
  - `terminal_velocity_x`, `terminal_velocity_y` (float32, default 0.0) を追加
- `crane_sender/src/ibis_sender_node.cpp`
  - `position_target_mode` が設定されているときは新モードを使用
  - 空のときは `POLAR_VELOCITY_TARGET_MODE` で `target_global_pos = command.current_pose.x/y` に設定し、ファーム側で位置ターゲット+到着速度として統一処理可能に
- `crane_sender/test/test_robot_packet.cpp`
  - 新モードのラウンドトリップテストを追加
- `crane_bag/src/bag/bag_types.hpp` / `msg_extractors.cpp`
  - `PositionTarget` 構造体と抽出ロジックに `terminal_velocity_x/y` を追加
- `crane_web_debugger/src/websocket_server.cpp`
  - `position_target_mode` の JSON 出力に `terminal_velocity_x/y` を追加

## 互換性に関する注意
- `POLAR_VELOCITY_TARGET_MODE` の wire layout (mode_args 4byte 利用、target_global_pos / terminal_velocity の offset) は変更していない。
- `POLAR` モード時の `target_global_pos` を「(0,0)」から「現在位置」に変える挙動差はある。ファーム側で両モードを「位置ターゲット + 到着速度」として統一処理する前提のため、ファーム側対応 (新モード値 4 のハンドリング) が別途必要。
- `PositionTargetMode.msg` 変更で MD5 ハッシュが変わるため、`crane_msgs` 依存パッケージの再ビルドが必要。

## 検証
- `colcon build --packages-up-to crane_sender crane_msgs crane_bag crane_web_debugger`: 21 パッケージ成功 (exit 0)
- `colcon test --packages-select crane_sender`: 3/3 pass (test_robot_packet, copyright, xmllint)