### PR TITLE
feat(crane_bag): パス試行検出とKPI集計の pass サブコマンドを追加

### DIFF
--- a/crane_bag/CMakeLists.txt
+++ b/crane_bag/CMakeLists.txt
@@ -25,6 +25,7 @@ ament_auto_add_executable(crane_bag
   src/bag/bag_tracking.cpp
   src/bag/bag_control.cpp
   src/bag/bag_referee.cpp
+  src/bag/bag_pass.cpp
   src/bag/msg_extractors.cpp
 )
 target_include_directories(crane_bag PRIVATE src/bag)
@@ -37,5 +38,14 @@ target_link_libraries(crane_bag
   mcap_vendor::mcap
   magic_enum::magic_enum
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  # パスイベント検出器の単体テスト（bag_pass は rosx_introspection 非依存の純関数）
+  ament_auto_add_gtest(test_bag_pass test/test_bag_pass.cpp src/bag/bag_pass.cpp)
+  target_include_directories(test_bag_pass PRIVATE src/bag)
+endif()
 
 ament_auto_package()

--- a/crane_bag/package.xml
+++ b/crane_bag/package.xml
@@ -14,6 +14,7 @@
   <depend>nlohmann-json-dev</depend>
   <depend>rosx_introspection</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>crane_lint_common</test_depend>
 

--- a/crane_bag/src/bag/bag_events.cpp
+++ b/crane_bag/src/bag/bag_events.cpp
@@ -14,6 +14,8 @@
 #include <unordered_set>
 #include <utility>
 
+#include "bag_pass.hpp"
+
 namespace crane::bag
 {
 
@@ -332,6 +334,36 @@ std::vector<Event> detect_fouls(const BagData & data)
   return events;
 }
 
+std::vector<Event> detect_pass_attempt_events(const BagData & data)
+{
+  std::vector<Event> events;
+  for (const auto & pe : detect_pass_events(data)) {
+    std::string toucher_note;
+    if (pe.first_toucher_id >= 0 && pe.first_toucher_id != pe.intended_receiver_id) {
+      toucher_note = std::string(" toucher=") + (pe.first_toucher_ours ? "our" : "their") +
+                     std::to_string(pe.first_toucher_id);
+    }
+    char buf[192];
+    std::snprintf(
+      buf, sizeof(buf), "PASS: %d -> %d %s d=%.2fm v=%.2fm/s%s", pe.kicker_id,
+      pe.intended_receiver_id, to_string(pe.outcome).c_str(), pe.pass_distance, pe.kick_speed,
+      toucher_note.c_str());
+    Event e;
+    e.timestamp_ns = pe.timestamp_ns;
+    e.t = pe.t;
+    e.event_type = EVENT_PASS;
+    e.description = buf;
+    events.push_back(e);
+  }
+  return events;
+}
+
+bool event_types_require_full_world_model(const std::vector<std::string> & types)
+{
+  const std::vector<std::string> & target = types.empty() ? ALL_EVENT_TYPES : types;
+  return std::find(target.begin(), target.end(), EVENT_PASS) != target.end();
+}
+
 std::unordered_set<std::string> topics_for_event_types(const std::vector<std::string> & types)
 {
   const std::vector<std::string> & target = types.empty() ? ALL_EVENT_TYPES : types;
@@ -343,7 +375,7 @@ std::unordered_set<std::string> topics_for_event_types(const std::vector<std::st
       topics.insert("/robot_select_results");
     } else if (t == EVENT_KICK) {
       topics.insert("/robot_commands");
-    } else if (t == EVENT_BALL_SPEED || t == EVENT_GOAL) {
+    } else if (t == EVENT_BALL_SPEED || t == EVENT_GOAL || t == EVENT_PASS) {
       topics.insert("/world_model");
     } else if (t == EVENT_FOUL) {
       topics.insert("/referee");
@@ -371,6 +403,7 @@ std::vector<Event> detect_events(const BagData & data, const std::vector<std::st
   append_if(EVENT_BALL_SPEED, [&] { return detect_ball_speed_spikes(data); });
   append_if(EVENT_GOAL, [&] { return detect_goals(data); });
   append_if(EVENT_FOUL, [&] { return detect_fouls(data); });
+  append_if(EVENT_PASS, [&] { return detect_pass_attempt_events(data); });
 
   std::sort(all.begin(), all.end(), [](const Event & a, const Event & b) {
     return a.timestamp_ns < b.timestamp_ns;

--- a/crane_bag/src/bag/bag_events.hpp
+++ b/crane_bag/src/bag/bag_events.hpp
@@ -31,9 +31,13 @@ constexpr const char * EVENT_ROLE = "role";
 constexpr const char * EVENT_KICK = "kick";
 constexpr const char * EVENT_BALL_SPEED = "ball_speed";
 constexpr const char * EVENT_FOUL = "foul";
+constexpr const char * EVENT_PASS = "pass";
 
-inline const std::vector<std::string> ALL_EVENT_TYPES = {EVENT_GOAL, EVENT_PLAY,       EVENT_ROLE,
-                                                         EVENT_KICK, EVENT_BALL_SPEED, EVENT_FOUL};
+inline const std::vector<std::string> ALL_EVENT_TYPES = {
+  EVENT_GOAL, EVENT_PLAY, EVENT_ROLE, EVENT_KICK, EVENT_BALL_SPEED, EVENT_FOUL, EVENT_PASS};
+
+/// pass イベント検出には /world_model のロボット配列が必要（ball-only モード不可）
+bool event_types_require_full_world_model(const std::vector<std::string> & types);
 
 std::vector<Event> detect_events(const BagData & data, const std::vector<std::string> & types = {});
 
@@ -47,6 +51,7 @@ std::vector<Event> detect_kick_events(const BagData & data);
 std::vector<Event> detect_ball_speed_spikes(const BagData & data, double threshold = 3.0);
 std::vector<Event> detect_goals(const BagData & data);
 std::vector<Event> detect_fouls(const BagData & data);
+std::vector<Event> detect_pass_attempt_events(const BagData & data);
 
 std::string game_event_type_to_string(int32_t type_value);
 

--- a/crane_bag/src/bag/bag_json.hpp
+++ b/crane_bag/src/bag/bag_json.hpp
@@ -10,6 +10,7 @@
 
 #include "bag_control.hpp"
 #include "bag_events.hpp"
+#include "bag_pass.hpp"
 #include "bag_reader.hpp"
 #include "bag_referee.hpp"
 #include "bag_tracking.hpp"
@@ -140,6 +141,53 @@ inline void to_json(nlohmann::json & j, const RefereeSnapshot & v)
     j["next_command"] = nullptr;
     j["next_command_value"] = nullptr;
   }
+}
+
+// PassEvent
+inline void to_json(nlohmann::json & j, const PassEvent & v)
+{
+  j = {
+    {"t", v.t},
+    {"timestamp_ns", v.timestamp_ns},
+    {"kicker_id", v.kicker_id},
+    {"intended_receiver_id", v.intended_receiver_id},
+    {"reserved_receiver_id", v.reserved_receiver_id},
+    {"outcome", to_string(v.outcome)},
+    {"first_toucher_id", v.first_toucher_id},
+    {"first_toucher_ours", v.first_toucher_ours},
+    {"kick_speed", v.kick_speed},
+    {"pass_distance", v.pass_distance},
+    {"forward_progress", v.forward_progress},
+    {"duration", v.duration},
+    {"kick_pos", {{"x", v.kick_pos.x}, {"y", v.kick_pos.y}}},
+    {"end_pos", {{"x", v.end_pos.x}, {"y", v.end_pos.y}}},
+  };
+}
+
+// PassSummary
+inline void to_json(nlohmann::json & j, const PassSummary & v)
+{
+  nlohmann::json bands = nlohmann::json::array();
+  for (size_t b = 0; b < v.band_attempts.size(); ++b) {
+    bands.push_back(
+      {{"band", kPassDistanceBandLabels[b]},
+       {"attempts", v.band_attempts[b]},
+       {"success", v.band_success[b]}});
+  }
+  j = {
+    {"attempts", v.attempts},
+    {"success", v.success},
+    {"wrong_receiver", v.wrong_receiver},
+    {"intercepted", v.intercepted},
+    {"overrun", v.overrun},
+    {"out_of_play", v.out_of_play},
+    {"unresolved", v.unresolved},
+    {"avg_distance", v.avg_distance},
+    {"avg_forward_progress", v.avg_forward_progress},
+    {"avg_duration", v.avg_duration},
+    {"avg_kick_speed", v.avg_kick_speed},
+    {"by_distance_band", bands},
+  };
 }
 
 }  // namespace crane::bag

--- a/crane_bag/src/bag/bag_pass.cpp
+++ b/crane_bag/src/bag/bag_pass.cpp
@@ -1,0 +1,422 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "bag_pass.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <sstream>
+
+namespace crane::bag
+{
+
+namespace
+{
+
+// ─── 検出パラメータ ──────────────────────────────────────────────────────────
+// vision ノイズと実測レートを考慮した閾値。値の根拠はコメント参照。
+
+/// キック開始とみなすボール速度の立ち上がり閾値 [m/s]
+constexpr double kKickDetectSpeed = 1.5;
+/// 立ち上がり確認用の次フレーム最低速度 [m/s]（単発ノイズ除去）
+constexpr double kKickConfirmSpeed = 1.2;
+/// キッカー帰属のためのボール近傍距離 [m]
+constexpr double kKickProximity = 0.35;
+/// ongoing_kick を探す先読み時間 [s]（検出器の遅延吸収）
+constexpr double kOngoingKickLookahead = 0.25;
+/// キック直後に接触・停止判定を無効化する時間 [s]（キッカー自身の接触除外）
+constexpr double kSettleTime = 0.15;
+/// 接触とみなすロボット中心-ボール距離 [m]（ロボット半径0.09+ボール半径0.02+マージン）
+constexpr double kContactDist = 0.15;
+/// ball_contact スタンプを「接触中」とみなす鮮度 [s]
+constexpr double kContactRecentSec = 0.1;
+/// キッカー自身の再接触を有効とみなすためにボールがキック点から離れるべき距離 [m]
+constexpr double kKickerReleaseDist = 0.5;
+/// パス終端（こぼれ）とみなすボール速度 [m/s]
+constexpr double kStopSpeed = 0.3;
+/// チップキック飛行中とみなすボール高さ [m]（距離ベース接触判定を無効化）
+constexpr double kFlyingHeight = 0.15;
+/// 追跡打ち切り時間 [s]
+constexpr double kMaxTrackTime = 5.0;
+/// シュート除外: ゴールマウス角度範囲に加えるマージン [rad]
+constexpr double kShotConeMargin = 0.1;
+/// ゴールマウス半幅 [m]（bag_events.cpp の detect_goals と同一値）
+constexpr double kGoalHalfWidth = 0.5;
+/// 場外判定マージン [m]
+constexpr double kOutOfFieldMargin = 0.05;
+
+double norm2(double x, double y) { return std::sqrt(x * x + y * y); }
+
+double ball_speed(const WorldModel & wm)
+{
+  return norm2(wm.ball_info.velocity.x, wm.ball_info.velocity.y);
+}
+
+double dist2d(const Point2D & a, double bx, double by) { return norm2(a.x - bx, a.y - by); }
+
+/// 攻撃方向は +x（world_model は自ゴールが -x に正規化されている。detect_goals と同前提）
+bool is_shot_direction(const WorldModel & wm, const Point2D & kick_pos)
+{
+  const double half_length = wm.field_info.x / 2.0;
+  if (half_length <= 0.0) {
+    return false;  // フィールド情報なし（合成データ等）は除外しない
+  }
+  if (kick_pos.x >= half_length) {
+    return false;  // ゴールラインより先からのキックは角度が定義できない
+  }
+  const double vx = wm.ball_info.velocity.x;
+  const double vy = wm.ball_info.velocity.y;
+  if (norm2(vx, vy) < 1e-6) {
+    return false;
+  }
+  const double dir = std::atan2(vy, vx);
+  const double angle_high = std::atan2(kGoalHalfWidth - kick_pos.y, half_length - kick_pos.x);
+  const double angle_low = std::atan2(-kGoalHalfWidth - kick_pos.y, half_length - kick_pos.x);
+  return dir >= angle_low - kShotConeMargin && dir <= angle_high + kShotConeMargin;
+}
+
+/// 意図受け手がキック射線の近く（前方0.3m以降・横ずれ0.6m以内）にいるか。
+/// ゴール方向へのキックでも、受け手が射線上にいるならパスとみなすために使う。
+bool receiver_on_kick_ray(const WorldModel & wm, const Point2D & kick_pos, int32_t receiver_id)
+{
+  const double vx = wm.ball_info.velocity.x;
+  const double vy = wm.ball_info.velocity.y;
+  const double vnorm = norm2(vx, vy);
+  if (vnorm < 1e-6) {
+    return false;
+  }
+  for (const auto & r : wm.robot_info_ours) {
+    if (static_cast<int32_t>(r.id) != receiver_id) {
+      continue;
+    }
+    const double rx = r.pose.x - kick_pos.x;
+    const double ry = r.pose.y - kick_pos.y;
+    const double along = (rx * vx + ry * vy) / vnorm;
+    if (along < 0.3) {
+      return false;
+    }
+    const double perp = std::abs(rx * vy - ry * vx) / vnorm;
+    return perp <= 0.6;
+  }
+  return false;
+}
+
+struct ContactHit
+{
+  int32_t id = -1;
+  bool ours = false;
+  double dist = std::numeric_limits<double>::max();
+};
+
+}  // namespace
+
+std::string to_string(PassOutcome o)
+{
+  switch (o) {
+    case PassOutcome::SUCCESS:
+      return "SUCCESS";
+    case PassOutcome::WRONG_RECEIVER:
+      return "WRONG_RECEIVER";
+    case PassOutcome::INTERCEPTED:
+      return "INTERCEPTED";
+    case PassOutcome::OVERRUN:
+      return "OVERRUN";
+    case PassOutcome::OUT_OF_PLAY:
+      return "OUT_OF_PLAY";
+    case PassOutcome::UNRESOLVED:
+      return "UNRESOLVED";
+  }
+  return "UNKNOWN";
+}
+
+size_t pass_distance_band(double distance)
+{
+  if (distance < 1.5) return 0;
+  if (distance <= 4.0) return 1;
+  return 2;
+}
+
+std::vector<PassEvent> detect_pass_events(const BagData & data)
+{
+  std::vector<PassEvent> events;
+  const auto & wms = data.world_models;
+  if (wms.size() < 2) {
+    return events;
+  }
+
+  bool prev_above = ball_speed(wms.front().msg) >= kKickDetectSpeed;
+
+  for (size_t i = 1; i < wms.size(); ++i) {
+    const auto & wm = wms[i].msg;
+    const double speed = ball_speed(wm);
+    const bool above = speed >= kKickDetectSpeed;
+    if (!above || prev_above) {
+      prev_above = above;
+      continue;
+    }
+    prev_above = above;
+
+    // 単発ノイズ除去: 次フレームでも速度が維持されていること
+    if (i + 1 < wms.size() && ball_speed(wms[i + 1].msg) < kKickConfirmSpeed) {
+      continue;
+    }
+
+    const auto & prev_wm = wms[i - 1].msg;
+    const Point2D kick_pos = {prev_wm.ball_info.position.x, prev_wm.ball_info.position.y};
+
+    // ─ キッカー帰属: ongoing_kick を優先、なければ最近傍ロボット ─
+    int32_t kicker_id = -1;
+    bool attribution_found = false;
+    bool enemy_kick = false;
+    for (size_t j = i; j < wms.size(); ++j) {
+      if (
+        wms[j].t(data.info.start_time_ns) - wms[i].t(data.info.start_time_ns) >
+        kOngoingKickLookahead) {
+        break;
+      }
+      const auto & ok = wms[j].msg.ongoing_kick;
+      if (ok.present) {
+        attribution_found = true;
+        enemy_kick = !ok.is_kicker_friend;
+        kicker_id = ok.kicker_id;
+        break;
+      }
+    }
+    if (!attribution_found) {
+      // フォールバック: キック直前のボールに最も近いロボット
+      double our_best = std::numeric_limits<double>::max();
+      double their_best = std::numeric_limits<double>::max();
+      int32_t our_best_id = -1;
+      for (const auto & r : prev_wm.robot_info_ours) {
+        const double d = dist2d(kick_pos, r.pose.x, r.pose.y);
+        if (d < our_best) {
+          our_best = d;
+          our_best_id = r.id;
+        }
+      }
+      for (const auto & r : prev_wm.robot_info_theirs) {
+        their_best = std::min(their_best, dist2d(kick_pos, r.pose.x, r.pose.y));
+      }
+      if (our_best <= kKickProximity && our_best <= their_best) {
+        kicker_id = our_best_id;
+      } else {
+        enemy_kick = true;
+      }
+    }
+    if (enemy_kick || kicker_id < 0) {
+      continue;
+    }
+
+    // ─ パス意図: キック判断時点（直前フレーム）の pass_target_id ─
+    int32_t intended = prev_wm.pass_target_id >= 0 ? prev_wm.pass_target_id : wm.pass_target_id;
+    if (intended < 0 || intended == kicker_id) {
+      continue;  // パス意図なし（シュート・クリア等）
+    }
+    const int32_t reserved = prev_wm.recommended_pass_receiver_id;
+
+    // ─ シュート除外: キック方向がゴールマウスを向いている ─
+    // ただし意図受け手が射線上にいる場合はパスとして扱う
+    if (is_shot_direction(wm, kick_pos) && !receiver_on_kick_ray(wm, kick_pos, intended)) {
+      continue;
+    }
+
+    // ─ パス試行として追跡 ─
+    PassEvent ev;
+    ev.timestamp_ns = wms[i].timestamp_ns;
+    ev.t = wms[i].t(data.info.start_time_ns);
+    ev.kicker_id = kicker_id;
+    ev.intended_receiver_id = intended;
+    ev.reserved_receiver_id = reserved;
+    ev.kick_pos = kick_pos;
+
+    const int64_t kick_header_ns = wm.header_stamp_ns;
+    bool ball_left_kicker = false;
+    size_t resolve_frame = wms.size() - 1;
+
+    for (size_t j = i; j < wms.size(); ++j) {
+      const auto & cur = wms[j].msg;
+      const double dt = (wms[j].timestamp_ns - wms[i].timestamp_ns) / 1e9;
+      const double cur_speed = ball_speed(cur);
+      const double bx = cur.ball_info.position.x;
+      const double by = cur.ball_info.position.y;
+
+      if (dt <= 0.3) {
+        ev.kick_speed = std::max(ev.kick_speed, cur_speed);
+      }
+      if (!ball_left_kicker && norm2(bx - kick_pos.x, by - kick_pos.y) > kKickerReleaseDist) {
+        ball_left_kicker = true;
+      }
+
+      ev.end_pos = {bx, by};
+      ev.duration = dt;
+      resolve_frame = j;
+
+      if (dt < kSettleTime) {
+        continue;
+      }
+
+      // 場外
+      const double half_x = cur.field_info.x / 2.0;
+      const double half_y = cur.field_info.y / 2.0;
+      if (
+        half_x > 0.0 &&
+        (std::abs(bx) > half_x + kOutOfFieldMargin || std::abs(by) > half_y + kOutOfFieldMargin)) {
+        ev.outcome = PassOutcome::OUT_OF_PLAY;
+        break;
+      }
+
+      // 接触判定（チップ飛行中は距離ベース判定を無効化）
+      const bool flying = cur.ball_info.position.z > kFlyingHeight;
+      ContactHit hit;
+      for (const auto & r : cur.robot_info_ours) {
+        if (r.id == kicker_id && !ball_left_kicker) {
+          continue;  // キッカー自身の接触はボールが離れるまで除外
+        }
+        const double d = dist2d({r.pose.x, r.pose.y}, bx, by);
+        const bool by_stamp =
+          kick_header_ns > 0 && r.ball_contact_last_ns > 0 && cur.header_stamp_ns > 0 &&
+          r.ball_contact_last_ns >= kick_header_ns + static_cast<int64_t>(kSettleTime * 1e9) &&
+          (cur.header_stamp_ns - r.ball_contact_last_ns) <=
+            static_cast<int64_t>(kContactRecentSec * 1e9);
+        const bool by_dist = !flying && d <= kContactDist;
+        if ((by_stamp || by_dist) && d < hit.dist) {
+          hit = {static_cast<int32_t>(r.id), true, d};
+        }
+      }
+      if (!flying) {
+        for (const auto & r : cur.robot_info_theirs) {
+          const double d = dist2d({r.pose.x, r.pose.y}, bx, by);
+          if (d <= kContactDist && d < hit.dist) {
+            hit = {static_cast<int32_t>(r.id), false, d};
+          }
+        }
+      }
+      if (hit.id >= 0) {
+        ev.first_toucher_id = hit.id;
+        ev.first_toucher_ours = hit.ours;
+        if (!hit.ours) {
+          ev.outcome = PassOutcome::INTERCEPTED;
+        } else if (hit.id == intended) {
+          ev.outcome = PassOutcome::SUCCESS;
+        } else {
+          ev.outcome = PassOutcome::WRONG_RECEIVER;
+        }
+        break;
+      }
+
+      // 停止（こぼれ）
+      if (cur_speed < kStopSpeed) {
+        ev.outcome = PassOutcome::OVERRUN;
+        break;
+      }
+
+      // 打ち切り
+      if (dt > kMaxTrackTime) {
+        ev.outcome = PassOutcome::UNRESOLVED;
+        break;
+      }
+    }
+
+    ev.pass_distance = norm2(ev.end_pos.x - ev.kick_pos.x, ev.end_pos.y - ev.kick_pos.y);
+    ev.forward_progress = ev.end_pos.x - ev.kick_pos.x;
+    events.push_back(ev);
+
+    // 解決フレームから走査を再開（同一キックの二重検出を防ぐ）
+    i = resolve_frame;
+    prev_above = ball_speed(wms[resolve_frame].msg) >= kKickDetectSpeed;
+  }
+
+  return events;
+}
+
+PassSummary summarize_passes(const std::vector<PassEvent> & events)
+{
+  PassSummary s;
+  s.attempts = events.size();
+  if (events.empty()) {
+    return s;
+  }
+
+  double sum_dist = 0, sum_fwd = 0, sum_dur = 0, sum_speed = 0;
+  for (const auto & e : events) {
+    switch (e.outcome) {
+      case PassOutcome::SUCCESS:
+        ++s.success;
+        break;
+      case PassOutcome::WRONG_RECEIVER:
+        ++s.wrong_receiver;
+        break;
+      case PassOutcome::INTERCEPTED:
+        ++s.intercepted;
+        break;
+      case PassOutcome::OVERRUN:
+        ++s.overrun;
+        break;
+      case PassOutcome::OUT_OF_PLAY:
+        ++s.out_of_play;
+        break;
+      case PassOutcome::UNRESOLVED:
+        ++s.unresolved;
+        break;
+    }
+    sum_dist += e.pass_distance;
+    sum_fwd += e.forward_progress;
+    sum_dur += e.duration;
+    sum_speed += e.kick_speed;
+    const size_t band = pass_distance_band(e.pass_distance);
+    ++s.band_attempts[band];
+    if (e.outcome == PassOutcome::SUCCESS) {
+      ++s.band_success[band];
+    }
+  }
+  const double n = static_cast<double>(events.size());
+  s.avg_distance = sum_dist / n;
+  s.avg_forward_progress = sum_fwd / n;
+  s.avg_duration = sum_dur / n;
+  s.avg_kick_speed = sum_speed / n;
+  return s;
+}
+
+std::string format_pass_summary(const PassSummary & s)
+{
+  std::ostringstream out;
+  char buf[256];
+  out << "=== PASS SUMMARY (ours) ===\n";
+  std::snprintf(buf, sizeof(buf), "attempts: %zu\n", s.attempts);
+  out << buf;
+  if (s.attempts == 0) {
+    return out.str();
+  }
+  const double rate = 100.0 * static_cast<double>(s.success) / static_cast<double>(s.attempts);
+  const double int_rate =
+    100.0 * static_cast<double>(s.intercepted) / static_cast<double>(s.attempts);
+  std::snprintf(
+    buf, sizeof(buf),
+    "success: %zu (%.1f%%)  wrong_receiver: %zu  intercepted: %zu (%.1f%%)  overrun: %zu  "
+    "out_of_play: %zu  unresolved: %zu\n",
+    s.success, rate, s.wrong_receiver, s.intercepted, int_rate, s.overrun, s.out_of_play,
+    s.unresolved);
+  out << buf;
+  std::snprintf(
+    buf, sizeof(buf),
+    "avg pass distance: %.2fm / avg forward progress: %+.2fm / avg duration: %.2fs / avg kick "
+    "speed: %.2fm/s\n",
+    s.avg_distance, s.avg_forward_progress, s.avg_duration, s.avg_kick_speed);
+  out << buf;
+  out << "by distance band:";
+  for (size_t b = 0; b < 3; ++b) {
+    std::snprintf(
+      buf, sizeof(buf), "  %s: %zu/%zu", kPassDistanceBandLabels[b], s.band_success[b],
+      s.band_attempts[b]);
+    out << buf;
+  }
+  out << "\n";
+  return out.str();
+}
+
+}  // namespace crane::bag

--- a/crane_bag/src/bag/bag_pass.hpp
+++ b/crane_bag/src/bag/bag_pass.hpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include "bag_reader.hpp"
+
+namespace crane::bag
+{
+
+/// パス試行の結果分類
+enum class PassOutcome {
+  SUCCESS,         ///< 意図した受け手（キック時点の pass_target_id）が最初に接触
+  WRONG_RECEIVER,  ///< 意図と別の味方が最初に接触（機能的成功・意図不一致）
+  INTERCEPTED,     ///< 敵が最初に接触
+  OVERRUN,         ///< 誰も触れずにボールが停止（届かない・こぼれた）
+  OUT_OF_PLAY,     ///< ボールが場外に出た
+  UNRESOLVED,      ///< bag終端・追跡打ち切りで結果不明
+};
+
+std::string to_string(PassOutcome o);
+
+/// 検出されたパス試行1件。
+/// 注意: 「味方キック + キック時点で pass_target_id が有効 + 非シュート方向」を
+/// パス試行とみなすヒューリスティック分類であり、少数の偽陽性/偽陰性を含み得る。
+struct PassEvent
+{
+  int64_t timestamp_ns = 0;  ///< キック検出時刻（bagタイムスタンプ）
+  double t = 0.0;            ///< bag先頭からの相対秒
+  int32_t kicker_id = -1;
+  int32_t intended_receiver_id = -1;  ///< キック時点の pass_target_id
+  int32_t reserved_receiver_id = -1;  ///< キック時点の recommended_pass_receiver_id
+  PassOutcome outcome = PassOutcome::UNRESOLVED;
+  int32_t first_toucher_id = -1;  ///< 最初にボールに触れたロボット（-1: なし）
+  bool first_toucher_ours = false;
+  double kick_speed = 0.0;        ///< キック直後の最大ボール速度 [m/s]
+  double pass_distance = 0.0;     ///< キック点→解決点の距離 [m]
+  double forward_progress = 0.0;  ///< 攻撃方向(+x)への前進距離 [m]
+  double duration = 0.0;          ///< キック→解決までの時間 [s]
+  Point2D kick_pos;
+  Point2D end_pos;
+};
+
+/// 距離帯: [0]=<1.5m, [1]=1.5-4.0m, [2]=>4.0m
+inline constexpr std::array<const char *, 3> kPassDistanceBandLabels = {
+  "<1.5m", "1.5-4.0m", ">4.0m"};
+
+struct PassSummary
+{
+  size_t attempts = 0;
+  size_t success = 0;
+  size_t wrong_receiver = 0;
+  size_t intercepted = 0;
+  size_t overrun = 0;
+  size_t out_of_play = 0;
+  size_t unresolved = 0;
+  double avg_distance = 0.0;
+  double avg_forward_progress = 0.0;
+  double avg_duration = 0.0;
+  double avg_kick_speed = 0.0;
+  std::array<size_t, 3> band_attempts{};
+  std::array<size_t, 3> band_success{};
+};
+
+/// /world_model 時系列から味方のパス試行と結果を検出する。
+/// BagData のみに依存する純粋関数（合成データで単体テスト可能）。
+std::vector<PassEvent> detect_pass_events(const BagData & data);
+
+PassSummary summarize_passes(const std::vector<PassEvent> & events);
+
+std::string format_pass_summary(const PassSummary & s);
+
+/// 距離帯インデックス（kPassDistanceBandLabels に対応）
+size_t pass_distance_band(double distance);
+
+}  // namespace crane::bag

--- a/crane_bag/src/bag/bag_types.hpp
+++ b/crane_bag/src/bag/bag_types.hpp
@@ -47,6 +47,18 @@ struct RobotInfo
   Pose2D pose;
   Point2D velocity;
   bool available_vision = false;
+  /// ball_contact/last_contacted_time [ns]（WorldModel header と同一クロック）
+  int64_t ball_contact_last_ns = 0;
+};
+
+/// WorldModel.game_analysis.ongoing_kick[<=1] の抜粋（パス解析用）
+struct OngoingKickInfo
+{
+  bool present = false;
+  int32_t kicker_id = -1;
+  bool is_kicker_friend = false;
+  Point2D origin;
+  double direction = 0.0;
 };
 
 struct FieldInfo
@@ -61,6 +73,12 @@ struct WorldModel
   bool is_yellow = false;
   std::vector<RobotInfo> robot_info_ours;
   std::vector<RobotInfo> robot_info_theirs;
+  /// header/stamp [ns]。ball_contact_last_ns との比較に使う（同一クロック保証）
+  int64_t header_stamp_ns = 0;
+  // ─ 内包 game_analysis の抜粋（パス解析用。未記録の古いbagでは既定値）─
+  int32_t pass_target_id = -1;
+  int32_t recommended_pass_receiver_id = -1;
+  OngoingKickInfo ongoing_kick;
 };
 
 // ─── PlaySituation ────────────────────────────────────────────────────────────

--- a/crane_bag/src/bag/crane_bag_main.cpp
+++ b/crane_bag/src/bag/crane_bag_main.cpp
@@ -15,6 +15,7 @@
 #include "bag_control.hpp"
 #include "bag_events.hpp"
 #include "bag_json.hpp"
+#include "bag_pass.hpp"
 #include "bag_reader.hpp"
 #include "bag_referee.hpp"
 #include "bag_survey.hpp"
@@ -67,7 +68,7 @@ static Args parse_args(int argc, char ** argv)
     std::fprintf(
       stderr,
       "使い方: crane_bag <command> <bag_path> [options]\n"
-      "コマンド: info, survey, track, events, control, referee\n");
+      "コマンド: info, survey, track, events, control, referee, pass\n");
     std::exit(1);
   }
 
