### PR TITLE
feat(crane_physics): パスキック物理計画の純関数化とAttacker初速置換

### DIFF
--- a/crane_game_analyzer/src/metrics/pass_target_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/pass_target_metrics.cpp
@@ -6,9 +6,7 @@
 
 #include "crane_game_analyzer/metrics/pass_target_metrics.hpp"
 
-#include <crane_physics/ball_physics_model.hpp>
 #include <crane_physics/pass_evaluation.hpp>
-#include <crane_physics/pass_kick.hpp>
 #include <range/v3/algorithm/find_if.hpp>
 #include <range/v3/algorithm/min.hpp>
 #include <range/v3/algorithm/sort.hpp>
@@ -19,13 +17,6 @@
 
 namespace crane::metrics
 {
-namespace
-{
-// パスキック初速の物理逆算パラメータ（attacker.cpp の configurePassKick と一致させる）
-constexpr double kPassArrivalSpeed = 2.0;  // 望ましい受領点到達速度 [m/s]
-constexpr double kPassMinKickSpeed = 2.0;  // 直進パス初速の下限 [m/s]
-constexpr double kPassMaxKickSpeed = 5.5;  // 直進パス初速の上限 [m/s]
-}  // namespace
 
 PassTargetMetric::PassTargetMetric() : MetricBase(MetricId::PASS_TARGET, "PassTarget") {}
 
@@ -95,13 +86,8 @@ auto PassTargetMetric::calcScore(
     score *= (1.0 - normed_distance_to_their_goal * 0.5);
   }
 
-  // 実際のキック速度に合わせて距離依存（attacker.cpp の configurePassKick と同じ物理式）。
-  // 敵slack評価は定速近似のため、ここでは初速のみ物理逆算し ball_velocity/ball_time の整合を保つ。
-  const double deceleration = ctx.world_model->ball().getPhysicsModel()->getDeceleration();
-  const double kick_speed =
-    planStraightPass(
-      pass_distance, kPassArrivalSpeed, deceleration, kPassMinKickSpeed, kPassMaxKickSpeed)
-      .initial_speed;
+  // 実際のキック速度に合わせて距離依存（attacker.cpp の configurePassKick と同じ式）
+  const double kick_speed = std::clamp(pass_distance, 2.0, 4.0);
   const Segment pass_line{pass_origin, p};
   const Vector2 pass_dir = p - pass_origin;
   const Vector2 ball_velocity =

--- a/crane_game_analyzer/src/metrics/pass_target_metrics.cpp
+++ b/crane_game_analyzer/src/metrics/pass_target_metrics.cpp
@@ -6,7 +6,9 @@
 
 #include "crane_game_analyzer/metrics/pass_target_metrics.hpp"
 
+#include <crane_physics/ball_physics_model.hpp>
 #include <crane_physics/pass_evaluation.hpp>
+#include <crane_physics/pass_kick.hpp>
 #include <range/v3/algorithm/find_if.hpp>
 #include <range/v3/algorithm/min.hpp>
 #include <range/v3/algorithm/sort.hpp>
@@ -17,6 +19,13 @@
 
 namespace crane::metrics
 {
+namespace
+{
+// パスキック初速の物理逆算パラメータ（attacker.cpp の configurePassKick と一致させる）
+constexpr double kPassArrivalSpeed = 2.0;  // 望ましい受領点到達速度 [m/s]
+constexpr double kPassMinKickSpeed = 2.0;  // 直進パス初速の下限 [m/s]
+constexpr double kPassMaxKickSpeed = 5.5;  // 直進パス初速の上限 [m/s]
+}  // namespace
 
 PassTargetMetric::PassTargetMetric() : MetricBase(MetricId::PASS_TARGET, "PassTarget") {}
 
@@ -86,8 +95,13 @@ auto PassTargetMetric::calcScore(
     score *= (1.0 - normed_distance_to_their_goal * 0.5);
   }
 
-  // 実際のキック速度に合わせて距離依存（attacker.cpp の configurePassKick と同じ式）
-  const double kick_speed = std::clamp(pass_distance, 2.0, 4.0);
+  // 実際のキック速度に合わせて距離依存（attacker.cpp の configurePassKick と同じ物理式）。
+  // 敵slack評価は定速近似のため、ここでは初速のみ物理逆算し ball_velocity/ball_time の整合を保つ。
+  const double deceleration = ctx.world_model->ball().getPhysicsModel()->getDeceleration();
+  const double kick_speed =
+    planStraightPass(
+      pass_distance, kPassArrivalSpeed, deceleration, kPassMinKickSpeed, kPassMaxKickSpeed)
+      .initial_speed;
   const Segment pass_line{pass_origin, p};
   const Vector2 pass_dir = p - pass_origin;
   const Vector2 ball_velocity =

--- a/crane_robot_skills/src/attacker.cpp
+++ b/crane_robot_skills/src/attacker.cpp
@@ -5,7 +5,9 @@
 // https://opensource.org/licenses/MIT.
 
 #include <crane_geometry/ddps.hpp>
+#include <crane_physics/ball_physics_model.hpp>
 #include <crane_physics/pass.hpp>
+#include <crane_physics/pass_kick.hpp>
 #include <crane_robot_skills/attacker.hpp>
 #include <magic_enum/magic_enum.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -32,6 +34,10 @@ constexpr double MIN_PASS_SCORE_ATTACKER = 0.2;        // パス品質の下限�
 constexpr double KICK_TIMEOUT_SEC = 3.0;               // KICK状態でボール無接触の場合のタイムアウト
 constexpr double KICK_NO_CONTACT_THRESHOLD_SEC = 0.1;  // ボール接触とみなす最小継続時間
 constexpr double KICK_BALL_STOPPED_VEL = 0.3;          // タイムアウト判定でのボール停止閾値
+constexpr double PASS_ARRIVAL_SPEED =
+  2.0;  // パス受領点での望ましい到達速度 [m/s]（M3でplanから上書き予定）
+constexpr double PASS_MIN_KICK_SPEED = 2.0;  // 直進パス初速の下限 [m/s]
+constexpr double PASS_MAX_KICK_SPEED = 5.5;  // 直進パス初速の上限 [m/s]
 }  // namespace
 void Attacker::initialize()
 {
@@ -327,8 +333,12 @@ void Attacker::configurePassKick(const Point & target, KickOld & kick_skill)
   } else {
     kick_skill.setParameter("chip_kick", false);
     kick_skill.setParameter("use_target_kick_speed", true);
-    kick_skill.setParameter(
-      "target_kick_speed", std::clamp((world_model()->ball().pos - target).norm(), 2.0, 4.0));
+    // 望ましい受領点到達速度から必要初速を物理逆算（旧: clamp(距離, 2, 4) のアドホック式）
+    const double pass_distance = (world_model()->ball().pos - target).norm();
+    const double deceleration = world_model()->ball().getPhysicsModel()->getDeceleration();
+    const auto plan = planStraightPass(
+      pass_distance, PASS_ARRIVAL_SPEED, deceleration, PASS_MIN_KICK_SPEED, PASS_MAX_KICK_SPEED);
+    kick_skill.setParameter("target_kick_speed", plan.initial_speed);
     kick_skill.setParameter("dribble_power", 0.0);
   }
 }

