### PR TITLE
fix(crane_robot_receiver): grSimステータス受信のrobot_id境界チェック追加

### DIFF
--- a/crane_robot_receiver/src/grsim_robot_status_node.cpp
+++ b/crane_robot_receiver/src/grsim_robot_status_node.cpp
@@ -56,6 +56,11 @@ public:
             auto received_msg = get_status_msg(packet);
             std::lock_guard<std::mutex> lock(status_mutex_);
             for (const auto & received_status : received_msg.robots_status) {
+              if (
+                received_status.robot_id < 0 ||
+                static_cast<size_t>(received_status.robot_id) >= target.robots_status.size()) {
+                continue;
+              }
               target.robots_status[received_status.robot_id] = received_status;
             }
           }
@@ -99,6 +104,9 @@ private:
     auto statuses_msg = robocup_ssl_msgs::msg::RobotsStatus();
 
     for (const auto & status : robots_status.robots_status()) {
+      if (status.robot_id() < 0 || status.robot_id() >= 20) {
+        continue;
+      }
       robocup_ssl_msgs::msg::RobotStatus status_msg;
       status_msg.robot_id = status.robot_id();
       status_msg.infrared = status.infrared();


### PR DESCRIPTION
## 概要

grSim ロボットステータス受信処理において、外部 UDP パケット由来の `robot_id` を範囲チェックなしに固定長配列の添字として使用していた問題を修正します。

## 問題

`crane_robot_receiver/src/grsim_robot_status_node.cpp` の受信コールバック（旧 58-59 行付近）で、外部 UDP パケットをパースして得た `received_status.robot_id` を範囲チェックなしに `target.robots_status[robot_id]` へ書き込んでいました。`robots_status` は 20 要素で初期化された `std::vector` であり、`robot_id` が負値または 20 以上の場合に範囲外書き込みが発生し、未定義動作（クラッシュ・メモリ破壊）を引き起こす可能性がありました。

`get_status_msg`（旧 96-112 行付近）でも、proto の `robot_id` を検証せずにそのままメッセージへ詰め直していました。

## 原因

proto 定義上 `robot_id` は `int32` であり値域が検証されません。`ParseFromArray` 成功後の値をそのまま `std::vector` の添字に使用していたため、悪意ある／壊れた外部パケットによって範囲外アクセスが起こり得ました。

## 修正内容

- 受信コールバックの代入直前に境界チェックを追加し、範囲外 ID はスキップ（`continue`）するようにしました。
  - `received_status.robot_id < 0 || static_cast<size_t>(received_status.robot_id) >= target.robots_status.size()` の場合スキップ。
- `get_status_msg` 側でも、proto の `robot_id` が `0` 以上 `20` 未満でない場合はスキップするガードを追加しました。

いずれも対象バグに限定した最小限の変更で、無関係な整形・リファクタは行っていません。

## 検証

cwm の独立オーバーレイ worktree 上で colcon build（`--no-rdeps`）を実行し、`crane_robot_receiver` がコンパイル成功することを確認しました（"Build complete."、failed/Error なし）。

## レビュー観点

- 範囲外 ID を単純にスキップする挙動で問題ないか（ログ出力や警告の要否）。
- `get_status_msg` 側のハードコードされた上限値 `20` が受信先配列サイズと一致している前提で問題ないか。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
