### PR TITLE
fix(crane_world_model_publisher): on_positive_halfの未初期化を修正

### DIFF
--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -273,7 +273,7 @@ private:
     double penalty_area_h;
   } game_data;
 
-  bool on_positive_half;
+  bool on_positive_half = false;
 
   bool is_emplace_positive_side;
 


### PR DESCRIPTION
## 概要

`crane_world_model_publisher` の `WorldModelDataProvider` において、メンバ変数 `on_positive_half` が未初期化のまま使用される不具合を修正します。

## 問題

`world_model_data_provider.hpp:276` の `bool on_positive_half;` はコンストラクタ初期化リストにもデフォルトメンバ初期化子にも含まれておらず、未初期化のままでした。

レフェリー (`PlaySituation`) を受信する前に `getMsg()` (`world_model_data_provider.cpp:380`) が呼ばれると、不定値が `WorldModel` メッセージに載って publish されてしまいます。さらに `selectClosestBallToOurGoal()` 内の自ゴール側座標決定 (`world_model_data_provider.cpp:340` 付近) でもこの不定値が参照され、ゴール側の判定が非決定的になります。

## 原因

メンバ初期化漏れです。同種のフラグ `is_emplace_positive_side` はパラメータから初期化されている一方、`on_positive_half` はレフェリーコールバック (`world_model_data_provider.cpp:226` / `242`) でのみ代入されるため、受信前は初期値が存在しませんでした。

## 修正内容

宣言を `bool on_positive_half = false;` に変更し、デフォルトメンバ初期化子で `false` を与えました。これにより、レフェリー受信前でも決定的な初期値が保証されます。

なお、可視化側の同等フラグ `VisualizationManager::on_positive_half_` も既に `= false` で初期化されており、本修正は既存のコード方針と整合します。

## 検証

cwm の独立オーバーレイ worktree 上で `colcon build`（`--no-rdeps`）を実行し、`crane_world_model_publisher` がコンパイルエラーなくビルドできることを確認しました（`Build complete.`）。

## レビュー観点

初期既定値 `false` が半面練習モードを含む初期挙動として妥当か確認をお願いします。レフェリー受信前のごく短時間における自ゴール側判定が `false`（負側を自陣とする）で問題ないかが論点です。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