--- a/utility/crane_physics/CMakeLists.txt
+++ b/utility/crane_physics/CMakeLists.txt
@@ -46,6 +46,10 @@ if(BUILD_TESTING)
   target_include_directories(test_travel_time PUBLIC include)
   target_link_libraries(test_travel_time Eigen3::Eigen)
 
+  ament_auto_add_gtest(test_pass_kick test/test_pass_kick.cpp)
+  target_include_directories(test_pass_kick PUBLIC include)
+  target_link_libraries(test_pass_kick Eigen3::Eigen)
+
   ament_auto_add_gtest(test_pid_controller test/test_pid_controller.cpp)
   target_include_directories(test_pid_controller PUBLIC include)
   target_link_libraries(test_pid_controller Eigen3::Eigen)

--- a/utility/crane_physics/include/crane_physics/pass_kick.hpp
+++ b/utility/crane_physics/include/crane_physics/pass_kick.hpp
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#ifndef CRANE_PHYSICS__PASS_KICK_HPP_
+#define CRANE_PHYSICS__PASS_KICK_HPP_
+
+#include <algorithm>
+#include <cmath>
+#include <crane_physics/pass.hpp>
+#include <crane_physics/robot_info.hpp>
+#include <limits>
+#include <vector>
+
+namespace crane
+{
+namespace pass_kick
+{
+/// ボール減速度の既定値 [m/s^2]（BallPhysicsModel と整合。実行時は ball().getPhysicsModel() 参照）
+constexpr double kDefaultDeceleration = 0.7;
+
+/// 直進パスの計画結果
+struct StraightPlan
+{
+  double initial_speed = 0.0;  ///< キック初速 [m/s]（setKickStraightTargetSpeed へ渡す値）
+  double arrival_speed = 0.0;  ///< 受領点での到達速度 [m/s]
+  double travel_time = 0.0;    ///< 受領点までの転がり所要時間 [s]
+  bool reachable = false;      ///< クランプ後の初速で受領点に到達できるか
+};
+
+/// パスキック（直進 or チップ）の計画結果
+struct KickPlan
+{
+  bool is_chip = false;        ///< チップキックを使うか
+  double chip_distance = 0.0;  ///< is_chip 時のチップ着地距離 [m]
+  StraightPlan straight;       ///< is_chip=false 時の直進計画
+  bool feasible = false;       ///< 有効な計画が得られたか
+};
+}  // namespace pass_kick
+
+/**
+ * @brief 必要初速: 距離 d 先で到達速度 v_arr にするためのキック初速
+ *
+ * 一定減速 a のもとで v(d)^2 = v0^2 - 2 a d より v0 = sqrt(v_arr^2 + 2 a d)。
+ */
+inline auto requiredInitialSpeed(double distance, double arrival_speed, double deceleration)
+  -> double
+{
+  const double d = std::max(0.0, distance);
+  const double a = std::max(0.0, deceleration);
+  const double v_arr = std::max(0.0, arrival_speed);
+  return std::sqrt(v_arr * v_arr + 2.0 * a * d);
+}
+
+/**
+ * @brief 到達速度: 初速 v0 のボールが距離 d 先で持つ速度
+ *
+ * sqrt(max(0, v0^2 - 2 a d))。停止して届かない場合は 0。
+ */
+inline auto arrivalSpeed(double distance, double initial_speed, double deceleration) -> double
+{
+  const double d = std::max(0.0, distance);
+  const double a = std::max(0.0, deceleration);
+  const double v0 = std::max(0.0, initial_speed);
+  const double v_sq = v0 * v0 - 2.0 * a * d;
+  return v_sq > 0.0 ? std::sqrt(v_sq) : 0.0;
+}
+
+/**
+ * @brief 転がり時間: 初速 v0 のボールが距離 d を転がる所要時間 [s]
+ *
+ * v_arr = v0 - a t より t = (v0 - v_arr)/a。停止して届かない場合は無限大。
+ */
+inline auto rollingTravelTime(double distance, double initial_speed, double deceleration) -> double
+{
+  const double d = std::max(0.0, distance);
+  const double v0 = std::max(0.0, initial_speed);
+  const double a = std::max(0.0, deceleration);
+  if (d < 1e-9) {
+    return 0.0;
+  }
+  if (a < 1e-9) {
+    return v0 > 1e-9 ? d / v0 : std::numeric_limits<double>::infinity();
+  }
+  const double v_arr_sq = v0 * v0 - 2.0 * a * d;
+  if (v_arr_sq <= 0.0) {
+    return std::numeric_limits<double>::infinity();
+  }
+  return (v0 - std::sqrt(v_arr_sq)) / a;
+}
+
+/**
+ * @brief 直進パスの初速・到達速度・所要時間を計画する
+ *
+ * 望ましい到達速度から必要初速を逆算し、[min, max] にクランプする。
+ * クランプにより到達速度・所要時間は再計算される。
+ *
+ * @param distance             パス距離 [m]
+ * @param desired_arrival_speed 望ましい受領点到達速度 [m/s]
+ * @param deceleration          ボール減速度 [m/s^2]
+ * @param min_initial_speed     初速下限 [m/s]
+ * @param max_initial_speed     初速上限 [m/s]
+ */
+inline auto planStraightPass(
+  double distance, double desired_arrival_speed, double deceleration, double min_initial_speed,
+  double max_initial_speed) -> pass_kick::StraightPlan
+{
+  pass_kick::StraightPlan plan;
+  const double a = std::max(0.0, deceleration);
+  const double lo = std::min(min_initial_speed, max_initial_speed);
+  const double hi = std::max(min_initial_speed, max_initial_speed);
+  const double v0 = std::clamp(requiredInitialSpeed(distance, desired_arrival_speed, a), lo, hi);
+  plan.initial_speed = v0;
+  plan.arrival_speed = arrivalSpeed(distance, v0, a);
+  plan.travel_time = rollingTravelTime(distance, v0, a);
+  plan.reachable = plan.arrival_speed > 0.0 && std::isfinite(plan.travel_time);
+  return plan;
+}
+
+/**
+ * @brief パスキック（直進/チップ）の統合計画
+ *
+ * getPassAnalysis でパスライン上の敵遮蔽を判定し、遮蔽があればチップ、
+ * なければ planStraightPass による直進を計画する。
+ *
+ * @param ball                  パス起点（ボール位置）
+ * @param target                受領点
+ * @param their_robots          敵ロボット
+ * @param desired_arrival_speed 望ましい受領点到達速度 [m/s]
+ * @param deceleration          ボール減速度 [m/s^2]
+ * @param min_initial_speed     直進初速下限 [m/s]
+ * @param max_initial_speed     直進初速上限 [m/s]
+ * @param block_distance        パスライン遮蔽と見なす敵距離 [m]
+ * @param chip_margin           チップ着地距離に足す余裕 [m]
+ */
+inline auto planPassKick(
+  const Point & ball, const Point & target, std::vector<RobotInfo::SharedPtr> their_robots,
+  double desired_arrival_speed, double deceleration, double min_initial_speed,
+  double max_initial_speed, double block_distance = 0.2, double chip_margin = 0.2)
+  -> pass_kick::KickPlan
+{
+  pass_kick::KickPlan plan;
+  const auto analysis = getPassAnalysis(ball, target, std::move(their_robots), block_distance);
+  if (analysis.need_chip) {
+    plan.is_chip = true;
+    plan.chip_distance = analysis.required_chip_distance + chip_margin;
+    plan.feasible = plan.chip_distance > 0.0;
+    return plan;
+  }
+  const double distance = (target - ball).norm();
+  plan.is_chip = false;
+  plan.straight = planStraightPass(
+    distance, desired_arrival_speed, deceleration, min_initial_speed, max_initial_speed);
+  plan.feasible = plan.straight.reachable;
+  return plan;
+}
+}  // namespace crane
+
+#endif  // CRANE_PHYSICS__PASS_KICK_HPP_

