### PR TITLE
feat(receive): ボール接近時のドリブラートラップを配線

### DIFF
--- a/crane_robot_skills/src/receive.cpp
+++ b/crane_robot_skills/src/receive.cpp
@@ -161,6 +161,17 @@ Status Receive::update()
     }
   } else {
     command->lookAtBall().kickStraight(0.);
+    // ソフトバンパーと同条件（有効かつボール接近）でドリブラー(既定0.3)を回しトラップ性を高める。
+    // software_bumper を切る側（Attacker/ball_placement）は条件不成立で挙動不変。
+    // 発火時のみ withDribble し、共有command の継承 dribble を else 側で上書きしない。
+    const double ball_speed = world_model()->ball().vel.norm();
+    if (
+      getParameter<bool>("enable_software_bumper") &&
+      robot()->getDistance(world_model()->ball().pos) <
+        ball_speed * getParameter<double>("software_bumper_start_time")) {
+      command->withDribble(getParameter<double>("dribble_power"));
+      command->addPlanningFactor("Receive", "dribbler ON (ボール接近・トラップ)");
+    }
   }
   command->setDribblerTargetPosition(interception_point).disableBallAvoidance();
 


### PR DESCRIPTION
## 概要

Receive スキルで宣言済み未使用だった `dribble_power`（既定0.3）を配線し、受領時にボール接近で
ドリブラーを起動してトラップ性を高める（M1-4）。低リスク・即効の独立変更。

## 変更

- `crane_robot_skills/src/receive.cpp` — 非redirect（else）分岐に、ソフトバンパー有効かつ
  ボール到達猶予条件（`distance < ball_speed * software_bumper_start_time`）成立時のみ
  `withDribble(dribble_power)` を追加。redirect 分岐は従来どおり `dribble(0.0)` で不変。

## 設計判断（advisor 2回で確定）

- `dribble_power` は `prepareFrame` でリセットされず tick を跨いで永続する。当初検討した
  「else で無条件に `withDribble(0/power)`」は、Receive を**共有 command で**生成する消費者
  （single_ball_placement / Attacker）の継承 dribble を 0 に潰す退行になるため却下。
- **positive-only + software_bumper ゲート**を採用（発火時のみ書き込み、else-zero なし）。
  ソフトバンパーの「同条件流用」の忠実な解釈でもある。

## 消費者への影響（リポジトリ全体で列挙）

| 消費者 | command | enable_software_bumper | 影響 |
|---|---|---|---|
| single_ball_placement | 共有 | false | 条件不成立 → 挙動不変 |
| Attacker（受け） | 共有 | false（両分岐） | 条件不成立 → 挙動不変 |
| **PassReceiverSession** | 専用 | true（既定） | ボール接近で dribble 0.3 起動＝唯一の受益者 |

挙動変化は「software_bumper=true の Receive 消費者が非redirectでボール接近時にドリブラーを
`dribble_power` で回す」の1点のみ。パス受け手のトラップ改善が狙い。

## 検証・注記

- `colcon build`（crane_robot_skills）成功。skill は live world_model/node を要し単体テスト不可のため
  sim 検証は後続。
- **延期**: PassReceiverSession（専用wrapper）は一度乗った dribble が永続する latch あり。ボール把持
  としては妥当。crisp 化するなら `prepareFrame` に `dribble_power=0` 対称化が正道だが全skill影響のため
  本 PR から除外。
- 独立変更（develop 直基点）。他の M1 スタックと直交。
