### PR TITLE
fix(crane_world_model_publisher): estimateInitialVelocityが減速度引数を無視する不具合を修正

### DIFF
--- a/crane_world_model_publisher/src/calibration/simple_ball_physics_optimizer.cpp
+++ b/crane_world_model_publisher/src/calibration/simple_ball_physics_optimizer.cpp
@@ -392,7 +392,7 @@ auto SimpleBallPhysicsOptimizer::optimizeGlobalDeceleration(
 }
 
 auto SimpleBallPhysicsOptimizer::estimateInitialVelocity(
-  const TrajectoryData & trajectory, double /* deceleration */) -> KickPowerVelocityPair
+  const TrajectoryData & trajectory, double deceleration) -> KickPowerVelocityPair
 {
   KickPowerVelocityPair result;
   result.event_id = trajectory.event_id;
@@ -407,25 +407,43 @@ auto SimpleBallPhysicsOptimizer::estimateInitialVelocity(
     return result;
   }
 
-  // 速度vs時間の線形回帰: v(t) = v0 - deceleration * t
+  // 速度vs時間の固定傾きモデル: v(t) = v0 - deceleration * t
   // ここで固定された減速度を使用して初速度を推定
-  auto [slope, intercept, r_squared] =
-    performLinearRegression(trajectory.time_points, trajectory.velocities);
+  // v0 = v(t) + deceleration * t を各時刻で算出し平均をとる
+  double v0_sum = 0.0;
+  for (size_t i = 0; i < trajectory.time_points.size(); ++i) {
+    v0_sum += trajectory.velocities[i] + deceleration * trajectory.time_points[i];
+  }
+  double estimated_initial_velocity = v0_sum / trajectory.time_points.size();
 
-  result.estimated_initial_velocity = intercept;  // 切片 = 初速度
+  // 固定傾きモデルでの決定係数(R^2)を算出
+  double mean_velocity = 0.0;
+  for (size_t i = 0; i < trajectory.velocities.size(); ++i) {
+    mean_velocity += trajectory.velocities[i];
+  }
+  mean_velocity /= trajectory.velocities.size();
+
+  double ss_res = 0.0;
+  double ss_tot = 0.0;
+  for (size_t i = 0; i < trajectory.time_points.size(); ++i) {
+    double predicted_velocity =
+      estimated_initial_velocity - deceleration * trajectory.time_points[i];
+    double residual = trajectory.velocities[i] - predicted_velocity;
+    ss_res += residual * residual;
+    double deviation = trajectory.velocities[i] - mean_velocity;
+    ss_tot += deviation * deviation;
+  }
+  double r_squared = (ss_tot > 0.0) ? (1.0 - ss_res / ss_tot) : 0.0;
+
+  result.estimated_initial_velocity = estimated_initial_velocity;
   result.fitting_r_squared = r_squared;
 
   // 信頼区間の計算
-  double velocity_std = 0.0;
-  for (size_t i = 0; i < trajectory.time_points.size(); ++i) {
-    double predicted_velocity = intercept + slope * trajectory.time_points[i];
-    double error = trajectory.velocities[i] - predicted_velocity;
-    velocity_std += error * error;
-  }
-  velocity_std = std::sqrt(velocity_std / trajectory.time_points.size());
+  double velocity_std = std::sqrt(ss_res / trajectory.time_points.size());
 
   double confidence_margin = 1.96 * velocity_std;  // 95%信頼区間
-  result.confidence_interval = {intercept - confidence_margin, intercept + confidence_margin};
+  result.confidence_interval = {
+    estimated_initial_velocity - confidence_margin, estimated_initial_velocity + confidence_margin};
 
   return result;
 }


### PR DESCRIPTION
## 概要

`crane_world_model_publisher` のオフライン較正ツールにおいて、`SimpleBallPhysicsOptimizer::estimateInitialVelocity` が引数で渡された減速度 `deceleration` を無視していた不具合を修正します。

## 問題

`estimateInitialVelocity` は引数 `deceleration` を `/* deceleration */` とコメントアウトして未使用にしており、`v(t) = v0 - deceleration * t` のコメント記述に反して、傾き・切片を自由に推定する2パラメータ線形回帰の切片をそのまま初速度としていました。

このため、別途最適化された「グローバル減速度」が初速度推定に一切反映されず、出力される初速度と減速度の2パラメータが物理的に整合しない状態でした。コメント「固定減速度を使用して初速度を推定」とも矛盾していました。

## 原因

固定傾き(固定減速度)モデルで初速度のみを推定する意図に反し、`performLinearRegression` による自由2パラメータ回帰の切片を初速度に採用していたため、引数 `deceleration` が使われていませんでした。

## 修正内容

- 引数のコメントアウト `/* deceleration */` を解除し、`deceleration` を使用するように修正。
- 固定傾きモデル `v(t) = v0 - deceleration * t` に基づき、各時刻について `v0 = v(t) + deceleration * t` を算出し、その平均値を初速度推定値としました。
- 固定傾きモデルでの予測値を用いて決定係数 (R^2) と信頼区間を再計算し、推定値と整合させました。

## 検証

cwm の独立オーバーレイ worktree 上で対象パッケージ `crane_world_model_publisher` を `colcon build`(`--no-rdeps`)し、コンパイルが正常に完了することを確認しました(Build complete.)。

## レビュー観点

- オフライン較正ツールであり、`fix/ball-calib-global-decel-v0` と同種の修正方針です。
- 固定傾きモデルにおける初速度推定式 `v0 = mean(velocities + deceleration * time_points)` の妥当性。
- R^2・信頼区間の算出が固定傾きモデルと整合していること。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