--- a/utility/crane_physics/test/test_pass_kick.cpp
+++ b/utility/crane_physics/test/test_pass_kick.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 ibis-ssl
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <crane_physics/pass_kick.hpp>
+#include <memory>
+#include <vector>
+
+namespace crane
+{
+namespace
+{
+constexpr double kA = 0.7;  // ボール減速度 [m/s^2]
+
+auto makeEnemy(double x, double y) -> RobotInfo::SharedPtr
+{
+  auto r = std::make_shared<RobotInfo>();
+  r->pose = Pose2D{.pos = Point(x, y), .theta = 0.0};
+  r->vel = Velocity2D{.linear = Point(0.0, 0.0), .omega = 0.0};
+  return r;
+}
+}  // namespace
+
+// ── requiredInitialSpeed ──────────────────────────────────────────
+
+TEST(PassKickTest, RequiredInitialSpeed_ZeroDistance)
+{
+  // 距離0なら到達速度がそのまま必要初速
+  EXPECT_NEAR(requiredInitialSpeed(0.0, 2.5, kA), 2.5, 1e-9);
+}
+
+TEST(PassKickTest, RequiredInitialSpeed_ZeroArrival)
+{
+  // 到達速度0 → v0 = sqrt(2 a d)
+  EXPECT_NEAR(requiredInitialSpeed(2.0, 0.0, kA), std::sqrt(2.0 * kA * 2.0), 1e-9);
+}
+
+// ── arrivalSpeed（requiredInitialSpeed の逆関数）──────────────────
+
+TEST(PassKickTest, ArrivalSpeed_RoundTrip)
+{
+  const double d = 3.0, v_arr = 2.0;
+  const double v0 = requiredInitialSpeed(d, v_arr, kA);
+  EXPECT_NEAR(arrivalSpeed(d, v0, kA), v_arr, 1e-9);
+}
+
+TEST(PassKickTest, ArrivalSpeed_Unreachable)
+{
+  // 初速が小さすぎて届かない → 0
+  EXPECT_DOUBLE_EQ(arrivalSpeed(10.0, 1.0, kA), 0.0);
+}
+
+// ── rollingTravelTime ─────────────────────────────────────────────
+
+TEST(PassKickTest, RollingTravelTime_Basic)
+{
+  const double d = 3.0, v_arr = 2.0;
+  const double v0 = requiredInitialSpeed(d, v_arr, kA);
+  // t = (v0 - v_arr) / a
+  EXPECT_NEAR(rollingTravelTime(d, v0, kA), (v0 - v_arr) / kA, 1e-9);
+}
+
+TEST(PassKickTest, RollingTravelTime_Unreachable)
+{
+  EXPECT_TRUE(std::isinf(rollingTravelTime(10.0, 1.0, kA)));
+}
+
+TEST(PassKickTest, RollingTravelTime_NoDeceleration)
+{
+  // 減速なし → 等速 d / v0
+  EXPECT_NEAR(rollingTravelTime(4.0, 2.0, 0.0), 2.0, 1e-9);
+}
+
+TEST(PassKickTest, RollingTravelTime_ZeroDistance)
+{
+  EXPECT_DOUBLE_EQ(rollingTravelTime(0.0, 3.0, kA), 0.0);
+}
+
+// ── planStraightPass ──────────────────────────────────────────────
+
+TEST(PassKickTest, PlanStraightPass_Nominal)
+{
+  const auto plan = planStraightPass(3.0, 2.0, kA, 1.0, 6.0);
+  EXPECT_TRUE(plan.reachable);
+  EXPECT_NEAR(plan.initial_speed, requiredInitialSpeed(3.0, 2.0, kA), 1e-9);
+  EXPECT_NEAR(plan.arrival_speed, 2.0, 1e-9);
+  EXPECT_GT(plan.travel_time, 0.0);
+}
+
+TEST(PassKickTest, PlanStraightPass_MaxClamp_Unreachable)
+{
+  // 遠距離＋低い上限 → 上限にクランプされ届かない
+  const auto plan = planStraightPass(10.0, 2.0, kA, 1.0, 3.0);
+  EXPECT_DOUBLE_EQ(plan.initial_speed, 3.0);
+  EXPECT_DOUBLE_EQ(plan.arrival_speed, 0.0);
+  EXPECT_FALSE(plan.reachable);
+  EXPECT_TRUE(std::isinf(plan.travel_time));
+}
+
+TEST(PassKickTest, PlanStraightPass_MinClamp_FasterArrival)
+{
+  // 近距離＋高い下限 → 下限にクランプされ望ましい到達速度より速く着く
+  const auto plan = planStraightPass(0.5, 2.0, kA, 3.0, 6.0);
+  EXPECT_DOUBLE_EQ(plan.initial_speed, 3.0);
+  EXPECT_GT(plan.arrival_speed, 2.0);
+  EXPECT_TRUE(plan.reachable);
+}
+
+// ── planPassKick（チップ/直進の統合）──────────────────────────────
+
+TEST(PassKickTest, PlanPassKick_NoEnemies_Straight)
+{
+  const auto plan = planPassKick(Point(0, 0), Point(3, 0), {}, 2.0, kA, 1.0, 6.0);
+  EXPECT_FALSE(plan.is_chip);
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_TRUE(plan.straight.reachable);
+}
+
+TEST(PassKickTest, PlanPassKick_BlockedEnemy_Chip)
+{
+  // パスライン(0,0)-(4,0)上に敵(2,0.1) → 遮蔽ありチップ
+  std::vector<crane::RobotInfo::SharedPtr> enemies = {makeEnemy(2.0, 0.1)};
+  const auto plan = planPassKick(Point(0, 0), Point(4, 0), enemies, 2.0, kA, 1.0, 6.0, 0.2, 0.2);
+  EXPECT_TRUE(plan.is_chip);
+  // ball から遮蔽点(2,0)までの距離 2.0 + margin 0.2
+  EXPECT_NEAR(plan.chip_distance, 2.2, 1e-6);
+  EXPECT_TRUE(plan.feasible);
+}
+
+TEST(PassKickTest, PlanPassKick_ClearLine_Straight)
+{
+  // 敵(2,1.0)はパスラインから十分離れている → 直進
+  std::vector<crane::RobotInfo::SharedPtr> enemies = {makeEnemy(2.0, 1.0)};
+  const auto plan = planPassKick(Point(0, 0), Point(4, 0), enemies, 2.0, kA, 1.0, 6.0, 0.2, 0.2);
+  EXPECT_FALSE(plan.is_chip);
+  EXPECT_TRUE(plan.feasible);
+}
+}  // namespace crane


