### PR TITLE
fix(crane_game_analyzer): パス評価の敵インターセプトslack符号を修正

### DIFF
--- a/crane_game_analyzer/src/metrics/pass_target_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/pass_target_metrics.cpp
@@ -100,7 +100,11 @@ auto PassTargetMetric::calcScore(
     auto slack_result = ctx.world_model->getBallSlackTime(
       pass_origin, ball_velocity, ball_time, {enemy}, enemy_slack_config_);
 
-    return slack_result.has_value() ? slack_result->slack_time : 1.0;
+    // getBallSlackTime の slack_time = ball_time - robot_time（正なら渡したロボットが
+    // ボールに先着＝インターセプト可能）。ここでは敵を渡すため符号を反転し、
+    // 「敵がボールに間に合わない安全余裕（robot_time - ball_time）」として扱う。
+    // 正＝安全、負＝奪われる。下流の min は最も脅威的な敵、clamp/fallback は余裕を加点。
+    return slack_result.has_value() ? -slack_result->slack_time : 1.0;
   };
 
   auto enemies = ctx.world_model->theirs().robotsWhere().available().get();


### PR DESCRIPTION
## 概要

`PassTargetMetric::calcScore` の敵インターセプト評価が `getBallSlackTime` の返す
`slack_time`（= `ball_time - robot_time`、正なら**渡したロボットがボールに先着＝インターセプト可能**）を
**符号反転せずに**消費していた。敵を渡す本評価では正の slack は「敵が先着して奪える」＝危険を意味するが、
`score *= clamp(slack, 0, 1)` がこれを**加点**しており、レーン内に敵がいる contested パスを構造的に 0 評価
していた（安全に通過するパスほど棄却され、`best_score < min_pass_score_(0.5)` で `pass_target_id` が
未選定になりやすい）。

## 変更

`calc_slack_time` の返り値を `-slack_result->slack_time` に反転（1行＋説明コメント）。
これで下流の `min`（最も脅威的な敵を選択）/ `clamp`（安全余裕を加点）/ `fallback 1.0`（レーンに敵なしで満点）が
すべて整合する。

`getBallSlackTime` 本体は**変更しない** — 受け手系（`receive.cpp:233/357`・`attacker_metrics.cpp:64`）が
現符号（`slack>0` = 自ロボットが間に合う）に正しく依存して動作しているため。本体を反転すると受け手側が回帰する。

## 根拠（2つの独立論拠が同じ1行修正に着地）

1. **受け手系の符号慣習**: `receive.cpp` は `slack<0` の交差点を受領候補から除外し、`attacker_metrics.cpp:64` は
   「`slack>0` なら有効なインターセプト地点」とコメント。つまり「渡したロボットが先着」= 正。敵に対しては逆にすべき。
2. **fallback 定数 `1.0`**: 「レーンに敵なし → 1.0 → 満点」が成立するには、スケールが「安全余裕（正=安全）」で
   なければならない。しかし生の `getBallSlackTime` は敵が速いほど正を返すため、消費側の意図スケールと逆符号。
   → fallback 定数の存在自体が反転の必要性を独立に証明する。

## 影響（仮説として明示）

contested なパス（レーン内に敵）が初めて選定対象になる。ユーザー主訴「パスプレイに難」の一因の可能性が高いが、
定量確認は未実施。M0 の run0706 bag は別理由（crane が終始ボールに絡まず）で退化サンプルのため因果の証拠には
できない。

## 検証状況

- **静的**: コードのみで確定（上記2独立論拠）。
- **ビルド/テスト**: `crane_game_analyzer` ビルド成功・111 tests パス。ただしこれは**コンパイル＋lint のみ**で、
  本パッケージに機能テストは無く**挙動カバレッジはゼロ**。
- **挙動検証（保留）**: `PASS_UNDER_MARK.py`（受け手1m隣に敵）の before/after A/B。成功基準は「成功率↑」だけでなく
  **INTERCEPTED 分類が急増しないこと**（旧メトリクスが contested を棄却していた前提で下流ゲート 0.5/0.2 と
  ヒステリシスが調整済みのため）。crane スタックの sim 投入環境が整い次第、別途実施。

## フォローアップ

- 再反転を防ぐピン留めテストは、crane_game_analyzer 初の機能テスト基盤＋world_model スキャフォールドが必要なため
  別途検討（本 PR はコメントで意図を明示）。
- 同種の敵 slack consumer（`attacker.cpp:87/93`・`free_kicker.cpp:239`・`attacker_metrics.cpp:46`）は
  一律反転せず、各 usage を個別にトレースして符号を判断する（`attacker_metrics.cpp:64` は自 slack で正しい）。
