### PR TITLE
fix(crane_local_planner): 未指令の味方RVOエージェント残留(幽霊障害物)を修正

### DIFF
--- a/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
+++ b/crane_local_planner/include/crane_local_planner/rvo2_planner.hpp
@@ -111,6 +111,11 @@ private:
   auto applyRVOInputStage(
     const PreprocessContext & ctx, const crane_msgs::msg::RobotCommand & command) -> void;
 
+  auto retireAgent(size_t agent_id) -> void;
+
+  auto updateActiveAllyAgent(crane_msgs::msg::RobotCommand & command, uint8_t referee_command)
+    -> void;
+
   auto getCurrentEstimatedPosition(uint8_t robot_id, const Point & fallback) const -> Point;
 
   auto adjustForPenaltyAreaAvoidance(

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -7,6 +7,7 @@
 #include "crane_local_planner/rvo2_planner.hpp"
 
 #include <algorithm>
+#include <array>
 #include <boost/stacktrace.hpp>
 #include <crane_msg_wrappers/command_wrapper_base.hpp>
 #include <crane_visualization_interfaces/crane_visualizer_wrapper.hpp>
@@ -473,7 +474,11 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
     }
   }
   // 味方ロボット：RVO内の位置・速度（＝進みたい方向）の更新
+  std::array<bool, 20> ally_commanded{};
   for (auto & command : msg.robot_commands) {
+    if (command.robot_id < 20) {
+      ally_commanded[command.robot_id] = true;
+    }
     if (command.position_target_mode.empty()) {
       RCLCPP_WARN(
         rclcpp::get_logger("rvo2_local_planner"),
@@ -508,6 +513,19 @@ auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> 
     applyPreConstraintStage(ctx, command);
     setPlanningStage(command, "RVO_INPUT");
     applyRVOInputStage(ctx, command);
+  }
+
+  // 敵側と対称に、今サイクルで指令が無い／available() が false の味方エージェントを
+  // (20,20) へ退避させ速度0にする。これにより指令が止まった味方（退場・通信断）が
+  // 前回位置のまま残り、他の味方経路計画に対する幽霊障害物となるのを防ぐ。
+  for (const auto & ally_robot : world_model->ours().robots) {
+    if (ally_robot->id >= 20) {
+      continue;
+    }
+    if (!ally_commanded[ally_robot->id] || !ally_robot->available()) {
+      rvo_sim->setAgentPosition(ally_robot->id, RVO::Vector2(20.f, 20.f));
+      rvo_sim->setAgentPrefVelocity(ally_robot->id, RVO::Vector2(0.f, 0.f));
+    }
   }
 
   for (const auto & enemy_robot : world_model->theirs().robots) {

--- a/crane_local_planner/src/rvo2_planner.cpp
+++ b/crane_local_planner/src/rvo2_planner.cpp
@@ -51,6 +51,9 @@ void drawRobotRadiusWithSpeed(
     .fill(color, text_opacity)
     .build();
 }
+
+const RVO::Vector2 RETIRED_AGENT_POS(20.0f, 20.0f);
+const RVO::Vector2 ZERO_VELOCITY(0.0f, 0.0f);
 }  // namespace
 
 RVO2Planner::RVO2Planner(rclcpp::Node & node)
@@ -119,7 +122,7 @@ RVO2Planner::RVO2Planner(rclcpp::Node & node)
   // friend robots -> 0~19
   // enemy robots -> 20~39
   for (int i = 0; i < 40; i++) {
-    rvo_sim->addAgent(RVO::Vector2(20.0f, 20.0f));
+    rvo_sim->addAgent(RETIRED_AGENT_POS);
   }
 
   sub_feedback_array = node.create_subscription<crane_msgs::msg::RobotFeedbackArray>(
@@ -459,84 +462,105 @@ auto RVO2Planner::applyRVOInputStage(
   rvo_sim->setAgentMaxSpeed(command.robot_id, ctx.max_vel);
 }
 
+auto RVO2Planner::retireAgent(size_t agent_id) -> void
+{
+  rvo_sim->setAgentPosition(agent_id, RETIRED_AGENT_POS);
+  rvo_sim->setAgentPrefVelocity(agent_id, ZERO_VELOCITY);
+  rvo_sim->setAgentRadius(agent_id, RVO_RADIUS);
+}
+
+auto RVO2Planner::updateActiveAllyAgent(
+  crane_msgs::msg::RobotCommand & command, uint8_t referee_command) -> void
+{
+  auto ctx = createPreprocessContext(command);
+  initializePlanningFactors(command);
+  applyInputValidation(ctx, command);
+  if (!ctx.is_valid) {
+    applyRVOInputStage(ctx, command);
+    return;
+  }
+
+  setPlanningStage(command, "RVO_INPUT");
+  auto vel = std::hypot(command.current_velocity.x, command.current_velocity.y);
+  double radius = 0.05f + vel * 0.1f;
+  rvo_sim->setAgentRadius(command.robot_id, radius);
+
+  auto robot = world_model->getOurRobot(command.robot_id);
+  drawRobotRadiusWithSpeed(visualizer, robot->pose.pos, radius, vel, "yellow");
+
+  if (ctx.run_target_adjustments) {
+    applyTargetAdjustmentPipeline(ctx, command);
+  } else if (!command.position_target_mode.empty()) {
+    auto & pos_mode = command.position_target_mode.front();
+    pos_mode.target_x = ctx.target_pos.x();
+    pos_mode.target_y = ctx.target_pos.y();
+    addOrUpdatePlanningFactor(command, "RVO2TargetAdjustedDistance", "0.000");
+  }
+  computePreferredVelocityStage(ctx, command, referee_command);
+  applyPreConstraintStage(ctx, command);
+  setPlanningStage(command, "RVO_INPUT");
+  applyRVOInputStage(ctx, command);
+}
+
 auto RVO2Planner::reflectWorldToRVOSim(crane_msgs::msg::RobotCommands & msg) -> void
 {
   const auto referee_command = world_model->getMsg().play_situation.referee_raw.command.value;
-  if (
-    referee_command == robocup_ssl_msgs::msg::RefereeCommand::STOP &&
-    !world_model->isPracticeNormalSpeed()) {
-    for (int i = 0; i < 40; i++) {
-      rvo_sim->setAgentMaxSpeed(i, STOP_STATE_MAX_VELOCITY);
-    }
-  } else {
-    for (int i = 0; i < 40; i++) {
-      rvo_sim->setAgentMaxSpeed(i, RVO_MAX_SPEED);
-    }
+  const float max_speed = (referee_command == robocup_ssl_msgs::msg::RefereeCommand::STOP &&
+                           !world_model->isPracticeNormalSpeed())
+                            ? STOP_STATE_MAX_VELOCITY
+                            : RVO_MAX_SPEED;
+  for (int i = 0; i < 40; i++) {
+    rvo_sim->setAgentMaxSpeed(i, max_speed);
   }
-  // 味方ロボット：RVO内の位置・速度（＝進みたい方向）の更新
-  std::array<bool, 20> ally_commanded{};
+
+  // 1. コマンドのマップ化（robot_id -> commandポインタ）
+  std::array<crane_msgs::msg::RobotCommand *, 20> cmd_map{};
   for (auto & command : msg.robot_commands) {
     if (command.robot_id < 20) {
-      ally_commanded[command.robot_id] = true;
+      if (command.position_target_mode.empty()) {
+        RCLCPP_WARN(
+          rclcpp::get_logger("rvo2_local_planner"),
+          "robot_id=%d has no position_target_mode. skipping.", static_cast<int>(command.robot_id));
+        continue;
+      }
+      cmd_map[command.robot_id] = &command;
     }
-    if (command.position_target_mode.empty()) {
-      RCLCPP_WARN(
-        rclcpp::get_logger("rvo2_local_planner"),
-        "robot_id=%d has no position_target_mode. skipping.", static_cast<int>(command.robot_id));
-      continue;
-    }
-    auto ctx = createPreprocessContext(command);
-    initializePlanningFactors(command);
-    applyInputValidation(ctx, command);
-    if (!ctx.is_valid) {
-      applyRVOInputStage(ctx, command);
-      continue;
-    }
-
-    setPlanningStage(command, "RVO_INPUT");
-    auto vel = std::hypot(command.current_velocity.x, command.current_velocity.y);
-    double radius = 0.05f + vel * 0.1f;
-    rvo_sim->setAgentRadius(command.robot_id, radius);
-
-    auto robot = world_model->getOurRobot(command.robot_id);
-    drawRobotRadiusWithSpeed(visualizer, robot->pose.pos, radius, vel, "yellow");
-
-    if (ctx.run_target_adjustments) {
-      applyTargetAdjustmentPipeline(ctx, command);
-    } else if (!command.position_target_mode.empty()) {
-      auto & pos_mode = command.position_target_mode.front();
-      pos_mode.target_x = ctx.target_pos.x();
-      pos_mode.target_y = ctx.target_pos.y();
-      addOrUpdatePlanningFactor(command, "RVO2TargetAdjustedDistance", "0.000");
-    }
-    computePreferredVelocityStage(ctx, command, referee_command);
-    applyPreConstraintStage(ctx, command);
-    setPlanningStage(command, "RVO_INPUT");
-    applyRVOInputStage(ctx, command);
   }
 
-  // 敵側と対称に、今サイクルで指令が無い／available() が false の味方エージェントを
-  // (20,20) へ退避させ速度0にする。これにより指令が止まった味方（退場・通信断）が
-  // 前回位置のまま残り、他の味方経路計画に対する幽霊障害物となるのを防ぐ。
+  // 2. 味方ロボット (0..19) の更新
+  // - 不在 (!available)：RVOシミュレータ外 (20,20) へ退避
+  // - 能動 (commandあり)：RVO入力パイプラインによる経路計画
+  // - 受動 (availableだがcommandなし)：現在位置で静止障害物として配置
   for (const auto & ally_robot : world_model->ours().robots) {
     if (ally_robot->id >= 20) {
       continue;
     }
-    if (!ally_commanded[ally_robot->id] || !ally_robot->available()) {
-      rvo_sim->setAgentPosition(ally_robot->id, RVO::Vector2(20.f, 20.f));
-      rvo_sim->setAgentPrefVelocity(ally_robot->id, RVO::Vector2(0.f, 0.f));
+    const auto id = ally_robot->id;
+    if (!ally_robot->available()) {
+      retireAgent(id);
+    } else if (auto * command = cmd_map[id]; command != nullptr) {
+      updateActiveAllyAgent(*command, referee_command);
+    } else {
+      rvo_sim->setAgentPosition(id, toRVO(ally_robot->pose.pos));
+      rvo_sim->setAgentPrefVelocity(id, ZERO_VELOCITY);
+      rvo_sim->setAgentRadius(id, RVO_RADIUS);
     }
   }
 
+  // 3. 敵ロボット (20..39) の更新
   for (const auto & enemy_robot : world_model->theirs().robots) {
+    if (enemy_robot->id >= 20) {
+      continue;
+    }
+    const auto agent_id = enemy_robot->id + 20;
     if (enemy_robot->available()) {
       const auto & pos = enemy_robot->pose.pos;
       const auto & vel = enemy_robot->vel.linear;
-      rvo_sim->setAgentPosition(enemy_robot->id + 20, toRVO(pos));
-      rvo_sim->setAgentPrefVelocity(enemy_robot->id + 20, toRVO(vel));
+      rvo_sim->setAgentPosition(agent_id, toRVO(pos));
+      rvo_sim->setAgentPrefVelocity(agent_id, toRVO(vel));
+      rvo_sim->setAgentRadius(agent_id, RVO_RADIUS);
     } else {
-      rvo_sim->setAgentPosition(enemy_robot->id + 20, RVO::Vector2(20.f, 20.f));
-      rvo_sim->setAgentPrefVelocity(enemy_robot->id + 20, RVO::Vector2(0.f, 0.f));
+      retireAgent(agent_id);
     }
   }
 }


### PR DESCRIPTION
## 概要

crane_local_planner の RVO2 プランナにおいて、通信断や退場により不在になった味方ロボットが RVO シミュレータ上に前回位置のまま残り、他の味方の経路計画に対する「幽霊障害物」となる不具合を修正します。
あわせて、実在する未指令味方ロボットの衝突回避安全性と、エージェント状態管理の構造を改善しました。

## 問題と背景

rvo2_planner.cpp の reflectWorldToRVOSim は、味方エージェント (0-19) のうち msg.robot_commands に含まれるものだけを更新していました。一方、敵エージェント (20-39) は available() が false の場合に退避座標へ退避して速度0にする処理が存在します。

味方側にはこの退避処理が無いため、不在（退場・通信断などで available() が false になった）味方エージェントが RVO シミュレータ内に前回位置のまま残留し、他の味方ロボットの経路計画に影響する幽霊障害物となっていました。

## 修正内容

味方ロボットの状態管理を以下の3ステートに明確化し、敵側処理との対称性と安全性を確保しました。

1. **不在（available() == false）**:
   - retireAgent() により RVO シミュレータ外 (20, 20) へ退避させ、速度0・標準半径 (RVO_RADIUS) にリセット。
   - これにより幽霊障害物の残留を完全に解消。
2. **能動エージェント（available() == true かつ commandあり）**:
   - updateActiveAllyAgent() に分離したパイプラインにより、指令に応じた目標速度・速度連動半径を設定。
3. **受動障害物（available() == true かつ commandなし/停止中）**:
   - 待機中などで指令が届いていない実在ロボットは、現在位置・速度0・標準半径の静止障害物として RVO に配置。
   - ※未指令ロボットまで退避させてしまうと他の味方が回避運動を行わず突撃・衝突する危険があるため、実在する限り静止障害物として正しく回避させます。

### 構造改善
- 退避定数 RETIRED_AGENT_POS (20.0f, 20.0f) および ZERO_VELOCITY を定義し、マジックナンバーを排除。
- エージェント退避ヘルパー retireAgent(agent_id) を新設し、コンストラクタ初期化・味方退避・敵退避を一元化。エージェント半径のリセット漏れも防止。
- コマンド処理を cmd_map および updateActiveAllyAgent に整理し、reflectWorldToRVOSim 本体の見通しと保守性を向上。

## 検証

- colcon build による crane_local_planner のビルド成功を確認。
- colcon test による単体テスト（gtest, copyright, xmllint）全3件 Passed を確認。
- pre-commit hooks (clang-format, cpplint 等) のパスを確認。