### PR TITLE
fix(crane_sender): SSLシミュレータのkick_angleを度単位で送信するよう修正

### DIFF
--- a/crane_sender/src/ibis_sender_node.cpp
+++ b/crane_sender/src/ibis_sender_node.cpp
@@ -393,7 +393,9 @@ private:
       cmd->set_allocated_move_command(move_command);
 
       const auto kick = computeKick(command.kick_power, command.chip_enable);
-      cmd->set_kick_angle(kick.angle_rad);
+      // ssl_simulation_robot_control.proto の kick_angle は度単位を要求するため、
+      // ラジアンから度へ変換して渡す（grSim 経路は cos/sin に渡すためラジアンのまま）。
+      cmd->set_kick_angle(kick.angle_rad * 180.0 / M_PI);
       cmd->set_kick_speed(kick.speed);
       cmd->set_dribbler_speed(command.dribble_power * 1000.0);
     }

--- a/crane_sender/src/ibis_sender_node.cpp
+++ b/crane_sender/src/ibis_sender_node.cpp
@@ -393,8 +393,6 @@ private:
       cmd->set_allocated_move_command(move_command);
 
       const auto kick = computeKick(command.kick_power, command.chip_enable);
-      // ssl_simulation_robot_control.proto の kick_angle は度単位を要求するため、
-      // ラジアンから度へ変換して渡す（grSim 経路は cos/sin に渡すためラジアンのまま）。
       cmd->set_kick_angle(kick.angle_rad * 180.0 / M_PI);
       cmd->set_kick_speed(kick.speed);
       cmd->set_dribbler_speed(command.dribble_power * 1000.0);


### PR DESCRIPTION
## 概要

SSL シミュレータ（ssl_simulation_robot_control.proto 経路）へ送信する `kick_angle` の単位が誤っていたため、チップキックがほぼ機能していなかった問題を修正します。

## 問題

`ssl_simulation_robot_control.proto` の `kick_angle` フィールドは度単位を要求します。しかし `crane_sender/src/ibis_sender_node.cpp` の `sendSSL` では、`computeKick` が返すラジアン値（`angle_rad`）をそのまま `cmd->set_kick_angle()` に渡していました。

その結果、30 度のチップキックが約 0.52（度として解釈）となり、チップキックがほぼ平面キックとして扱われ機能しませんでした。

## 原因

`computeKick` は `chip_angle_deg_ * M_PI / 180.0` によりチップ角度をラジアンで返します。

- grSim 経路（`sendGrSim`）では `kick.angle_rad` を `cos` / `sin` に渡して `kickspeedx` / `kickspeedz` を算出するため、ラジアンのままで正しい。
- 一方 SSL 経路（`sendSSL`）では proto が度単位を要求するにもかかわらず、変換せずラジアン値を渡していた。

## 修正内容

`sendSSL` の `set_kick_angle` 呼び出しでラジアン→度へ変換するよう修正しました。

```cpp
cmd->set_kick_angle(kick.angle_rad * 180.0 / M_PI);
```

`computeKick` の戻り値はラジアンのまま維持し、grSim 経路の挙動は一切変更していません。SSL 経路のみ単位変換を追加する最小限の修正です。

## 検証

cwm の独立オーバーレイ worktree 上で、対象パッケージ `crane_sender` の colcon build（`--no-rdeps`）を実行し、コンパイルが正常に完了することを確認しました（`Build complete.`、ビルドエラーなし）。

## レビュー観点

- SSL シミュレータ実機でチップ角度が意図通り（例: 30 度チップ）に反映されるか確認を推奨します。
- grSim 経路に影響がないことの再確認。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
