### PR TITLE
fix(crane_physics): FLYINGボールの着地時間計算でpos_zを考慮するよう修正

### DIFF
--- a/utility/crane_physics/include/crane_physics/ball_physics_model.hpp
+++ b/utility/crane_physics/include/crane_physics/ball_physics_model.hpp
@@ -58,8 +58,8 @@ public:
     const Point & position, const Point & velocity, Ball::State state, double pos_z, double vel_z,
     double time_ahead) const -> Point;
 
-  [[nodiscard]] auto getStopTime(const Point & velocity, Ball::State state, double vel_z) const
-    -> double;
+  [[nodiscard]] auto getStopTime(
+    const Point & velocity, Ball::State state, double pos_z, double vel_z) const -> double;
 
   [[nodiscard]] auto getMaxDistance(
     const Point & position, const Point & velocity, Ball::State state, double pos_z,
@@ -86,6 +86,11 @@ private:
   Config config_;
 
   // ヘルパー関数
+  // FLYING状態のボールが着地するまでの時間を計算する。
+  // z(t) = pos_z + vel_z * t + 0.5 * gravity * t^2 = 0 の正の最小根を返す。
+  // 判別式が負、または正の根が存在しない場合は 0 を返す。
+  [[nodiscard]] auto getFlyingLandingTime(double pos_z, double vel_z) const -> double;
+
   [[nodiscard]] auto getRollingStopTime(const Point & velocity) const -> double;
 
   [[nodiscard]] auto getRollingMaxDistance(const Point & velocity) const -> double;

--- a/utility/crane_physics/src/ball_info.cpp
+++ b/utility/crane_physics/src/ball_info.cpp
@@ -46,7 +46,10 @@ auto Ball::getPredictedVelocity(double time_ahead) const -> Point
   return physics_model_->predictVelocity(pos, vel, state, pos_z, vel_z, time_ahead);
 }
 
