### PR TITLE
perf(game_analyzer): SubAttackerPosition推奨位置計算にスロットルを追加

### DIFF
--- a/crane_game_analyzer/include/crane_game_analyzer/metrics/sub_attacker_metrics.hpp
+++ b/crane_game_analyzer/include/crane_game_analyzer/metrics/sub_attacker_metrics.hpp
@@ -8,6 +8,7 @@
 #define CRANE_GAME_ANALYZER__METRICS__SUB_ATTACKER_METRICS_HPP_
 
 #include <crane_geometry/boost_geometry.hpp>
+#include <rclcpp/time.hpp>
 
 #include "metric_base.hpp"
 #include "metric_context.hpp"
@@ -48,6 +49,16 @@ private:
   // ヒステリシス用状態（位置の急変を防ぐ）
   Point last_position_{0.0, 0.0};
   bool has_last_position_ = false;
+
+  // 計算結果の再利用用状態（スロットル中に前回結果を再送出する）
+  bool last_has_position_ = false;
+  float last_score_ = 0.0f;
+
+  // 計算頻度スロットル用状態
+  // DPPS探索(候補点2560個)は元々オンデマンド用にチューニングされたパラメータで、
+  // ヒステリシス閾値(0.5m)より高頻度の探索は無駄になるため計算間隔を制限する
+  rclcpp::Time last_compute_time_;
+  bool has_computed_ = false;
 };
 
 }  // namespace crane::metrics

--- a/crane_game_analyzer/src/metrics/sub_attacker_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/sub_attacker_metrics.cpp
@@ -22,12 +22,32 @@ auto SubAttackerPositionMetric::compute(MetricContext & ctx) -> void
   auto & wm = ctx.world_model;
   auto & analysis = ctx.analysis;
 
+  // 計算頻度スロットル: 前回計算からMIN_COMPUTE_INTERVAL_SEC未満なら前回結果を再送出する
+  // NOTE: DPPS探索(候補点2560個)自体の所要時間が約130msあるため、
+  // 間隔をそれより十分大きく取らないと実質的に間引けない（130ms未満の閾値では常に
+  // elapsed >= 閾値になってしまう）。ヒステリシス閾値(0.5m)を踏まえ0.3秒(約3.3Hz)とする。
+  constexpr double MIN_COMPUTE_INTERVAL_SEC = 0.3;
+  auto now = ctx.clock->now();
+  if (has_computed_ && (now - last_compute_time_).seconds() < MIN_COMPUTE_INTERVAL_SEC) {
+    analysis.has_sub_attacker_position = last_has_position_;
+    analysis.sub_attacker_position_score = last_score_;
+    if (last_has_position_) {
+      analysis.recommended_sub_attacker_position.x = last_position_.x();
+      analysis.recommended_sub_attacker_position.y = last_position_.y();
+    }
+    return;
+  }
+  last_compute_time_ = now;
+  has_computed_ = true;
+
   // デフォルトでは無効
   analysis.has_sub_attacker_position = false;
   analysis.sub_attacker_position_score = 0.0f;
 
   // ボールが自陣にある場合はSubAttacker不要
   if (wm->point_checker.isInOurHalf(wm->ball().pos)) {
+    last_has_position_ = false;
+    last_score_ = 0.0f;
     return;
   }
 
@@ -44,6 +64,8 @@ auto SubAttackerPositionMetric::compute(MetricContext & ctx) -> void
   }
 
   if (valid_candidates.empty()) {
+    last_has_position_ = false;
+    last_score_ = 0.0f;
     return;
   }
 
@@ -80,6 +102,8 @@ auto SubAttackerPositionMetric::compute(MetricContext & ctx) -> void
   // 状態を更新
   last_position_ = best_position;
   has_last_position_ = true;
+  last_has_position_ = true;
+  last_score_ = static_cast<float>(best_score);
 }
 
 }  // namespace crane::metrics


### PR DESCRIPTION
## 概要

- `crane_game_analyzer` ノードがCPU使用率101%に張り付き、`/world_model` 発行段の処理遅延を悪化させていた問題を修正
- 原因調査（`gdb`/`strace`/`perf` がptrace制限で使用不可のため、手動計測コード埋め込みによるプロファイリング）により、`SubAttackerPositionMetric::compute()` 内のDPPS探索（候補点2560個の評価）が1回あたり約130msを要し、`/world_model` 更新のたびに毎回実行されていたことが判明
- 推奨位置には既存のヒステリシス（0.5m以上の変化でのみ更新）があり、DPPS探索自体の頻度をそれより落としても実質的な劣化はないと判断し、計算間隔を0.3秒（約3.3Hz）に制限
  - 130ms未満の閾値では計算時間自体が閾値を超えてしまい実質的にスロットルされないため、130msより十分大きい0.3秒とした
- スロットル中は前回の計算結果（位置・スコア・有効フラグ）を再送出する

## 下流影響の確認

推奨位置（`recommended_sub_attacker_position` / `has_sub_attacker_position`）の唯一の消費者は `SubAttackerSkillSession::getRobotSuitabilityFunc()`（100ms周期のロール再割当における適性コスト計算）。実際のロボット制御を行う `SubAttacker::update()` スキル自体は毎フレーム独自にDPPS探索を行うため、このスロットルによる遅延の影響を受けない。

## 効果

- game_analyzerのCPU使用率が101%から64.6%に低下（`pidstat` 計測）
- world_model発行段のheadline latencyへの影響は、テスト環境のネットワーク不安定性により精密な非制御A/B比較ができなかったため未確認。CPU競合経由の間接効果である可能性が高く、大きな回帰があれば別途対応する

## Test plan

- [x] `colcon build --packages-select crane_game_analyzer` が成功すること
- [x] `pidstat` でgame_analyzerのCPU使用率が101%→64.6%に低下することを確認
- [ ] レビュアーによる `/codex:review` の実施（Claude側からは自動呼び出し不可のため未実施）