@@ -219,7 +220,9 @@ static void cmd_events(const Args & args)
   opts.topics = topics_for_event_types(args.event_types);
   // goal/ball_speed は world_model を全件走査するが ball/field しか使わないため、
   // ロボット配列を破棄する高速デシリアライズを有効化する。
-  opts.world_model_ball_only = opts.topics.count("/world_model") > 0;
+  // ただし pass 検出はロボット配列・game_analysis を必要とするため全量読みに切り替える。
+  opts.world_model_ball_only = opts.topics.count("/world_model") > 0 &&
+                               !crane::bag::event_types_require_full_world_model(args.event_types);
   auto data = BagReader::read(args.bag_path, opts);
   auto events = detect_events(data, args.event_types);
 
@@ -341,6 +344,53 @@ static void cmd_referee(const Args & args)
   }
 }
 
+static void cmd_pass(const Args & args)
+{
+  std::fprintf(stderr, "Reading %s ...\n", args.bag_path.c_str());
+  ReadOptions opts;
+  // 接触タイミングの精度が要るため全レートで読む（ダウンサンプルなし）
+  opts.topics = {"/world_model"};
+  opts.time_range = args.time_range;
+  auto data = BagReader::read(args.bag_path, opts);
+
+  if (data.world_models.empty()) {
+    std::printf("/world_model トピックが見つかりません\n");
+    return;
+  }
+
+  auto events = crane::bag::detect_pass_events(data);
+  auto summary = crane::bag::summarize_passes(events);
+
+  if (args.format == "json") {
+    nlohmann::json j;
+    j["events"] = events;
+    j["summary"] = summary;
+    std::printf("%s\n", j.dump(2).c_str());
+    return;
+  }
+
+  std::printf("%s", crane::bag::format_pass_summary(summary).c_str());
+  if (!events.empty()) {
+    std::printf("\n=== PASS EVENTS (%zu) ===\n", events.size());
+    for (const auto & e : events) {
+      std::string notes;
+      if (
+        e.first_toucher_id >= 0 &&
+        !(e.first_toucher_ours && e.first_toucher_id == e.intended_receiver_id)) {
+        notes += std::string("  toucher=") + (e.first_toucher_ours ? "our" : "their") +
+                 std::to_string(e.first_toucher_id);
+      }
+      if (e.reserved_receiver_id >= 0 && e.reserved_receiver_id != e.intended_receiver_id) {
+        notes += "  reserved=" + std::to_string(e.reserved_receiver_id);
+      }
+      std::printf(
+        "  t=%8.2f  %d -> %-2d  %-14s d=%5.2fm v=%4.2fm/s fwd=%+5.2fm dur=%4.2fs%s\n", e.t,
+        e.kicker_id, e.intended_receiver_id, crane::bag::to_string(e.outcome).c_str(),
+        e.pass_distance, e.kick_speed, e.forward_progress, e.duration, notes.c_str());
+    }
+  }
+}
+
 // ─── main ──────────────────────────────────────────────────────────────────
 
 int main(int argc, char ** argv)
