### PR TITLE
fix(crane_msgs,crane_robot_receiver): kick_stateの×10スケールによるuint8オーバーフローを修正

### DIFF
--- a/crane_msgs/msg/RobotFeedback.msg
+++ b/crane_msgs/msg/RobotFeedback.msg
@@ -16,7 +16,7 @@ uint32 counter_jump_count
 
 uint8 counter
 
-uint8 kick_state
+uint16 kick_state
 
 uint8 TEMP_MOTOR_1=0
 uint8 TEMP_MOTOR_2=1

--- a/crane_robot_receiver/include/crane_robot_receiver/robot_feedback_protocol.hpp
+++ b/crane_robot_receiver/include/crane_robot_receiver/robot_feedback_protocol.hpp
@@ -178,7 +178,7 @@ struct RobotFeedback
 
   uint8_t counter = 0;
 
-  uint8_t kick_state = 0;
+  uint16_t kick_state = 0;
 
   uint8_t temperature[7] = {};
 


### PR DESCRIPTION
## 概要

`crane_robot_receiver` の `RobotFeedback.kick_state` は、生バイトを `KICK_STATE_SCALE(=10)` でスケールした値を保持する。しかし格納先が `uint8`(0〜255)であったため、スケール後の値が256以上になると剰余化(オーバーフロー)していた。本PRでは `kick_state` の型を `uint8` → `uint16` に変更し、スケール後の値域を正しく保持する。

## 問題

`crane_robot_receiver/src/robot_receiver_node.cpp:192-193` で以下のように代入している。

```cpp
feedback.kick_state =
  protocol::readByte(buf, protocol::offset::KICK_STATE) * protocol::KICK_STATE_SCALE;
```

生バイトが26以上の場合、積が256を超え `uint8` の範囲を超過して剰余化する。
例: 生バイト 30 → 30 × 10 = 300 → uint8 へ縮小代入で 300 mod 256 = 44 となり、本来の 300 が 44 として観測される。

## 原因

スケール後の値域(最大 255 × 10 = 2550)を保持できる型ではなく、`RobotFeedback.msg` の定義および `robot_feedback_protocol.hpp` の `struct RobotFeedback` メンバがともに `uint8` のままだった。

## 修正内容

- `crane_msgs/msg/RobotFeedback.msg`: `uint8 kick_state` → `uint16 kick_state`
- `crane_robot_receiver/include/crane_robot_receiver/robot_feedback_protocol.hpp`: `struct RobotFeedback` の `uint8_t kick_state` → `uint16_t kick_state`

これによりスケール後の値域(最大 2550)を欠損なく保持できる。代入式(line 192-193)は整数演算の結果を `uint16` に格納するため、追加のキャストは不要。

## 検証

cwm の独立オーバーレイ worktree 上で `colcon build`(`--no-rdeps`、`MAKEFLAGS=-j3`/`CMAKE_BUILD_PARALLEL_LEVEL=3`)を実行し、`crane_msgs` および `crane_robot_receiver` のコンパイルが成功(`Build complete.`)することを確認した。stderr には CMake のバージョン非推奨警告のみが含まれ、ビルド失敗はない。

## レビュー観点

- 本修正は `crane_msgs` のメッセージ定義(`RobotFeedback.msg`)変更を含む。下流(web debugger 等)の consumer は `kick_state` を整数として表示するため、`uint8` → `uint16` への拡大は互換である。
- 代替案として、(a) スケール(×10)自体を除去して生バイトをそのまま保持する、(b) 255 でクランプする、といった案も考えられる。ただしこれらは観測値の意味(スケール後値)を変えるため、値域を正しく保持する型拡大を採用した。

本PRはソースコード監査ワークフローで検出・敵対的検証されたバグに対する単一修正です。
