### PR TITLE
fix(crane_robot_skills): Forwardのパススコア線分でball.velをball.posに修正

### DIFF
--- a/crane_robot_skills/src/forward.cpp
+++ b/crane_robot_skills/src/forward.cpp
@@ -57,8 +57,14 @@ auto Forward::update() -> Status
     ranges::views::transform([&](const Point & p) {
       double score = 1.0;
       // ボールの受取やすさ
+      // ボール位置からp方向へ1.5m進めた点までの線分で敵との最近接距離を評価
+      const Point ball_to_p = p - ball.pos;
+      const double ball_to_p_norm = ball_to_p.norm();
+      // p == ball.pos のときはゼロ長線分になるため、ボール位置のみの点で評価
       Segment segment{
-        p, ball.pos + (p - ball.vel).normalized() * 1.5};  // ボール近くはチップで無視可能
+        p, ball_to_p_norm < 1e-6
+             ? ball.pos
+             : (ball.pos + ball_to_p / ball_to_p_norm * 1.5)};  // ボール近くはチップで無視可能
       auto nearest_enemy =
         world_model()->getNearestRobotWithDistanceFromSegment(segment, available_enemy_robots);
       if (nearest_enemy) {


### PR DESCRIPTION
## 概要

`crane_robot_skills` の Forward スキルにおいて、パススコア評価に用いる線分の終点計算で `ball.pos` と書くべきところを `ball.vel` と取り違えていたバグを修正します。

## 問題

`forward.cpp` のパス先スコア評価では、ボール位置からサンプル点 `p` 方向へ 1.5m 進めた点までの線分を生成し、その線分と敵ロボットとの最近接距離からパスの受け取りやすさを評価しています。

しかし実装は以下のようになっていました。

```cpp
Segment segment{
  p, ball.pos + (p - ball.vel).normalized() * 1.5};  // ボール近くはチップで無視可能
```

ここで方向ベクトルとして `p - ball.vel`（位置からボール速度を引いたもの）を使っており、単位が位置と速度で取り違えられていました。本来は `p - ball.pos`（ボール位置からサンプル点への方向）であるべきです。`ball.pos` と `ball.vel` はいずれも `Eigen::Vector2d` のためコンパイルは通ってしまい、誤った線分で敵との最近接距離を評価した結果、パス先スコアが不正になっていました。

## 原因

`ball.pos` と記述すべき箇所を `ball.vel` と記述していたタイプミス。両者とも `Eigen::Vector2d` 型のため型エラーが発生せず、コンパイル時に検出できなかった。

## 修正内容

- 方向ベクトルを `p - ball.pos` に修正し、ボール位置からサンプル点方向へ 1.5m 進めた点を正しく計算するようにしました。
- `p == ball.pos` の場合に方向ベクトルがゼロ長となり `normalized()` の結果が不定になるため、ゼロ長ガードを追加しました。ノルムが極小（1e-6 未満）の場合は線分終点をボール位置そのものとして退避させます。

```cpp
const Point ball_to_p = p - ball.pos;
const double ball_to_p_norm = ball_to_p.norm();
// p == ball.pos のときはゼロ長線分になるため、ボール位置のみの点で評価
Segment segment{
  p, ball_to_p_norm < 1e-6 ? ball.pos
                           : (ball.pos + ball_to_p / ball_to_p_norm * 1.5)};
```

## 検証

cwm の独立オーバーレイ worktree 上で colcon build（`--no-rdeps`）を実行し、`crane_robot_skills` パッケージが正常にコンパイルされること（Build complete.）を確認しました。エラーは無く、既存の `-Wunused-result` 警告のみです。

## レビュー観点

- パススコア評価で用いる線分が「ボール位置からサンプル点方向へ 1.5m」という意図どおりになっているか。
- ゼロ長ガードの閾値（1e-6）および退避時の挙動（線分終点をボール位置とする）が妥当か。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