@@ -354,7 +404,8 @@ int main(int argc, char ** argv)
       "  survey   <path>                                             概要サーベイを実行\n"
       "  track    <path> --robot <id>|--ball [--enemy]              ロボット/ボール追跡\n"
       "                  [--time start:end] [--interval 0.5] [--format json|text]\n"
-      "  events   <path> [--type goal kick play role ball_speed foul] [--format json|text]\n"
+      "  events   <path> [--type goal kick play role ball_speed foul pass] [--format json|text]\n"
+      "  pass     <path> [--time start:end] [--format json|text]    パス試行の検出とKPI集計\n"
       "  control  <path> --robot <id> [--time start:end] [--changes-only] [--format json|text]\n"
       "  referee  <path> [--time start:end] [--changes-only] [--format json|text]\n"
       "           デフォルト: 全メッセージをサンプリング (--interval で間隔指定)\n"
@@ -377,6 +428,8 @@ int main(int argc, char ** argv)
       cmd_control(args);
     } else if (args.command == "referee") {
       cmd_referee(args);
+    } else if (args.command == "pass") {
+      cmd_pass(args);
     } else {
       std::fprintf(stderr, "不明なコマンド: %s\n", args.command.c_str());
       return 1;

--- a/crane_bag/src/bag/msg_extractors.cpp
+++ b/crane_bag/src/bag/msg_extractors.cpp
@@ -156,10 +156,38 @@ WorldModel extract_world_model(const RosMsgParser::FlatMessage & flat)
       r.velocity.y = m.get_d_exact(FlatValueMap::arr_path(prefix, i, "velocity/y"));
       r.available_vision =
         m.get_d_exact(FlatValueMap::arr_path(prefix, i, "available_vision")) != 0.0;
+      r.ball_contact_last_ns =
+        static_cast<int64_t>(m.get_d_exact(
+          FlatValueMap::arr_path(prefix, i, "ball_contact/last_contacted_time/sec"))) *
+          1'000'000'000LL +
+        static_cast<int64_t>(m.get_d_exact(
+          FlatValueMap::arr_path(prefix, i, "ball_contact/last_contacted_time/nanosec")));
     }
   };
   fill_robots(p + "/robot_info_ours", wm.robot_info_ours);
   fill_robots(p + "/robot_info_theirs", wm.robot_info_theirs);
