### PR TITLE
perf(crane_bag): コマンド別トピック選択とサンプリングでCLIを大幅高速化

### DIFF
--- a/crane_bag/src/bag/bag_events.cpp
+++ b/crane_bag/src/bag/bag_events.cpp
@@ -332,6 +332,26 @@ std::vector<Event> detect_fouls(const BagData & data)
   return events;
 }
 
+std::unordered_set<std::string> topics_for_event_types(const std::vector<std::string> & types)
+{
+  const std::vector<std::string> & target = types.empty() ? ALL_EVENT_TYPES : types;
+  std::unordered_set<std::string> topics;
+  for (const auto & t : target) {
+    if (t == EVENT_PLAY) {
+      topics.insert("/play_situation");
+    } else if (t == EVENT_ROLE) {
+      topics.insert("/robot_select_results");
+    } else if (t == EVENT_KICK) {
+      topics.insert("/robot_commands");
+    } else if (t == EVENT_BALL_SPEED || t == EVENT_GOAL) {
+      topics.insert("/world_model");
+    } else if (t == EVENT_FOUL) {
+      topics.insert("/referee");
+    }
+  }
+  return topics;
+}
+
 std::vector<Event> detect_events(const BagData & data, const std::vector<std::string> & types)
 {
   const std::vector<std::string> & target = types.empty() ? ALL_EVENT_TYPES : types;

--- a/crane_bag/src/bag/bag_events.hpp
+++ b/crane_bag/src/bag/bag_events.hpp
@@ -8,6 +8,7 @@
 
 #include <map>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "bag_reader.hpp"
@@ -35,6 +36,10 @@ inline const std::vector<std::string> ALL_EVENT_TYPES = {EVENT_GOAL, EVENT_PLAY,
                                                          EVENT_KICK, EVENT_BALL_SPEED, EVENT_FOUL};
 
 std::vector<Event> detect_events(const BagData & data, const std::vector<std::string> & types = {});
+
+/// 要求された event type の検出に必要なトピック集合を返す（空 types = 全タイプ）。
+/// read() に渡して不要トピックのデシリアライズを省くために使う。
+std::unordered_set<std::string> topics_for_event_types(const std::vector<std::string> & types);
 
 std::vector<Event> detect_play_transitions(const BagData & data);
 std::vector<Event> detect_role_changes(const BagData & data);

--- a/crane_bag/src/bag/bag_reader.cpp
+++ b/crane_bag/src/bag/bag_reader.cpp
@@ -8,11 +8,13 @@
 
 #include <filesystem>
 #include <mcap/reader.hpp>
+#include <optional>
 #include <regex>
 #include <rosx_introspection/deserializer.hpp>
 #include <rosx_introspection/ros_parser.hpp>
 #include <rosx_introspection/ros_type.hpp>
 #include <stdexcept>
+#include <unordered_map>
 #include <unordered_set>
 
 #include "msg_extractors.hpp"
@@ -103,8 +105,7 @@ BagInfo BagReader::read_info(const std::string & bag_path)
   return info;
 }
 
