### PR TITLE
fix(pre-commit): CIビルドサイズ超過を解消するためprettier系XMLフックを削除

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,11 +26,6 @@ repos:
       - id: markdownlint
         args: [-c, .markdownlint.yaml, --fix]
 
-#  - repo: https://github.com/pre-commit/mirrors-prettier
-#    rev: v3.0.0-alpha.6
-#    hooks:
-#      - id: prettier
-
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:
@@ -39,10 +34,6 @@ repos:
   - repo: https://github.com/tier4/pre-commit-hooks-ros
     rev: v0.10.2
     hooks:
-      #      - id: flake8-ros
-      - id: prettier-xacro
-      - id: prettier-launch-xml
-      - id: prettier-package-xml
       - id: ros-include-guard
       - id: sort-package-xml
 
@@ -56,11 +47,6 @@ repos:
     hooks:
       - id: shfmt
         args: [-w, -s, -i=4]
-
-#  - repo: https://github.com/pycqa/isort
-#    rev: 5.12.0
-#    hooks:
-#      - id: isort
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
@@ -81,9 +67,3 @@ repos:
       - id: cpplint
         args: [--quiet]
         exclude: .cu
-
-#  - repo: https://github.com/streetsidesoftware/cspell-cli
-#    rev: v8.19.0
-#    hooks:
-#      - id: cspell
-#        args: [--config, "https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json", --config, .github/workflows/custom_dict.json]


### PR DESCRIPTION
## 概要

pre-commit.ciでのビルドサイズ超過エラーを解消するため、prettier系XMLフックを削除する。

## 背景・根本原因

pre-commit.ciで以下のエラーが発生していた:

```
build of https://github.com/tier4/pre-commit-hooks-ros:prettier@2.8.7,@prettier/plugin-xml@2.2.0@v0.10.2 for node@22.20.0 exceeds tier max size 250MiB: 375.8MiB
```

`tier4/pre-commit-hooks-ros` のprettier系フック3つがNode.js 22.20.0環境でビルドすると375.8MiBになり、pre-commit.ciの250MiB制限を超過していた。

## 変更内容

- `prettier-xacro` / `prettier-launch-xml` / `prettier-package-xml` を削除（サイズ超過の根本原因）
- コメントアウト済みフック定義を全削除（`mirrors-prettier`, `flake8-ros`, `isort`, `cspell`）
- `ros-include-guard` / `sort-package-xml` は保持（Pythonベースでサイズ問題なし）

## 影響

`.xacro` / `launch.xml` / `package.xml` の自動フォーマットは廃止されるが、CIのビルドサイズは250MiB制限以内に収まる。