### PR TITLE
fix(crane_world_model_publisher): グローバル減速度最適化の初速度推定を制約付き回帰に修正

### DIFF
--- a/crane_world_model_publisher/src/calibration/simple_ball_physics_optimizer.cpp
+++ b/crane_world_model_publisher/src/calibration/simple_ball_physics_optimizer.cpp
@@ -328,18 +328,15 @@ auto SimpleBallPhysicsOptimizer::optimizeGlobalDeceleration(
       if (trajectory.time_points.size() < config_.min_data_points_per_trajectory) continue;
 
       // 固定減速度を仮定した初速度推定（v(t) = v0 - decel * t）
-      // 線形回帰で v0 を求める: velocities = v0 - decel * time_points
-      std::vector<double> expected_velocities;
+      // 傾きを -decel に固定したモデルの最適 v0 は残差 (v + decel * t) の平均で与えられる。
+      // 自由回帰の切片を使うと傾きが 1 に固定されず v0 が候補 decel と無関係な定数になり、
+      // 各 decel 候補の RMSE 評価が歪んでグローバル減速度選定がバイアスするため、
+      // 制約付き（固定傾き）推定 v0 = mean(v + decel * t) を用いる。
+      double v0_sum = 0.0;
       for (size_t i = 0; i < trajectory.time_points.size(); ++i) {
-        expected_velocities.push_back(-decel * trajectory.time_points[i]);  // -decel * t の部分
+        v0_sum += trajectory.velocities[i] + decel * trajectory.time_points[i];
       }
-
-      // velocities - expected_velocities = v0 (定数) を線形回帰で求める
-      auto [slope, intercept, r_squared] =
-        performLinearRegression(expected_velocities, trajectory.velocities);
-
-      // slope は 1 に近く、intercept が推定初速度 v0
-      double estimated_v0 = intercept;
+      double estimated_v0 = v0_sum / trajectory.time_points.size();
 
       // 固定減速度モデルでの予測誤差を計算
       double rmse = 0.0;


### PR DESCRIPTION
## 概要

`crane_world_model_publisher` のグローバル減速度最適化（グリッドサーチ）における初速度 v0 の推定を、自由回帰の切片から固定傾きモデルの制約付き推定へ修正します。

## 問題

`simple_ball_physics_optimizer.cpp` のグローバル減速度探索では、減速度候補 `decel` ごとに固定減速度モデル `v(t) = v0 - decel * t` を仮定して各軌道の RMSE を評価しています。しかし v0 の推定に `performLinearRegression(expected_velocities, velocities)` の切片を用いていたため、推定 v0 が傾きを自由に持つ回帰の切片となり、候補 `decel` に依存しない定数になっていました。

その結果、各 `decel` 候補の RMSE 評価が固定傾き（-decel）モデルの最適 v0 を反映せず歪み、グローバル減速度選定がバイアスする問題がありました。

## 原因

説明変数 `x = expected_velocities (= -decel * t)` に対する OLS の切片を v0 として採用していたため、モデルの傾きが 1 に固定されず、v0 が候補 `decel` と無関係になっていました。固定傾きモデルの最適 v0 とは一致しません。

## 修正内容

固定傾き（-decel）モデルの最適初速度は残差の平均で与えられます。

- 最適 v0 = mean(velocities - expected_velocities) = mean(v + decel * t)

`performLinearRegression` の切片を用いる処理を廃止し、各軌道について `mean(velocities[i] + decel * time_points[i])` を直接計算して `estimated_v0` とするよう置換しました。これにより各 `decel` 候補ごとに正しい最適 v0 が用いられ、RMSE 評価とグローバル減速度選定のバイアスが解消されます。

変更は当該推定ロジックのみに限定し、後続の RMSE 計算・品質フィルタリングなどは従来どおりです。

## 検証

cwm の独立オーバーレイ worktree 上で colcon build（`--no-rdeps`）によるコンパイル確認を実施し、`crane_world_model_publisher` のビルドが成功することを確認しました（Build complete.）。本変更はオフライン較正ツールであり、実機・シミュレーション環境での減速度推定の数値検証を併せて推奨します。

## レビュー観点

- 固定傾きモデルの最適 v0 = mean(v + decel * t) という数式が妥当であることの確認
- 各 decel 候補で v0 が候補依存となり、RMSE 評価のバイアスが解消されていること
- 減速度推定結果の数値検証（較正データに対する回帰前後の比較）

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
