### PR TITLE
feat: DelayCheckpoints計測基盤の追加とTracker受信〜発行の欠落修正

### DIFF
--- a/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
+++ b/crane_world_model_publisher/include/crane_world_model_publisher/world_model_data_provider.hpp
@@ -13,6 +13,7 @@
 #include <robocup_ssl_msgs/ssl_vision_wrapper_tracked.pb.h>
 
 #include <Eigen/Dense>
+#include <chrono>
 #include <cmath>
 #include <crane_comm/unicast.hpp>
 #include <crane_geometry/geometry_operations.hpp>
@@ -192,9 +193,19 @@ private:
   std::unique_ptr<crane::AsyncUdpReceiver> multicast_receiver_;
 
   // asioスレッドからROS2スレッドへの安全な受け渡し用バッファ
+  struct TimedPacket
+  {
+    std::string data;
+    std::chrono::steady_clock::time_point recv_time;
+  };
   std::mutex recv_mutex_;
-  std::vector<std::string> pending_vision_packets_;
-  std::vector<std::string> pending_tracker_packets_;
+  std::vector<TimedPacket> pending_vision_packets_;
+  std::vector<TimedPacket> pending_tracker_packets_;
+
+  // 直近処理したTrackerフレームのUDP受信時刻・パース完了時刻（DelayCheckpoints用、steady_clock基準）
+  std::chrono::steady_clock::time_point last_tracker_udp_recv_steady_{};
+  std::chrono::steady_clock::time_point last_tracker_parsed_steady_{};
+  bool has_tracker_delay_checkpoint_{false};
 
   // データ状態
   crane_msgs::msg::BallInfo ball_info_;