-auto Ball::getStopTime() const -> double { return physics_model_->getStopTime(vel, state, vel_z); }
+auto Ball::getStopTime() const -> double
+{
+  return physics_model_->getStopTime(vel, state, pos_z, vel_z);
+}
 
 auto Ball::getMaxDistance() const -> double
 {

--- a/utility/crane_physics/src/ball_physics_model.cpp
+++ b/utility/crane_physics/src/ball_physics_model.cpp
@@ -233,8 +233,8 @@ auto BallPhysicsModel::predictVelocity(
   return {0, 0};
 }
 
-auto BallPhysicsModel::getStopTime(const Point & velocity, Ball::State state, double vel_z) const
-  -> double
+auto BallPhysicsModel::getStopTime(
+  const Point & velocity, Ball::State state, double pos_z, double vel_z) const -> double
 {
   switch (state) {
     case Ball::State::STOPPED:
@@ -244,11 +244,8 @@ auto BallPhysicsModel::getStopTime(const Point & velocity, Ball::State state, do
       return getRollingStopTime(velocity);
 
     case Ball::State::FLYING: {
-      // 簡単な着地時間計算（pos_z=0と仮定）
-      double landing_time = 0.0;
-      if (vel_z != 0) {
-        landing_time = std::max(0.0, -2.0 * vel_z / config_.gravity);
-      }
+      // 現在高度 pos_z を考慮した着地時間を計算する。
+      double landing_time = getFlyingLandingTime(pos_z, vel_z);
 
       double rolling_stop_time = getRollingStopTime(velocity);
       return landing_time + rolling_stop_time;
@@ -258,7 +255,7 @@ auto BallPhysicsModel::getStopTime(const Point & velocity, Ball::State state, do
 }
 
 auto BallPhysicsModel::getMaxDistance(
-  const Point & position, const Point & velocity, Ball::State state, [[maybe_unused]] double pos_z,
+  const Point & position, const Point & velocity, Ball::State state, double pos_z,
   double vel_z) const -> double
 {
   switch (state) {
@@ -269,11 +266,8 @@ auto BallPhysicsModel::getMaxDistance(
       return getRollingMaxDistance(velocity);
 
     case Ball::State::FLYING: {
-      // 着地位置計算
-      double landing_time = 0.0;
-      if (vel_z != 0) {
-        landing_time = std::max(0.0, -2.0 * vel_z / config_.gravity);
-      }
+      // 現在高度 pos_z を考慮した着地時間から着地位置を計算する。
+      double landing_time = getFlyingLandingTime(pos_z, vel_z);
 
       Point landing_pos;
       landing_pos.x() = position.x() + velocity.x() * landing_time;
@@ -286,6 +280,34 @@ auto BallPhysicsModel::getMaxDistance(
     }
   }
   return 0.0;
+}
+
+auto BallPhysicsModel::getFlyingLandingTime(double pos_z, double vel_z) const -> double
+{
+  // z(t) = pos_z + vel_z * t + 0.5 * gravity * t^2 = 0 を解く（gravity は負値）。
+  // predictPosition / predictVelocity と同一のロジックで現在高度 pos_z を考慮する。
+  double a = 0.5 * config_.gravity;
+  double b = vel_z;
+  double c = pos_z;
+
+  double landing_time = 0.0;
+  double discriminant = b * b - 4 * a * c;
+
+  if (discriminant >= 0) {
+    double sqrt_discriminant = std::sqrt(discriminant);
+    double t1 = (-b + sqrt_discriminant) / (2 * a);
+    double t2 = (-b - sqrt_discriminant) / (2 * a);
+
+    if (t1 > 1e-6 && t2 > 1e-6) {
+      landing_time = std::min(t1, t2);
+    } else if (t1 > 1e-6) {
+      landing_time = t1;
+    } else if (t2 > 1e-6) {
+      landing_time = t2;
+    }
+  }
+
+  return landing_time;
 }
 
 auto BallPhysicsModel::getRollingStopTime(const Point & velocity) const -> double


### PR DESCRIPTION
## 概要

`crane_physics` の `BallPhysicsModel` において、FLYING（チップキック飛行中）状態のボールの着地時間計算が現在高度 `pos_z` を無視していた不具合を修正します。

## 問題

`ball_physics_model.cpp` の `getStopTime` / `getMaxDistance` の FLYING 分岐では、着地時間を

```
landing_time = max(0, -2 * vel_z / gravity)
```

で算出していました。この式は地面（z=0）から打ち上げたボールの滞空時間を表すものであり、現在のボール高度 `pos_z` を完全に無視しています。

そのため、高所からの落下中（`vel_z <= 0`）では `landing_time` が 0 にクランプされ、飛行中の水平移動が一切加算されません。結果として停止時間・最大到達距離（着地位置）の推定が過小評価されていました。

一方で同クラスの `predictPosition` / `predictVelocity` は正しく `pos_z` を考慮した放物運動の根を解いており、関数間で挙動が不整合な状態でした。

## 原因

地面（z=0）からの打ち上げ滞空時間の式を流用し、`getMaxDistance` では引数 `pos_z` を `[[maybe_unused]]` として無視、`getStopTime` ではそもそも `pos_z` を受け取っていませんでした。

## 修正内容

- `predictPosition` / `predictVelocity` と同一のロジックで着地時間を解く private ヘルパー `getFlyingLandingTime(pos_z, vel_z)` を新設しました。
  - `z(t) = pos_z + vel_z * t + 0.5 * gravity * t^2 = 0`（`gravity` は負値）の正の最小根を返します。
  - 判別式が負、または正の根が存在しない場合は 0 を返すフォールバックを備えます。
- `getStopTime` のシグネチャに `pos_z` を追加し、FLYING 分岐で当該ヘルパーを使用するよう変更しました。
- `getMaxDistance` の引数 `pos_z` の `[[maybe_unused]]` を外し、FLYING 分岐で当該ヘルパーを使用するよう変更しました。
- 呼び出し側 `ball_info.cpp` の `Ball::getStopTime()` を新シグネチャ（`pos_z` 受け渡し）に追従させました。

これにより、飛行中の高度を考慮した着地時間・着地位置が算出され、`predictPosition` / `predictVelocity` との整合性が取れます。

## 検証

- cwm の独立オーバーレイ worktree 上で、`colcon build`（`--no-rdeps`）による `crane_physics` のコンパイルが成功することを確認しました（`Build complete.`、エラーなし。既存テストコードの警告のみ）。
- 当該パッケージのユニットテストを実行し、全件パスを確認しました。
  - `colcon test --packages-select crane_physics`: 1 package finished
  - `colcon test-result --verbose`: 118 tests, 0 errors, 0 failures, 0 skipped（gtest 10 件含む）

## レビュー観点

- チップキック飛行中（FLYING、`vel_z <= 0` を含む高所落下中）における停止時間・最大到達距離（着地位置）推定の妥当性。
- `getFlyingLandingTime` の根の選択（正の最小根）とフォールバック（判別式負・非正根）の妥当性、および `predictPosition` / `predictVelocity` との一貫性。
- `getStopTime` のシグネチャ変更に伴う呼び出し側の追従漏れがないこと。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