+
+  // header stamp（ball_contact と同一クロックでの時刻基準）
+  wm.header_stamp_ns =
+    static_cast<int64_t>(m.get_d_exact(p + "/header/stamp/sec")) * 1'000'000'000LL +
+    static_cast<int64_t>(m.get_d_exact(p + "/header/stamp/nanosec"));
+
+  // 内包 game_analysis の抜粋（パス解析用）。ball-only モードや古いbagでは既定値のまま。
+  const std::string ga = p + "/game_analysis";
+  wm.pass_target_id = static_cast<int32_t>(m.get_d_exact(ga + "/pass_target_id", -1.0));
+  wm.recommended_pass_receiver_id =
+    static_cast<int32_t>(m.get_d_exact(ga + "/recommended_pass_receiver_id", -1.0));
+  const std::string ok_prefix = ga + "/ongoing_kick";
+  if (m.count_array(ok_prefix) > 0) {
+    wm.ongoing_kick.present = true;
+    wm.ongoing_kick.kicker_id =
+      static_cast<int32_t>(m.get_d_exact(FlatValueMap::arr_path(ok_prefix, 0, "kicker_id"), -1.0));
+    wm.ongoing_kick.is_kicker_friend =
+      m.get_d_exact(FlatValueMap::arr_path(ok_prefix, 0, "is_kicker_friend")) != 0.0;
+    wm.ongoing_kick.origin.x = m.get_d_exact(FlatValueMap::arr_path(ok_prefix, 0, "origin_x"));
+    wm.ongoing_kick.origin.y = m.get_d_exact(FlatValueMap::arr_path(ok_prefix, 0, "origin_y"));
+    wm.ongoing_kick.direction = m.get_d_exact(FlatValueMap::arr_path(ok_prefix, 0, "direction"));
+  }
 
   return wm;
 }

