### PR TITLE
fix(crane_sender): latency_time_msのuint8キャストによる上位バイト破棄を修正

### DIFF
--- a/crane_sender/src/ibis_sender_node.cpp
+++ b/crane_sender/src/ibis_sender_node.cpp
@@ -262,7 +262,7 @@ private:
         : selected_acceleration;
     packet.linear_velocity_limit = resolved_max_velocity;
     packet.angular_velocity_limit = command.omega_limit;
-    packet.latency_time_ms = static_cast<uint8_t>(command.latency_ms);
+    packet.latency_time_ms = static_cast<uint16_t>(command.latency_ms);
     packet.elapsed_time_ms_since_last_vision = command.elapsed_time_ms_since_last_vision;
 
     // POSITION_TARGET_WITH_TERMINAL_VELOCITY_MODE (mode=4) は、上位レイヤが明示的に


### PR DESCRIPTION
## 概要

`crane_sender` の ibis 送信処理において、遅延時間 `latency_time_ms` の代入時に誤った型へのキャストが行われており、255ms を超える遅延値で上位バイトが破棄され値が折り返す不具合を修正します。

## 問題

ibis へ送信するパケットの `latency_time_ms` フィールド（`uint16_t`）に対し、255ms を超える遅延値を設定すると上位バイトが失われ、意図しない小さな値に折り返されていました（例: 300ms → 44ms）。これにより遅延補償が正しく機能しませんでした。

## 原因

`crane_sender/src/ibis_sender_node.cpp` の 265 行目で、`uint16_t` のフィールド `packet.latency_time_ms` に対して `static_cast<uint8_t>(command.latency_ms)` を用いて代入していました。`uint8_t` へのキャストにより 0〜255 の範囲に切り詰められ、上位 8 ビットが破棄されていました。

## 修正内容

`static_cast<uint8_t>` を `static_cast<uint16_t>` に変更し、フィールド型と一致させることで上位バイトの破棄を防ぎます。

```cpp
packet.latency_time_ms = static_cast<uint16_t>(command.latency_ms);
```

## 検証

cwm 独立オーバーレイ worktree での colcon build(--no-rdeps)でコンパイル確認を行い、`crane_sender` が正常にビルドされることを確認しました。

## レビュー観点

- `command.latency_ms` の取りうる値域が `uint16_t`（最大 65535ms）の範囲に収まること。
- 65535ms を超える遅延が発生し得る場合の追加の上限クランプの要否。
- `latency_time_ms` フィールドを受信する ibis 側の解釈が `uint16_t` 前提であること。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
