### PR TITLE
fix(robocup_ssl_comm): Vision受信でParseFromArrayの戻り値を検証

### DIFF
--- a/consai_ros2/robocup_ssl_comm/src/vision_component.cpp
+++ b/consai_ros2/robocup_ssl_comm/src/vision_component.cpp
@@ -45,7 +45,12 @@ Vision::Vision(const rclcpp::NodeOptions & options) : Node("vision", options)
   receiver->startReceive([this](const std::vector<char> & buf, size_t size) {
     if (size > 0) {
       robocup_ssl::SSL_WrapperPacket wrapper_packet;
-      wrapper_packet.ParseFromArray(buf.data(), static_cast<int>(size));
+      if (!wrapper_packet.ParseFromArray(buf.data(), static_cast<int>(size))) {
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 5000,
+          "Visionパケットのパース失敗 (size=%zu) — protoバージョン不整合の可能性", size);
+        return;
+      }
       if (wrapper_packet.has_detection()) {
         auto detection_frame_msg = parse_detection_frame(wrapper_packet);
         uint32_t camera_id = detection_frame_msg.camera_id;


### PR DESCRIPTION
## 概要

Vision コンポーネントの UDP 受信処理で `SSL_WrapperPacket::ParseFromArray` の戻り値を検証するように修正しました。これにより、パース失敗時に不正なフレームを取り込むことを防ぎ、失敗を可視化します。

## 問題

`vision_component.cpp` の受信コールバックでは `wrapper_packet.ParseFromArray(...)` の戻り値を無視し、`has_detection()` のみで処理を継続していました。tracker / game_controller の各コンポーネントは戻り値を確認しているのに対し、Vision だけはパース失敗を握りつぶしていました。

その結果、UDP パケットが切り詰められた場合などに部分的にパースされた不正な検出フレームをそのまま取り込んでしまい、さらに失敗ログも一切出力されないため問題の検知も困難でした。

## 原因

`ParseFromArray` の成否チェックが欠落していました。

## 修正内容

`game_controller_component.cpp:41-49` と同様のパターンで、`ParseFromArray` の戻り値を `if` で確認し、`false` の場合は `RCLCPP_WARN_THROTTLE`（5000ms スロットル）でパース失敗をログ出力したうえで `return` するように変更しました。

```cpp
robocup_ssl::SSL_WrapperPacket wrapper_packet;
if (!wrapper_packet.ParseFromArray(buf.data(), static_cast<int>(size))) {
  RCLCPP_WARN_THROTTLE(
    get_logger(), *get_clock(), 5000,
    "Visionパケットのパース失敗 (size=%zu) — protoバージョン不整合の可能性", size);
  return;
}
```

## 検証

cwm の独立オーバーレイ worktree 上で `colcon build`（`--no-rdeps`）を実行し、`robocup_ssl_comm` パッケージが正常にコンパイルできることを確認しました（Build complete.）。既存の protobuf 由来の deprecation 警告以外にエラーはありません。

## レビュー観点

- ログの throttle 頻度（5000ms）が game_controller の実装と揃っているか。
- パース失敗時に `return` でコールバックを抜け、不正フレームを取り込まないこと。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