--- a/crane_bag/test/test_bag_pass.cpp
+++ b/crane_bag/test/test_bag_pass.cpp
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "bag_pass.hpp"
+
+namespace cb = crane::bag;
+
+namespace
+{
+
+constexpr double kDt = 0.02;  // 50Hz
+
+/// 合成 WorldModel 時系列のビルダー。
+/// record() 時点の状態をフレームとして積み、step() でボール物理（等減速転がり）を進める。
+struct Sim
+{
+  cb::BagData data;
+  double t = 0.0;
+  double ball_x = 0.0, ball_y = 0.0, ball_z = 0.0;
+  double vel_x = 0.0, vel_y = 0.0;
+  double decel = 0.5;  // [m/s^2]
+  std::vector<cb::RobotInfo> ours;
+  std::vector<cb::RobotInfo> theirs;
+  int32_t pass_target_id = -1;
+  int32_t reserved_id = -1;
+  cb::OngoingKickInfo ongoing;
+
+  Sim() { data.info.start_time_ns = 0; }
+
+  cb::RobotInfo & our(uint8_t id)
+  {
+    for (auto & r : ours) {
+      if (r.id == id) return r;
+    }
+    cb::RobotInfo r;
+    r.id = id;
+    r.available_vision = true;
+    ours.push_back(r);
+    return ours.back();
+  }
+
+  cb::RobotInfo & their(uint8_t id)
+  {
+    for (auto & r : theirs) {
+      if (r.id == id) return r;
+    }
+    cb::RobotInfo r;
+    r.id = id;
+    r.available_vision = true;
+    theirs.push_back(r);
+    return theirs.back();
+  }
+
+  void place_our(uint8_t id, double x, double y)
+  {
+    auto & r = our(id);
+    r.pose.x = x;
+    r.pose.y = y;
+  }
+
+  void place_their(uint8_t id, double x, double y)
+  {
+    auto & r = their(id);
+    r.pose.x = x;
+    r.pose.y = y;
+  }
+
+  void kick(double vx, double vy, int32_t kicker_id, bool friendly = true)
+  {
+    vel_x = vx;
+    vel_y = vy;
+    ongoing.present = true;
+    ongoing.kicker_id = kicker_id;
+    ongoing.is_kicker_friend = friendly;
+    ongoing.origin = {ball_x, ball_y};
+    ongoing.direction = std::atan2(vy, vx);
+  }
+
+  int64_t now_ns() const { return static_cast<int64_t>(t * 1e9); }
+
+  void step(size_t n = 1)
+  {
+    for (size_t k = 0; k < n; ++k) {
+      cb::TimestampedMsg<cb::WorldModel> f;
+      f.timestamp_ns = now_ns();
+      auto & wm = f.msg;
+      wm.header_stamp_ns = f.timestamp_ns;
+      wm.ball_info.position = {ball_x, ball_y, ball_z};
+      wm.ball_info.velocity = {vel_x, vel_y};
+      wm.field_info = {12.0, 9.0};
+      wm.robot_info_ours = ours;
+      wm.robot_info_theirs = theirs;
+      wm.pass_target_id = pass_target_id;
+      wm.recommended_pass_receiver_id = reserved_id;
+      wm.ongoing_kick = ongoing;
+      data.world_models.push_back(f);
+
+      t += kDt;
+      ball_x += vel_x * kDt;
+      ball_y += vel_y * kDt;
+      const double speed = std::sqrt(vel_x * vel_x + vel_y * vel_y);
+      if (speed > 0.0) {
+        const double new_speed = std::max(0.0, speed - decel * kDt);
+        vel_x *= new_speed / speed;
+        vel_y *= new_speed / speed;
+      }
+    }
+  }
+};
+
+}  // namespace
+
+TEST(BagPass, SuccessfulPassToIntendedReceiver)
+{
+  Sim sim;
+  sim.place_our(1, 0.0, -0.1);  // キッカー
+  sim.place_our(3, 2.0, 2.0);   // 受け手（45°方向 2.83m 先）
+  sim.pass_target_id = 3;
+  sim.reserved_id = 3;
+  sim.step(10);               // 静止 0.2s
+  sim.kick(2.121, 2.121, 1);  // |v| = 3.0, 45°
+  sim.step(100);              // 2.0s 追跡
+
+  auto events = cb::detect_pass_events(sim.data);
+  ASSERT_EQ(events.size(), 1u);
+  const auto & e = events[0];
+  EXPECT_EQ(e.outcome, cb::PassOutcome::SUCCESS);
+  EXPECT_EQ(e.kicker_id, 1);
+  EXPECT_EQ(e.intended_receiver_id, 3);
+  EXPECT_EQ(e.reserved_receiver_id, 3);
+  EXPECT_EQ(e.first_toucher_id, 3);
+  EXPECT_TRUE(e.first_toucher_ours);
+  EXPECT_NEAR(e.kick_speed, 3.0, 0.15);
+  EXPECT_NEAR(e.pass_distance, 2.83, 0.3);
+  EXPECT_GT(e.forward_progress, 1.5);
+
+  auto s = cb::summarize_passes(events);
+  EXPECT_EQ(s.attempts, 1u);
+  EXPECT_EQ(s.success, 1u);
+  EXPECT_EQ(s.band_attempts[1], 1u);  // 1.5-4.0m 帯
+  EXPECT_EQ(s.band_success[1], 1u);
+}
+
+TEST(BagPass, InterceptedByEnemyOnPassLine)
+{
+  Sim sim;
+  sim.place_our(1, 0.0, -0.1);
+  sim.place_our(3, 3.0, 3.0);
+  sim.place_their(7, 1.0, 1.0);  // パスライン上の敵
+  sim.pass_target_id = 3;
+  sim.step(10);
+  sim.kick(2.121, 2.121, 1);
+  sim.step(150);
+
+  auto events = cb::detect_pass_events(sim.data);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].outcome, cb::PassOutcome::INTERCEPTED);
+  EXPECT_EQ(events[0].first_toucher_id, 7);
+  EXPECT_FALSE(events[0].first_toucher_ours);
+}
+
+TEST(BagPass, WrongReceiverWhenAnotherFriendTouchesFirst)
+{
+  Sim sim;
+  sim.place_our(1, 0.0, -0.1);
+  sim.place_our(3, 3.0, 3.0);  // 意図受け手
+  sim.place_our(4, 1.5, 1.5);  // ライン上の別味方
+  sim.pass_target_id = 3;
+  sim.step(10);
+  sim.kick(2.121, 2.121, 1);
+  sim.step(150);
+
+  auto events = cb::detect_pass_events(sim.data);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].outcome, cb::PassOutcome::WRONG_RECEIVER);
+  EXPECT_EQ(events[0].first_toucher_id, 4);
+  EXPECT_TRUE(events[0].first_toucher_ours);
+}
+
+TEST(BagPass, OverrunWhenBallStopsShort)
+{
+  Sim sim;
+  sim.decel = 1.5;
+  sim.place_our(1, 0.0, -0.1);
+  sim.place_our(3, 5.0, 5.0);  // 遠すぎる受け手
+  sim.pass_target_id = 3;
+  sim.step(10);
+  sim.kick(1.6, 1.6, 1);  // |v|=2.26 → 最大到達 ~1.7m
+  sim.step(200);
+
+  auto events = cb::detect_pass_events(sim.data);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].outcome, cb::PassOutcome::OVERRUN);
+  EXPECT_EQ(events[0].first_toucher_id, -1);
+}
+
+TEST(BagPass, OutOfPlayWhenBallLeavesField)
+{
+  Sim sim;
+  sim.ball_y = 4.0;  // タッチライン際
+  sim.place_our(1, 0.0, 3.9);
+  sim.place_our(3, 2.0, 3.0);
+  sim.pass_target_id = 3;
+  sim.step(10);
+  sim.kick(0.0, 3.0, 1);  // 場外方向
+  sim.step(100);
+
+  auto events = cb::detect_pass_events(sim.data);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].outcome, cb::PassOutcome::OUT_OF_PLAY);
+}
+
+TEST(BagPass, ShotTowardGoalIsExcluded)
+{
+  Sim sim;
+  sim.ball_x = 2.0;
+  sim.place_our(1, 1.9, 0.0);
+  sim.place_our(3, 2.0, 2.0);  // 受け手は射線外
+  sim.pass_target_id = 3;      // 分析器は継続的に pass_target を出している想定
+  sim.step(10);
+  sim.kick(4.0, 0.0, 1);  // ゴールマウス直撃方向
+  sim.step(100);
+
+  auto events = cb::detect_pass_events(sim.data);
+  EXPECT_TRUE(events.empty());
+}
+
+TEST(BagPass, GoalwardKickWithReceiverOnRayIsPass)
+{
+  Sim sim;
+  sim.place_our(1, 0.0, -0.1);
+  sim.place_our(3, 2.5, 0.0);  // ゴール方向の射線上に受け手
+  sim.pass_target_id = 3;
+  sim.step(10);
+  sim.kick(3.0, 0.0, 1);  // ゴール方向だが受け手が射線上
+  sim.step(100);
+
+  auto events = cb::detect_pass_events(sim.data);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].outcome, cb::PassOutcome::SUCCESS);
+}
+
+TEST(BagPass, NoPassTargetMeansNoAttempt)
+{
+  Sim sim;
+  sim.place_our(1, 0.0, -0.1);
+  sim.place_our(3, 2.0, 2.0);
+  sim.pass_target_id = -1;
+  sim.step(10);
+  sim.kick(2.121, 2.121, 1);
+  sim.step(100);
+
+  auto events = cb::detect_pass_events(sim.data);
+  EXPECT_TRUE(events.empty());
+}
+
+TEST(BagPass, EnemyKickIsIgnored)
+{
+  Sim sim;
+  sim.place_their(5, 0.0, -0.1);
+  sim.place_our(3, 2.0, 2.0);
+  sim.pass_target_id = 3;  // 古い値が残っている想定
+  sim.step(10);
+  sim.kick(2.121, 2.121, 5, /*friendly=*/false);
+  sim.step(100);
+
+  auto events = cb::detect_pass_events(sim.data);
+  EXPECT_TRUE(events.empty());
+}
+
+TEST(BagPass, FallbackAttributionWithoutOngoingKick)
+{
+  Sim sim;
+  sim.place_our(1, 0.0, -0.1);  // ボール至近の味方 → キッカー帰属
+  sim.place_our(3, 2.0, 2.0);
+  sim.pass_target_id = 3;
+  sim.step(10);
+  sim.vel_x = 2.121;  // ongoing_kick なしで速度だけ立ち上げる
+  sim.vel_y = 2.121;
+  sim.step(100);
+
+  auto events = cb::detect_pass_events(sim.data);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].kicker_id, 1);
+  EXPECT_EQ(events[0].outcome, cb::PassOutcome::SUCCESS);
+}
+
+TEST(BagPass, StampBasedContactDetection)
+{
+  Sim sim;
+  sim.place_our(1, 0.0, -0.1);
+  sim.place_our(3, 2.0, 2.4);  // 射線から 0.28m 外（距離ベース接触は発火しない）
+  sim.pass_target_id = 3;
+  sim.step(10);
+  sim.kick(2.121, 2.121, 1);
+  // ボールが受け手最接近点付近に到達するまで進める
+  while (sim.ball_x < 2.1) {
+    sim.step(1);
+  }
+  // ドリブラーセンサー接触を模擬（header と同一クロックのスタンプ）
+  sim.our(3).ball_contact_last_ns = sim.now_ns();
+  sim.step(3);
+  sim.our(3).ball_contact_last_ns = 0;
+  sim.step(100);
+
+  auto events = cb::detect_pass_events(sim.data);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].outcome, cb::PassOutcome::SUCCESS);
+  EXPECT_EQ(events[0].first_toucher_id, 3);
+}
+
+TEST(BagPass, DistanceBandBoundaries)
+{
+  EXPECT_EQ(cb::pass_distance_band(0.5), 0u);
+  EXPECT_EQ(cb::pass_distance_band(1.5), 1u);
+  EXPECT_EQ(cb::pass_distance_band(4.0), 1u);
+  EXPECT_EQ(cb::pass_distance_band(4.01), 2u);
+}


