### PR TITLE
fix(crane_msg_wrappers): WorldModel更新時のrobot.id境界チェック追加

### DIFF
--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/world_model_wrapper.hpp
@@ -166,18 +166,36 @@ struct WorldModelWrapper : public DelayMonitorMixin<WorldModelWrapper>
     callbacks.emplace_back(callback_func);
   }
 
-  [[nodiscard]] auto getRobot(RobotIdentifier robot) const
+  [[nodiscard]] auto getRobot(RobotIdentifier robot) const -> RobotInfo::SharedPtr
   {
     if (robot.is_ours) {
+      if (robot.id >= ours_.robots.size()) {
+        return nullptr;
+      }
       return ours_.robots.at(robot.id);
     } else {
+      if (robot.id >= theirs_.robots.size()) {
+        return nullptr;
+      }
       return theirs_.robots.at(robot.id);
     }
   }
 
-  [[nodiscard]] auto getOurRobot(uint8_t id) const { return ours_.robots.at(id); }
+  [[nodiscard]] auto getOurRobot(uint8_t id) const -> RobotInfo::SharedPtr
+  {
+    if (id >= ours_.robots.size()) {
+      return nullptr;
+    }
+    return ours_.robots.at(id);
+  }
 
-  [[nodiscard]] auto getTheirRobot(uint8_t id) const { return theirs_.robots.at(id); }
+  [[nodiscard]] auto getTheirRobot(uint8_t id) const -> RobotInfo::SharedPtr
+  {
+    if (id >= theirs_.robots.size()) {
+      return nullptr;
+    }
+    return theirs_.robots.at(id);
+  }
 
   [[nodiscard]] auto getOurMaxAllowedBots() const { return ours_.max_allowed_bots; }
 

--- a/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
+++ b/utility/crane_msg_wrappers/src/world_model_wrapper.cpp
@@ -122,6 +122,10 @@ auto WorldModelWrapper::update(const crane_msgs::msg::WorldModel & world_model) 
   const auto now = rclcpp::Time(world_model.header.stamp);
 
   for (auto & robot : world_model.robot_info_ours) {
+    // 外部publisherから確保数(robots.size())を超えるidを受信した場合は安全にスキップ
+    if (robot.id >= ours_.robots.size()) {
+      continue;
+    }
     auto & info = ours_.robots.at(robot.id);
 
     info->available_vision = robot.available_vision;
@@ -154,6 +158,10 @@ auto WorldModelWrapper::update(const crane_msgs::msg::WorldModel & world_model) 
   }
 
   for (const auto & robot : world_model.robot_info_theirs) {
+    // 外部publisherから確保数(robots.size())を超えるidを受信した場合は安全にスキップ
+    if (robot.id >= theirs_.robots.size()) {
+      continue;
+    }
     auto & info = theirs_.robots.at(robot.id);
 
     // 敵ロボットはビジョン検出のみで判定（診断情報なし）


### PR DESCRIPTION
## 概要

`WorldModelWrapper` が `/world_model` から受信したロボット情報を反映する際、`robot.id` の境界チェックが無く、確保数を超える `id` を含むメッセージを受信するとノードが異常終了していた問題を修正する。

## 問題

`world_model_wrapper.cpp` の `update()` 内（味方・敵ロボットそれぞれのループ）で `ours_.robots.at(robot.id)` / `theirs_.robots.at(robot.id)` を範囲チェックなしで使用していた。`robots` は固定数（20要素）しか確保していないため、`id >= 20` のロボット情報を含む `WorldModel` を受信すると `std::out_of_range` が `/world_model` 購読コールバック内で送出され、ノードが異常終了していた。

同様に `world_model_wrapper.hpp` のゲッター `getRobot` / `getOurRobot` / `getTheirRobot` も `.at()` を範囲チェックなしで呼び出しており、範囲外 `id` で例外送出の危険があった。

## 原因

`RobotInfo.id` は `uint8`（0-255）であるのに対し、`robots` コンテナは `MAX_ROBOT_NUM`（=20）分しか確保していない。外部 publisher から送られてくる想定外の `id` を検証していなかったため、範囲外アクセスが発生し得た。

## 修正内容

- `update()` の味方ロボットループ・敵ロボットループそれぞれで、`robots.at(robot.id)` アクセス前に `robot.id >= robots.size()` の場合は `continue` で安全にスキップするようにした。境界値には確保済みコンテナの実サイズ（`robots.size()`）を使用し、確保数との一貫性を保証している。
- ゲッター `getRobot` / `getOurRobot` / `getTheirRobot` について、戻り値型を `RobotInfo::SharedPtr` に明示し、範囲外 `id` の場合は `nullptr` を返すようにした。これにより範囲外アクセスによる例外送出を回避する。

## 検証

cwm の独立オーバーレイ worktree 上で対象パッケージ `crane_msg_wrappers` の colcon build（`--no-rdeps`）を実行し、コンパイルが正常に完了することを確認した（`Build complete.`）。

## レビュー観点

- ゲッターの戻り値型を `RobotInfo::SharedPtr` に明示し、範囲外時に `nullptr` を返す変更が呼び出し側の契約として妥当か。既存呼び出しはいずれも 0-19 の正当な `id` を渡しており、挙動は変わらない。
- 境界値に `robots.size()` を用いることで、確保数定義との二重管理を避けている点。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
