### PR TITLE
fix(crane_play_switcher): レフェリータイムアウト復帰後のSTOP固着を修正

### DIFF
--- a/crane_play_switcher/src/play_switcher.cpp
+++ b/crane_play_switcher/src/play_switcher.cpp
@@ -78,6 +78,16 @@ auto PlaySwitcher::referee_callback(const robocup_ssl_msgs::msg::Referee & msg) 
   if (referee_timeout_active_) {
     RCLCPP_WARN(get_logger(), "レフェリーメッセージの受信が復帰しました");
     referee_timeout_active_ = false;
+    // タイムアウト中に play_situation_msg.command を STOP へ強制遷移させたが
+    // latest_raw_referee は据え置いたため、同一 RAW コマンドで復帰すると
+    // 後段の差分判定 (latest_raw_referee.command.value != msg.command.value) を
+    // すり抜けて STOP に固着してしまう。復帰検出時に latest_raw_referee の
+    // コマンドを実在しない sentinel 値へ無効化し、次の差分判定を必ず成立させて
+    // 最新の referee コマンドで状況を再評価できるようにする。
+    // RefereeCommand.value は int32 で有効値は 0 以上のため、-1 は実在しない
+    // sentinel として安全に利用できる。
+    constexpr int32_t INVALID_REFEREE_COMMAND = -1;
+    latest_raw_referee.command.value = INVALID_REFEREE_COMMAND;
   }
   using crane_msgs::msg::PlaySituation;
   using robocup_ssl_msgs::msg::Referee;


### PR DESCRIPTION
## 概要

`crane_play_switcher` において、レフェリーメッセージのタイムアウトで安全のため STOP に強制遷移した後、同一の RAW コマンドでレフェリーが復帰すると INPLAY 等へ戻れず STOP に固着する不具合を修正します。

## 問題

`check_referee_timeout()` はタイムアウト検出時に `play_situation_msg.command` を STOP へ強制遷移させますが、その際 `latest_raw_referee` を更新しません。このため、レフェリーが直前と同一の RAW コマンドで復帰した場合、`referee_callback()` の差分判定 `latest_raw_referee.command.value != msg.command.value` が偽となり、コマンド更新ブロックに入れません。結果として INPLAY などへ復帰できず STOP に張り付いたままとなり、復帰時の警告も出ませんでした。

## 原因

タイムアウトでの STOP 強制遷移時に `latest_raw_referee` を据え置いたため、復帰時の差分検出をすり抜けます。STOP からの復帰経路は `referee_callback()` の差分判定ゲート配下のみであり、それ以外に状況を再評価する機構が存在しないことが根本原因です。

## 修正内容

`referee_callback()` の冒頭、タイムアウト復帰を検出する箇所（`referee_timeout_active_` を `false` に戻す箇所）で、`latest_raw_referee.command.value` を実在しない sentinel 値（`-1`）へ無効化します。`RefereeCommand.value` は `int32` で有効値は 0 以上のため、`-1` は決して実コマンドと一致しません。これにより、復帰後の最初の `referee_callback()` で差分判定が必ず成立し、最新の referee コマンドに基づいて状況が再評価され、STOP が正しく上書きされることを保証します。

- 変更ファイル: `crane_play_switcher/src/play_switcher.cpp`

## 検証

cwm の独立オーバーレイ worktree 上で `colcon build`（`--no-rdeps`）を実行し、`crane_play_switcher` パッケージが警告・エラーなくコンパイル完了することを確認しました（`Build complete.`）。

## レビュー観点

ステートマシンの変更です。レフェリー瞬断 → 同一コマンドでの復帰シナリオにおける動作（STOP からの正常な復帰、復帰警告の出力、sentinel 値が後段判定に悪影響を与えないこと）を重点的にレビューしてください。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
