### PR TITLE
fix(crane_robot_skills): BallNearbyPositionerのstraightポリシーで基点欠落を修正

### DIFF
--- a/crane_robot_skills/src/ball_nearby_positioner.cpp
+++ b/crane_robot_skills/src/ball_nearby_positioner.cpp
@@ -75,7 +75,9 @@ auto BallNearByPositioner::update() -> Status
       return target +
              getNormVec(base_angle + normalized_offset * angle_interval) * distance_from_target;
     } else if (policy == "straight") {
-      return target_to_base + getVerticalVec(target_to_base.normalized()) * offset;
+      Vector2 base_dir =
+        target_to_base.squaredNorm() > 1e-6 ? target_to_base.normalized() : Vector2(1.0, 0.0);
+      return target + target_to_base + getVerticalVec(base_dir) * offset;
     } else {
       throw std::runtime_error(
         "[BallNearByPositioner] 予期しないパラメータ「line_policy」が入力されています: " + policy);


### PR DESCRIPTION
## 概要

`BallNearbyPositioner` の `line_policy == "straight"` 分岐において、基点 `target` の加算が欠落していたバグを修正します。これにより、straight ポリシー選択時にロボットがフィールド原点付近へ移動してしまう不具合を解消します。

## 問題

`crane_robot_skills/src/ball_nearby_positioner.cpp` の straight 分岐は、オフセットベクトル `target_to_base`(= `base_position - target`)を加算した値をそのまま返していました。`target_to_base` は基点 `target` からの相対ベクトルであるため、これを絶対座標として返すと、本来 `base_position` 付近に位置すべきロボットがフィールド原点付近へ移動してしまいます。

一方、arc 分岐は `target + ...` と基点を加算して絶対位置を返しており、straight 分岐との間で座標系の扱いに不整合がありました。

## 原因

straight 分岐の戻り値で、先頭の `target +`(基点の加算)が欠落していました。

## 修正内容

- straight 分岐の戻り値を `target + target_to_base + getVerticalVec(...) * offset`(= `base_position + 垂直オフセット`)に修正し、arc 分岐と同様に絶対座標を返すようにしました。
- `target_to_base.normalized()` のゼロ長ガードを追加しました。`target_to_base` の長さがほぼ 0 の場合は `Vector2(1.0, 0.0)` をフォールバック方向として使用し、ゼロベクトルの正規化による未定義動作を防ぎます。

## 検証

cwm の独立オーバーレイ worktree 上で `colcon build`(`--no-rdeps`)を実行し、`crane_robot_skills` パッケージがコンパイルエラーなくビルドできることを確認しました(`Build complete.`)。出力された警告はいずれも本修正と無関係な既存の `nodiscard` 警告です。

## レビュー観点

- 現状デフォルトの `line_policy` は arc であり straight は未使用ですが、straight 選択時に `base_position + 垂直オフセット` という意図した絶対座標が返ることを確認してください。
- ゼロ長ガードのフォールバック方向 `Vector2(1.0, 0.0)` が妥当かご確認ください。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
