### PR TITLE
fix(ci): PRワークフローのユニットテストを再有効化しvendorのinstall欠落を修正

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -106,13 +106,15 @@ jobs:
           . /opt/ros/${{ matrix.rosdistro }}/setup.sh
           colcon build --symlink-install --event-handlers console_cohesion+ \
             --parallel-workers $(nproc) \
-            --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+            --packages-skip proto2ros_tests speak_ros_voicevox_plugin \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
         shell: bash
 
-      # Temporarily disabled due to closest_point_vendor include path issue
-      # - name: Test
-      #   run: |
-      #     . /opt/ros/${{ matrix.rosdistro }}/setup.sh
-      #     colcon test --event-handlers console_cohesion+ \
-      #       --parallel-workers $(nproc)
-      #   shell: bash
+      - name: Test
+        run: |
+          . /opt/ros/${{ matrix.rosdistro }}/setup.sh
+          colcon test --event-handlers console_cohesion+ \
+            --parallel-workers $(nproc) \
+            --packages-skip proto2ros proto2ros_tests speak_ros speak_ros_interfaces speak_ros_voicevox_plugin
+          colcon test-result --verbose
+        shell: bash

--- a/3rdparty/closest_point_vendor/CMakeLists.txt
+++ b/3rdparty/closest_point_vendor/CMakeLists.txt
@@ -27,46 +27,44 @@ macro(build_closest_point)
   set(closest_point_source_path ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install/src/closest_point-ext)
   set(closest_point_cmake_file_path ${closest_point_source_path}/CMakeLists.txt)
 
-  # Check if already built or if SKIP_VENDOR_CLONE is set
+  # ビルド済み/SKIP_VENDOR_CLONE の場合は ExternalProject の作成のみをスキップする。
+  # 注意: macro内でreturn()すると呼び出し元のファイルスコープを抜けてしまい、
+  # 再configure時に install()/ament_package() が登録されずパッケージが空になる。
   if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install/include/${PROJECT_NAME}/boost)
-    message(STATUS "closest_point_vendor already built, skipping")
-    return()
-  endif()
-
-  if(DEFINED ENV{SKIP_VENDOR_CLONE} OR SKIP_VENDOR_CLONE)
+    message(STATUS "closest_point_vendor already built, skipping external project")
+  elseif(DEFINED ENV{SKIP_VENDOR_CLONE} OR SKIP_VENDOR_CLONE)
     message(STATUS "SKIP_VENDOR_CLONE is set, skipping closest_point_vendor clone")
-    return()
-  endif()
-
-  # Check if source already exists to enable offline build
-  set(CLOSEST_POINT_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install/src/closest_point-ext)
-  if(EXISTS ${CLOSEST_POINT_SOURCE_DIR}/.git)
-    message(STATUS "既存のclosest_pointソースを検出しました。オフラインモードで利用します: ${CLOSEST_POINT_SOURCE_DIR}")
-    set(UPDATE_DISCONNECTED_FLAG UPDATE_DISCONNECTED 1)
   else()
-    message(STATUS "closest_pointソースが見つかりません。GitHubからダウンロードします")
-    set(UPDATE_DISCONNECTED_FLAG UPDATE_DISCONNECTED 0)
-  endif()
+    # Check if source already exists to enable offline build
+    set(CLOSEST_POINT_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install/src/closest_point-ext)
+    if(EXISTS ${CLOSEST_POINT_SOURCE_DIR}/.git)
+      message(STATUS "既存のclosest_pointソースを検出しました。オフラインモードで利用します: ${CLOSEST_POINT_SOURCE_DIR}")
+      set(UPDATE_DISCONNECTED_FLAG UPDATE_DISCONNECTED 1)
+    else()
+      message(STATUS "closest_pointソースが見つかりません。GitHubからダウンロードします")
+      set(UPDATE_DISCONNECTED_FLAG UPDATE_DISCONNECTED 0)
+    endif()
 