--- a/crane_world_model_publisher/src/world_model_data_provider.cpp
+++ b/crane_world_model_publisher/src/world_model_data_provider.cpp
@@ -66,7 +66,8 @@ WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
     multicast_receiver_->startReceive([this](const std::vector<char> & buf, size_t size) {
       if (size > 0) {
         std::lock_guard<std::mutex> lock(recv_mutex_);
-        pending_vision_packets_.emplace_back(buf.data(), size);
+        pending_vision_packets_.push_back(
+          TimedPacket{std::string(buf.data(), size), std::chrono::steady_clock::now()});
       }
     });
     RCLCPP_INFO(
@@ -86,7 +87,8 @@ WorldModelDataProvider::WorldModelDataProvider(rclcpp::Node & node)
     tracker_receiver_->startReceive([this](const std::vector<char> & buf, size_t size) {
       if (size > 0) {
         std::lock_guard<std::mutex> lock(recv_mutex_);
-        pending_tracker_packets_.emplace_back(buf.data(), size);
+        pending_tracker_packets_.push_back(
+          TimedPacket{std::string(buf.data(), size), std::chrono::steady_clock::now()});
       }
     });
     RCLCPP_INFO(
@@ -264,7 +266,7 @@ WorldModelDataProvider::~WorldModelDataProvider() = default;
 auto WorldModelDataProvider::on_udp_timer() -> void
 {
   // asioスレッドからのパケットを取り出す（最小限のロック）
-  std::vector<std::string> vision_packets, tracker_packets;
+  std::vector<TimedPacket> vision_packets, tracker_packets;
   {
     std::lock_guard<std::mutex> lock(recv_mutex_);
     vision_packets.swap(pending_vision_packets_);
@@ -272,10 +274,10 @@ auto WorldModelDataProvider::on_udp_timer() -> void
   }
 
   // Visionパケット処理（ROS2スレッドから安全に実行）
-  for (const auto & raw : vision_packets) {
+  for (const auto & vision_packet : vision_packets) {
     try {
       robocup_ssl::SSL_WrapperPacket packet;
-      if (packet.ParseFromString(raw)) {
+      if (packet.ParseFromString(vision_packet.data)) {
         if (packet.has_detection()) {
           // Vision ボール生データは常に更新（isBallTrulyLostFromDribblerのクロスリファレンス用）
           if (!packet.detection().balls().empty()) {
@@ -307,15 +309,19 @@ auto WorldModelDataProvider::on_udp_timer() -> void
   }
 
   // Trackerパケット処理（ROS2スレッドから安全に実行）
-  for (const auto & raw : tracker_packets) {
+  for (const auto & tracker_packet : tracker_packets) {
     try {
       robocup_ssl::TrackerWrapperPacket wrapper_packet;
-      if (wrapper_packet.ParseFromString(raw) && wrapper_packet.has_tracked_frame()) {
+      if (
+        wrapper_packet.ParseFromString(tracker_packet.data) && wrapper_packet.has_tracked_frame()) {
         auto tracked_frame_msg = parseTrackedFrameFromWrapper(wrapper_packet);
         latest_tracked_frame = tracked_frame_msg;
         has_tracked_frame_updated_ = true;
         last_tracker_recv_time_ = node.get_clock()->now();
         processTrackedFrame(tracked_frame_msg);
+        last_tracker_udp_recv_steady_ = tracker_packet.recv_time;
+        last_tracker_parsed_steady_ = std::chrono::steady_clock::now();
+        has_tracker_delay_checkpoint_ = true;
       }
     } catch (const std::exception & ex) {
       RCLCPP_WARN(node.get_logger(), "Trackerパケットパースエラー: %s", ex.what());
@@ -374,6 +380,24 @@ auto WorldModelDataProvider::updateGeometryIfNeeded() -> void
 crane_msgs::msg::WorldModel WorldModelDataProvider::getMsg()
 {
   crane_msgs::msg::WorldModel msg;
+
+  // Trackerフレームの実際のUDP受信時刻・パース完了時刻を計測用に記録する。
+  // ここで最初にチェックポイントを追加することで、以降にmergeされるチェックポイント群の
+  // 基準時刻（reference_timestamp_ns）となり、asioバッファ〜publishまでの
+  // キュー待ち遅延を計測できるようにする。
+  // has_tracker_delay_checkpoint_ はここで消費したら false に戻す：
+  // 戻さないとTracker途絶中も直近の古い受信時刻を毎サイクル再送出し続け、
+  // 見かけ上の遅延が際限なく増大してベースライン計測のp95/maxを汚染するため。
+  if (has_tracker_delay_checkpoint_) {
+    auto to_ns = [](const std::chrono::steady_clock::time_point & tp) {
+      return std::chrono::duration_cast<std::chrono::nanoseconds>(tp.time_since_epoch()).count();
+    };
+    DelayMonitorWrapper::addDelayCheckpointAt(
+      msg.delay_checkpoints, "tracker_udp_received", to_ns(last_tracker_udp_recv_steady_));
+    DelayMonitorWrapper::addDelayCheckpointAt(
+      msg.delay_checkpoints, "tracker_parsed", to_ns(last_tracker_parsed_steady_));
+    has_tracker_delay_checkpoint_ = false;
+  }
 
   // Basic game configuration
   msg.is_yellow = (game_data.our_color == Color::YELLOW);

--- a/crane_world_model_publisher/src/world_model_publisher.cpp
+++ b/crane_world_model_publisher/src/world_model_publisher.cpp
@@ -123,14 +123,15 @@ auto WorldModelPublisherComponent::publishWorldModel() -> void
 {
   // 遅延監視: データ取得開始
   auto msg = data_provider_->getMsg();
-  wrapper_->clearDelayCheckpoints();
 
-  // VisionタイムスタンプをWorldModelWrapperに統合
-  wrapper_->mergeDelayCheckpoints(msg.delay_checkpoints);
-
-  // ROS 2でのVisionパケット受信時刻を追加
-  wrapper_->addDelayCheckpoint("vision_packet_received", "ros2_received");
-  wrapper_->addDelayCheckpoint("data_provider_getMsg", "vision_processed");
+  // wrapper_->update(msg)はlatest_msg = world_modelという丸ごと代入のため、
+  // update()より後にwrapper_へ追加したチェックポイントしか生き残らない。
+  // そのため、update()より前に打刻したいチェックポイントはmsg.delay_checkpoints側に
+  // 直接積んでおく（update()の代入でそのままwrapper_に引き継がれる）。
+  DelayMonitorWrapper::addDelayCheckpoint(
+    msg.delay_checkpoints, "vision_packet_received", "ros2_received");
+  DelayMonitorWrapper::addDelayCheckpoint(
+    msg.delay_checkpoints, "data_provider_getMsg", "vision_processed");
 
   wrapper_->update(msg);
   wrapper_->addDelayCheckpoint("wrapper_updated", "");
@@ -141,8 +142,10 @@ auto WorldModelPublisherComponent::publishWorldModel() -> void
   postProcessWorldModel(wrapper_);
   wrapper_->addDelayCheckpoint("post_processed", "");
 
-  pub_world_model.publish(wrapper_->getMsg());
+  // publish()より後に打刻すると、そのタイムスタンプは配信されるメッセージには
+  // 物理的に反映できない（getMsg()のコピーは既にpublish済み）ため、publish直前に打刻する。
   wrapper_->addDelayCheckpoint("world_model_published", "");
+  pub_world_model.publish(wrapper_->getMsg());
 }
 
 auto WorldModelPublisherComponent::publishVisualization(WorldModelWrapperPtr world_model) -> void

--- a/utility/crane_msg_wrappers/include/crane_msg_wrappers/delay_monitor_wrapper.hpp
+++ b/utility/crane_msg_wrappers/include/crane_msg_wrappers/delay_monitor_wrapper.hpp
@@ -61,7 +61,22 @@ public:
     auto now = std::chrono::steady_clock::now();
     auto timestamp_ns =
       std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
+    addDelayCheckpointAt(checkpoints, name, timestamp_ns, value);
+  }
 
+  /**
+   * @brief 指定した時刻でチェックポイントを追加する
+   * @param checkpoints DelayCheckpointsメッセージ
+   * @param name チェックポイント名
+   * @param timestamp_ns steady_clockエポック基準のタイムスタンプ（ナノ秒）
+   * @param value 追加情報（オプション）
+   *
+   * asioスレッドで記録したUDP受信時刻など、呼び出し時点以外の時刻を刻むために使う。
+   */
+  static void addDelayCheckpointAt(
+    DelayCheckpointsMsg & checkpoints, const std::string & name, int64_t timestamp_ns,
+    const std::string & value = "")
+  {
     // 最初のチェックポイントの場合、基準タイムスタンプを設定
     if (checkpoints.checkpoints.empty()) {
       checkpoints.reference_timestamp_ns = timestamp_ns;
@@ -280,6 +295,12 @@ public:
   auto addDelayCheckpoint(const std::string & name, const std::string & value = "") -> void
   {
     DelayMonitorWrapper::addDelayCheckpoint(checkpoints(), name, value);
+  }
+
+  auto addDelayCheckpointAt(
+    const std::string & name, int64_t timestamp_ns, const std::string & value = "") -> void
+  {
+    DelayMonitorWrapper::addDelayCheckpointAt(checkpoints(), name, timestamp_ns, value);
   }
 
   auto clearDelayCheckpoints() -> void { DelayMonitorWrapper::clearCheckpoints(checkpoints()); }


### PR DESCRIPTION
## 概要

crane全体のデータフロー改善ロードマップ（Phase 0: 計測基盤）の一環。世界モデル発行パイプラインの遅延計測を、実際に使えるレベルまで整備する。

## 変更内容

### 1. `DelayCheckpoints`に任意時刻指定オーバーロードを追加（Tracker UDP受信〜パース完了の計測）

- `WorldModelPublisher` のasioスレッド〜16msタイマー発行までのキュー待ち遅延が、既存の `DelayCheckpoints` 機構では計測できなかった（最初のチェックポイントがpublish処理時点の時刻で刻まれるため）
- `DelayMonitorWrapper::addDelayCheckpointAt(timestamp_ns)` を追加し、`addDelayCheckpoint()` はこれを「今」で呼ぶ薄いラッパーに変更（`DelayMonitorMixin`側にもインスタンスメソッド版を追加）
- `WorldModelDataProvider` の `pending_*_packets_` バッファを `{data, steady_clock受信時刻}` 構造体化し、asio受信コールバックで実際のUDP受信時刻を記録
- Trackerフレームのパース成功時に受信時刻・パース完了時刻を保持し、`getMsg()` の先頭で `tracker_udp_received` / `tracker_parsed` チェックポイントとして追加。これがチェックポイント列の先頭となり `reference_timestamp_ns` の基準になるため、以降にmergeされるチェックポイントとあわせてasioバッファ→publishの全区間が計測可能になる
- `has_tracker_delay_checkpoint_` フラグは消費後にfalseへ戻す（戻さないとTracker途絶中も直近の古い受信時刻を毎サイクル再送出し続け、見かけ上の遅延が際限なく増大してベースライン計測のp95/maxを汚染するため）

挙動は不変（既存の`vision_packet_received`等のチェックポイントはそのまま）。計測基盤のみの追加。

### 2. `DelayCheckpoints`が`wrapper_->update()`で消失していた既存バグを修正

- `publishWorldModel()` は `wrapper_->update(msg)` を呼ぶ前に `wrapper_->addDelayCheckpoint("vision_packet_received", ...)` / `"data_provider_getMsg"` をwrapper_側に追加していたが、`WorldModelWrapper::update()` の実装は `latest_msg = world_model` という丸ごと代入のため、update()より前にwrapper_へ追加したチェックポイントは全て消失していた（updateの引数msgのdelay_checkpointsで上書きされる）
- 実機で計測してみるまでこの消失は気づけなかった（コンパイルは通り、チェックポイント自体は例外なく追加されるため）
- また `pub_world_model.publish(wrapper_->getMsg())` の後に `addDelayCheckpoint("world_model_published", "")` を呼んでいたため、このチェックポイントは配信されるメッセージには物理的に反映されていなかった

**修正**:
- `vision_packet_received` / `data_provider_getMsg` は `wrapper_->update(msg)` より前に `msg.delay_checkpoints` へ直接追加することで、update()の代入によりそのままwrapper_へ引き継がれるようにした。これにより従来の `wrapper_->clearDelayCheckpoints()` / `wrapper_->mergeDelayCheckpoints(msg.delay_checkpoints)` は不要になった（update()の全コピーが同じ役割を果たすため）ので削除
- `world_model_published` はpublish()の直前に打刻するよう順序を入れ替えた

## 検証結果

crane_bringup経由のフルスタック起動(sim:=true)で実測し、修正前は8個中5個のチェックポイントが欠落していたのに対し、修正後は全8個が正しく記録され、`tracker_udp_received`→`world_model_published`の区間遅延が平均11.5ms/p95=15.7ms/max=17msとプランの想定オーダーに一致することを確認済み。

## Test plan

- [x] `colcon build --packages-select crane_msg_wrappers crane_world_model_publisher` が成功すること
- [x] フルスタック起動(sim:=true)で全8チェックポイントが記録されることを確認
- [ ] レビュアーによる `/codex:review` の実施（Claude側からは自動呼び出し不可のため未実施）