### PR TITLE
fix(crane_sender): SSL/GrSim送信パスのrobot_states_境界チェック追加

### DIFF
--- a/crane_sender/src/ibis_sender_node.cpp
+++ b/crane_sender/src/ibis_sender_node.cpp
@@ -378,6 +378,12 @@ private:
 
     robocup_ssl::RobotControl packet;
     for (const auto & command : msg.robot_commands) {
+      if (command.robot_id >= CommConfig::AI_CMD_V2_ROBOT_NUM) {
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 1000, "robot_id %u is out of range (>= %d); skipping command",
+          command.robot_id, CommConfig::AI_CMD_V2_ROBOT_NUM);
+        continue;
+      }
       auto cmd = packet.add_robot_commands();
       cmd->set_id(command.robot_id);
 
@@ -411,6 +417,12 @@ private:
     commands->set_timestamp(0.0);
 
     for (const auto & command : msg.robot_commands) {
+      if (command.robot_id >= CommConfig::AI_CMD_V2_ROBOT_NUM) {
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 1000, "robot_id %u is out of range (>= %d); skipping command",
+          command.robot_id, CommConfig::AI_CMD_V2_ROBOT_NUM);
+        continue;
+      }
       auto * robot_cmd = commands->add_robot_commands();
       robot_cmd->set_id(command.robot_id);
 


### PR DESCRIPTION
## 概要

`crane_sender` の SSL/GrSim 送信パスにおいて、`robot_states_` への範囲外アクセスが発生しうる問題を修正します。IBIS 送信パスと同じ境界チェックを追加し、3 つの送信パスでガードを統一します。

## 問題

`sendSSL` と `sendGrSim` は `robot_states_[command.robot_id]` を境界チェックなしでアクセスしていました。`robot_states_` は固定長の `std::array<PerRobotState, CommConfig::AI_CMD_V2_ROBOT_NUM>`（要素数 11）です。`command.robot_id` は `uint8`(0-255) のため、11 以上の値が渡されると配列範囲外参照が発生します。さらに `convertToLocalVelocity` は受け取った `state` への書き込みを行うため、範囲外書き込みによる未定義動作（メモリ破壊）につながります。

## 原因

IBIS 送信パス `sendIbis` には `if (command.robot_id < CommConfig::AI_CMD_V2_ROBOT_NUM)` のガードが存在しますが、SSL/GrSim パスには同等のガードがありませんでした。

上流の入力検証も不十分で、teleop の `robot_id` パラメータは無検証で 11 以上を設定可能であり、local_planner のガードも 20 未満しか弾かないため、範囲外 ID が送信ノードに到達しえます。

## 修正内容

`sendSSL` および `sendGrSim` の `robot_states_` アクセス前に、`sendIbis` と同じ境界条件 `command.robot_id >= CommConfig::AI_CMD_V2_ROBOT_NUM` を判定するガードを追加しました。範囲外 ID のコマンドは `continue` でスキップします。

また、無言でスキップすると不具合の発見が困難になるため、スキップ時に `RCLCPP_WARN_THROTTLE`（1 秒スロットル）で範囲外 ID を警告ログに出力します。これによりログ氾濫を避けつつ、異常な ID の混入を検知できます。

これにより SSL / GrSim / IBIS の 3 送信パスで境界チェックが統一されました。

## 検証

cwm の独立オーバーレイ worktree 上で `colcon build`（`--no-rdeps`）を実行し、`crane_sender` パッケージのコンパイルが正常に完了することを確認しました（Build complete.）。stderr は gtest_vendor 由来の CMake 非推奨警告のみで、本修正に起因するエラー・警告はありません。

## レビュー観点

- 範囲外 ID を単純にスキップする方針で問題ないか（本実装ではスロットル付き警告ログを追加しています）。警告レベル・スロットル間隔(1000ms)の妥当性。
- IBIS パスは無言でスキップしている一方、本修正の SSL/GrSim パスでは警告を出す差異の許容可否。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