-  externalproject_add(closest_point-ext
-    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
-    INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
-    GIT_REPOSITORY https://github.com/artemp/closest_point.git
-    GIT_TAG master
-    GIT_SHALLOW ON
-    GIT_PROGRESS ON
-    ${UPDATE_DISCONNECTED_FLAG}
-    TIMEOUT 6000
-    PATCH_COMMAND
-      COMMAND echo cmake_minimum_required( VERSION 3.5 ) > ${closest_point_cmake_file_path}
-      COMMAND echo project( closest_point_vendor ) >> ${closest_point_cmake_file_path}
-      COMMAND echo install( DIRECTORY boost DESTINATION include/${PROJECT_NAME} FILES_MATCHING PATTERN "*.hpp*" ) >> ${closest_point_cmake_file_path}
-    CMAKE_ARGS
-      ${cmake_configure_args}
-    ${cmake_commands}
-    CMAKE_ARGS
-      ${cmake_configure_args}
-  )
+    externalproject_add(closest_point-ext
+      PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
+      INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+      GIT_REPOSITORY https://github.com/artemp/closest_point.git
+      GIT_TAG master
+      GIT_SHALLOW ON
+      GIT_PROGRESS ON
+      ${UPDATE_DISCONNECTED_FLAG}
+      TIMEOUT 6000
+      PATCH_COMMAND
+        COMMAND echo cmake_minimum_required( VERSION 3.5 ) > ${closest_point_cmake_file_path}
+        COMMAND echo project( closest_point_vendor ) >> ${closest_point_cmake_file_path}
+        COMMAND echo install( DIRECTORY boost DESTINATION include/${PROJECT_NAME} FILES_MATCHING PATTERN "*.hpp*" ) >> ${closest_point_cmake_file_path}
+      CMAKE_ARGS
+        ${cmake_configure_args}
+      ${cmake_commands}
+      CMAKE_ARGS
+        ${cmake_configure_args}
+    )
+  endif()
   install(
     DIRECTORY
       ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install/include/

--- a/3rdparty/closest_point_vendor/package.xml
+++ b/3rdparty/closest_point_vendor/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>closest_point_vendor</name>
   <version>1.0.377</version>
-  <description>TODO: Package description</description>
+  <description>Vendor package for the Boost.Geometry closest_point extension headers (artemp/closest_point)</description>
   <maintainer email="pythagora.yoshimoto@gmail.com">hans</maintainer>
   <license>TODO: License declaration</license>
 

--- a/3rdparty/matplotlib_cpp_17_vendor/CMakeLists.txt
+++ b/3rdparty/matplotlib_cpp_17_vendor/CMakeLists.txt
@@ -26,49 +26,47 @@ macro(build_matplotlibcpp17)
   set(cmake_configure_args -Wno-dev)
   set(cmake_configure_args -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install)
 
-  # Check if already built or if SKIP_VENDOR_CLONE is set
+  # ビルド済み/SKIP_VENDOR_CLONE の場合は ExternalProject の作成のみをスキップする。
+  # 注意: macro内でreturn()すると呼び出し元のファイルスコープを抜けてしまい、
+  # 再configure時に install()/ament_package() が登録されずパッケージが空になる。
   if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install/include)
-    message(STATUS "matplotlib_cpp_17_vendor already built, skipping")
-    return()
-  endif()
-
-  if(DEFINED ENV{SKIP_VENDOR_CLONE} OR SKIP_VENDOR_CLONE)
+    message(STATUS "matplotlib_cpp_17_vendor already built, skipping external project")
+  elseif(DEFINED ENV{SKIP_VENDOR_CLONE} OR SKIP_VENDOR_CLONE)
     message(STATUS "SKIP_VENDOR_CLONE is set, skipping matplotlib_cpp_17_vendor clone")
-    return()
-  endif()
-
-  # Check if source already exists to enable offline build
-  set(MATPLOTLIB_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/matplotlib-cpp-ext-prefix/src/matplotlib-cpp-ext)
-  if(EXISTS ${MATPLOTLIB_SOURCE_DIR}/.git)
-    message(STATUS "既存のmatplotlibcpp17ソースを検出しました。オフラインモードで利用します: ${MATPLOTLIB_SOURCE_DIR}")
-    set(UPDATE_DISCONNECTED_FLAG UPDATE_DISCONNECTED 1)
   else()
-    message(STATUS "matplotlibcpp17ソースが見つかりません。GitHubからダウンロードします")
-    set(UPDATE_DISCONNECTED_FLAG UPDATE_DISCONNECTED 0)
-  endif()
+    # Check if source already exists to enable offline build
+    set(MATPLOTLIB_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/matplotlib-cpp-ext-prefix/src/matplotlib-cpp-ext)
+    if(EXISTS ${MATPLOTLIB_SOURCE_DIR}/.git)
+      message(STATUS "既存のmatplotlibcpp17ソースを検出しました。オフラインモードで利用します: ${MATPLOTLIB_SOURCE_DIR}")
+      set(UPDATE_DISCONNECTED_FLAG UPDATE_DISCONNECTED 1)
+    else()
+      message(STATUS "matplotlibcpp17ソースが見つかりません。GitHubからダウンロードします")
+      set(UPDATE_DISCONNECTED_FLAG UPDATE_DISCONNECTED 0)
+    endif()
 