### PR DESCRIPTION
## 概要

パスキックの初速決定を物理逆算の純関数へ一元化する土台（M1-1）と、Attacker 実行側の
アドホックな `clamp(距離, 2.0, 4.0)` 置換（M1-2 実行半分）を導入する。

## 変更

### M1-1: `crane_physics` にパスキック計画の純関数
- **新規** `utility/crane_physics/include/crane_physics/pass_kick.hpp`
  - `requiredInitialSpeed(distance, arrival_speed, deceleration)` = √(v_arr² + 2ad)
  - `arrivalSpeed` / `rollingTravelTime` / `planStraightPass(...)`（min/max クランプ付き、reachable 判定）
- **新規** `utility/crane_physics/test/test_pass_kick.cpp` — 純関数の float 完全一致テスト
- 減速度はスキル側で `world_model()->ball()` の物理モデル経由で取得可能（初速→kick_power 変換は
  local_planner の KickerModel が担うため、意思決定層は「到達速度→必要初速」の逆算のみ）

### M1-2（実行半分）: Attacker のキック速度を物理逆算に
- `crane_robot_skills/src/attacker.cpp` — パス初速の算出を `planStraightPass` 系に置換

## 補足（レビュー観点）

- 本 PR は**挙動保存中心のリファクタ**。M1-2 の analyzer 側置換は意図と逆方向にスコアを
  動かすことが判明したため撤回済み（`revert` コミットを同梱）。analyzer 側のキック速度式は
  従来の `clamp(距離,2,4)` のまま。
- 検証: `colcon build` / `colcon test`（test_pass_kick 含む）成功。

## PR スタック

このブランチは develop 直基点。後続の `feature/pass-rating`（M1-3/M1-5）がこの上にスタックする。