### PR DESCRIPTION
## 概要

パスプレイ改良プロジェクトの第一歩（M0-1: 検証基盤）。既存の rosbag（毎週の TIGERs 自動対戦を含む）からパス試行と結果を検出し、改良前のベースライン KPI を確定できるようにします。

## 背景

パスプレイの課題（パス判断・出し手受け手の連携・受け手ポジショニング・実行精度）を改良するにあたり、現状は定量的な計測手段がありません。まず bag からパス成功率等を抽出できるようにし、以後の改良の効果を before/after で比較可能にします。

## 変更内容

- **`crane_bag pass <bag>` サブコマンド新設**: パス試行の検出と KPI 集計（text / json 出力、`--time` 対応）
  - 結果分類: `SUCCESS` / `WRONG_RECEIVER`（別味方が受けた）/ `INTERCEPTED` / `OVERRUN`（誰も触れず停止）/ `OUT_OF_PLAY` / `UNRESOLVED`
  - KPI: 成功率・インターセプト率・距離帯別成功率（<1.5m / 1.5-4.0m / >4.0m）・平均前進距離・平均キック初速など
  - 予約受け手（`recommended_pass_receiver_id`）と意図受け手（`pass_target_id`）の食い違いも記録（今後の受け手一本化の効果測定用）