-  include(ExternalProject)
-  message(STATUS "Configure/build/install external matplotlibcpp17 with PYTHONNOUSERSITE=1")
-  externalproject_add(matplotlib-cpp-ext
-    GIT_REPOSITORY https://github.com/soblin/matplotlibcpp17.git
-    GIT_TAG 4d025b5975b701598fce8487cd8feaf82eb5923f
-    GIT_PROGRESS ON
-    ${UPDATE_DISCONNECTED_FLAG}
-    GIT_SUBMODULES_RECURSE OFF
-    TIMEOUT 6000
-    CONFIGURE_COMMAND
-      ${CMAKE_COMMAND} -E env PYTHONNOUSERSITE=1
-      ${CMAKE_COMMAND} <SOURCE_DIR> ${cmake_configure_args}
-    BUILD_COMMAND
-      ${CMAKE_COMMAND} -E env PYTHONNOUSERSITE=1
-      ${CMAKE_COMMAND} --build <BINARY_DIR>
-    INSTALL_COMMAND
-      ${CMAKE_COMMAND} -E env PYTHONNOUSERSITE=1
-      ${CMAKE_COMMAND} --install <BINARY_DIR>
-    ${cmake_commands}
-    CMAKE_ARGS
-      ${cmake_configure_args}
-  )
+    include(ExternalProject)
+    message(STATUS "Configure/build/install external matplotlibcpp17 with PYTHONNOUSERSITE=1")
+    externalproject_add(matplotlib-cpp-ext
+      GIT_REPOSITORY https://github.com/soblin/matplotlibcpp17.git
+      GIT_TAG 4d025b5975b701598fce8487cd8feaf82eb5923f
+      GIT_PROGRESS ON
+      ${UPDATE_DISCONNECTED_FLAG}
+      GIT_SUBMODULES_RECURSE OFF
+      TIMEOUT 6000
+      CONFIGURE_COMMAND
+        ${CMAKE_COMMAND} -E env PYTHONNOUSERSITE=1
+        ${CMAKE_COMMAND} <SOURCE_DIR> ${cmake_configure_args}
+      BUILD_COMMAND
+        ${CMAKE_COMMAND} -E env PYTHONNOUSERSITE=1
+        ${CMAKE_COMMAND} --build <BINARY_DIR>
+      INSTALL_COMMAND
+        ${CMAKE_COMMAND} -E env PYTHONNOUSERSITE=1
+        ${CMAKE_COMMAND} --install <BINARY_DIR>
+      ${cmake_commands}
+      CMAKE_ARGS
+        ${cmake_configure_args}
+    )
+  endif()
 
   # The external project will install to the build folder, but we'll install that on make install.
   install(

--- a/3rdparty/matplotlib_cpp_17_vendor/package.xml
+++ b/3rdparty/matplotlib_cpp_17_vendor/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>matplotlib_cpp_17_vendor</name>
   <version>1.0.377</version>
-  <description>TODO: Package description</description>
+  <description>Vendor package for matplotlibcpp17, a C++17 wrapper of matplotlib (soblin/matplotlibcpp17)</description>
   <maintainer email="pythagora.yoshimoto@gmail.com">groundstation</maintainer>
   <license>TODO: License declaration</license>
 

--- a/3rdparty/rvo2_vendor/package.xml
+++ b/3rdparty/rvo2_vendor/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>rvo2_vendor</name>
   <version>1.0.377</version>
-  <description>TODO: Package description</description>
+  <description>Vendor package for the RVO2 multi-agent collision avoidance library (snape/RVO2)</description>
   <maintainer email="pythagora.yoshimoto@gmail.com">groundstation</maintainer>
   <license>TODO: License declaration</license>
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,7 @@ ros2 launch robocup_ssl_comm comm.launch.py
 ### コアコンポーネント
 
 - crane_session_coordinator: 試合進行とゲーム状態管理
-- crane_sessions: プラグイン型の戦略プランナー
+- crane_sessions: ファクトリ登録型の戦略プランナー（`session_factory` 経由で生成）
 - crane_robot_skills: 個別ロボット振る舞い（ゴールキーパー等）
 - crane_local_planner: RVO2 ベースの局所経路計画
 - crane_world_model_publisher: 状態推定とトラッキング
@@ -235,7 +235,7 @@ ros2 launch robocup_ssl_comm comm.launch.py
 
 ### メッセージフロー
 
-1. `robocup_ssl_comm` がSSLの視覚/審判データを受信
+1. `crane_world_model_publisher` が SSL-Vision データを直接UDP受信、`robocup_ssl_comm` が審判（GameController）データを受信
 2. `crane_world_model_publisher` が世界モデルを配信
 3. セッションコントローラが上位意思決定
 4. プランナが割当と戦略を生成
@@ -245,7 +245,7 @@ ros2 launch robocup_ssl_comm comm.launch.py
 ### 主なディレクトリ
 
 - `crane_session_coordinator/` 最上位制御・ゲーム状態管理
-- `crane_sessions/` 戦略タクティックプラグイン群
+- `crane_sessions/` 戦略セッション群（ファクトリ登録）
 - `crane_robot_skills/` 個別ロボットスキルライブラリ
 - `crane_local_planner/` 経路計画・衝突回避
 - `utility/` 共有ユーティリティライブラリ（幾何・物理・通信・メッセージラッパー等）
@@ -284,9 +284,9 @@ ros2 launch robocup_ssl_comm comm.launch.py
 
 ### 依存レイヤ構成（概略）
 
-1. メッセージ層: `crane_msgs`, `robocup_ssl_msgs`, `crane_visualization_interfaces`
-2. ユーティリティ層: `crane_geometry`, `crane_physics`, `crane_comm`, `crane_msg_wrappers`
-3. コンポーネント層: `crane_world_model_publisher`, `crane_game_analyzer`, `crane_robot_skills`
+1. メッセージ層: `crane_msgs`, `robocup_ssl_msgs`, `crane_visualization_interfaces`（可視化ラッパーを含むため `crane_geometry` にも依存）
+2. ユーティリティ層: `crane_geometry`, `crane_physics`, `crane_comm`, `crane_msg_wrappers`, `crane_utils`
+3. コンポーネント層: `crane_world_model_publisher`, `crane_game_analyzer`, `crane_play_switcher`, `crane_robot_skills`
 4. 計画層: `crane_session_coordinator`, `crane_sessions`, `crane_local_planner`
 5. 統合層: `crane_bringup`, `crane_sender`, `robocup_ssl_comm`
 

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -142,7 +142,7 @@ auto WorldModelPublisherComponent::publishWorldModel() -> void
   wrapper_->addDelayCheckpoint("post_processed", "");
 
   pub_world_model.publish(wrapper_->getMsg());
-  wrapper_->addDelayCheckpoint("world_model_published", "30Hz");
+  wrapper_->addDelayCheckpoint("world_model_published", "");
 }
 
 auto WorldModelPublisherComponent::publishVisualization(WorldModelWrapperPtr world_model) -> void


