### PR TITLE
fix(crane_geometry): getSeparatedPointsが線分長を無視する不具合を修正

### DIFF
--- a/utility/crane_geometry/include/crane_geometry/geometry_operations.hpp
+++ b/utility/crane_geometry/include/crane_geometry/geometry_operations.hpp
@@ -209,10 +209,12 @@ inline auto getCircle(const Point & p1, const Point & p2, const Point & p3) -> s
 inline auto getSeparatedPoints(const Segment & segment1, int separated_num) -> std::vector<Point>
 {
   std::vector<Point> points;
-  Vector2 segment_vec = (segment1.second - segment1.first).normalized();
-  for (int i = 0; i < separated_num - 1; ++i) {
-    points.push_back(
-      segment1.first + segment_vec * (i + 1) / static_cast<double>(separated_num + 1));
+  Vector2 segment_vec = segment1.second - segment1.first;
+  if (segment_vec.isZero()) {
+    return points;
+  }
+  for (int i = 1; i <= separated_num; ++i) {
+    points.push_back(segment1.first + segment_vec * i / static_cast<double>(separated_num + 1));
   }
   return points;
 }


### PR DESCRIPTION
## 概要

`crane_geometry` の `getSeparatedPoints` が線分の長さを無視して分割点を生成していた不具合を修正します。

## 問題

`geometry_operations.hpp` の `getSeparatedPoints` は、線分を等分する内部分割点を返すユーティリティです。しかし方向ベクトルを `normalized()` で単位ベクトル化していたため、実際の線分長が失われ、生成される点が始点から最大1m弱の範囲に密集していました。

`goalie.cpp:272` の `forward_line`（守備位置から前進ラインを20分割する用途）のような長い線分では、本来期待される「線分を区間分割した点列」として機能していませんでした。

加えて、除数が `separated_num + 1`、反復回数が `separated_num - 1` と不整合（off-by-one）であり、分割点の個数も意図と合っていませんでした。

## 原因

線分方向ベクトルを `normalized()` で単位化したことにより区間長が消失し、内分計算で線分長が反映されない状態になっていました。また反復範囲と除数が一致していませんでした。

## 修正内容

- 方向ベクトルの正規化を廃止し、フルの線分ベクトル `segment.second - segment.first` を使用するよう変更。
- 分割点を `first + (second - first) * i / (separated_num + 1)`（`i = 1 .. separated_num`）として生成し、線分を等分する内部分割点が正しい位置・個数で得られるよう修正。
- 始点と終点が一致するゼロ長線分のガードを追加（空のベクトルを返す）。これにより従来のゼロ長 `normalized()` 問題も解消されます。

## 検証

- cwm の独立オーバーレイ worktree 上で `colcon build`（`--no-rdeps`）によりコンパイルが成功することを確認（Build complete.、failed/Error なし）。
- 当該パッケージ `crane_geometry` のユニットテストを実行し、全テストが成功（23 tests, 0 errors, 0 failures, 0 skipped）。
- 呼び出し元 `goalie.cpp:272`（`getSeparatedPoints(forward_line, 20)`）は分割点列を始点側から終点側へ走査して到達可能な前進守備位置を選定する用途であり、本修正で線分全長にわたる分割点が得られるようになることで、期待される挙動に整合します。

## レビュー観点

- 分割点の個数・位置の意味が変わります（正しく線分全長を等分する内部分割点に修正）。呼び出し元 `goalie.cpp:272` の前進ライン分割用途における期待と整合しているかをご確認ください。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