-BagData BagReader::read(
-  const std::string & bag_path, std::optional<std::pair<double, double>> time_range)
+BagData BagReader::read(const std::string & bag_path, const ReadOptions & opts)
 {
   const std::string mcap_path = resolve_mcap_path(bag_path);
 
@@ -126,31 +127,74 @@ BagData BagReader::read(
   RosMsgParser::ParsersCollection<RosMsgParser::ROS2_Deserializer> parsers;
   std::unordered_set<std::string> registered_topics;
 
+  // /world_model の ball-only 用パーサ（ロボット配列を破棄する MaxArrayPolicy を適用）。
+  // ParsersCollection は既定ポリシーで生成されるため、専用 Parser を別管理する。
+  std::optional<RosMsgParser::Parser> wm_ball_only_parser;
+  RosMsgParser::FlatMessage wm_ball_only_flat;
+  RosMsgParser::ROS2_Deserializer wm_ball_only_deser;
+  bool wm_ball_only_registered = false;
+
+  // --- 読み込み対象トピック（空指定なら全デフォルトターゲット）---
+  const std::unordered_set<std::string> & targets =
+    opts.topics.empty() ? target_topics() : opts.topics;
+
+  // --- トピックごとの読み込み時ダウンサンプル状態 ---
+  std::unordered_map<std::string, int64_t> last_kept_ns;
+
   // --- 時間範囲フィルタを設定 ---
   mcap::Timestamp start_ts = 0;
   mcap::Timestamp end_ts = mcap::MaxTime;
-  if (time_range && data.info.start_time_ns != 0) {
+  if (opts.time_range && data.info.start_time_ns != 0) {
     int64_t bag_start = data.info.start_time_ns;
     start_ts =
-      static_cast<mcap::Timestamp>(bag_start + static_cast<int64_t>(time_range->first * 1e9));
+      static_cast<mcap::Timestamp>(bag_start + static_cast<int64_t>(opts.time_range->first * 1e9));
     end_ts =
-      static_cast<mcap::Timestamp>(bag_start + static_cast<int64_t>(time_range->second * 1e9));
+      static_cast<mcap::Timestamp>(bag_start + static_cast<int64_t>(opts.time_range->second * 1e9));
   }
 
   // --- メッセージをワンパスで読み込み ---
-  const auto & targets = target_topics();
   for (const auto & view : reader.readMessages(start_ts, end_ts)) {
     const std::string & topic = view.channel->topic;
     if (targets.find(topic) == targets.end()) continue;
 
+    const int64_t ts = static_cast<int64_t>(view.message.logTime);
+
+    // 読み込み時ダウンサンプル（BagData::sample と同一の貪欲規則: last 初期値0）。
+    // last_kept は「デシリアライズに成功して格納したフレーム」でのみ進める（下のpush後）。
+    // 旧実装はサンプリングを格納済みフレームに対して行うため、デシリアライズに失敗する
+    // フレームがあっても採用フレームが一致するようにする（生ストリーム基準で進めない）。
+    bool ds_candidate = false;
+    {
+      auto di = opts.downsample_interval_sec.find(topic);
+      if (di != opts.downsample_interval_sec.end() && di->second > 0.0) {
+        const int64_t interval_ns = static_cast<int64_t>(di->second * 1e9);
+        auto lk = last_kept_ns.find(topic);
+        const int64_t last = (lk != last_kept_ns.end()) ? lk->second : 0;
+        if (ts - last < interval_ns) continue;  // 間隔未満はデシリアライズせずスキップ
+        ds_candidate = true;                    // 採用候補。格納成功後に last_kept を進める
+      }
+    }
+
+    const bool ball_only_wm = opts.world_model_ball_only && topic == "/world_model";
+
     // 初回出現時にパーサを登録（view.schema はチャンネルに紐付く正確なスキーマ）
-    if (registered_topics.find(topic) == registered_topics.end()) {
+    auto build_definition = [&]() {
+      std::string definition = schema_data_to_string(*view.schema);
+      // rosx_introspection は bounded sequence 記法 [<=N] を isArray=false に誤パースする。
+      // [] (unbounded) に正規化して可変長シーケンスとして正しく扱わせる。
+      return std::regex_replace(definition, std::regex(R"(\[<=\d+\])"), "[]");
+    };
+    if (ball_only_wm) {
+      if (!wm_ball_only_registered && view.schema && view.schema->encoding == "ros2msg") {
+        wm_ball_only_parser.emplace(
+          topic, RosMsgParser::ROSType(view.schema->name), build_definition());
+        // ロボット配列（要素数 > 1）を破棄し、ball_info/field_info 等のスカラのみ抽出する。
+        wm_ball_only_parser->setMaxArrayPolicy(RosMsgParser::Parser::DISCARD_LARGE_ARRAYS, 1);
+        wm_ball_only_registered = true;
+      }
+    } else if (registered_topics.find(topic) == registered_topics.end()) {
       if (view.schema && view.schema->encoding == "ros2msg") {
-        std::string definition = schema_data_to_string(*view.schema);
-        // rosx_introspection は bounded sequence 記法 [<=N] を isArray=false に誤パースする。
-        // [] (unbounded) に正規化して可変長シーケンスとして正しく扱わせる。
-        definition = std::regex_replace(definition, std::regex(R"(\[<=\d+\])"), "[]");
-        parsers.registerParser(topic, RosMsgParser::ROSType(view.schema->name), definition);
+        parsers.registerParser(topic, RosMsgParser::ROSType(view.schema->name), build_definition());
         registered_topics.insert(topic);
       }
     }
@@ -163,12 +207,21 @@ BagData BagReader::read(
     // スキップせずそのまま渡す。
     RosMsgParser::Span<const uint8_t> buf(raw, raw_size);
 
-    int64_t ts = static_cast<int64_t>(view.message.logTime);
-
     try {
-      const RosMsgParser::FlatMessage * flat = parsers.deserialize(topic, buf);
+      const RosMsgParser::FlatMessage * flat = nullptr;
+      if (ball_only_wm) {
+        if (!wm_ball_only_parser) continue;
+        // 配列破棄により false が返るが、ball_info/field_info は抽出済み。
+        wm_ball_only_parser->deserialize(buf, &wm_ball_only_flat, &wm_ball_only_deser);
+        flat = &wm_ball_only_flat;
+      } else {
+        flat = parsers.deserialize(topic, buf);
+      }
       if (!flat) continue;
 
+      // opts.topics に含めるトピックは必ず下のいずれかの分岐で push すること。
+      // 分岐の無いトピックを追加すると、格納せずに ds_candidate のカーソルだけ進み
+      // ダウンサンプルの整合性が崩れる。
       if (topic == "/play_situation") {
         data.play_situations.push_back({ts, extract_play_situation(*flat)});
       } else if (topic == "/world_model") {
@@ -186,8 +239,12 @@ BagData BagReader::read(
       } else if (topic == "/referee") {
         data.referees.push_back({ts, extract_referee(*flat)});
       }
+
+      // 格納に成功したフレームでのみダウンサンプルのカーソルを進める。
+      if (ds_candidate) last_kept_ns[topic] = ts;
     } catch (const std::exception &) {
-      // デシリアライズ失敗は静かにスキップ（古いbagでのフィールド不足等）
+      // デシリアライズ失敗は静かにスキップ（古いbagでのフィールド不足等）。
+      // last_kept は進めないため、次フレームが同じ間隔基準で再評価される。
     }
   }
 

--- a/crane_bag/src/bag/bag_reader.hpp
+++ b/crane_bag/src/bag/bag_reader.hpp
@@ -10,6 +10,8 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -82,16 +84,36 @@ inline std::pair<int64_t, int64_t> make_ns_range(
     bag_start_ns + static_cast<int64_t>(time_range->second * 1e9)};
 }
 
+/// read() の読み込み挙動を制御するオプション。
+/// 各コマンドが必要とするトピック/サンプリングだけをデシリアライズすることで、
+/// 巨大な /world_model 等の無駄な展開を避ける。
+struct ReadOptions
+{
+  /// デシリアライズ対象トピック。空 = 既存の全デフォルトターゲット（後方互換）。
+  std::unordered_set<std::string> topics;
+
+  /// 相対秒の時間範囲フィルタ。
+  std::optional<std::pair<double, double>> time_range;
+
+  /// トピックごとの最小サンプリング間隔[秒]。
+  /// ts - last_kept_ns >= interval*1e9 を満たすメッセージのみデシリアライズする
+  /// （last_kept 初期値 0、貪欲規則は BagData::sample と同一）。
+  /// 未登録/0 以下 = 全件。track/survey の読み込み時ダウンサンプル用。
+  std::unordered_map<std::string, double> downsample_interval_sec;
+
+  /// /world_model を ball_info/field_info のみ抽出し、ロボット配列を破棄する高速モード。
+  /// goal/ball_speed イベント検出など、ロボット情報が不要な経路で使う。
+  bool world_model_ball_only = false;
+};
+
 class BagReader
 {
 public:
   /// メタデータのみ取得（メッセージ読み込みなし）
   static BagInfo read_info(const std::string & bag_path);
 
-  /// 全トピックをワンパスで読み込む
-  static BagData read(
-    const std::string & bag_path,
-    std::optional<std::pair<double, double>> time_range = std::nullopt);
+  /// 必要なトピック/サンプリングをワンパスで読み込む（既定 = 全ターゲット全件）
+  static BagData read(const std::string & bag_path, const ReadOptions & opts = {});
 };
 
 }  // namespace crane::bag

--- a/crane_bag/src/bag/bag_survey.cpp
+++ b/crane_bag/src/bag/bag_survey.cpp
@@ -135,7 +135,7 @@ std::string section_planning_factors(const BagData & data)
   return oss.str();
 }
 
-std::string section_velocity_status(const BagData & data, double interval = 10.0)
+std::string section_velocity_status(const BagData & data, double interval = kSurveyVelocityInterval)
 {
   std::ostringstream oss;
   char buf[256];

--- a/crane_bag/src/bag/bag_survey.hpp
+++ b/crane_bag/src/bag/bag_survey.hpp
@@ -13,7 +13,12 @@
 namespace crane::bag
 {
 
+/// survey が使うサンプリング間隔[秒]。read() の読み込み時ダウンサンプルと
+/// 各セクションの sample() で同一値を共有し、出力を変えずに展開件数を減らす。
+constexpr double kSurveySampleInterval = 5.0;     ///< world_model / game_analysis セクション
+constexpr double kSurveyVelocityInterval = 10.0;  ///< robot_commands 速度セクション
+
 /// 概要サーベイを実行してテキストを返す（analyze-rosbag Step 2 テンプレート移植）
-std::string run_survey(const BagData & data, double sample_interval = 5.0);
+std::string run_survey(const BagData & data, double sample_interval = kSurveySampleInterval);
 
 }  // namespace crane::bag

--- a/crane_bag/src/bag/crane_bag_main.cpp
+++ b/crane_bag/src/bag/crane_bag_main.cpp
@@ -26,9 +26,11 @@ using crane::bag::detect_events;
 using crane::bag::detect_factor_transitions;
 using crane::bag::extract_referee_transitions;
 using crane::bag::format_factor_pairs;
+using crane::bag::ReadOptions;
 using crane::bag::RefereeSnapshot;
 using crane::bag::run_survey;
 using crane::bag::sample_referee;
+using crane::bag::topics_for_event_types;
 using crane::bag::track_ball;
 using crane::bag::track_robot;
 
@@ -144,7 +146,17 @@ static void cmd_info(const Args & args)
 static void cmd_survey(const Args & args)
 {
   std::fprintf(stderr, "Reading %s ...\n", args.bag_path.c_str());
-  auto data = BagReader::read(args.bag_path);
+  ReadOptions opts;
+  // survey が参照するトピックのみ（referee は不要）。
+  opts.topics = {"/play_situation", "/robot_select_results", "/world_model", "/control_targets",
+                 "/robot_commands", "/game_analysis",        "/rosout"};
+  // 各セクションのサンプリング間隔と一致させ、出力を変えずに展開件数を削減する。
+  // robot_select_results(.back()) と rosout(全件dedup) はダウンサンプルしない。
+  opts.downsample_interval_sec = {
+    {"/world_model", crane::bag::kSurveySampleInterval},
+    {"/robot_commands", crane::bag::kSurveyVelocityInterval},
+    {"/game_analysis", crane::bag::kSurveySampleInterval}};
+  auto data = BagReader::read(args.bag_path, opts);
   std::printf("%s\n", run_survey(data).c_str());
 }
 
@@ -155,10 +167,17 @@ static void cmd_track(const Args & args)
     std::exit(1);
   }
   std::fprintf(stderr, "Reading %s ...\n", args.bag_path.c_str());
-  auto data = BagReader::read(args.bag_path, args.time_range);
+  ReadOptions opts;
+  opts.topics = {"/world_model"};
+  opts.time_range = args.time_range;
+  // 読み込み時に interval 間隔へ間引く。track 側は再サンプルせず全件を通す（interval=0）。
+  // read のダウンサンプルは track_ball/track_robot と同一の貪欲規則のため、
+  // 「windowed ストリームへの単一の貪欲パス」となり、従来の track 単独サンプルと一致する。
+  opts.downsample_interval_sec = {{"/world_model", args.interval}};
+  auto data = BagReader::read(args.bag_path, opts);
 
   if (args.ball) {
-    auto states = track_ball(data, args.interval);
+    auto states = track_ball(data, 0.0);
     if (states.empty()) {
       std::printf("ボールのデータが見つかりません\n");
       return;
@@ -175,7 +194,7 @@ static void cmd_track(const Args & args)
   bool is_ours = !args.enemy;
   const char * side = is_ours ? "ours" : "enemy";
 
-  auto states = track_robot(data, args.robot_id, is_ours, args.interval);
+  auto states = track_robot(data, args.robot_id, is_ours, 0.0);
   if (states.empty()) {
     std::printf("robot=%d (%s) のデータが見つかりません\n", args.robot_id, side);
     return;
@@ -195,7 +214,13 @@ static void cmd_track(const Args & args)
 static void cmd_events(const Args & args)
 {
   std::fprintf(stderr, "Reading %s ...\n", args.bag_path.c_str());
-  auto data = BagReader::read(args.bag_path);
+  ReadOptions opts;
+  // 要求された event type の検出に必要なトピックのみ読む（空 = 全タイプ）。
+  opts.topics = topics_for_event_types(args.event_types);
+  // goal/ball_speed は world_model を全件走査するが ball/field しか使わないため、
+  // ロボット配列を破棄する高速デシリアライズを有効化する。
+  opts.world_model_ball_only = opts.topics.count("/world_model") > 0;
+  auto data = BagReader::read(args.bag_path, opts);
   auto events = detect_events(data, args.event_types);
 
   if (print_json(args, events)) return;
@@ -218,7 +243,10 @@ static void cmd_control(const Args & args)
     std::exit(1);
   }
   std::fprintf(stderr, "Reading %s ...\n", args.bag_path.c_str());
-  auto data = BagReader::read(args.bag_path, args.time_range);
+  ReadOptions opts;
+  opts.topics = {"/control_targets"};
+  opts.time_range = args.time_range;
+  auto data = BagReader::read(args.bag_path, opts);
 
   if (args.changes_only) {
     auto transitions = detect_factor_transitions(data, args.robot_id);
@@ -270,7 +298,10 @@ static void cmd_control(const Args & args)
 static void cmd_referee(const Args & args)
 {
   std::fprintf(stderr, "Reading %s ...\n", args.bag_path.c_str());
-  auto data = BagReader::read(args.bag_path, args.time_range);
+  ReadOptions opts;
+  opts.topics = {"/referee"};
+  opts.time_range = args.time_range;
+  auto data = BagReader::read(args.bag_path, opts);
 
   if (data.referees.empty()) {
     std::printf("/referee トピックが見つかりません\n");


### PR DESCRIPTION
## 背景・問題

`crane_bag` CLI は `BagReader::read()` がコマンドの必要性に関わらず**常に対象8トピックを全件デシリアライズ**しており、337K件の `/world_model`（約395Hz）が支配的でした。その結果、実試合bag（852秒・3.5GB）で `info` 以外の全コマンドが一律 **約66秒・1.2GB** を消費していました（MCAPチャンクは非圧縮のため、コストはほぼ純粋な動的デシリアライズ）。

各コマンドが実際に使うトピックはごく一部です（例: `referee`→`/referee` 144件、`control`→`/control_targets` 1705件）。

## 変更内容

- **トピック選択読み込み**: `read()` に `ReadOptions`（対象トピック集合・`time_range`・トピック別ダウンサンプル間隔・`world_model_ball_only`）を導入。各コマンドは必要トピックのみ指定。
- **読み込み時ダウンサンプル**: `track`/`survey` はサンプリング間隔で読み込み時に間引き、間引かれるフレームのデシリアライズ自体を省略。`survey` のサンプリング間隔（5.0/10.0s）を定数化して読み込み側と共有。
- **events の type→トピック写像**: `topics_for_event_types()` を追加し、指定 `--type` に必要なトピックのみ読む。
- **ball-only world_model**: `events` の `goal`/`ball_speed` は world_model 全件が必要だが `ball_info`/`field_info` しか使わないため、専用パーサに `setMaxArrayPolicy(DISCARD_LARGE_ARRAYS, 1)` を適用しロボット配列を破棄して高速デシリアライズ。

### 出力一致のための要点

ダウンサンプルの `last_kept` は**デシリアライズに成功して格納したフレームでのみ前進**させます。一部の world_model フレームはデシリアライズに失敗する（この bag に実在）ため、生ストリーム基準で `last` を進めると旧実装（格納済みフレームに対するサンプリング）と採用フレームがずれます。成功後前進により「成功フレームへの単一貪欲パス」となり旧出力と完全一致します。

## 検証

実試合bag（852秒・3.5GB）で、変更前バイナリのゴールデン出力と**全コマンド・全オプションがバイト一致**:
- フルbag一致: `info` / `survey` / `events`（default・goal・ball_speed・foul・kick/play、json含む）
- 窓指定(30:150)一致: `track`（ball/robot/enemy/interval変更）/ `control` / `referee`（text・json・changes-only）

ball-only の正しさは `goal`/`ball_speed` のバイト一致が `field_info` 抽出を保証（`half_length = field_info.x/2` に依存するため）。ビルドは警告0。

## 効果

| コマンド | 変更前 | 変更後 | 倍率 |
|---|---|---|---|
| referee | 67s | 2.1s | 32x |
| track --ball/--robot | 65s | 1.5s | 44x |
| control --robot | 67s | 10.6s | 6.3x |
| survey | 66s | 11.3s | 5.8x |
| events --type foul | 66s | ~1s | 60x |
| events --type goal/ball_speed | 66s | ~5s | 14x |
| events（default） | 66s | 32.9s | 2x |

`events`（default）はエッジ検出のため `robot_commands`/`robot_select_results` の全件走査が必要で最重量のままですが、`--type` 指定で大幅に高速化されます。