### PR DESCRIPTION
## 概要

アーキテクチャレビューで判明した最優先課題「PRでユニットテストが一切実行されない」を解消します。

## 背景と根本原因

`build_test.yaml` は「closest_point_vendor include path issue」を理由に `-DBUILD_TESTING=OFF` でテストステップがコメントアウトされており（#1108）、ユニットテストは develop への push 後（full_build.yaml）まで実行されない状態でした。

調査の結果、include path issue の根本原因は **vendor パッケージの CMakeLists における macro 内 `return()`** と特定しました:

- CMake の macro は展開方式のため、macro 内の `return()` は呼び出し元（ファイルスコープ）を抜ける
- 「ビルド済みスキップ」パスに入ると `install()` と `ament_package()` が未登録のまま configure が終了
- ビルドキャッシュが残った状態で再configure すると installルールが **24件→7件に消失**（実測）し、vendored ヘッダ（`boost/geometry/extensions/...`）が install されなくなる

## 変更内容

1. **fix(3rdparty)**: closest_point_vendor / matplotlib_cpp_17_vendor の skip 判定を if/elseif/else に組み替え、ExternalProject の作成のみをスキップして `install()`/`ament_package()` を常に登録。vendor 3パッケージの description（TODO のまま）も記入
2. **ci**: `BUILD_TESTING=ON` 化＋テストステップ復活。skip リストは full_build.yaml で実績のある構成を使用し、`colcon test-result --verbose` で失敗を検知
3. **docs**: AGENTS.md のメッセージフロー（Vision は world_model_publisher が直接UDP受信）・依存レイヤ表（crane_utils / crane_play_switcher 追記）等を実態に整合

## 検証

- [x] vendor 再configure 実験: 旧版は installルール 24→7 件に消失、修正版は 24件維持
- [x] CI相当構成でのローカル全体ビルド: 35パッケージ全成功
- [x] `colcon test`（CI と同じ skip リスト）: **510テスト、エラー0、失敗0**
- [x] pre-commit 全チェック通過
- [ ] 本PRの GitHub Actions で Test ステップが実行・通過することを確認