- **抽出フィールド追加**（`bag_types` / `msg_extractors`）: `ball_contact` スタンプ・header stamp・WorldModel 内包 `game_analysis` の抜粋（`pass_target_id` / `recommended_pass_receiver_id` / `ongoing_kick`）
- **`events` サブコマンドに `pass` イベント種別を追加**（pass 検出時は ball-only 高速モードを自動無効化）
- **crane_bag 初の単体テスト導入**: `BUILD_TESTING` + gtest。合成 WorldModel 時系列 12 ケースで分類器の挙動を固定化

## 検出ロジックの要点

- キック検出: ボール速度の立ち上がり（>1.5 m/s、次フレーム確認付き）
- キッカー帰属: `ongoing_kick`（is_kicker_friend）優先、なければ最近傍ロボットへフォールバック。敵キックは除外
- パス意図: キック判断時点（直前フレーム）の `pass_target_id`。無ければパス試行と見なさない
- シュート除外: キック方向がゴールマウス角度範囲内。ただし意図受け手が射線上にいる場合はパス扱い
- 接触判定: `ball_contact` スタンプ（header と同一クロックで鮮度判定）＋距離ベース。チップ飛行中（z>0.15m）は距離判定を無効化。キッカー自身はボールが 0.5m 離れるまで除外

## 制約（設計上の割り切り）

分類はヒューリスティック近似であり少数の誤分類を含み得ます。PassPlan（意図の明示的共有）導入後に意図ベース判定へ置換し、本分類器はクロスチェック用として残す計画です。

## テスト

- `colcon build --packages-select crane_bag` ✅
- `colcon test --packages-select crane_bag`: **12/12 passed** ✅
- pre-commit（clang-format / cpplint 等）✅